### PR TITLE
feat: update inscribe to use Claude CLI exclusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ for fun. Several tools have also been ported to Rust for improved performance an
     - A fast terminal image and video display utility, designed as a high-performance alternative to `imgcat`. Supports
       multiple image and video formats, resizing with aspect ratio preservation, and reading from files or stdin. Video support requires ffmpeg.
     - To install: `cargo install --git https://github.com/timmattison/tools ic`
+- inscribe
+    - Automatically generates clear and consistent git commit messages using Claude AI. Analyzes staged changes and creates
+      conventional commit messages. Supports credential storage in system credential managers (Keychain on macOS, Credential
+      Manager on Windows, Secret Service on Linux). **Note: Currently only tested on macOS.**
+    - Usage: `inscribe` (requires staged changes), `inscribe -a` (stages all changes), `inscribe -d` (dry run),
+      `inscribe --store-key` (save API key)
+    - To install: `cargo install --git https://github.com/timmattison/tools inscribe`
 - idear
     - IDEA Reaper. Cleans up orphaned .idea directories that remain when you delete a project directory before closing 
       JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, PhpStorm, RubyMine, CLion, DataGrip, GoLand, Rider, Android Studio). 

--- a/src/inscribe/Cargo.toml
+++ b/src/inscribe/Cargo.toml
@@ -6,8 +6,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.11", features = ["json"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 anyhow = "1"
 git2 = "0.18"

--- a/src/inscribe/Cargo.toml
+++ b/src/inscribe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "inscribe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+git2 = "0.18"

--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -1,0 +1,180 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use git2::{DiffOptions, Repository};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Automatically generate git commit messages using Claude")]
+struct Args {
+    #[arg(short, long, help = "Path to repository (defaults to current directory)")]
+    path: Option<String>,
+    
+    #[arg(short, long, help = "Don't actually create the commit, just show the message")]
+    dry_run: bool,
+    
+    #[arg(short, long, help = "Stage all modified files before committing")]
+    all: bool,
+}
+
+#[derive(Serialize)]
+struct ClaudeRequest {
+    model: String,
+    max_tokens: u32,
+    messages: Vec<Message>,
+}
+
+#[derive(Serialize)]
+struct Message {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ClaudeResponse {
+    content: Vec<Content>,
+}
+
+#[derive(Deserialize)]
+struct Content {
+    text: String,
+}
+
+fn get_api_key() -> Result<String> {
+    let output = Command::new("security")
+        .args(&["find-generic-password", "-s", "Claude Code-credentials", "-w"])
+        .output()
+        .context("Failed to retrieve Claude credentials")?;
+    
+    if !output.status.success() {
+        anyhow::bail!("Failed to retrieve API key from keychain");
+    }
+    
+    let key = String::from_utf8(output.stdout)?
+        .trim()
+        .to_string();
+    
+    Ok(key)
+}
+
+fn get_diff(repo: &Repository, staged: bool) -> Result<String> {
+    let mut diff_options = DiffOptions::new();
+    
+    let diff = if staged {
+        let head = repo.head()?.peel_to_tree()?;
+        let mut index = repo.index()?;
+        let oid = index.write_tree()?;
+        let index_tree = repo.find_tree(oid)?;
+        repo.diff_tree_to_tree(Some(&head), Some(&index_tree), Some(&mut diff_options))?
+    } else {
+        let head = repo.head()?.peel_to_tree()?;
+        repo.diff_tree_to_workdir_with_index(Some(&head), Some(&mut diff_options))?
+    };
+    
+    let mut diff_text = String::new();
+    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        if let Ok(content) = std::str::from_utf8(line.content()) {
+            diff_text.push_str(content);
+        }
+        true
+    })?;
+    
+    Ok(diff_text)
+}
+
+async fn generate_commit_message(diff: &str, api_key: &str) -> Result<String> {
+    let client = reqwest::Client::new();
+    
+    let prompt = format!(
+        "Based on the following git diff, generate a clear and concise commit message. \
+        Follow conventional commit format (type: description). \
+        The message should explain what was changed and why, not just describe the diff. \
+        Keep it under 72 characters for the subject line.\n\n{}",
+        diff
+    );
+    
+    let request = ClaudeRequest {
+        model: "claude-3-5-sonnet-20241022".to_string(),
+        max_tokens: 300,
+        messages: vec![Message {
+            role: "user".to_string(),
+            content: prompt,
+        }],
+    };
+    
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .context("Failed to send request to Claude API")?;
+    
+    if !response.status().is_success() {
+        let error_text = response.text().await?;
+        anyhow::bail!("Claude API error: {}", error_text);
+    }
+    
+    let claude_response: ClaudeResponse = response.json().await?;
+    let message = claude_response
+        .content
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No response from Claude"))?
+        .text
+        .trim()
+        .to_string();
+    
+    Ok(message)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    
+    let repo_path = args.path.as_deref().unwrap_or(".");
+    let repo = Repository::open(repo_path)
+        .context("Failed to open git repository")?;
+    
+    if args.all {
+        let mut index = repo.index()?;
+        index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+        index.write()?;
+    }
+    
+    let staged_diff = get_diff(&repo, true)?;
+    if staged_diff.is_empty() {
+        anyhow::bail!("No staged changes found. Use -a to stage all changes.");
+    }
+    
+    let api_key = get_api_key()?;
+    
+    println!("Generating commit message...");
+    let commit_message = generate_commit_message(&staged_diff, &api_key).await?;
+    
+    println!("\nGenerated commit message:");
+    println!("{}", commit_message);
+    
+    if !args.dry_run {
+        println!("\nCreating commit...");
+        
+        let signature = repo.signature()?;
+        let tree_oid = repo.index()?.write_tree()?;
+        let tree = repo.find_tree(tree_oid)?;
+        let parent_commit = repo.head()?.peel_to_commit()?;
+        
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            &commit_message,
+            &tree,
+            &[&parent_commit],
+        )?;
+        
+        println!("Commit created successfully!");
+    }
+    
+    Ok(())
+}

--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use git2::{DiffOptions, Repository};
-use serde::{Deserialize, Serialize};
-use std::process::Command;
+use git2::{DiffOptions, Oid, Repository};
+use std::env;
+use std::path::PathBuf;
+
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Automatically generate git commit messages using Claude")]
@@ -15,46 +16,90 @@ struct Args {
     
     #[arg(short, long, help = "Stage all modified files before committing")]
     all: bool,
-}
-
-#[derive(Serialize)]
-struct ClaudeRequest {
-    model: String,
-    max_tokens: u32,
-    messages: Vec<Message>,
-}
-
-#[derive(Serialize)]
-struct Message {
-    role: String,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct ClaudeResponse {
-    content: Vec<Content>,
-}
-
-#[derive(Deserialize)]
-struct Content {
-    text: String,
-}
-
-fn get_api_key() -> Result<String> {
-    let output = Command::new("security")
-        .args(&["find-generic-password", "-s", "Claude Code-credentials", "-w"])
-        .output()
-        .context("Failed to retrieve Claude credentials")?;
     
-    if !output.status.success() {
-        anyhow::bail!("Failed to retrieve API key from keychain");
+    #[arg(short, long, help = "Reword a previous commit (provide commit hash)")]
+    fixup: Option<String>,
+    
+    #[arg(short, long, help = "Reword the most recent commit")]
+    reword: bool,
+}
+
+
+
+fn find_git_repository(start_path: Option<&str>) -> Result<Repository> {
+    let start = if let Some(path) = start_path {
+        PathBuf::from(path)
+    } else {
+        env::current_dir().context("Failed to get current directory")?
+    };
+    
+    // Try to open repository using git2's discovery mechanism
+    // This will search up the directory tree for a .git directory
+    Repository::discover(&start)
+        .with_context(|| format!("No git repository found starting from {:?}", start))
+}
+
+
+fn check_claude_cli() -> Result<()> {
+    use std::process::Command;
+    
+    // Try different possible Claude locations
+    let home = env::var("HOME").unwrap_or_default();
+    let claude_paths = vec![
+        "claude".to_string(),  // In PATH
+        format!("{}/.claude/local/claude", home),  // Common install location
+        "/usr/local/bin/claude".to_string(),  // Another common location
+    ];
+    
+    let mut claude_check = None;
+    let mut used_path = String::new();
+    
+    for path in &claude_paths {
+        let result = Command::new(path)
+            .arg("--version")
+            .output();
+            
+        if result.is_ok() {
+            claude_check = Some(result);
+            used_path = path.clone();
+            break;
+        }
     }
     
-    let key = String::from_utf8(output.stdout)?
-        .trim()
-        .to_string();
-    
-    Ok(key)
+    match claude_check {
+        Some(Ok(output)) => {
+            if output.status.success() {
+                // Claude CLI is available, now check if it's authenticated by trying a minimal command
+                // We'll check authentication when we actually try to use it
+                return Ok(());
+            } else {
+                // Claude CLI had an error even with --version
+                let error_msg = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!(
+                    "Claude Code encountered an error: {}\n\n\
+                    Try reinstalling Claude Code from https://claude.ai/code",
+                    error_msg.trim()
+                )
+            }
+        },
+        Some(Err(e)) => {
+            anyhow::bail!("Failed to run Claude CLI at {}: {}", used_path, e)
+        },
+        None => {
+            // Claude CLI is not found in any of the expected locations
+            anyhow::bail!(
+                "Claude Code is not installed or not in expected locations.\n\n\
+                Checked locations:\n\
+                - claude (in PATH)\n\
+                - ~/.claude/local/claude\n\
+                - /usr/local/bin/claude\n\n\
+                To use inscribe with your Claude.ai subscription:\n\
+                1. Install Claude Code from: https://claude.ai/code\n\
+                2. Run 'claude login' to authenticate\n\
+                3. Then run inscribe again"
+            )
+        }
+    }
 }
 
 fn get_diff(repo: &Repository, staged: bool) -> Result<String> {
@@ -82,98 +127,215 @@ fn get_diff(repo: &Repository, staged: bool) -> Result<String> {
     Ok(diff_text)
 }
 
-async fn generate_commit_message(diff: &str, api_key: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+fn get_commit_diff(repo: &Repository, commit_hash: &str) -> Result<String> {
+    let oid = Oid::from_str(commit_hash)
+        .context("Invalid commit hash")?;
+    
+    let commit = repo.find_commit(oid)
+        .context("Commit not found")?;
+    
+    let commit_tree = commit.tree()?;
+    
+    let parent_tree = if commit.parent_count() > 0 {
+        Some(commit.parent(0)?.tree()?)
+    } else {
+        None
+    };
+    
+    let mut diff_options = DiffOptions::new();
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut diff_options))?;
+    
+    let mut diff_text = String::new();
+    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        if let Ok(content) = std::str::from_utf8(line.content()) {
+            diff_text.push_str(content);
+        }
+        true
+    })?;
+    
+    Ok(diff_text)
+}
+
+
+async fn generate_commit_message(diff: &str) -> Result<String> {
+    use std::process::Command;
     
     let prompt = format!(
         "Based on the following git diff, generate a clear and concise commit message. \
         Follow conventional commit format (type: description). \
         The message should explain what was changed and why, not just describe the diff. \
-        Keep it under 72 characters for the subject line.\n\n{}",
+        Keep it under 72 characters for the subject line. \
+        Return ONLY the commit message, no explanation or additional text.\n\n{}",
         diff
     );
     
-    let request = ClaudeRequest {
-        model: "claude-3-5-sonnet-20241022".to_string(),
-        max_tokens: 300,
-        messages: vec![Message {
-            role: "user".to_string(),
-            content: prompt,
-        }],
-    };
+    // Try different possible Claude locations
+    let home = env::var("HOME").unwrap_or_default();
+    let claude_paths = vec![
+        "claude".to_string(),  // In PATH
+        format!("{}/.claude/local/claude", home),  // Common install location
+        "/usr/local/bin/claude".to_string(),  // Another common location
+    ];
     
-    let response = client
-        .post("https://api.anthropic.com/v1/messages")
-        .header("x-api-key", api_key)
-        .header("anthropic-version", "2023-06-01")
-        .header("content-type", "application/json")
-        .json(&request)
-        .send()
-        .await
-        .context("Failed to send request to Claude API")?;
+    let mut output = None;
     
-    if !response.status().is_success() {
-        let error_text = response.text().await?;
-        anyhow::bail!("Claude API error: {}", error_text);
+    for path in &claude_paths {
+        let result = Command::new(path)
+            .args(&["--print", &prompt])
+            .output();
+            
+        if let Ok(o) = result {
+            output = Some(o);
+            break;
+        }
     }
     
-    let claude_response: ClaudeResponse = response.json().await?;
-    let message = claude_response
-        .content
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("No response from Claude"))?
-        .text
+    let output = output
+        .ok_or_else(|| anyhow::anyhow!("Failed to execute Claude CLI. Make sure Claude Code is installed and you're logged in with 'claude login'"))?;
+    
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        if error.contains("not authenticated") || error.contains("login") {
+            anyhow::bail!(
+                "Claude Code is not authenticated.\n\n\
+                Please run: claude login\n\
+                Then authenticate with your Claude.ai account."
+            );
+        }
+        anyhow::bail!("Claude CLI error: {}", error);
+    }
+    
+    let message = String::from_utf8(output.stdout)?
         .trim()
         .to_string();
     
     Ok(message)
 }
 
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
     
-    let repo_path = args.path.as_deref().unwrap_or(".");
-    let repo = Repository::open(repo_path)
-        .context("Failed to open git repository")?;
+    // Check if Claude CLI is available
+    check_claude_cli()?;
     
-    if args.all {
-        let mut index = repo.index()?;
-        index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
-        index.write()?;
-    }
+    let repo = find_git_repository(args.path.as_deref())?;
     
-    let staged_diff = get_diff(&repo, true)?;
-    if staged_diff.is_empty() {
-        anyhow::bail!("No staged changes found. Use -a to stage all changes.");
-    }
-    
-    let api_key = get_api_key()?;
-    
-    println!("Generating commit message...");
-    let commit_message = generate_commit_message(&staged_diff, &api_key).await?;
-    
-    println!("\nGenerated commit message:");
-    println!("{}", commit_message);
-    
-    if !args.dry_run {
-        println!("\nCreating commit...");
+    if args.reword {
+        // Handle reword mode for the most recent commit
+        let head = repo.head()?.peel_to_commit()?;
+        let head_oid = head.id();
+        let head_hash = head_oid.to_string();
         
-        let signature = repo.signature()?;
-        let tree_oid = repo.index()?.write_tree()?;
-        let tree = repo.find_tree(tree_oid)?;
-        let parent_commit = repo.head()?.peel_to_commit()?;
+        println!("\nRewording the most recent commit: {}", &head_hash[..8]);
+        println!("Original message: {}", head.message().unwrap_or(""));
         
-        repo.commit(
-            Some("HEAD"),
-            &signature,
-            &signature,
-            &commit_message,
-            &tree,
-            &[&parent_commit],
-        )?;
+        // Get the diff of the HEAD commit
+        let commit_diff = get_commit_diff(&repo, &head_hash)?;
         
-        println!("Commit created successfully!");
+        println!("\nGenerating new commit message...");
+        let new_message = generate_commit_message(&commit_diff).await?;
+        
+        println!("\nGenerated commit message:");
+        println!("{}", new_message);
+        
+        if !args.dry_run {
+            use std::process::Command;
+            
+            println!("\nAmending commit...");
+            
+            // Use git commit --amend to update the message
+            let output = Command::new("git")
+                .args(&["commit", "--amend", "-m", &new_message])
+                .output()
+                .context("Failed to amend commit")?;
+            
+            if !output.status.success() {
+                let error = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("Failed to amend commit: {}", error);
+            }
+            
+            println!("Commit successfully reworded!");
+            println!("\nWARNING: The commit hash has changed. If you've already pushed this commit,");
+            println!("you'll need to force push with: git push --force-with-lease");
+        }
+    } else if let Some(commit_hash) = args.fixup {
+        // Handle fixup mode
+        println!("\nWARNING: Using --fixup will create a fixup commit that will:");
+        println!("- Change the commit message of commit {}", commit_hash);
+        println!("- Require running 'git rebase -i --autosquash' to apply the change");
+        println!("- Change all commit hashes after the target commit\n");
+        
+        // Get the diff of the commit to reword
+        let commit_diff = get_commit_diff(&repo, &commit_hash)?;
+        
+        println!("Generating new commit message for commit {}...", commit_hash);
+        let new_message = generate_commit_message(&commit_diff).await?;
+        
+        println!("\nGenerated commit message:");
+        println!("{}", new_message);
+        
+        if !args.dry_run {
+            use std::process::Command;
+            
+            println!("\nCreating fixup commit...");
+            
+            // Create the fixup commit using git command
+            let output = Command::new("git")
+                .args(&["commit", "--allow-empty", &format!("--fixup=reword:{}:{}", commit_hash, new_message)])
+                .output()
+                .context("Failed to create fixup commit")?;
+            
+            if !output.status.success() {
+                let error = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("Failed to create fixup commit: {}", error);
+            }
+            
+            println!("Fixup commit created successfully!");
+            println!("\nTo apply this change, run:");
+            println!("  git rebase -i --autosquash {}", commit_hash);
+            println!("\nOr to automatically apply it:");
+            println!("  git rebase -i --autosquash {}~1", commit_hash);
+        }
+    } else {
+        // Normal commit mode
+        if args.all {
+            let mut index = repo.index()?;
+            index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+            index.write()?;
+        }
+        
+        let staged_diff = get_diff(&repo, true)?;
+        if staged_diff.is_empty() {
+            anyhow::bail!("No staged changes found. Use -a to stage all changes.");
+        }
+        
+        println!("Generating commit message...");
+        let commit_message = generate_commit_message(&staged_diff).await?;
+        
+        println!("\nGenerated commit message:");
+        println!("{}", commit_message);
+        
+        if !args.dry_run {
+            println!("\nCreating commit...");
+            
+            let signature = repo.signature()?;
+            let tree_oid = repo.index()?.write_tree()?;
+            let tree = repo.find_tree(tree_oid)?;
+            let parent_commit = repo.head()?.peel_to_commit()?;
+            
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                &commit_message,
+                &tree,
+                &[&parent_commit],
+            )?;
+            
+            println!("Commit created successfully!");
+        }
     }
     
     Ok(())


### PR DESCRIPTION
## Summary
- Simplified inscribe to use only Claude CLI (no API keys required)
- Added new features for rewording commits
- Fixed hanging issue when checking Claude availability

## Changes
- **Removed API functionality**: No more API keys, credential storage, or keychain integration
- **Claude CLI only**: Works exclusively with Claude.ai subscriptions via `claude` CLI
- **New `--reword` option**: Easily reword the most recent commit
- **New `--fixup` option**: Create fixup commits for older commits
- **Performance fix**: Changed from `claude --print` to `claude --version` for availability check
- **Better error handling**: Clear messages for authentication issues

## Usage
```bash
# Generate commit message for staged changes
inscribe

# Stage all changes and commit
inscribe -a

# Reword the most recent commit
inscribe --reword

# Create a fixup commit for an older commit
inscribe --fixup abc123

# Dry run (preview without committing)
inscribe --dry-run
```

## Requirements
- Claude Code installed (`https://claude.ai/code`)
- Authenticated with `claude login`
- Active Claude.ai subscription

## Testing
Tested on macOS with Claude Code CLI.

🤖 Generated with [Claude Code](https://claude.ai/code)