### PR TITLE
fix: correct git fixup command format in inscribe

### DIFF
--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -283,7 +283,7 @@ async fn main() -> Result<()> {
             
             // Create the fixup commit using git command
             let output = Command::new("git")
-                .args(&["commit", "--allow-empty", &format!("--fixup=reword:{}:{}", commit_hash, new_message)])
+                .args(&["commit", "--allow-empty", &format!("--fixup=reword:{}", commit_hash), "-m", &new_message])
                 .output()
                 .context("Failed to create fixup commit")?;
             


### PR DESCRIPTION
## Summary
- Fixed incorrect git fixup command format that was causing "could not lookup commit" errors
- Separated the `--fixup=reword:<hash>` argument from the commit message
- The message is now properly passed via the `-m` flag as git expects

## Details
The inscribe tool was incorrectly formatting the git fixup command by including the new commit message within the fixup argument itself:
```
--fixup=reword:<hash>:<message>
```

This caused git to interpret the entire string (including the message) as the commit reference, leading to lookup failures.

The fix properly separates these arguments:
```
--fixup=reword:<hash> -m <message>
```

## Test plan
- [x] Built and installed the updated inscribe tool
- [ ] Test with a valid commit hash from another repository
- [ ] Verify the fixup commit is created successfully
- [ ] Confirm the rebase process works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)