### PR TITLE
fix: handle short commit hashes in inscribe without panicking

### DIFF
--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -315,7 +315,7 @@ fn reword_commit_with_rebase(repo: &Repository, commit_hash: &str, new_message: 
     rebase.finish(Some(&signature))?;
     
     println!("Commit message successfully updated!");
-    println!("\nWARNING: All commit hashes after {} have changed.", &commit_hash[..8]);
+    println!("\nWARNING: All commit hashes after {} have changed.", &commit_hash[..commit_hash.len().min(8)]);
     println!("If you've already pushed, you'll need to force push.");
     
     Ok(())
@@ -336,7 +336,7 @@ async fn main() -> Result<()> {
         let head_oid = head.id();
         let head_hash = head_oid.to_string();
         
-        println!("\nRewording the most recent commit: {}", &head_hash[..8]);
+        println!("\nRewording the most recent commit: {}", &head_hash[..head_hash.len().min(8)]);
         println!("Original message: {}", head.message().unwrap_or(""));
         
         // Get the diff of the HEAD commit
@@ -359,7 +359,7 @@ async fn main() -> Result<()> {
         }
     } else if let Some(commit_hash) = args.fixup {
         // Handle fixup mode
-        println!("\nRewording commit {}...", &commit_hash[..8]);
+        println!("\nRewording commit {}...", &commit_hash[..commit_hash.len().min(8)]);
         println!("This will:");
         println!("- Generate a new commit message using Claude");
         println!("- Update the commit message directly");


### PR DESCRIPTION
## Summary
- Fixed panic when using `inscribe -f` with commit hashes shorter than 8 characters
- Replaced unsafe string slicing with safe bounds checking using `.len().min(8)`
- Affected lines: 318, 339, and 362 in main.rs

## Test plan
- [x] Build the project with `cargo build`
- [x] Test with short hash: `inscribe -f e855 --dry-run` (no longer panics)
- [x] Test with valid hash: `inscribe --reword --dry-run` (works correctly)
- [x] Test with single character hash: `inscribe -f a --dry-run` (handles gracefully)

🤖 Generated with [Claude Code](https://claude.ai/code)