### PR TITLE
feat: update gitrdun to use gpt-oss as default model

### DIFF
--- a/src/gitrdun/README.md
+++ b/src/gitrdun/README.md
@@ -62,7 +62,7 @@ gitrdun --find-nested
 
 ```bash
 # Generate meta-summary across all repositories
-gitrdun --meta-ollama --ollama-model qwen3:30b-a3b
+gitrdun --meta-ollama --ollama-model gpt-oss
 
 # Save results to file
 gitrdun --output results.txt
@@ -85,7 +85,7 @@ gitrdun path1 path2 path3
 - `--find-nested`: Include nested Git repositories
 - `--ollama`: Generate AI summaries using Ollama
 - `--meta-ollama`: Generate cross-repository meta-summary
-- `--ollama-model <MODEL>`: Ollama model to use (default: "qwen3:30b-a3b")
+- `--ollama-model <MODEL>`: Ollama model to use (default: "gpt-oss")
 - `--ollama-url <URL>`: Ollama API URL (default: "http://localhost:11434")
 - `--output <FILE>`: Write results to file
 - `--summary-only`: Show only repository names and commit counts

--- a/src/gitrdun/src/cli.rs
+++ b/src/gitrdun/src/cli.rs
@@ -54,7 +54,7 @@ pub struct Args {
     pub meta_ollama: bool,
 
     /// Ollama model to use for summaries
-    #[arg(long = "ollama-model", default_value = "qwen3:30b-a3b")]
+    #[arg(long = "ollama-model", default_value = "gpt-oss")]
     pub ollama_model: String,
 
     /// URL for Ollama API

--- a/src/gitrdun/src/main.rs
+++ b/src/gitrdun/src/main.rs
@@ -468,7 +468,7 @@ impl Default for Args {
             all: false,
             ollama: false,
             meta_ollama: false,
-            ollama_model: "qwen3:30b-a3b".to_string(),
+            ollama_model: "gpt-oss".to_string(),
             ollama_url: "http://localhost:11434".to_string(),
             root: None,
             output: None,

--- a/src/gitrdun/src/ollama.rs
+++ b/src/gitrdun/src/ollama.rs
@@ -14,6 +14,9 @@ const MODEL_CONTEXT_SIZES: &[(&str, usize)] = &[
     ("llama2:13b", 4096),
     ("mistral:7b", 8192),
     ("qwen3:30b-a3b", 32768),
+    ("gpt-oss", 131072),
+    ("gpt-oss:20b", 131072),
+    ("gpt-oss:120b", 131072),
 ];
 
 /// Default context size if model not found

--- a/src/gitrdun/tests/integration.rs
+++ b/src/gitrdun/tests/integration.rs
@@ -70,7 +70,7 @@ mod cli_tests {
         assert!(!args.all);
         assert!(!args.ollama);
         assert!(!args.meta_ollama);
-        assert_eq!(args.ollama_model, "qwen3:30b-a3b");
+        assert_eq!(args.ollama_model, "gpt-oss");
         assert_eq!(args.ollama_url, "http://localhost:11434");
         assert!(args.filter_user);
         assert!(!args.keep_thinking);


### PR DESCRIPTION
## Summary
- Updated gitrdun to use `gpt-oss` as the default Ollama model instead of `qwen3:30b-a3b`
- Added support for gpt-oss model variants with their 128k token context length
- Updated all references across the codebase including tests and documentation

## Changes
- Changed default model from `qwen3:30b-a3b` to `gpt-oss` in CLI arguments
- Added gpt-oss model context sizes (131,072 tokens) to the model configuration
- Updated README documentation to reflect the new default
- Updated tests to expect the new default model

## Context Length Information
The gpt-oss model family supports:
- **Context Length**: 131,072 tokens (128k) - 4x larger than the previous default
- **Variants**: `gpt-oss`, `gpt-oss:20b`, `gpt-oss:120b`
- **Memory Requirements**: 
  - gpt-oss-120b: ~80GB RAM
  - gpt-oss-20b: ~16GB RAM

## Test Plan
- [x] All existing tests pass
- [x] Build completes successfully in release mode
- [x] Verified default model is correctly set

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect "gpt-oss" as the new default model for generating AI summaries.

* **New Features**
  * Added support for context size information for "gpt-oss" models.

* **Bug Fixes**
  * Updated default model in the command-line interface and related tests to "gpt-oss" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->