### PR TITLE
feat: add progress indicators to inscribe CLI

### DIFF
--- a/src/inscribe/Cargo.toml
+++ b/src/inscribe/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 git2 = "0.20.2"
+indicatif = "0.17"


### PR DESCRIPTION
## Summary
- Add visual progress indicators to inscribe using the indicatif library
- Improve user experience during long-running operations  
- Provide real-time feedback when waiting for Claude API responses

## Changes
- Added `indicatif` dependency for progress bars and spinners
- Implemented progress indicators for:
  - Claude CLI installation checks
  - Git diff analysis (staged changes and commits)
  - Commit message generation via Claude API
  - Git operations (staging, creating, amending, rewording commits)
- Used consistent cyan-colored spinners with contextual messages
- Added automatic cleanup on errors and success checkmarks on completion

## Test plan
- [x] Built successfully with `cargo build --release`
- [x] Tested with `--dry-run --all` flag to verify progress indicators display correctly
- [x] Verified spinners appear during Claude API calls
- [x] Confirmed proper cleanup on both success and error paths

This addresses the issue where users might think inscribe has frozen during API calls or complex git operations, especially when generating commit messages which can take several seconds.

🤖 Generated with [Claude Code](https://claude.ai/code)