### PR TITLE
feat: improve gitrdun status display with repo names and branches

### DIFF
--- a/src/gitrdun/src/git.rs
+++ b/src/gitrdun/src/git.rs
@@ -76,6 +76,18 @@ fn git_time_to_datetime(time: &Time) -> DateTime<Local> {
     Local.timestamp_opt(time.seconds(), 0).unwrap()
 }
 
+/// Get the current branch name of a repository
+pub fn get_current_branch(repo_path: &Path) -> String {
+    if let Ok(repo) = Repository::open(repo_path) {
+        if let Ok(head) = repo.head() {
+            if let Some(branch_name) = head.shorthand() {
+                return branch_name.to_string();
+            }
+        }
+    }
+    "HEAD".to_string() // Default fallback
+}
+
 /// Get the first line of a commit message
 fn get_first_line(message: &str) -> &str {
     message.lines().next().unwrap_or("")

--- a/src/gitrdun/src/main.rs
+++ b/src/gitrdun/src/main.rs
@@ -291,12 +291,14 @@ async fn display_results(result: &SearchResult, args: &Args, use_ollama: bool, p
 
                 // Generate Ollama summary
                 let repo_name = repo_path.file_name().unwrap_or_default().to_string_lossy();
+                let branch_name = git::get_current_branch(repo_path);
+                let full_repo_info = format!("{} ({})", repo_path.display(), branch_name);
                 write_output(&format!("\n🤖 Generating summary for {} with Ollama ({})...\n", repo_name, args.ollama_model));
 
                 // Update progress display with current repo
                 if let Some(progress_ref) = &progress {
-                    progress_ref.update_ollama_repo(repo_name.to_string());
-                    progress_ref.update_ollama_status(format!("Generating summary for {}", repo_name));
+                    progress_ref.update_ollama_repo(full_repo_info.clone());
+                    progress_ref.update_ollama_status(format!("Generating summary for {}", full_repo_info));
                 }
 
                 let status_callback: Box<dyn Fn(&str) + Send + Sync> = if let Some(progress_ref) = &progress {

--- a/src/gitrdun/src/ui.rs
+++ b/src/gitrdun/src/ui.rs
@@ -299,10 +299,22 @@ impl ProgressDisplay {
                     "✅ Scanning complete - preparing results...".to_string()
                 } else {
                     let current_path = self.current_path.lock().clone();
-                    let truncated_path = if current_path.len() > 60 {
-                        format!("...{}", &current_path[current_path.len().saturating_sub(57)..])
+                    // Extract repo name from path if it contains .git
+                    let display_path = if current_path.contains(".git") {
+                        // Get the parent directory of .git (the actual repo)
+                        if let Some(repo_end) = current_path.rfind(".git") {
+                            current_path[..repo_end].trim_end_matches('/').to_string()
+                        } else {
+                            current_path.clone()
+                        }
                     } else {
-                        current_path
+                        current_path.clone()
+                    };
+                    
+                    let truncated_path = if display_path.len() > 60 {
+                        format!("...{}", &display_path[display_path.len().saturating_sub(57)..])
+                    } else {
+                        display_path
                     };
                     format!("🔎 Current: {}", truncated_path)
                 };
@@ -399,15 +411,27 @@ impl ProgressDisplay {
         } else {
             let current_path = self.current_path.lock().clone();
             
+            // Extract repo name from path if it contains .git
+            let display_path = if current_path.contains(".git") {
+                // Get the parent directory of .git (the actual repo)
+                if let Some(repo_end) = current_path.rfind(".git") {
+                    current_path[..repo_end].trim_end_matches('/').to_string()
+                } else {
+                    current_path.clone()
+                }
+            } else {
+                current_path.clone()
+            };
+            
             print!(
                 "\r🔍 Scanned: {} dirs, Found: {} repos, Rate: {:.1} dirs/sec, Current: {}",
                 dirs_checked,
                 repos_found,
                 scan_rate,
-                if current_path.len() > 40 {
-                    format!("...{}", &current_path[current_path.len().saturating_sub(37)..])
+                if display_path.len() > 40 {
+                    format!("...{}", &display_path[display_path.len().saturating_sub(37)..])
                 } else {
-                    current_path
+                    display_path
                 }
             );
         }


### PR DESCRIPTION
## Summary
- Enhanced gitrdun's status display to show more informative repository information
- Added branch names to Ollama processing status
- Cleaned up path display by removing `.git` suffixes

## Changes

### 1. Added Branch Name Support
- Created `get_current_branch()` function in `git.rs` to retrieve the current branch name of repositories
- Falls back to "HEAD" if branch name cannot be determined

### 2. Enhanced Ollama Status Display
- Updated Ollama processing status to show full repository path with branch name
- Format: `/full/path/to/repo (branch-name)`
- Makes it clear which repository and branch is being processed

### 3. Improved Path Display
- Removed `.git` suffix from displayed paths in both TUI and CLI modes
- Shows actual repository directory instead of internal git paths
- Cleaner, more readable path presentation

### 4. Updated Both UI Modes
- **Interactive TUI**: "Current" field now shows clean repository paths
- **Non-interactive CLI**: Progress line displays clean paths
- **Ollama Processing**: Shows full repository path with branch information

## Test Plan
- [x] Code compiles successfully with `cargo build`
- [x] Tested path display improvements in scanning mode
- [x] Verified Ollama status shows full path with branch name

## Benefits
These changes make it much easier to understand which repository is being processed at any given time, especially when running Ollama summaries across multiple repositories. Users can now see exactly which repository and branch is being analyzed.

🤖 Generated with [Claude Code](https://claude.ai/code)