### PR TITLE
fix: strip markdown backticks from Claude's commit messages in inscribe

### DIFF
--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -324,7 +324,23 @@ async fn generate_commit_message(diff: &str, long_format: bool) -> Result<String
         anyhow::bail!("Claude CLI error: {}", error);
     }
 
-    let message = String::from_utf8(output.stdout)?.trim().to_string();
+    let mut message = String::from_utf8(output.stdout)?.trim().to_string();
+    
+    // Strip markdown code block formatting if present
+    // Claude sometimes wraps responses in ```
+    if message.starts_with("```") {
+        // Remove opening backticks (and optional language identifier)
+        if let Some(idx) = message.find('\n') {
+            message = message[idx + 1..].to_string();
+        } else {
+            message = message[3..].to_string();
+        }
+    }
+    
+    // Remove closing backticks if present
+    if message.ends_with("```") {
+        message = message[..message.len() - 3].trim().to_string();
+    }
 
     if message.is_empty() {
         spinner.finish_and_clear();


### PR DESCRIPTION
## Summary
- Fixed inscribe tool generating commit messages with backticks
- Added logic to strip markdown code block formatting from Claude's responses
- Handles both opening backticks (with optional language identifiers) and closing backticks

## Problem
The inscribe tool was creating commit messages that started and ended with three backticks (```) because Claude sometimes returns responses wrapped in markdown code blocks.

## Solution
Added post-processing logic in the `generate_commit_message` function to:
1. Detect and remove opening backticks (including optional language identifiers like ```text)
2. Remove closing backticks
3. Trim the resulting message

This ensures commit messages are clean and don't contain markdown formatting artifacts.

## Test plan
- [x] Build the inscribe tool successfully
- [ ] Test with a sample commit to verify backticks are stripped
- [ ] Verify commit messages are properly formatted without backticks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of commit messages generated by the Claude CLI by automatically removing any Markdown code block formatting from the output. This ensures commit messages are clean and free of unnecessary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->