### PR TITLE
fix: increase Claude CLI timeout from 30s to 120s in inscribe

### DIFF
--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -301,12 +301,12 @@ async fn generate_commit_message(diff: &str, long_format: bool) -> Result<String
             .context("Failed to write prompt to Claude CLI stdin")?;
     }
 
-    // Wait for output with timeout
+    // Wait for output with timeout (increased for large commits)
     let output = tokio::task::spawn_blocking(move || child.wait_with_output());
 
-    let output = timeout(Duration::from_secs(30), output)
+    let output = timeout(Duration::from_secs(120), output)
         .await
-        .context("Claude CLI timed out after 30 seconds")?
+        .context("Claude CLI timed out after 120 seconds. This may happen with large commits or complex diffs. Try using the --short flag for a more concise message.")?
         .context("Failed to join Claude CLI task")?
         .context("Failed to wait for Claude CLI output")?;
 


### PR DESCRIPTION
## Summary
- Increased Claude CLI timeout from 30 seconds to 120 seconds to handle large commits
- Improved timeout error message with helpful suggestion to use --short flag
- Fixes frequent "Execution error" messages when generating commit messages for complex diffs

## Test plan
- [x] Built the project successfully with `cargo build --release`
- [ ] Test with a large commit to verify timeout no longer occurs
- [ ] Test with --short flag for faster generation on large commits
- [ ] Verify error message displays correctly when timeout still occurs

🤖 Generated with [Claude Code](https://claude.ai/code)