### PR TITLE
Split repoup into goup and polish utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,16 @@ for fun.
     - Calculates and displays the total size of a git repository in human-readable format. Shows the total
       byte count with thousands separators based on your locale.
     - To install: `cargo install --git https://github.com/timmattison/tools reposize`
-- repoup
-    - Updates dependencies across Go, Node.js, and Rust projects in a git repository. Automatically detects
-      project types and uses the appropriate package manager (npm/pnpm/yarn for Node.js). Continues
-      processing even if individual updates fail.
-    - To install: `cargo install --git https://github.com/timmattison/tools repoup`
+- goup
+    - Updates Go dependencies in a git repository. Automatically finds all go.mod files and updates
+      dependencies. Supports `--update` flag to use `go get -u all` for latest versions, otherwise
+      uses `go mod tidy` for cleanup.
+    - To install: `cargo install --git https://github.com/timmattison/tools goup`
+- polish
+    - Polishes Rust dependencies in a git repository. Automatically finds all Cargo.toml files and
+      updates dependencies. Supports `--latest` flag to use cargo-edit's `cargo upgrade` for latest
+      versions (requires cargo-edit installed), otherwise uses standard `cargo update`.
+    - To install: `cargo install --git https://github.com/timmattison/tools polish`
 - nodenuke
     - Removes node_modules directories and lock files (pnpm-lock.yaml, package-lock.json) throughout a
       repository. Supports `--no-root` flag to start from current directory instead of git root.

--- a/src/goup/Cargo.toml
+++ b/src/goup/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "goup"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "goup"
+path = "src/main.rs"
+
+[dependencies]
+walkdir = "2.5"
+clap = { version = "4.5", features = ["derive"] }

--- a/src/goup/src/main.rs
+++ b/src/goup/src/main.rs
@@ -1,0 +1,145 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, exit};
+use walkdir::{DirEntry, WalkDir};
+use clap::Parser;
+
+fn find_git_repo() -> Option<String> {
+    let mut current_dir = env::current_dir().ok()?;
+    
+    loop {
+        let git_dir = current_dir.join(".git");
+        if git_dir.exists() {
+            return Some(current_dir.to_string_lossy().to_string());
+        }
+        
+        if !current_dir.pop() {
+            break;
+        }
+    }
+    
+    None
+}
+
+fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io::Error> {
+    let output = Command::new(command[0])
+        .args(&command[1..])
+        .current_dir(dir)
+        .output()?;
+    
+    if !output.status.success() {
+        eprintln!("Warning: Error running {} in {}: {}", 
+                 command.join(" "), 
+                 dir.display(), 
+                 String::from_utf8_lossy(&output.stderr));
+        return Err(std::io::Error::new(std::io::ErrorKind::Other, "Command failed"));
+    }
+    
+    println!("Ran {} in {}", command.join(" "), dir.display());
+    Ok(())
+}
+
+fn is_git_worktree(dir: &Path) -> bool {
+    let git_path = dir.join(".git");
+    
+    // If .git is a file (not a directory), it's likely a worktree
+    if git_path.is_file() {
+        if let Ok(content) = fs::read_to_string(&git_path) {
+            // Git worktrees have .git files that contain "gitdir: <path>"
+            return content.trim().starts_with("gitdir:");
+        }
+    }
+    
+    false
+}
+
+fn should_skip_entry(entry: &DirEntry, repo_root: &Path) -> bool {
+    // Skip any path that has node_modules as a component
+    if entry.file_name() == "node_modules" {
+        return true;
+    }
+    
+    // Skip git worktree directories, but only if they're not the repo root we're running from
+    if entry.file_type().is_dir() && is_git_worktree(entry.path()) {
+        // Allow the root directory we're running from, even if it's a worktree
+        if entry.path() != repo_root {
+            println!("Skipping git worktree directory: {}", entry.path().display());
+            return true;
+        }
+    }
+    
+    false
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Update Go dependencies in a repository", long_about = None)]
+struct Args {
+    /// Update to latest versions (use go get -u)
+    #[arg(long, short = 'u')]
+    update: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+    
+    let repo_root = match find_git_repo() {
+        Some(root) => root,
+        None => {
+            eprintln!("Error: Could not find git repository");
+            exit(1);
+        }
+    };
+    
+    let repo_path = Path::new(&repo_root);
+    
+    println!("Updating Go dependencies in repository: {}", repo_root);
+    println!();
+    
+    // Collect all Go project directories
+    let mut go_dirs: Vec<PathBuf> = Vec::new();
+    
+    // Walk through all directories and find Go projects
+    for entry in WalkDir::new(repo_path)
+        .into_iter()
+        .filter_entry(|e| !should_skip_entry(e, repo_path))
+    {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!("Warning: Error accessing path: {}", e);
+                continue;
+            }
+        };
+        
+        if entry.file_type().is_dir() {
+            let dir_path = entry.path();
+            
+            if dir_path.join("go.mod").exists() {
+                go_dirs.push(dir_path.to_path_buf());
+            }
+        }
+    }
+    
+    // Process all Go projects
+    if go_dirs.is_empty() {
+        println!("No Go projects found in repository");
+        return;
+    }
+    
+    for dir_path in go_dirs {
+        println!("[Go] Found go.mod in {}", dir_path.display());
+        
+        let cmd = if args.update {
+            vec!["go", "get", "-u", "all"]
+        } else {
+            vec!["go", "mod", "tidy"]
+        };
+        
+        if let Err(e) = run_command_in_directory(&dir_path, &cmd) {
+            eprintln!("Warning: {}", e);
+        }
+    }
+    
+    println!("\n✓ Go dependency update complete!");
+}

--- a/src/polish/Cargo.toml
+++ b/src/polish/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "repoup"
+name = "polish"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "repoup"
+name = "polish"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Split `repoup` into two focused utilities: `goup` for Go and `polish` for Rust
- Removed Node.js dependency management as it's handled by the existing `nodeup` utility
- Maintained all existing functionality with cleaner separation of concerns

## Changes
- Created `goup` utility for Go dependency updates
  - Default: runs `go mod tidy` for cleanup
  - With `--update` flag: runs `go get -u all` for latest versions
- Created `polish` utility for Rust dependency updates  
  - Default: runs `cargo update` (respects version constraints)
  - With `--latest` flag: runs `cargo upgrade` then `cargo update` (requires cargo-edit)
- Removed the original `repoup` utility
- Updated README documentation

## Test plan
- [x] Built both utilities successfully
- [x] Tested help output for both programs
- [x] Verified compilation with `cargo build --release`

🤖 Generated with [Claude Code](https://claude.ai/code)