### PR TITLE
feat: add .open-next directory removal to nodenuke

### DIFF
--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
     
-    let target_dirs = vec!["node_modules", ".next"];
+    let target_dirs = vec!["node_modules", ".next", ".open-next"];
     let target_files = vec!["pnpm-lock.yaml", "package-lock.json"];
     
     let start_dir = if cli.no_root {


### PR DESCRIPTION
## Summary
- Added `.open-next` to the list of directories that nodenuke removes
- The tool now removes `.open-next` directories with the same rules as `.next` directories

## Test plan
- [x] Build the tool successfully with `cargo build`
- [ ] Run nodenuke in a project with `.open-next` directories to verify removal
- [ ] Verify that `.open-next` directories are removed even when gitignored

🤖 Generated with [Claude Code](https://claude.ai/code)