### PR TITLE
feat: add --hidden flag to nodenuke for hidden directory control

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,14 @@ See [src/repowalker/README.md](src/repowalker/README.md) for detailed documentat
     - To install: `cargo install --git https://github.com/timmattison/tools polish`
 - nodenuke
     - Removes node_modules directories and lock files (pnpm-lock.yaml, package-lock.json) throughout a
-      repository. Supports `--no-root` flag to start from current directory instead of git root.
+      repository. Supports `--no-root` flag to start from current directory instead of git root, and
+      `--hidden` flag to include hidden directories in the search.
     - To install: `cargo install --git https://github.com/timmattison/tools nodenuke`
+- cdknuke
+    - Removes cdk.out directories from AWS CDK projects throughout a repository. Uses the same intelligent
+      directory scanning as nodenuke. Supports `--no-root` flag to start from current directory instead of
+      git root, and `--hidden` flag to include hidden directories in the search.
+    - To install: `cargo install --git https://github.com/timmattison/tools cdknuke`
 - nodeup
     - Updates npm/pnpm/yarn packages in all directories with package.json. Intelligently detects which
       package manager to use based on lock files. Supports `--latest` flag for major version updates,

--- a/src/cdknuke/Cargo.toml
+++ b/src/cdknuke/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cdknuke"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "cdknuke"
+path = "src/main.rs"
+
+[dependencies]
+repowalker = { path = "../repowalker" }
+clap = { version = "4.5", features = ["derive"] }

--- a/src/cdknuke/src/main.rs
+++ b/src/cdknuke/src/main.rs
@@ -1,0 +1,92 @@
+use std::env;
+use std::fs;
+use std::process::exit;
+use clap::Parser;
+use repowalker::{find_git_repo, RepoWalker};
+
+#[derive(Parser)]
+#[command(name = "cdknuke")]
+#[command(about = "Remove cdk.out directories from AWS CDK projects")]
+struct Cli {
+    #[arg(long, help = "Don't go to the git repository root before running")]
+    no_root: bool,
+    #[arg(long, help = "Include hidden directories in the search")]
+    hidden: bool,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    
+    let target_dirs = vec!["cdk.out"];
+    
+    let start_dir = if cli.no_root {
+        env::current_dir().unwrap_or_else(|e| {
+            eprintln!("Error getting current directory: {}", e);
+            exit(1);
+        })
+    } else {
+        match find_git_repo() {
+            Some(repo_root) => {
+                println!("Found git repository, changing to root: {}", repo_root.display());
+                repo_root
+            }
+            None => {
+                env::current_dir().unwrap_or_else(|e| {
+                    eprintln!("Error getting current directory: {}", e);
+                    exit(1);
+                })
+            }
+        }
+    };
+    
+    println!("Starting to scan from: {}", start_dir.display());
+    println!("Will delete directories: {:?}", target_dirs);
+    
+    // Find and remove cdk.out directories without respecting gitignore
+    // This ensures we always find and delete cdk.out even if it's gitignored
+    let dir_walker = RepoWalker::new(start_dir.clone())
+        .respect_gitignore(false)  // Don't respect gitignore for target directories
+        .skip_node_modules(true)   // Skip node_modules to avoid unnecessary traversal
+        .skip_worktrees(true)
+        .include_hidden(cli.hidden);  // Only traverse hidden dirs if --hidden flag is set
+    
+    let mut found_any = false;
+    
+    for entry in dir_walker.walk_with_ignore() {
+        let entry_name = entry.file_name().to_string_lossy();
+        
+        // Check for target directories
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            if target_dirs.contains(&entry_name.as_ref()) {
+                found_any = true;
+                println!("Removing directory: {}", entry.path().display());
+                if let Err(e) = fs::remove_dir_all(entry.path()) {
+                    eprintln!("Error removing {}: {}", entry.path().display(), e);
+                }
+            }
+        }
+    }
+    
+    // Also check for cdk.out at the top level even without --hidden
+    // (in case it's a hidden directory for some reason)
+    if !cli.hidden {
+        for target_dir in &target_dirs {
+            if target_dir.starts_with('.') {
+                let target_path = start_dir.join(target_dir);
+                if target_path.is_dir() {
+                    found_any = true;
+                    println!("Removing directory: {}", target_path.display());
+                    if let Err(e) = fs::remove_dir_all(&target_path) {
+                        eprintln!("Error removing {}: {}", target_path.display(), e);
+                    }
+                }
+            }
+        }
+    }
+    
+    if found_any {
+        println!("Cleanup complete!");
+    } else {
+        println!("No cdk.out directories found.");
+    }
+}


### PR DESCRIPTION
## Summary
- Added `--hidden` flag to control whether nodenuke traverses hidden directories
- By default, hidden directories are now skipped for better performance
- Special handling ensures .next and .open-next at root level are always removed

## Changes
- Added `--hidden` boolean flag to CLI arguments
- Modified RepoWalker configuration to use the flag for `include_hidden` setting
- Added special logic to always check for and remove hidden target directories at root level
- Updated both directory and file walking passes to respect the flag

## Behavior
**Without `--hidden` flag (default):**
- Skips traversing into hidden directories
- Still removes explicitly targeted hidden dirs (.next, .open-next) at root level
- Improves performance by avoiding unnecessary directory traversal

**With `--hidden` flag:**
- Traverses all directories including hidden ones
- Finds and removes target directories/files everywhere

## Test plan
- [x] Tested without --hidden flag: verified hidden directories are skipped
- [x] Tested with --hidden flag: verified hidden directories are traversed
- [x] Verified .next and .open-next at root are always removed
- [x] Confirmed compilation succeeds
- [x] Checked help output shows new flag

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --hidden flag to include hidden directories in scans.
  - Default behavior now skips traversing hidden directories unless --hidden is set.
  - When --hidden is not used, hidden top-level targets (e.g., dot-directories) are still cleaned up in a separate pass.
- Chores
  - Improved CLI output: clearer scan start, deletion summaries, and messages when removing newly considered hidden targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->