### PR TITLE
Fix: nodenuke finds .next and .open-next without --hidden flag

### DIFF
--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -46,14 +46,20 @@ fn main() {
     
     // First pass: Find and remove target directories without respecting gitignore
     // This ensures we always find and delete node_modules/.next even if they're gitignored
+    // We need to include hidden directories to find .next and .open-next
     let dir_walker = RepoWalker::new(start_dir.clone())
         .respect_gitignore(false)  // Don't respect gitignore for target directories
         .skip_node_modules(false)  // We want to find and delete them
         .skip_worktrees(true)
-        .include_hidden(cli.hidden);  // Only traverse hidden dirs if --hidden flag is set
+        .include_hidden(true);  // Always include hidden dirs to find .next and .open-next
     
     for entry in dir_walker.walk_with_ignore() {
         let entry_name = entry.file_name().to_string_lossy();
+        
+        // Skip hidden directories that are not our targets when --hidden is not set
+        if !cli.hidden && entry_name.starts_with('.') && !target_dirs.contains(&entry_name.as_ref()) {
+            continue;
+        }
         
         // Check for target directories
         if entry.file_type().is_some_and(|ft| ft.is_dir()) {
@@ -66,28 +72,14 @@ fn main() {
         }
     }
     
-    // Also check for hidden target directories at the top level even without --hidden
-    if !cli.hidden {
-        for target_dir in &target_dirs {
-            if target_dir.starts_with('.') {
-                let target_path = start_dir.join(target_dir);
-                if target_path.is_dir() {
-                    println!("Removing directory: {}", target_path.display());
-                    if let Err(e) = fs::remove_dir_all(&target_path) {
-                        eprintln!("Error removing {}: {}", target_path.display(), e);
-                    }
-                }
-            }
-        }
-    }
     
-    // Second pass: Find and remove target files, respecting gitignore for other files
-    // but still checking everywhere for lock files
+    // Second pass: Find and remove target files
+    // We need to include hidden directories to find lock files in .next and .open-next
     let file_walker = RepoWalker::new(start_dir)
         .respect_gitignore(false)  // Don't respect gitignore to find lock files everywhere
         .skip_node_modules(true)   // Skip node_modules since we just deleted them
         .skip_worktrees(true)
-        .include_hidden(cli.hidden);  // Only traverse hidden dirs if --hidden flag is set
+        .include_hidden(true);  // Always include hidden dirs to find files in .next and .open-next
     
     for entry in file_walker.walk_with_ignore() {
         let entry_name = entry.file_name().to_string_lossy();

--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -74,12 +74,12 @@ fn main() {
     
     
     // Second pass: Find and remove target files
-    // We need to include hidden directories to find lock files in .next and .open-next
+    // Only search in hidden directories if --hidden flag is set
     let file_walker = RepoWalker::new(start_dir)
         .respect_gitignore(false)  // Don't respect gitignore to find lock files everywhere
         .skip_node_modules(true)   // Skip node_modules since we just deleted them
         .skip_worktrees(true)
-        .include_hidden(true);  // Always include hidden dirs to find files in .next and .open-next
+        .include_hidden(cli.hidden);  // Only traverse hidden dirs if --hidden flag is set
     
     for entry in file_walker.walk_with_ignore() {
         let entry_name = entry.file_name().to_string_lossy();


### PR DESCRIPTION
## Summary
- Fixed nodenuke to properly find and remove `.next` and `.open-next` directories without requiring the `--hidden` flag
- Ensures target directories are always found while respecting the `--hidden` flag for other hidden directories

## Problem
When running `nodenuke` without the `--hidden` flag, it was failing to find and remove `.next` and `.open-next` directories because they start with a dot and were being skipped as hidden directories.

## Solution
Modified the directory walker to always include hidden directories in traversal, but added filtering logic to:
- Always process target directories (node_modules, .next, .open-next)
- Only process other hidden directories when `--hidden` flag is explicitly provided

## Test Plan
- [ ] Run `nodenuke` in a repository with `.next` and `.open-next` directories without the `--hidden` flag
- [ ] Verify that `.next` and `.open-next` directories are removed
- [ ] Verify that other hidden directories (e.g., `.github`) are not removed without `--hidden` flag
- [ ] Run `nodenuke --hidden` and verify all hidden directories are processed as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly cleans targeted hidden directories (e.g., node_modules, .next, .open-next) without requiring --hidden.
  - Ignores unrelated hidden directories by default, reducing accidental deletions.
  - Harmonized two-pass traversal for more consistent cleanup behavior.

- Refactor
  - Centralized hidden-directory handling within the traversal loop, removing redundant top-level cleanup logic.

- Safety
  - Skips files marked as worktrees to avoid unintended deletions in Git-managed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->