### PR TITLE
feat: add .turbo directory removal to nodenuke

### DIFF
--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
     
-    let target_dirs = vec!["node_modules", ".next", ".open-next"];
+    let target_dirs = vec!["node_modules", ".next", ".open-next", ".turbo"];
     let target_files = vec!["pnpm-lock.yaml", "package-lock.json"];
     
     let start_dir = if cli.no_root {


### PR DESCRIPTION
## Summary
- Adds `.turbo` to the list of directories that nodenuke removes
- `.turbo` is Turborepo's cache directory, similar to `node_modules`, `.next`, and `.open-next`
- This helps clean up build artifacts from Turborepo projects alongside other Node.js build directories

## Test plan
- [ ] Build nodenuke: `cd src/nodenuke && cargo build --release`
- [ ] Create test directories: `mkdir -p test-dir/.turbo test-dir/node_modules`
- [ ] Run nodenuke from test parent: `cd test-dir/.. && nodenuke`
- [ ] Verify both `.turbo` and `node_modules` directories are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded cleanup scope to remove additional cache directories during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->