### PR TITLE
feat: add --worktrees flag to nodenuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
     - To install: `cargo install --git https://github.com/timmattison/tools polish`
 - nodenuke
     - Removes node_modules directories and lock files (pnpm-lock.yaml, package-lock.json) throughout a
-      repository. Supports `--no-root` flag to start from current directory instead of git root, and
-      `--hidden` flag to include hidden directories in the search.
+      repository. Supports `--no-root` flag to start from current directory instead of git root,
+      `--hidden` flag to include hidden directories in the search, and `--worktrees` flag to include
+      git worktrees in the search.
     - To install: `cargo install --git https://github.com/timmattison/tools nodenuke`
 - cdknuke
     - Removes cdk.out directories from AWS CDK projects throughout a repository. Uses the same intelligent

--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -12,6 +12,8 @@ struct Cli {
     no_root: bool,
     #[arg(long, help = "Include hidden directories in the search")]
     hidden: bool,
+    #[arg(long, help = "Include git worktrees in the search")]
+    worktrees: bool,
 }
 
 fn main() {
@@ -50,7 +52,7 @@ fn main() {
     let dir_walker = RepoWalker::new(start_dir.clone())
         .respect_gitignore(false)  // Don't respect gitignore for target directories
         .skip_node_modules(false)  // We want to find and delete them
-        .skip_worktrees(true)
+        .skip_worktrees(!cli.worktrees)
         .include_hidden(true);  // Always include hidden dirs to find .next and .open-next
     
     for entry in dir_walker.walk_with_ignore() {
@@ -78,7 +80,7 @@ fn main() {
     let file_walker = RepoWalker::new(start_dir)
         .respect_gitignore(false)  // Don't respect gitignore to find lock files everywhere
         .skip_node_modules(true)   // Skip node_modules since we just deleted them
-        .skip_worktrees(true)
+        .skip_worktrees(!cli.worktrees)
         .include_hidden(cli.hidden);  // Only traverse hidden dirs if --hidden flag is set
     
     for entry in file_walker.walk_with_ignore() {


### PR DESCRIPTION
## Summary

- Adds `--worktrees` CLI flag to nodenuke to optionally include git worktrees in the search
- Updates both directory and file walkers to respect the new flag via `.skip_worktrees(!cli.worktrees)`
- Updates README documentation to describe the new flag
- Maintains backward compatibility (default behavior unchanged - worktrees are still skipped by default)

## Test plan

- [x] Build succeeds with `cargo build`
- [x] Help text displays `--worktrees` flag correctly
- [x] Test with `--worktrees` alone (includes worktrees from git root)
- [x] Test with `--worktrees --no-root` (includes worktrees from current directory)
- [x] Test without `--worktrees` (default behavior - skips worktrees)
- [ ] Manual testing in a repository with actual worktrees to verify deletion works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--worktrees` flag that enables inclusion of git worktrees when searching for node modules, extending coverage to scan across worktree directories in addition to the primary repository.

* **Documentation**
  * Updated tool documentation to describe the new `--worktrees` flag and its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->