### PR TITLE
feat: add --worktrees flag to rr for including worktrees

### DIFF
--- a/src/rr/src/main.rs
+++ b/src/rr/src/main.rs
@@ -11,9 +11,12 @@ use repowalker::{find_git_repo, RepoWalker};
 struct Cli {
     #[arg(long, help = "Don't go to the git repository root before running")]
     no_root: bool,
-    
+
     #[arg(long, help = "Dry run - show what would be cleaned without actually cleaning")]
     dry_run: bool,
+
+    #[arg(long, help = "Include git worktrees in the search")]
+    worktrees: bool,
 }
 
 
@@ -110,7 +113,7 @@ fn main() {
     let walker = RepoWalker::new(start_dir.clone())
         .respect_gitignore(false)  // Don't respect gitignore - find ALL Rust projects
         .skip_node_modules(true)
-        .skip_worktrees(true)
+        .skip_worktrees(!cli.worktrees)
         .include_hidden(true);     // Include hidden directories
     
     for entry in walker.walk_with_ignore() {


### PR DESCRIPTION
## Summary
- Adds `--worktrees` command-line flag to the `rr` tool
- Allows scanning and cleaning Rust projects in git worktrees when flag is specified
- Default behavior preserved (worktrees are skipped unless flag is used)
- Matches functionality added to `nodenuke` in #68

## Test plan
- [x] Build rr successfully
- [x] Verify `--help` shows the new `--worktrees` flag
- [x] Test default behavior (worktrees skipped)
- [x] Test with `--worktrees` flag (worktrees included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--worktrees` CLI flag to control inclusion of git worktrees in operations. By default, worktrees remain excluded; enable the flag to include them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->