### PR TITLE
feat: add --worktrees flag to rr for including worktrees

### DIFF
--- a/src/rr/src/main.rs
+++ b/src/rr/src/main.rs
@@ -11,9 +11,12 @@ use repowalker::{find_git_repo, RepoWalker};
 struct Cli {
     #[arg(long, help = "Don't go to the git repository root before running")]
     no_root: bool,
-    
+
     #[arg(long, help = "Dry run - show what would be cleaned without actually cleaning")]
     dry_run: bool,
+
+    #[arg(long, help = "Include git worktrees in the search")]
+    worktrees: bool,
 }
 
 
@@ -110,7 +113,7 @@ fn main() {
     let walker = RepoWalker::new(start_dir.clone())
         .respect_gitignore(false)  // Don't respect gitignore - find ALL Rust projects
         .skip_node_modules(true)
-        .skip_worktrees(true)
+        .skip_worktrees(!cli.worktrees)
         .include_hidden(true);     // Include hidden directories
     
     for entry in walker.walk_with_ignore() {


### PR DESCRIPTION
Add a `--worktrees` flag to the rr tool to match the functionality already present in nodenuke. This allows users to include Git worktrees in the search for Rust projects to clean. By default, worktrees are skipped for consistency with the previous behavior.

The change modifies the RepoWalker configuration to use the flag value, enabling users to opt-in to scanning worktrees when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--worktrees` CLI flag to include git worktrees in search operations.
  * Modified behavior: git worktrees are now included when the flag is set and excluded by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->