### PR TITLE
fix(prcp): keep cursor on same line as overwrite prompt

### DIFF
--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -402,7 +402,7 @@ async fn main() -> Result<()> {
             let should_overwrite = if args.yes {
                 true
             } else {
-                eprintln!(
+                eprint!(
                     "\nDestination '{}' already exists. Overwrite? (y/N): ",
                     dest_path.display()
                 );


### PR DESCRIPTION
## Summary
- Fix overwrite confirmation prompt so cursor appears after the prompt text instead of on the next line
- Changed `eprintln!` to `eprint!` for the destination exists prompt

## Test plan
- [ ] Run `prcp` to copy a file to an existing destination
- [ ] Verify the cursor appears immediately after `(y/N):` on the same line

🤖 Generated with [Claude Code](https://claude.com/claude-code)