### PR TITLE
fix(cwt): update shell alias from wtp to wtb and fix output alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,7 +1081,7 @@ function wt() {
 
 # Quick navigation aliases (reuse wt function for proper error handling)
 alias wtf='wt -f'  # Next worktree
-alias wtp='wt -p'  # Previous worktree
+alias wtb='wt -p'  # Previous worktree (back)
 ```
 
 #### Fish (~/.config/fish/config.fish)
@@ -1100,7 +1100,7 @@ end
 
 # Quick navigation aliases (reuse wt function for proper error handling)
 alias wtf 'wt -f'
-alias wtp 'wt -p'
+alias wtb 'wt -p'
 ```
 
 ### Examples

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -376,7 +376,7 @@ fn setup_shell_integration() -> Result<(), String> {
     println!("Or open a new terminal window.");
     println!();
     println!("Available commands:");
-    println!("  {}      - List worktrees or change to one", "wt".yellow());
+    println!("  {}  - List worktrees or change to one", "wt".yellow());
     println!("  {} - Next worktree", "wtf".yellow());
     println!("  {} - Previous worktree (back)", "wtb".yellow());
 


### PR DESCRIPTION
## Summary
- Update README shell examples to use `wtb` alias instead of `wtp` for previous worktree navigation
- Fix spacing in `cwt --shell-setup` output so "Available commands" descriptions align properly

## Test plan
- [ ] Run `cwt --shell-setup` and verify the output alignment looks correct
- [ ] Verify README examples show `wtb` instead of `wtp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated shell alias naming and clarifications.

* **Style**
  * Minor formatting adjustment to help text output for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->