### PR TITLE
feat(prcp): add --skip-existing flag to skip files that already exist

### DIFF
--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -179,7 +179,7 @@ struct Args {
     #[arg(long)]
     continue_on_error: bool,
 
-    /// Overwrite all existing destination files without prompting
+    /// Skip all confirmation prompts (assume yes)
     #[arg(long, short = 'y')]
     yes: bool,
 


### PR DESCRIPTION
## Summary
- Add `-s, --skip-existing` flag to silently skip destination files that already exist
- Make `--yes` and `--skip-existing` mutually exclusive (can't use both)
- Track skipped files separately from failures, so using `--skip-existing` doesn't cause error exit
- Report skipped files at end of operation for visibility

## Test plan
- [ ] Test `prcp -s src/*.txt dest/` with some existing files in dest - should skip existing without prompting
- [ ] Test `prcp -y src/*.txt dest/` with some existing files - should overwrite without prompting
- [ ] Test `prcp --yes --skip-existing src.txt dest/` - should error with mutual exclusivity message
- [ ] Verify skipped files are reported at end but don't cause non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-existing` command-line flag (short `-s`) to skip existing destination files without user prompts.
  * Files that are skipped are now tracked and reported after processing with their count.
  * Implemented mutual exclusion between `--yes` and `--skip-existing` flags to prevent conflicting behaviors.
  * Adjusted batch progress tracking to accurately account for skipped files in calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->