### PR TITLE
feat(prcp): add parallel copy for cross-device transfers

### DIFF
--- a/src/prcp/Cargo.toml
+++ b/src/prcp/Cargo.toml
@@ -16,6 +16,9 @@ glob = "0.3"
 dirs = "6.0"
 colored = "3.0"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints.rust]
 # Require explicit handling of must-use values
 unused_must_use = "warn"


### PR DESCRIPTION
## Summary

- Implements parallel copy mode for cross-device transfers to improve throughput by overlapping read and write operations
- Adds `--sequential` flag to force sequential mode (useful for benchmarking)
- Adds SIGINT signal handler as backup to key listener for reliable Ctrl+C handling

## Architecture

```
┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐
│   Reader    │────▶│  Bounded Queue  │────▶│     Writer      │
│   Thread    │     │   (4 buffers)   │     │   (async task)  │
└─────────────┘     └─────────────────┘     └─────────────────┘
      │                                              │
      ▼                                              ▼
 Source File                                   Dest File + Hashing
```

## Key Design Decisions (per issue #86)

- Reader thread does NOT check shutdown flag (avoids race conditions)
- Reader respects pause flag for spacebar pause/resume
- Cancellation uses channel disconnect - reader exits when `send()` fails
- SIGINT handler provides backup for Ctrl+C when raw mode isn't capturing it

## Test plan

- [ ] Build: `cargo build -p prcp`
- [ ] Unit tests: `cargo test -p prcp`
- [ ] Cross-device copy completes with matching hash
- [ ] `--sequential` forces sequential mode
- [ ] Ctrl+C during copy → confirm 'y' → exits, partial file deleted
- [ ] Ctrl+C during copy → decline 'n' → copy continues
- [ ] Space pauses, space resumes
- [ ] Ctrl+C while paused works

## Follow-up

Created #92 for buffer pool optimization (deferred to reduce complexity)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--sequential` flag to force sequential copy mode for explicit control over copy behavior
  * Enhanced graceful termination handling on Ctrl+C interrupt
  * Improved progress indicators with better styling, formatting, and dynamic terminal width adjustments
  * Added cancellation prompts during verification hashing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->