### PR TITLE
feat: add gr8 tool for GitHub API rate limit display

### DIFF
--- a/src/gr8/Cargo.toml
+++ b/src/gr8/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gr8"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "gr8"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = "0.4"
+colored = "2.1"
+anyhow = "1.0"

--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -1,0 +1,196 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Local, TimeZone};
+use colored::Colorize;
+use serde::Deserialize;
+use std::process::Command;
+
+/// Represents a single rate limit resource with its limits and usage statistics
+#[derive(Debug, Deserialize)]
+struct RateLimit {
+    /// Maximum number of requests allowed
+    limit: u32,
+    /// Number of requests already used
+    used: u32,
+    /// Number of requests remaining
+    remaining: u32,
+    /// Unix timestamp (epoch) when the rate limit resets
+    reset: i64,
+}
+
+/// Contains all GitHub API rate limit resources
+#[derive(Debug, Deserialize)]
+struct Resources {
+    core: RateLimit,
+    search: RateLimit,
+    graphql: RateLimit,
+    integration_manifest: RateLimit,
+    source_import: RateLimit,
+    code_scanning_upload: RateLimit,
+    code_scanning_autofix: RateLimit,
+    actions_runner_registration: RateLimit,
+    scim: RateLimit,
+    dependency_snapshots: RateLimit,
+    dependency_sbom: RateLimit,
+    audit_log: RateLimit,
+    audit_log_streaming: RateLimit,
+    code_search: RateLimit,
+}
+
+/// Top-level response structure from GitHub API rate_limit endpoint
+#[derive(Debug, Deserialize)]
+struct RateLimitResponse {
+    resources: Resources,
+    /// Rate limit for the core API (duplicates resources.core, kept for API structure completeness)
+    #[allow(dead_code)]
+    rate: RateLimit,
+}
+
+/// Executes the `gh api rate_limit` command and returns the JSON output
+fn fetch_rate_limit_data() -> Result<String> {
+    let output = Command::new("gh")
+        .args(["api", "rate_limit"])
+        .output()
+        .context("Failed to execute 'gh' command. Is GitHub CLI installed?")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh command failed: {}", stderr);
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .context("Failed to parse command output as UTF-8")?;
+
+    Ok(stdout)
+}
+
+/// Converts a Unix epoch timestamp to a formatted local time string
+/// Returns format: YYYY-MM-DD HH:MM:SS (local time, without timezone offset)
+fn format_reset_time(epoch: i64) -> String {
+    let datetime: DateTime<Local> = Local.timestamp_opt(epoch, 0)
+        .single()
+        .unwrap_or_else(Local::now);
+
+    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+/// Formats the duration until a rate limit resets as a human-readable string
+/// Returns format like "1h 23m 45s" or "5m 30s" or "45s"
+/// Returns None if the reset time is in the past
+fn format_time_until_reset(epoch: i64) -> Option<String> {
+    let now = Local::now().timestamp();
+    let seconds_remaining = epoch - now;
+
+    if seconds_remaining <= 0 {
+        return None;
+    }
+
+    let hours = seconds_remaining / 3600;
+    let minutes = (seconds_remaining % 3600) / 60;
+    let secs = seconds_remaining % 60;
+
+    let mut parts = Vec::new();
+    if hours > 0 {
+        parts.push(format!("{}h", hours));
+    }
+    if minutes > 0 {
+        parts.push(format!("{}m", minutes));
+    }
+    if secs > 0 || parts.is_empty() {
+        parts.push(format!("{}s", secs));
+    }
+
+    Some(parts.join(" "))
+}
+
+/// Determines the appropriate color for a rate limit based on remaining percentage
+/// Returns colored string for the remaining count with proper padding applied first.
+/// Padding is applied before colorization to ensure proper column alignment.
+/// - Red: No requests remaining (exceeded)
+/// - Yellow: Less than 20% remaining
+/// - Green: 20% or more remaining
+fn colorize_remaining(rate_limit: &RateLimit) -> String {
+    // Apply padding first (left-aligned, 10 characters wide)
+    let remaining_str = format!("{:<10}", rate_limit.remaining);
+
+    if rate_limit.remaining == 0 {
+        remaining_str.red().to_string()
+    } else {
+        // Defensive check: avoid division by zero (though GitHub API should never return limit=0)
+        let percentage = if rate_limit.limit > 0 {
+            rate_limit.remaining as f64 / rate_limit.limit as f64
+        } else {
+            0.0
+        };
+
+        if percentage < 0.2 {
+            remaining_str.yellow().to_string()
+        } else {
+            remaining_str.green().to_string()
+        }
+    }
+}
+
+/// Prints a formatted row for a single rate limit resource
+/// Shows time until reset to the right of reset time when the limit is exceeded
+fn print_rate_limit_row(name: &str, rate_limit: &RateLimit) {
+    let reset_time = format_reset_time(rate_limit.reset);
+    let remaining_colored = colorize_remaining(rate_limit);
+
+    // Show time until reset if the limit is exceeded (remaining == 0)
+    let time_until = if rate_limit.remaining == 0 {
+        format_time_until_reset(rate_limit.reset)
+            .map(|t| format!(" (resets in {})", t).red().to_string())
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    println!(
+        "{:<25} {:<8} {:<8} {} {}{}",
+        name,
+        rate_limit.limit,
+        rate_limit.used,
+        remaining_colored,
+        reset_time,
+        time_until
+    );
+}
+
+/// Main entry point - fetches, parses, and displays GitHub API rate limits
+fn main() -> Result<()> {
+    let json_data = fetch_rate_limit_data()?;
+    let response: RateLimitResponse = serde_json::from_str(&json_data)
+        .context("Failed to parse JSON response")?;
+
+    // Print header
+    let now = Local::now().format("%Y-%m-%d %H:%M:%S");
+    println!("\nGitHub API Rate Limits (as of {})\n", now);
+
+    // Print table header
+    println!(
+        "{:<25} {:<8} {:<8} {:<10} Reset Time",
+        "Resource", "Limit", "Used", "Remaining"
+    );
+    println!("{}", "─".repeat(74));
+
+    // Print all resource rate limits
+    print_rate_limit_row("core", &response.resources.core);
+    print_rate_limit_row("graphql", &response.resources.graphql);
+    print_rate_limit_row("search", &response.resources.search);
+    print_rate_limit_row("code_search", &response.resources.code_search);
+    print_rate_limit_row("code_scanning_upload", &response.resources.code_scanning_upload);
+    print_rate_limit_row("code_scanning_autofix", &response.resources.code_scanning_autofix);
+    // Abbreviated to fit within 25-character column width
+    print_rate_limit_row("actions_runner_reg", &response.resources.actions_runner_registration);
+    print_rate_limit_row("integration_manifest", &response.resources.integration_manifest);
+    print_rate_limit_row("source_import", &response.resources.source_import);
+    print_rate_limit_row("dependency_snapshots", &response.resources.dependency_snapshots);
+    print_rate_limit_row("dependency_sbom", &response.resources.dependency_sbom);
+    print_rate_limit_row("scim", &response.resources.scim);
+    print_rate_limit_row("audit_log", &response.resources.audit_log);
+    print_rate_limit_row("audit_log_streaming", &response.resources.audit_log_streaming);
+
+    println!();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `gr8` tool that displays GitHub API rate limits in a formatted table
- Color-codes remaining counts (green for healthy, yellow for <20%, red for exceeded)
- Shows time until reset when a limit is exceeded (e.g., "resets in 1h 23m 45s")
- Requires GitHub CLI (`gh`) to be installed and authenticated

## Test plan
- [ ] Run `cargo build -p gr8` to verify compilation
- [ ] Run `cargo clippy -p gr8` to verify no warnings
- [ ] Run `gr8` to verify output formatting
- [ ] Verify time-until-reset appears when a limit is exceeded (remaining = 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New command-line tool with colorized table display for GitHub API rate limit information, including usage statistics and reset times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->