### PR TITLE
feat(gr8): show time until reset for exceeded rate limits

### DIFF
--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -188,3 +188,50 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_time_until_reset_past_returns_none() {
+        let past_epoch = Utc::now().timestamp() - 100;
+        assert_eq!(format_time_until_reset(past_epoch), None);
+    }
+
+    #[test]
+    fn test_format_time_until_reset_zero_returns_none() {
+        let now_epoch = Utc::now().timestamp();
+        assert_eq!(format_time_until_reset(now_epoch), None);
+    }
+
+    #[test]
+    fn test_format_time_until_reset_seconds_only() {
+        let future_epoch = Utc::now().timestamp() + 45;
+        assert_eq!(format_time_until_reset(future_epoch), Some("45s".to_string()));
+    }
+
+    #[test]
+    fn test_format_time_until_reset_minutes_and_seconds() {
+        let future_epoch = Utc::now().timestamp() + 130; // 2m 10s
+        assert_eq!(format_time_until_reset(future_epoch), Some("2m 10s".to_string()));
+    }
+
+    #[test]
+    fn test_format_time_until_reset_hours_minutes_seconds() {
+        let future_epoch = Utc::now().timestamp() + 3665; // 1h 1m 5s
+        assert_eq!(format_time_until_reset(future_epoch), Some("1h 1m 5s".to_string()));
+    }
+
+    #[test]
+    fn test_format_time_until_reset_exact_hour() {
+        let future_epoch = Utc::now().timestamp() + 3600; // 1h 0m 0s
+        assert_eq!(format_time_until_reset(future_epoch), Some("1h 0m 0s".to_string()));
+    }
+
+    #[test]
+    fn test_format_time_until_reset_exact_minute() {
+        let future_epoch = Utc::now().timestamp() + 60; // 1m 0s
+        assert_eq!(format_time_until_reset(future_epoch), Some("1m 0s".to_string()));
+    }
+}


### PR DESCRIPTION
Display the remaining time until a rate limit resets in parentheses next to the reset time when the limit has been exceeded. The time is formatted as human-readable intervals (e.g., "1h 23m 45s", "5m 30s").

This helps users quickly see how long they need to wait when they've hit a rate limit.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limit messages now display the time remaining until your limit resets when exhausted (e.g., "1h 23m 45s"), providing clearer visibility into when you can resume requests.
* **Tests**
  * Added unit tests covering time-until-reset formatting for past, zero, seconds-only, minutes+seconds, and hours+minutes+seconds cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->