### PR TITLE
fix(nwt): create sibling worktrees from existing worktree

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# EditorConfig helps maintain consistent coding styles across editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+# Ensure files end with a newline (POSIX compliance)
+insert_final_newline = true
+
+# Use Unix-style line endings
+end_of_line = lf
+
+# Trim trailing whitespace (except in markdown where trailing spaces can be significant)
+trim_trailing_whitespace = true
+
+# Default charset
+charset = utf-8
+
+[*.md]
+# Markdown uses trailing spaces for line breaks
+trim_trailing_whitespace = false
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+
+[*.{yaml,yml,toml,json}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/src/nwt/src/main.rs
+++ b/src/nwt/src/main.rs
@@ -7,7 +7,7 @@ use std::thread;
 
 use clap::Parser;
 use names::Generator;
-use repowalker::find_git_repo;
+use repowalker::find_main_repo;
 use serde::Deserialize;
 
 /// Configuration file schema for nwt.
@@ -641,12 +641,15 @@ fn main() {
         exit(exit_codes::TMUX_NOT_RUNNING);
     }
 
-    // Find git repo root
-    let repo_root = match find_git_repo() {
+    // Find the main git repo root (resolves to main repo even from worktree)
+    let repo_root = match find_main_repo() {
         Some(root) => root,
         None => {
             error!(config.quiet, "Error: Not in a git repository");
-            error!(config.quiet, "Please run this command from within a git repository.");
+            error!(
+                config.quiet,
+                "Please run this command from within a git repository or worktree."
+            );
             exit(exit_codes::NOT_IN_REPO);
         }
     };

--- a/src/repowalker/src/lib.rs
+++ b/src/repowalker/src/lib.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use ignore::WalkBuilder;
 use walkdir::{DirEntry, WalkDir};
 
@@ -23,14 +24,50 @@ pub fn find_git_repo() -> Option<PathBuf> {
 
 pub fn is_git_worktree(dir: &Path) -> bool {
     let git_path = dir.join(".git");
-    
+
     if git_path.is_file() {
         if let Ok(content) = fs::read_to_string(&git_path) {
             return content.trim().starts_with("gitdir:");
         }
     }
-    
+
     false
+}
+
+/// Finds the root of the main git repository, even when called from a worktree.
+///
+/// Unlike `find_git_repo()` which returns the current worktree directory if inside one,
+/// this function always returns the path to the main repository (where `.git` is a directory,
+/// not a file).
+///
+/// Uses `git rev-parse --git-common-dir` to find the common git directory, which points
+/// to the main repository's `.git` directory for both worktrees and the main repo.
+pub fn find_main_repo() -> Option<PathBuf> {
+    let git_dir = find_git_repo()?;
+    let git_path = git_dir.join(".git");
+
+    if git_path.is_dir() {
+        // Already in the main repo
+        return Some(git_dir);
+    }
+
+    // We're in a worktree - use git to find the common directory
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(&git_dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    // Output is like: /path/to/main-repo/.git
+    let common_dir = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    let common_path = PathBuf::from(&common_dir);
+
+    // The parent of the .git directory is the repo root
+    common_path.parent().map(|p| p.to_path_buf())
 }
 
 pub struct RepoWalker {
@@ -128,8 +165,22 @@ impl RepoWalker {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
     #[test]
     fn test_find_git_repo() {
         let path = find_git_repo().expect("Tests should run within a git repository");
         assert!(path.join(".git").exists());
     }
+
+    #[test]
+    fn test_find_main_repo() {
+        let path = find_main_repo().expect("Tests should run within a git repository");
+        assert!(
+            path.join(".git").is_dir(),
+            "Main repo should have .git directory, not file"
+        );
+    }
+}


### PR DESCRIPTION
When nwt is run from inside a worktree, it now correctly creates new worktrees as siblings instead of nested. 

Adds find_main_repo() to repowalker which uses git rev-parse --git-common-dir to resolve the actual repository root even from within a worktree. Updates nwt to use this new function instead of find_git_repo().

Fixes the issue where running \`nwt\` in /path/repo-worktrees/my-worktree/ would incorrectly create /path/repo-worktrees/my-worktree-worktrees/new-worktree/ instead of /path/repo-worktrees/new-worktree/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)