### PR TITLE
fix(prcp): support literal paths with glob characters like brackets

### DIFF
--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -395,8 +395,12 @@ fn resolve_sources(patterns: &[PathBuf], literal: bool) -> Result<Vec<PathBuf>> 
     for pattern in patterns {
         let pattern_str = pattern.to_string_lossy();
 
-        // Check if pattern contains glob characters (skip if --literal is set)
-        if !literal && (pattern_str.contains('*') || pattern_str.contains('?') || pattern_str.contains('[')) {
+        // Check if literal path exists first (like `mv` does) - this allows paths
+        // with glob characters (e.g., [brackets]) to work when they're literal filenames
+        let literal_exists = pattern.is_file();
+
+        // Check if pattern contains glob characters (skip if --literal is set or path exists)
+        if !literal && !literal_exists && (pattern_str.contains('*') || pattern_str.contains('?') || pattern_str.contains('[')) {
             let glob_iter = glob::glob(&pattern_str)
                 .with_context(|| format!("Invalid glob pattern '{}'", pattern_str))?;
 


### PR DESCRIPTION
## Summary
- Check if the literal path exists as a file before attempting glob expansion
- Fixes issue where filenames with brackets like `[TGx]` were treated as glob patterns instead of literal paths
- Now works like `mv` command: if the exact path exists, use it directly

## Test plan
- Existing tests pass
- Manual testing confirms literal bracket paths now work and glob patterns still expand correctly