### PR TITLE
feat(cwt): add wtm alias and extract shellsetup library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ fn setup_shell_integration() -> Result<()> {
 }
 ```
 
+### Important: Using `with_old_end_marker()`
+
+**When to use:** If your tool has ever been released with shell integration that users may have installed, you **must** call `.with_old_end_marker()` with a distinctive pattern from the end of the old shell code block. This allows the library to safely upgrade old installations.
+
+**What to use as the marker:** Choose the last distinctive line of your old shell code. Good candidates are:
+- The last alias definition (e.g., `alias mc='mycommand --fast'`)
+- A distinctive command inside your last function (e.g., `mytool --rm "$@"`)
+
+**Why this matters:** Without an old end marker, upgrading from an old installation may lose user config that appears after the old shell integration block. The library will warn users if this happens, but it's better to prevent it.
+
 ### Tools Currently Using shellsetup
 
 - `cwt` - Change Worktree (provides `wt`, `wtf`, `wtb`, `wtm` commands)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Buffalo Tools - Development Guidelines
+
+## Shell Integration
+
+All tools in this repository that provide shell integration (shell functions, aliases, etc.) **must** use the `shellsetup` library crate located at `src/shellsetup/`.
+
+### Why
+
+The `shellsetup` library provides:
+- Consistent marker-based block detection for upgrades
+- Automatic shell detection (bash/zsh)
+- In-place replacement of existing shell integration when users re-run `--shell-setup`
+- Support for upgrading old installations that lack end markers
+- Standardized output and instructions
+
+### Usage
+
+```rust
+use shellsetup::ShellIntegration;
+
+const SHELL_CODE: &str = r#"
+function mycommand() {
+    mytool "$@"
+}
+alias mc='mycommand --fast'
+"#;
+
+fn setup_shell_integration() -> Result<()> {
+    let integration = ShellIntegration::new("mytool", "My Tool", SHELL_CODE)
+        .with_command("mycommand", "Run mytool")
+        .with_command("mc", "Run mytool with --fast")
+        .with_old_end_marker("alias mc='mycommand --fast'");  // For upgrading old installs
+    integration.setup().map_err(|e| anyhow::anyhow!("{}", e))
+}
+```
+
+### Tools Currently Using shellsetup
+
+- `cwt` - Change Worktree (provides `wt`, `wtf`, `wtb`, `wtm` commands)
+- `prcp` - Progress Copy (provides `prmv` command)

--- a/README.md
+++ b/README.md
@@ -1079,9 +1079,10 @@ function wt() {
     fi
 }
 
-# Quick navigation aliases (reuse wt function for proper error handling)
+# Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
+alias wtm='wt main'  # Main worktree
 ```
 
 #### Fish (~/.config/fish/config.fish)
@@ -1098,9 +1099,10 @@ function wt
     end
 end
 
-# Quick navigation aliases (reuse wt function for proper error handling)
-alias wtf 'wt -f'
-alias wtb 'wt -p'
+# Quick navigation aliases
+alias wtf 'wt -f'  # Next worktree
+alias wtb 'wt -p'  # Previous worktree (back)
+alias wtm 'wt main'  # Main worktree
 ```
 
 ### Examples
@@ -1123,6 +1125,7 @@ Jump to specific worktree:
 ```bash
 wt main           # By branch name
 wt absurd-rock    # By directory name
+wtm               # Quick alias for main worktree
 ```
 
 ### Exit Codes

--- a/src/cwt/Cargo.toml
+++ b/src/cwt/Cargo.toml
@@ -9,9 +9,9 @@ path = "src/main.rs"
 
 [dependencies]
 repowalker = { path = "../repowalker" }
+shellsetup = { path = "../shellsetup" }
 clap = { version = "4.5", features = ["derive"] }
 colored = "3.0"
-dirs = "6.0"
 
 [lints.rust]
 # Enforce stricter checks to catch issues early

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -1,11 +1,10 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
 use clap::Parser;
 use colored::Colorize;
 use repowalker::find_git_repo;
+use shellsetup::ShellIntegration;
 
 /// Exit codes for different error conditions.
 mod exit_codes {
@@ -280,10 +279,8 @@ fn display_worktree_list(worktrees: &[Worktree], current_idx: Option<usize>) {
     }
 }
 
-/// The shell integration code to add to shell config files.
-const SHELL_INTEGRATION: &str = r#"
-# cwt - Change Worktree shell integration
-# Added by: cwt --shell-setup
+/// The shell code to add to shell config files.
+const SHELL_CODE: &str = r#"
 function wt() {
     if [ $# -eq 0 ]; then
         # No args: show list interactively
@@ -300,197 +297,19 @@ function wt() {
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
 alias wtm='wt main'  # Main worktree
-# End cwt shell integration
 "#;
-
-/// Marker to detect if shell integration is already installed.
-const SHELL_INTEGRATION_MARKER: &str = "cwt - Change Worktree shell integration";
-
-/// End marker for shell integration block (used for upgrades).
-const SHELL_INTEGRATION_END_MARKER: &str = "# End cwt shell integration";
-
-/// Old alias marker used to detect the end of old-style installations.
-/// This is the last alias line in the old version (before wtm was added).
-const OLD_SHELL_INTEGRATION_END: &str = "alias wtb='wt -p'";
-
-/// Replaces the shell integration block between start and end markers.
-///
-/// Preserves all content before and after the block.
-fn replace_shell_integration_block(contents: &str) -> String {
-    let lines: Vec<&str> = contents.lines().collect();
-    let mut result = Vec::new();
-    let mut in_block = false;
-    let mut block_replaced = false;
-
-    for line in lines {
-        if !in_block && line.contains(SHELL_INTEGRATION_MARKER) {
-            // Start of block - skip until end marker
-            in_block = true;
-            continue;
-        }
-
-        if in_block {
-            if line.contains(SHELL_INTEGRATION_END_MARKER) {
-                // End of block - insert new integration and continue
-                // Trim leading newline from SHELL_INTEGRATION since we're inserting mid-file
-                result.push(SHELL_INTEGRATION.trim());
-                in_block = false;
-                block_replaced = true;
-            }
-            // Skip lines within the block
-            continue;
-        }
-
-        result.push(line);
-    }
-
-    // If we never found the end marker, something went wrong - append anyway
-    if !block_replaced {
-        result.push(SHELL_INTEGRATION.trim());
-    }
-
-    result.join("\n") + "\n"
-}
-
-/// Upgrades old-style shell integration (without end marker) to new format.
-///
-/// Finds the block by looking for the start marker and the old last alias line.
-fn upgrade_old_shell_integration(contents: &str) -> String {
-    let lines: Vec<&str> = contents.lines().collect();
-    let mut result = Vec::new();
-    let mut in_block = false;
-    let mut block_replaced = false;
-
-    for line in lines {
-        if !in_block && line.contains(SHELL_INTEGRATION_MARKER) {
-            // Start of old block - skip until we find the old end
-            in_block = true;
-            continue;
-        }
-
-        if in_block {
-            if line.contains(OLD_SHELL_INTEGRATION_END) {
-                // End of old block - insert new integration
-                result.push(SHELL_INTEGRATION.trim());
-                in_block = false;
-                block_replaced = true;
-            }
-            // Skip lines within the old block
-            continue;
-        }
-
-        result.push(line);
-    }
-
-    // If we never found the old end marker, just append the new block
-    if !block_replaced {
-        result.push(SHELL_INTEGRATION.trim());
-    }
-
-    result.join("\n") + "\n"
-}
-
-/// Prints activation instructions after shell integration is added or updated.
-fn print_activation_instructions(config_file: &Path) {
-    println!();
-    println!("To activate, run:");
-    println!("  {} {}", "source".cyan(), config_file.display());
-    println!();
-    println!("Or open a new terminal window.");
-    println!();
-    println!("Available commands:");
-    println!("  {}  - List worktrees or change to one", "wt".yellow());
-    println!("  {} - Next worktree", "wtf".yellow());
-    println!("  {} - Previous worktree (back)", "wtb".yellow());
-    println!("  {} - Main worktree", "wtm".yellow());
-}
 
 /// Sets up shell integration by adding the wt function to the user's shell config.
 fn setup_shell_integration() -> Result<(), String> {
-    // Get home directory
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let integration = ShellIntegration::new("cwt", "Change Worktree", SHELL_CODE)
+        .with_command("wt", "List worktrees or change to one")
+        .with_command("wtf", "Next worktree")
+        .with_command("wtb", "Previous worktree (back)")
+        .with_command("wtm", "Main worktree")
+        // Old installations ended with this alias (before end marker was added)
+        .with_old_end_marker("alias wtb='wt -p'");
 
-    // Detect shell from SHELL environment variable
-    let shell = std::env::var("SHELL").unwrap_or_default();
-    let shell_name = Path::new(&shell)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown");
-
-    // Determine which config file to use
-    let config_file = match shell_name {
-        "zsh" => home.join(".zshrc"),
-        "bash" => {
-            // Prefer .bashrc, but use .bash_profile on macOS if .bashrc doesn't exist
-            let bashrc = home.join(".bashrc");
-            let bash_profile = home.join(".bash_profile");
-            if bashrc.exists() {
-                bashrc
-            } else if bash_profile.exists() {
-                bash_profile
-            } else {
-                bashrc // Create .bashrc if neither exists
-            }
-        }
-        _ => {
-            return Err(format!(
-                "Unsupported shell: {shell_name}. Please manually add the shell integration to your config.\n\
-                 See the README for shell integration examples: https://github.com/timmattison/tools#cwt-change-worktree"
-            ));
-        }
-    };
-
-    // Check if already installed and handle upgrades
-    if config_file.exists() {
-        let contents = fs::read_to_string(&config_file)
-            .map_err(|e| format!("Could not read {}: {}", config_file.display(), e))?;
-
-        if contents.contains(SHELL_INTEGRATION_MARKER) {
-            // Check if this is a new-style installation (has end marker)
-            if contents.contains(SHELL_INTEGRATION_END_MARKER) {
-                // New-style: replace the entire block
-                let new_contents = replace_shell_integration_block(&contents);
-                fs::write(&config_file, new_contents)
-                    .map_err(|e| format!("Could not write {}: {}", config_file.display(), e))?;
-                println!(
-                    "{} Shell integration updated in {}",
-                    "✓".green(),
-                    config_file.display()
-                );
-            } else {
-                // Old-style (no end marker): upgrade to new format
-                let new_contents = upgrade_old_shell_integration(&contents);
-                fs::write(&config_file, new_contents)
-                    .map_err(|e| format!("Could not write {}: {}", config_file.display(), e))?;
-                println!(
-                    "{} Shell integration upgraded in {}",
-                    "✓".green(),
-                    config_file.display()
-                );
-            }
-            print_activation_instructions(&config_file);
-            return Ok(());
-        }
-    }
-
-    // Append shell integration to config file
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&config_file)
-        .map_err(|e| format!("Could not open {}: {}", config_file.display(), e))?;
-
-    file.write_all(SHELL_INTEGRATION.as_bytes())
-        .map_err(|e| format!("Could not write to {}: {}", config_file.display(), e))?;
-
-    println!(
-        "{} Shell integration added to {}",
-        "✓".green(),
-        config_file.display()
-    );
-    print_activation_instructions(&config_file);
-
-    Ok(())
+    integration.setup().map_err(|e| e.to_string())
 }
 
 fn main() {
@@ -728,69 +547,7 @@ mod tests {
     }
 
     #[test]
-    fn test_replace_shell_integration_block() {
-        let old_contents = r#"# Some other config
-export FOO=bar
-
-# cwt - Change Worktree shell integration
-# Added by: cwt --shell-setup
-function wt() {
-    old content
-}
-alias wtf='wt -f'
-alias wtb='wt -p'
-# End cwt shell integration
-
-# More config after
-export BAZ=qux
-"#;
-        let new_contents = replace_shell_integration_block(old_contents);
-
-        // Should preserve content before
-        assert!(new_contents.contains("export FOO=bar"));
-        // Should preserve content after
-        assert!(new_contents.contains("export BAZ=qux"));
-        // Should have the new wtm alias
-        assert!(new_contents.contains("alias wtm='wt main'"));
-        // Should have end marker
-        assert!(new_contents.contains(SHELL_INTEGRATION_END_MARKER));
-        // Should not have old content
-        assert!(!new_contents.contains("old content"));
-    }
-
-    #[test]
-    fn test_upgrade_old_shell_integration() {
-        let old_contents = r#"# Some other config
-export FOO=bar
-
-# cwt - Change Worktree shell integration
-# Added by: cwt --shell-setup
-function wt() {
-    old content
-}
-alias wtf='wt -f'  # Next worktree
-alias wtb='wt -p'  # Previous worktree (back)
-
-# More config after
-export BAZ=qux
-"#;
-        let new_contents = upgrade_old_shell_integration(old_contents);
-
-        // Should preserve content before
-        assert!(new_contents.contains("export FOO=bar"));
-        // Should preserve content after
-        assert!(new_contents.contains("export BAZ=qux"));
-        // Should have the new wtm alias
-        assert!(new_contents.contains("alias wtm='wt main'"));
-        // Should have end marker now
-        assert!(new_contents.contains(SHELL_INTEGRATION_END_MARKER));
-        // Should not have old content
-        assert!(!new_contents.contains("old content"));
-    }
-
-    #[test]
-    fn test_shell_integration_contains_wtm() {
-        assert!(SHELL_INTEGRATION.contains("alias wtm='wt main'"));
-        assert!(SHELL_INTEGRATION.contains(SHELL_INTEGRATION_END_MARKER));
+    fn test_shell_code_contains_wtm() {
+        assert!(SHELL_CODE.contains("alias wtm='wt main'"));
     }
 }

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -305,7 +305,7 @@ alias wtm='wt main'  # Main worktree
 "#;
 
 /// Sets up shell integration by adding the wt function to the user's shell config.
-fn setup_shell_integration() -> Result<(), String> {
+fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
     let integration = ShellIntegration::new("cwt", "Change Worktree", SHELL_CODE)
         .with_command("wt", "List worktrees or change to one")
         .with_command("wtf", "Next worktree")
@@ -314,7 +314,7 @@ fn setup_shell_integration() -> Result<(), String> {
         // Old installations ended with this alias (before end marker was added)
         .with_old_end_marker("alias wtb='wt -p'");
 
-    integration.setup().map_err(|e| e.to_string())
+    integration.setup()
 }
 
 fn main() {

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -91,8 +91,13 @@ struct Cli {
     #[arg(conflicts_with_all = ["forward", "prev", "shell_setup"])]
     target: Option<String>,
 
-    /// Add shell integration (wt function and aliases) to your shell config.
-    #[arg(long, conflicts_with_all = ["forward", "prev", "target"])]
+    /// Add shell integration to your shell config. Adds these commands:
+    ///
+    ///   wt [target]  - List worktrees or change to one
+    ///   wtf          - Next worktree (forward)
+    ///   wtb          - Previous worktree (back)
+    ///   wtm          - Main worktree
+    #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "target"])]
     shell_setup: bool,
 
     /// Suppress error messages.

--- a/src/prcp/Cargo.toml
+++ b/src/prcp/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 blake3 = "1"
 libc = "0.2"
 glob = "0.3"
-dirs = "6.0"
+shellsetup = { path = "../shellsetup" }
 colored = "3.0"
 
 [dev-dependencies]

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -164,8 +164,10 @@ struct Args {
     #[arg(num_args = 0..)]
     paths: Vec<PathBuf>,
 
-    /// Add shell integration (prmv function) to your shell config
-    #[arg(long)]
+    /// Add shell integration to your shell config. Adds these commands:
+    ///
+    ///   prmv <src...> <dst>  - Copy with progress, remove sources after verification
+    #[arg(long, verbatim_doc_comment)]
     shell_setup: bool,
 
     /// Remove source files after successful copy (verified by Blake3 hash)

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -220,7 +220,8 @@ fn setup_shell_integration() -> Result<()> {
         .with_command("prmv", "Copy files with progress, removing sources after verification")
         // Old installations ended with this line (before end marker was added)
         .with_old_end_marker(r#"prcp --rm "$@""#);
-    integration.setup().map_err(|e| anyhow::anyhow!("{}", e))
+    // Use ? operator to convert ShellSetupError -> anyhow::Error, preserving the error chain
+    Ok(integration.setup()?)
 }
 
 /// Minimum allowed buffer size (4KB)

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -12,8 +12,9 @@ use clap::Parser;
 use colored::Colorize;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressStyle};
+use shellsetup::ShellIntegration;
 // Blake3 imported via blake3 crate (no Digest trait needed)
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -204,95 +205,18 @@ struct Args {
     quiet: bool,
 }
 
-/// The shell integration code to add to shell config files.
-const SHELL_INTEGRATION: &str = r#"
-# prcp - Progress Copy shell integration
-# Added by: prcp --shell-setup
+/// The shell code to add to shell config files.
+const SHELL_CODE: &str = r#"
 function prmv() {
     prcp --rm "$@"
 }
 "#;
 
-/// Marker to detect if shell integration is already installed.
-const SHELL_INTEGRATION_MARKER: &str = "prcp - Progress Copy shell integration";
-
 /// Sets up shell integration by adding the prmv function to the user's shell config.
 fn setup_shell_integration() -> Result<()> {
-    // Get home directory
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-
-    // Detect shell from SHELL environment variable
-    let shell = std::env::var("SHELL").unwrap_or_default();
-    let shell_name = Path::new(&shell)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown");
-
-    // Determine which config file to use
-    let config_file = match shell_name {
-        "zsh" => home.join(".zshrc"),
-        "bash" => {
-            // Prefer .bashrc, but use .bash_profile on macOS if .bashrc doesn't exist
-            let bashrc = home.join(".bashrc");
-            let bash_profile = home.join(".bash_profile");
-            if bashrc.exists() {
-                bashrc
-            } else if bash_profile.exists() {
-                bash_profile
-            } else {
-                bashrc // Create .bashrc if neither exists
-            }
-        }
-        _ => {
-            anyhow::bail!(
-                "Unsupported shell: {}. Please manually add the shell integration to your config.\n\
-                 Add this to your shell config:\n{}",
-                shell_name,
-                SHELL_INTEGRATION
-            );
-        }
-    };
-
-    // Check if already installed
-    if config_file.exists() {
-        let contents = fs::read_to_string(&config_file)
-            .with_context(|| format!("Could not read {}", config_file.display()))?;
-
-        if contents.contains(SHELL_INTEGRATION_MARKER) {
-            println!(
-                "{} Shell integration already installed in {}",
-                "✓".green(),
-                config_file.display()
-            );
-            return Ok(());
-        }
-    }
-
-    // Append shell integration to config file
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&config_file)
-        .with_context(|| format!("Could not open {}", config_file.display()))?;
-
-    file.write_all(SHELL_INTEGRATION.as_bytes())
-        .with_context(|| format!("Could not write to {}", config_file.display()))?;
-
-    println!(
-        "{} Shell integration added to {}",
-        "✓".green(),
-        config_file.display()
-    );
-    println!();
-    println!("To activate, run:");
-    println!("  {} {}", "source".cyan(), config_file.display());
-    println!();
-    println!("Or open a new terminal window.");
-    println!();
-    println!("Available commands:");
-    println!("  {} - Copy files with progress, removing sources after verification", "prmv".yellow());
-
-    Ok(())
+    let integration = ShellIntegration::new("prcp", "Progress Copy", SHELL_CODE)
+        .with_command("prmv", "Copy files with progress, removing sources after verification");
+    integration.setup().map_err(|e| anyhow::anyhow!("{}", e))
 }
 
 /// Minimum allowed buffer size (4KB)

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -217,7 +217,9 @@ function prmv() {
 /// Sets up shell integration by adding the prmv function to the user's shell config.
 fn setup_shell_integration() -> Result<()> {
     let integration = ShellIntegration::new("prcp", "Progress Copy", SHELL_CODE)
-        .with_command("prmv", "Copy files with progress, removing sources after verification");
+        .with_command("prmv", "Copy files with progress, removing sources after verification")
+        // Old installations ended with this line (before end marker was added)
+        .with_old_end_marker(r#"prcp --rm "$@""#);
     integration.setup().map_err(|e| anyhow::anyhow!("{}", e))
 }
 

--- a/src/rr/src/main.rs
+++ b/src/rr/src/main.rs
@@ -147,9 +147,9 @@ fn main() {
 
                                 // Handle orphaned target directories
                                 if size_after > 0 {
+                                    let target_dir = entry.path().join("target");
                                     if cli.force {
                                         // Force delete orphaned target
-                                        let target_dir = entry.path().join("target");
                                         if target_dir.exists() {
                                             match std::fs::remove_dir_all(&target_dir) {
                                                 Ok(_) => {
@@ -164,8 +164,9 @@ fn main() {
                                         }
                                     } else {
                                         total_not_deleted += size_after;
-                                        println!("  Warning: {} could not be deleted (use --force to remove orphaned targets)",
-                                                format_size(size_after));
+                                        println!("  Warning: {} in {} could not be deleted (use --force to remove orphaned targets)",
+                                                format_size(size_after),
+                                                target_dir.display());
                                     }
                                 }
                             }

--- a/src/shellsetup/Cargo.toml
+++ b/src/shellsetup/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "shellsetup"
+version = "0.1.0"
+edition = "2021"
+description = "Shell integration library for adding tool functions to shell config files"
+license = "MIT"
+
+[dependencies]
+colored = "3.0"
+dirs = "6.0"
+thiserror = "2.0"

--- a/src/shellsetup/Cargo.toml
+++ b/src/shellsetup/Cargo.toml
@@ -9,3 +9,16 @@ license = "MIT"
 colored = "3.0"
 dirs = "6.0"
 thiserror = "2.0"
+
+[lints.rust]
+# Enforce stricter checks to catch issues early
+unsafe_code = "deny"
+
+[lints.clippy]
+# Pedantic lints help catch subtle issues
+pedantic = { level = "warn", priority = -1 }
+# Allow certain pedantic lints that are too strict for this codebase
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -1,0 +1,516 @@
+//! Shell integration library for adding tool functions to shell config files.
+//!
+//! This library provides a standardized way to add shell functions and aliases
+//! to user shell configuration files (`.bashrc`, `.zshrc`, etc.) with support
+//! for detecting existing installations and upgrading them in-place.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use shellsetup::{ShellIntegration, ShellCommand};
+//!
+//! let integration = ShellIntegration::new(
+//!     "mytool",
+//!     "My Tool",
+//!     r#"
+//! function mt() {
+//!     mytool "$@"
+//! }
+//! alias mtv='mt --verbose'
+//! "#,
+//! )
+//! .with_command("mt", "Run mytool")
+//! .with_command("mtv", "Run mytool with verbose output");
+//!
+//! integration.setup()?;
+//! ```
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+use thiserror::Error;
+
+/// Errors that can occur during shell integration setup.
+#[derive(Error, Debug)]
+pub enum ShellSetupError {
+    /// Could not determine the user's home directory.
+    #[error("Could not determine home directory")]
+    NoHomeDir,
+
+    /// The user's shell is not supported for automatic setup.
+    #[error("Unsupported shell: {shell}. Please manually add the shell integration to your config.\n{manual_instructions}")]
+    UnsupportedShell {
+        shell: String,
+        manual_instructions: String,
+    },
+
+    /// Failed to read the shell config file.
+    #[error("Could not read {path}: {source}")]
+    ReadError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Failed to write to the shell config file.
+    #[error("Could not write to {path}: {source}")]
+    WriteError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// Result type for shell setup operations.
+pub type Result<T> = std::result::Result<T, ShellSetupError>;
+
+/// A command that will be available after shell integration is set up.
+#[derive(Debug, Clone)]
+pub struct ShellCommand {
+    /// The command name (e.g., "wt", "wtf").
+    pub name: String,
+    /// A short description of what the command does.
+    pub description: String,
+}
+
+impl ShellCommand {
+    /// Creates a new shell command.
+    pub fn new(name: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+        }
+    }
+}
+
+/// Configuration for shell integration.
+///
+/// This struct holds all the information needed to set up shell integration
+/// for a tool, including the shell code to add, markers for detection, and
+/// information about available commands.
+#[derive(Debug, Clone)]
+pub struct ShellIntegration {
+    /// Short name of the tool (e.g., "cwt", "prcp").
+    tool_name: String,
+    /// Human-readable description (e.g., "Change Worktree", "Progress Copy").
+    tool_description: String,
+    /// The shell code to add (functions, aliases, etc.).
+    shell_code: String,
+    /// Commands that will be available after setup.
+    commands: Vec<ShellCommand>,
+    /// Previous end marker patterns for detecting old installations.
+    /// Used when upgrading from versions without the standard end marker.
+    old_end_markers: Vec<String>,
+}
+
+impl ShellIntegration {
+    /// Creates a new shell integration configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `tool_name` - Short name of the tool (e.g., "cwt")
+    /// * `tool_description` - Human-readable description (e.g., "Change Worktree")
+    /// * `shell_code` - The shell code to add (without markers - they're added automatically)
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let integration = ShellIntegration::new(
+    ///     "mytool",
+    ///     "My Tool",
+    ///     r#"
+    /// function mt() {
+    ///     mytool "$@"
+    /// }
+    /// "#,
+    /// );
+    /// ```
+    pub fn new(
+        tool_name: impl Into<String>,
+        tool_description: impl Into<String>,
+        shell_code: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            tool_description: tool_description.into(),
+            shell_code: shell_code.into(),
+            commands: Vec::new(),
+            old_end_markers: Vec::new(),
+        }
+    }
+
+    /// Adds a command to the list of available commands shown after setup.
+    pub fn with_command(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.commands.push(ShellCommand::new(name, description));
+        self
+    }
+
+    /// Adds an old end marker pattern for detecting legacy installations.
+    ///
+    /// Use this when upgrading from a version that didn't have the standard
+    /// end marker. The setup will look for this pattern to find the end of
+    /// the old installation block.
+    pub fn with_old_end_marker(mut self, marker: impl Into<String>) -> Self {
+        self.old_end_markers.push(marker.into());
+        self
+    }
+
+    /// Returns the start marker comment.
+    fn start_marker(&self) -> String {
+        format!("# {} - {} shell integration", self.tool_name, self.tool_description)
+    }
+
+    /// Returns the end marker comment.
+    fn end_marker(&self) -> String {
+        format!("# End {} shell integration", self.tool_name)
+    }
+
+    /// Returns the full shell integration block with markers.
+    fn full_block(&self) -> String {
+        format!(
+            "\n{}\n# Added by: {} --shell-setup{}\n{}\n",
+            self.start_marker(),
+            self.tool_name,
+            self.shell_code.trim_end(),
+            self.end_marker()
+        )
+    }
+
+    /// Sets up shell integration by adding or upgrading the shell config.
+    ///
+    /// This function:
+    /// 1. Detects the user's shell (bash or zsh)
+    /// 2. Finds the appropriate config file
+    /// 3. Checks for existing installation
+    /// 4. Either installs fresh, upgrades old installation, or updates existing
+    pub fn setup(&self) -> Result<()> {
+        let home = dirs::home_dir().ok_or(ShellSetupError::NoHomeDir)?;
+
+        // Detect shell from SHELL environment variable
+        let shell = std::env::var("SHELL").unwrap_or_default();
+        let shell_name = Path::new(&shell)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown");
+
+        // Determine which config file to use
+        let config_file = match shell_name {
+            "zsh" => home.join(".zshrc"),
+            "bash" => {
+                // Prefer .bashrc, but use .bash_profile on macOS if .bashrc doesn't exist
+                let bashrc = home.join(".bashrc");
+                let bash_profile = home.join(".bash_profile");
+                if bashrc.exists() {
+                    bashrc
+                } else if bash_profile.exists() {
+                    bash_profile
+                } else {
+                    bashrc // Create .bashrc if neither exists
+                }
+            }
+            _ => {
+                return Err(ShellSetupError::UnsupportedShell {
+                    shell: shell_name.to_string(),
+                    manual_instructions: format!(
+                        "Add this to your shell config:\n{}",
+                        self.full_block()
+                    ),
+                });
+            }
+        };
+
+        // Check if already installed and handle upgrades
+        if config_file.exists() {
+            let contents = fs::read_to_string(&config_file).map_err(|e| {
+                ShellSetupError::ReadError {
+                    path: config_file.clone(),
+                    source: e,
+                }
+            })?;
+
+            let start_marker = self.start_marker();
+            let end_marker = self.end_marker();
+
+            if contents.contains(&start_marker) {
+                // Check if this is a new-style installation (has end marker)
+                if contents.contains(&end_marker) {
+                    // New-style: replace the entire block
+                    let new_contents = self.replace_block(&contents);
+                    fs::write(&config_file, new_contents).map_err(|e| {
+                        ShellSetupError::WriteError {
+                            path: config_file.clone(),
+                            source: e,
+                        }
+                    })?;
+                    println!(
+                        "{} Shell integration updated in {}",
+                        "✓".green(),
+                        config_file.display()
+                    );
+                } else {
+                    // Old-style (no end marker): upgrade to new format
+                    let new_contents = self.upgrade_old_installation(&contents);
+                    fs::write(&config_file, new_contents).map_err(|e| {
+                        ShellSetupError::WriteError {
+                            path: config_file.clone(),
+                            source: e,
+                        }
+                    })?;
+                    println!(
+                        "{} Shell integration upgraded in {}",
+                        "✓".green(),
+                        config_file.display()
+                    );
+                }
+                self.print_activation_instructions(&config_file);
+                return Ok(());
+            }
+        }
+
+        // Fresh installation: append shell integration to config file
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&config_file)
+            .map_err(|e| ShellSetupError::WriteError {
+                path: config_file.clone(),
+                source: e,
+            })?;
+
+        file.write_all(self.full_block().as_bytes())
+            .map_err(|e| ShellSetupError::WriteError {
+                path: config_file.clone(),
+                source: e,
+            })?;
+
+        println!(
+            "{} Shell integration added to {}",
+            "✓".green(),
+            config_file.display()
+        );
+        self.print_activation_instructions(&config_file);
+
+        Ok(())
+    }
+
+    /// Replaces the shell integration block between start and end markers.
+    fn replace_block(&self, contents: &str) -> String {
+        let lines: Vec<&str> = contents.lines().collect();
+        let mut result: Vec<String> = Vec::new();
+        let mut in_block = false;
+        let mut block_replaced = false;
+
+        let start_marker = self.start_marker();
+        let end_marker = self.end_marker();
+        let new_block = self.full_block();
+
+        for line in lines {
+            if !in_block && line.contains(&start_marker) {
+                // Start of block - skip until end marker
+                in_block = true;
+                continue;
+            }
+
+            if in_block {
+                if line.contains(&end_marker) {
+                    // End of block - insert new integration
+                    result.push(new_block.trim().to_string());
+                    in_block = false;
+                    block_replaced = true;
+                }
+                // Skip lines within the block
+                continue;
+            }
+
+            result.push(line.to_string());
+        }
+
+        // If we never found the end marker, something went wrong - append anyway
+        if !block_replaced {
+            result.push(new_block.trim().to_string());
+        }
+
+        result.join("\n") + "\n"
+    }
+
+    /// Upgrades old-style shell integration (without end marker) to new format.
+    fn upgrade_old_installation(&self, contents: &str) -> String {
+        let lines: Vec<&str> = contents.lines().collect();
+        let mut result: Vec<String> = Vec::new();
+        let mut in_block = false;
+        let mut block_replaced = false;
+
+        let start_marker = self.start_marker();
+        let new_block = self.full_block();
+
+        for line in lines {
+            if !in_block && line.contains(&start_marker) {
+                // Start of old block - skip until we find the old end
+                in_block = true;
+                continue;
+            }
+
+            if in_block {
+                // Check if this line matches any old end marker
+                let is_old_end = self
+                    .old_end_markers
+                    .iter()
+                    .any(|marker| line.contains(marker));
+
+                if is_old_end {
+                    // End of old block - insert new integration
+                    result.push(new_block.trim().to_string());
+                    in_block = false;
+                    block_replaced = true;
+                }
+                // Skip lines within the old block
+                continue;
+            }
+
+            result.push(line.to_string());
+        }
+
+        // If we never found the old end marker, just append the new block
+        if !block_replaced {
+            result.push(new_block.trim().to_string());
+        }
+
+        result.join("\n") + "\n"
+    }
+
+    /// Prints activation instructions after shell integration is added or updated.
+    fn print_activation_instructions(&self, config_file: &Path) {
+        println!();
+        println!("To activate, run:");
+        println!("  {} {}", "source".cyan(), config_file.display());
+        println!();
+        println!("Or open a new terminal window.");
+
+        if !self.commands.is_empty() {
+            println!();
+            println!("Available commands:");
+            for cmd in &self.commands {
+                println!("  {} - {}", cmd.name.yellow(), cmd.description);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_integration() -> ShellIntegration {
+        ShellIntegration::new(
+            "testtool",
+            "Test Tool",
+            r#"
+function tt() {
+    testtool "$@"
+}
+alias ttv='tt --verbose'
+"#,
+        )
+        .with_command("tt", "Run testtool")
+        .with_command("ttv", "Run testtool with verbose output")
+        .with_old_end_marker("alias ttv='tt --verbose'")
+    }
+
+    #[test]
+    fn test_markers() {
+        let integration = create_test_integration();
+        assert_eq!(
+            integration.start_marker(),
+            "# testtool - Test Tool shell integration"
+        );
+        assert_eq!(integration.end_marker(), "# End testtool shell integration");
+    }
+
+    #[test]
+    fn test_full_block_contains_markers() {
+        let integration = create_test_integration();
+        let block = integration.full_block();
+        assert!(block.contains(&integration.start_marker()));
+        assert!(block.contains(&integration.end_marker()));
+        assert!(block.contains("function tt()"));
+    }
+
+    #[test]
+    fn test_replace_block() {
+        let integration = create_test_integration();
+        let old_contents = r#"# Some config
+export FOO=bar
+
+# testtool - Test Tool shell integration
+# Added by: testtool --shell-setup
+function tt() {
+    OLD CONTENT
+}
+# End testtool shell integration
+
+# More config
+export BAZ=qux
+"#;
+        let new_contents = integration.replace_block(old_contents);
+
+        // Should preserve content before and after
+        assert!(new_contents.contains("export FOO=bar"));
+        assert!(new_contents.contains("export BAZ=qux"));
+        // Should have new content
+        assert!(new_contents.contains("testtool \"$@\""));
+        // Should not have old content
+        assert!(!new_contents.contains("OLD CONTENT"));
+        // Should have end marker
+        assert!(new_contents.contains(&integration.end_marker()));
+    }
+
+    #[test]
+    fn test_upgrade_old_installation() {
+        let integration = create_test_integration();
+        let old_contents = r#"# Some config
+export FOO=bar
+
+# testtool - Test Tool shell integration
+# Added by: testtool --shell-setup
+function tt() {
+    OLD CONTENT
+}
+alias ttv='tt --verbose'
+
+# More config
+export BAZ=qux
+"#;
+        let new_contents = integration.upgrade_old_installation(old_contents);
+
+        // Should preserve content before and after
+        assert!(new_contents.contains("export FOO=bar"));
+        assert!(new_contents.contains("export BAZ=qux"));
+        // Should have new content
+        assert!(new_contents.contains("testtool \"$@\""));
+        // Should not have old content
+        assert!(!new_contents.contains("OLD CONTENT"));
+        // Should have end marker now
+        assert!(new_contents.contains(&integration.end_marker()));
+    }
+
+    #[test]
+    fn test_with_command() {
+        let integration = ShellIntegration::new("test", "Test", "code")
+            .with_command("cmd1", "Description 1")
+            .with_command("cmd2", "Description 2");
+
+        assert_eq!(integration.commands.len(), 2);
+        assert_eq!(integration.commands[0].name, "cmd1");
+        assert_eq!(integration.commands[1].description, "Description 2");
+    }
+
+    #[test]
+    fn test_with_old_end_marker() {
+        let integration = ShellIntegration::new("test", "Test", "code")
+            .with_old_end_marker("marker1")
+            .with_old_end_marker("marker2");
+
+        assert_eq!(integration.old_end_markers.len(), 2);
+        assert!(integration.old_end_markers.contains(&"marker1".to_string()));
+    }
+}

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -294,6 +294,9 @@ impl ShellIntegration {
     }
 
     /// Replaces the shell integration block between start and end markers.
+    ///
+    /// If the end marker is not found after the start marker, prints a warning
+    /// to stderr and appends the new block (content after start marker may be lost).
     fn replace_block(&self, contents: &str) -> String {
         let lines: Vec<&str> = contents.lines().collect();
         let mut result: Vec<String> = Vec::new();
@@ -325,8 +328,15 @@ impl ShellIntegration {
             result.push(line.to_string());
         }
 
-        // If we never found the end marker, something went wrong - append anyway
+        // If we never found the end marker, warn user and append new block
         if !block_replaced {
+            eprintln!(
+                "{} End marker not found for {} shell integration. \
+                 Content after the start marker may have been removed. \
+                 Please verify your shell config file.",
+                "Warning:".yellow(),
+                self.tool_name
+            );
             result.push(new_block.trim().to_string());
         }
 
@@ -334,6 +344,9 @@ impl ShellIntegration {
     }
 
     /// Upgrades old-style shell integration (without end marker) to new format.
+    ///
+    /// If none of the old end markers are found after the start marker, prints a warning
+    /// to stderr and appends the new block (content after start marker may be lost).
     fn upgrade_old_installation(&self, contents: &str) -> String {
         let lines: Vec<&str> = contents.lines().collect();
         let mut result: Vec<String> = Vec::new();
@@ -370,8 +383,15 @@ impl ShellIntegration {
             result.push(line.to_string());
         }
 
-        // If we never found the old end marker, just append the new block
+        // If we never found the old end marker, warn user and append new block
         if !block_replaced {
+            eprintln!(
+                "{} Could not find expected end of old {} shell integration block. \
+                 Content after the start marker may have been removed. \
+                 Please verify your shell config file.",
+                "Warning:".yellow(),
+                self.tool_name
+            );
             result.push(new_block.trim().to_string());
         }
 


### PR DESCRIPTION
## Summary
- Add `wtm` alias to cwt shell integration for quick navigation to main worktree
- Implement upgrade mechanism so users can re-run `--shell-setup` to get new aliases
- Extract shell integration into shared `shellsetup` library crate for reuse
- Update cwt and prcp to use the new library, reducing code duplication by ~340 lines
- Add CLAUDE.md documenting that all tools with shell integration must use shellsetup

## Test plan
- [ ] Run `cargo test -p shellsetup` - verify 6 tests pass
- [ ] Run `cargo test -p cwt` - verify 14 tests pass (includes `test_shell_code_contains_wtm`)
- [ ] Run `cargo test -p prcp` - verify 40 tests pass
- [ ] Test fresh install: Remove shell integration from `.zshrc`, run `cwt --shell-setup`
- [ ] Test upgrade: Keep old integration, run `cwt --shell-setup` - should replace block with new version
- [ ] Test `wtm` works: `source ~/.zshrc && wtm` should go to main worktree
- [ ] Test "no main" case: In repo without main worktree, `wtm` should show error

🤖 Generated with [Claude Code](https://claude.com/claude-code)