### PR TITLE
fix(prhash): properly clear progress bar when processing long filenames

### DIFF
--- a/src/prhash/Cargo.toml
+++ b/src/prhash/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 arithmetic_side_effects = "warn"
 # Warn about indexing/slicing that could panic
 indexing_slicing = "warn"
+# Warn about string slicing which can panic on UTF-8 character boundaries
+string_slice = "warn"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/prhash/Cargo.toml
+++ b/src/prhash/Cargo.toml
@@ -3,6 +3,12 @@ name = "prhash"
 version = "0.1.0"
 edition = "2021"
 
+[lints.clippy]
+# Prevent potential panics from arithmetic operations (subtraction overflow, etc.)
+arithmetic_side_effects = "warn"
+# Warn about indexing/slicing that could panic
+indexing_slicing = "warn"
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 indicatif = "0.18.0"


### PR DESCRIPTION
## Summary
- Switch from `pb.suspend()` to `pb.println()` for printing hash results, which properly handles terminal scrolling when the progress bar wraps across multiple lines
- Add `truncate_path_for_display()` function to limit paths to 60 characters in progress messages, preventing excessive line wrapping
- Full paths are still shown in the final hash output

## Problem
When processing files with long filenames, the progress bar wrapped across multiple terminal lines. The `pb.suspend()` method only cleared the current physical line via carriage return (`\r`), leaving remnants from wrapped lines visible, resulting in garbled output.

## Test plan
- [ ] Run `prhash` on files with long paths (100+ characters) and verify clean output
- [ ] Verify hash results still show the complete file path
- [ ] Verify progress bar message shows truncated path with filename visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)