### PR TITLE
fix(prcp): enable progress bar resizing on terminal resize

### DIFF
--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -527,7 +527,13 @@ async fn main() -> Result<()> {
 
             let mut sigwinch = match signal(SignalKind::window_change()) {
                 Ok(s) => s,
-                Err(_) => return,
+                Err(_e) => {
+                    // Non-critical: progress bar resize won't work in multi-file mode,
+                    // but crossterm Event::Resize may still work in single-file mode.
+                    #[cfg(debug_assertions)]
+                    eprintln!("Debug: SIGWINCH handler setup failed: {_e}");
+                    return;
+                }
             };
 
             loop {


### PR DESCRIPTION
The progress bar now updates its width when the terminal is resized during copy operations. Implements SIGWINCH signal handling (Unix) and Event::Resize handling (raw mode) to keep the progress bar width synchronized with terminal size changes. Updates occur within the existing 200ms UI throttle to prevent excessive redraws.

## Changes
- Keep terminal width transmitter to enable resize updates
- Add SIGWINCH signal handler for detecting terminal resize events on Unix
- Handle Event::Resize in key_task for immediate response in raw mode
- Await resize_task at completion to ensure proper cleanup

## Testing
1. Build: `cargo build -p prcp`
2. Copy a large file: `./target/debug/prcp /path/to/large/file /tmp/`
3. Resize terminal during copy and verify progress bar width updates within ~200ms