### PR TITLE
refactor(prhash): use .ok() pattern for intentionally ignored flush errors

### DIFF
--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -231,9 +231,10 @@ async fn main() -> Result<()> {
                 // break shell pipelines like `prhash file.txt > hashes.txt`.
                 pb.suspend(|| {
                     println!("{}  {}", hash, file.display());
-                    // Return cursor to column 0 for progress bar (needed in raw mode)
+                    // Return cursor to column 0 for progress bar (needed in raw mode).
+                    // Flush errors are ignored as they're non-critical for display purposes.
                     print!("\r");
-                    let _ = std::io::stdout().flush();
+                    std::io::stdout().flush().ok();
                 });
             }
             Err(e) => {


### PR DESCRIPTION
## Summary
- Use the more idiomatic `.ok()` pattern instead of `let _ =` for intentionally ignored stdout flush result
- Add clarifying comment explaining why flush errors are acceptable to ignore (non-critical for display purposes)

This is a follow-up to #109 addressing a minor code review suggestion.

## Test plan
- [x] Build passes (`cargo build -p prhash`)
- [x] Clippy passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)