### PR TITLE
feat(termbar): add reusable terminal progress bar library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,45 @@ fn setup_shell_integration() -> Result<()> {
 
 - `cwt` - Change Worktree (provides `wt`, `wtf`, `wtb`, `wtm` commands)
 - `prcp` - Progress Copy (provides `prmv` command)
+
+## Progress Bar Display
+
+All tools in this repository that display progress bars **should** use the `termbar` library crate located at `src/termbar/`.
+
+### Why
+
+The `termbar` library provides:
+- Terminal width detection with fallback
+- Progress bar width calculation that adapts to terminal size
+- Pre-built progress bar styles (copy, verify, batch, hash)
+- Escape function for template braces in filenames
+- Optional async terminal resize watching via SIGWINCH
+
+### Usage
+
+```rust
+use termbar::{ProgressStyleBuilder, TerminalWidth, calculate_bar_width, PROGRESS_CHARS};
+
+// Create a copy-style progress bar
+let width = TerminalWidth::get_or_default();
+let style = ProgressStyleBuilder::copy("myfile.txt")
+    .build(width)
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+// Or use width calculation for custom templates
+let bar_width = calculate_bar_width(width, 80); // 80 = overhead
+let template = format!("{{spinner}} [{{bar:{}.cyan}}] {{msg}}", bar_width);
+```
+
+### Available Style Builders
+
+- `ProgressStyleBuilder::copy(filename)` - File copy operations (cyan bar)
+- `ProgressStyleBuilder::verify(filename)` - File verification (yellow bar)
+- `ProgressStyleBuilder::batch()` - Batch operations with file counts (blue bar)
+- `ProgressStyleBuilder::hash()` - Hash operations with message (cyan bar)
+
+### Tools Currently Using termbar
+
+- `prcp` - Progress Copy (copy, verify, and batch styles)
+- `prhash` - Progress Hash (custom template with dynamic width)
+- `org-borg` - Organization Backup (custom template with dynamic width)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,14 @@ let bar_width = calculate_bar_width(width, 80); // 80 = overhead
 let template = format!("{{spinner}} [{{bar:{}.cyan}}] {{msg}}", bar_width);
 ```
 
-### Terminal Resize Watching (Recommended Approach)
+### Terminal Resize Watching
 
-For applications that need to respond to terminal resize events, use the shutdown channel API:
+For applications that need to respond to terminal resize events:
 
 ```rust
 use termbar::TerminalWidthWatcher;
 
-// Create watcher with shutdown channel (recommended)
+// Create watcher with automatic SIGWINCH handling
 let (watcher, resize_task, shutdown_tx) = TerminalWidthWatcher::with_sigwinch_channel();
 
 // Get current width or watch for changes
@@ -98,10 +98,10 @@ drop(shutdown_tx);  // or shutdown_tx.send(())
 resize_task.await;
 ```
 
-This approach is preferred over the legacy `Arc<AtomicBool>` polling method because:
-- Clean shutdown without 100ms polling overhead
+Benefits of the channel-based shutdown:
+- Clean shutdown without polling overhead
 - Immediate task termination when signaled
-- More idiomatic async Rust patterns
+- Idiomatic async Rust patterns
 
 ### Available Style Builders
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ env_logger = "0.11"
 tiktoken-rs = "0.5"
 num-format = "0.4"
 human_bytes = "0.4"
+unicode-width = "0.2"
 
 # Dev dependencies
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ clipboardmon = { path = "src/clipboardmon" }
 filewalker = { path = "src/filewalker" }
 repowalker = { path = "src/repowalker" }
 shellsetup = { path = "src/shellsetup" }
+termbar = { path = "src/termbar" }
 
 [workspace.lints.rust]
 # Require explicit handling of must-use values

--- a/src/org-borg/Cargo.toml
+++ b/src/org-borg/Cargo.toml
@@ -14,6 +14,7 @@ git2.workspace = true
 indicatif.workspace = true
 colored.workspace = true
 dirs.workspace = true
+termbar.workspace = true
 
 [lints]
 workspace = true

--- a/src/org-borg/src/auth.rs
+++ b/src/org-borg/src/auth.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 /// Get GitHub token from gh CLI if available
 pub fn get_gh_token() -> Result<Option<String>> {
     let output = Command::new("gh")
-        .args(&["auth", "token"])
+        .args(["auth", "token"])
         .output();
 
     match output {
@@ -26,7 +26,7 @@ pub fn get_gh_token() -> Result<Option<String>> {
 /// Get GitHub authentication status from gh CLI
 pub fn get_gh_auth_status() -> Result<Option<String>> {
     let output = Command::new("gh")
-        .args(&["auth", "status"])
+        .args(["auth", "status"])
         .output();
 
     match output {

--- a/src/org-borg/src/commands.rs
+++ b/src/org-borg/src/commands.rs
@@ -159,7 +159,7 @@ async fn clone_repositories(
     // if the terminal is resized during the operation. This is acceptable for
     // the relatively short duration of repository cloning operations.
     let terminal_width = TerminalWidth::get_or_default();
-    // Overhead: spinner(2) + brackets(4) + pos/len(15) + text(15) + spaces(4) = ~40
+    // Overhead: spinner(2) + brackets(4) + pos/len(15) + text(15) + spaces(4) = 40
     let bar_width = calculate_bar_width(terminal_width, 40);
     main_pb.set_style(
         ProgressStyle::default_bar()

--- a/src/org-borg/src/commands.rs
+++ b/src/org-borg/src/commands.rs
@@ -154,7 +154,10 @@ async fn clone_repositories(
 ) -> Result<()> {
     let multi_progress = MultiProgress::new();
     let main_pb = multi_progress.add(ProgressBar::new(repos.len() as u64));
-    // Calculate dynamic progress bar width based on terminal size
+    // Calculate dynamic progress bar width based on terminal size.
+    // Note: Width is calculated once at start; the progress bar won't resize
+    // if the terminal is resized during the operation. This is acceptable for
+    // the relatively short duration of repository cloning operations.
     let terminal_width = TerminalWidth::get_or_default();
     // Overhead: spinner(2) + brackets(4) + pos/len(15) + text(15) + spaces(4) = ~40
     let bar_width = calculate_bar_width(terminal_width, 40);

--- a/src/org-borg/src/commands.rs
+++ b/src/org-borg/src/commands.rs
@@ -215,7 +215,7 @@ async fn clone_repositories(
                             e
                         );
                     } else {
-                        println!("{} Archived {}", "📦".to_string(), repo.name.yellow());
+                        println!("📦 Archived {}", repo.name.yellow());
                     }
                 }
             }

--- a/src/org-borg/src/github.rs
+++ b/src/org-borg/src/github.rs
@@ -139,7 +139,7 @@ impl GitHubClient {
         loop {
             let response = self
                 .client
-                .get(&format!("https://api.github.com/orgs/{}/repos", org))
+                .get(format!("https://api.github.com/orgs/{}/repos", org))
                 .query(&[
                     ("per_page", per_page.to_string()),
                     ("page", page.to_string()),
@@ -207,7 +207,7 @@ impl GitHubClient {
     pub async fn archive_repository(&self, owner: &str, repo: &str) -> Result<()> {
         let response = self
             .client
-            .patch(&format!(
+            .patch(format!(
                 "https://api.github.com/repos/{}/{}",
                 owner, repo
             ))

--- a/src/prcp/Cargo.toml
+++ b/src/prcp/Cargo.toml
@@ -15,6 +15,7 @@ libc.workspace = true
 glob.workspace = true
 shellsetup.workspace = true
 colored.workspace = true
+termbar.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -513,6 +513,10 @@ async fn main() -> Result<()> {
     // This catches resize events even when raw mode is disabled (multi-file mode).
     // In single-file mode (raw mode enabled), crossterm's Event::Resize may also
     // fire; watch channels handle duplicate updates gracefully.
+    //
+    // Note: We use the legacy AtomicBool-based API here (rather than the recommended
+    // channel-based shutdown) because key_listener_done is already shared across
+    // multiple tasks (signal handler, key listener, copy tasks) for coordinated shutdown.
     let resize_task = term_width_watcher.spawn_sigwinch_handler(key_listener_done.clone());
 
     // Clone sender for key_task to handle crossterm Event::Resize

--- a/src/prhash/Cargo.toml
+++ b/src/prhash/Cargo.toml
@@ -14,6 +14,7 @@ sha2.workspace = true
 md-5.workspace = true
 sha1.workspace = true
 hex.workspace = true
+termbar.workspace = true
 
 [lints.clippy]
 # Prevent potential panics from arithmetic operations (subtraction overflow, etc.)

--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -222,7 +222,9 @@ async fn main() -> Result<()> {
     
     // Process each file
     for (idx, file) in args.files.iter().enumerate() {
-        pb.set_message(format!("Hashing {} ({}/{})", truncate_path_for_display(file, MAX_FILENAME_DISPLAY_LEN), idx.saturating_add(1), args.files.len()));
+        // idx + 1 is safe: idx comes from enumerate() over args.files which is bounded by memory,
+        // so idx < usize::MAX and idx + 1 cannot overflow.
+        pb.set_message(format!("Hashing {} ({}/{})", truncate_path_for_display(file, MAX_FILENAME_DISPLAY_LEN), idx + 1, args.files.len()));
         
         let result = hash_file_with_progress(
             file,

--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -222,9 +222,11 @@ async fn main() -> Result<()> {
     
     // Process each file
     for (idx, file) in args.files.iter().enumerate() {
-        // idx + 1 is safe: idx comes from enumerate() over args.files which is bounded by memory,
+        // SAFETY: idx comes from enumerate() over args.files which is bounded by memory,
         // so idx < usize::MAX and idx + 1 cannot overflow.
-        pb.set_message(format!("Hashing {} ({}/{})", truncate_path_for_display(file, MAX_FILENAME_DISPLAY_LEN), idx + 1, args.files.len()));
+        #[allow(clippy::arithmetic_side_effects)]
+        let file_num = idx + 1;
+        pb.set_message(format!("Hashing {} ({}/{})", truncate_path_for_display(file, MAX_FILENAME_DISPLAY_LEN), file_num, args.files.len()));
         
         let result = hash_file_with_progress(
             file,

--- a/src/termbar/Cargo.toml
+++ b/src/termbar/Cargo.toml
@@ -10,3 +10,6 @@ crossterm.workspace = true
 indicatif.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/src/termbar/Cargo.toml
+++ b/src/termbar/Cargo.toml
@@ -10,6 +10,7 @@ crossterm.workspace = true
 indicatif.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
+unicode-width.workspace = true
 
 [lints]
 workspace = true

--- a/src/termbar/Cargo.toml
+++ b/src/termbar/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "termbar"
+version = "0.1.0"
+edition.workspace = true
+description = "Terminal progress bar library with resize support"
+license = "MIT"
+
+[dependencies]
+crossterm.workspace = true
+indicatif.workspace = true
+tokio.workspace = true
+thiserror.workspace = true

--- a/src/termbar/src/error.rs
+++ b/src/termbar/src/error.rs
@@ -1,0 +1,18 @@
+//! Error types for the termbar library.
+
+use thiserror::Error;
+
+/// Errors that can occur during progress bar operations.
+#[derive(Error, Debug)]
+pub enum TermbarError {
+    /// Failed to create a progress style.
+    #[error("Failed to create progress style: {0}")]
+    StyleCreation(String),
+
+    /// Invalid template format.
+    #[error("Invalid template format: {0}")]
+    InvalidTemplate(String),
+}
+
+/// Result type for termbar operations.
+pub type Result<T> = std::result::Result<T, TermbarError>;

--- a/src/termbar/src/error.rs
+++ b/src/termbar/src/error.rs
@@ -8,10 +8,6 @@ pub enum TermbarError {
     /// Failed to create a progress style.
     #[error("Failed to create progress style: {0}")]
     StyleCreation(String),
-
-    /// Invalid template format.
-    #[error("Invalid template format: {0}")]
-    InvalidTemplate(String),
 }
 
 /// Result type for termbar operations.

--- a/src/termbar/src/lib.rs
+++ b/src/termbar/src/lib.rs
@@ -1,0 +1,177 @@
+//! Terminal progress bar library with resize support.
+//!
+//! This crate provides utilities for creating progress bars that automatically
+//! adapt to terminal width changes. It includes:
+//!
+//! - **Terminal width detection**: Synchronous and async utilities for getting
+//!   the current terminal width and watching for resize events.
+//! - **Progress style builders**: Pre-configured styles for common operations
+//!   like file copying, verification, hashing, and batch operations.
+//! - **Dynamic resizing**: Support for updating progress bar styles when the
+//!   terminal is resized.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use termbar::{ProgressStyleBuilder, TerminalWidth};
+//!
+//! // Get terminal width
+//! let width = TerminalWidth::get_or_default();
+//!
+//! // Create a progress style
+//! let style = ProgressStyleBuilder::copy("myfile.txt").build(width)?;
+//! ```
+//!
+//! # Async resize watching
+//!
+//! ```rust,ignore
+//! use std::sync::atomic::{AtomicBool, Ordering};
+//! use std::sync::Arc;
+//! use termbar::TerminalWidthWatcher;
+//!
+//! let done = Arc::new(AtomicBool::new(false));
+//! let (watcher, resize_task) = TerminalWidthWatcher::with_sigwinch(done.clone());
+//!
+//! // Get current width
+//! let width = watcher.current_width();
+//!
+//! // Get receiver for watching changes
+//! let receiver = watcher.receiver();
+//!
+//! // When done, signal the task to stop
+//! done.store(true, Ordering::SeqCst);
+//! resize_task.await;
+//! ```
+
+mod error;
+mod style;
+mod width;
+
+pub use error::{Result, TermbarError};
+pub use style::ProgressStyleBuilder;
+pub use width::{TerminalWidth, TerminalWidthWatcher};
+
+/// Default terminal width when detection fails (80 columns).
+pub const DEFAULT_TERMINAL_WIDTH: u16 = 80;
+
+/// Minimum progress bar width in characters.
+pub const MIN_BAR_WIDTH: u16 = 10;
+
+/// Maximum progress bar width in characters.
+pub const MAX_BAR_WIDTH: u16 = 100;
+
+/// Default progress characters for smooth sub-character progress visualization.
+///
+/// These characters provide 8 levels of progress within each character cell:
+/// `█▉▊▋▌▍▎▏  `
+pub const PROGRESS_CHARS: &str = "█▉▊▋▌▍▎▏  ";
+
+/// Escape braces in a string for use in indicatif templates.
+///
+/// Indicatif uses `{placeholder}` syntax, so literal braces must be doubled
+/// to be displayed as actual brace characters.
+///
+/// # Arguments
+///
+/// * `s` - The string to escape.
+///
+/// # Returns
+///
+/// The string with `{` replaced by `{{` and `}` replaced by `}}`.
+///
+/// # Example
+///
+/// ```
+/// use termbar::escape_template_braces;
+///
+/// let escaped = escape_template_braces("file{1}.txt");
+/// assert_eq!(escaped, "file{{1}}.txt");
+/// ```
+#[must_use]
+pub fn escape_template_braces(s: &str) -> String {
+    s.replace('{', "{{").replace('}', "}}")
+}
+
+/// Calculate the progress bar width based on terminal width and fixed element overhead.
+///
+/// The bar width is calculated by subtracting the overhead from the terminal width,
+/// then clamping to a reasonable range ([`MIN_BAR_WIDTH`] to [`MAX_BAR_WIDTH`]).
+///
+/// # Arguments
+///
+/// * `terminal_width` - The current terminal width in columns.
+/// * `fixed_overhead` - The number of columns used by fixed elements (spinner, text, etc.).
+///
+/// # Returns
+///
+/// The calculated bar width, clamped to the valid range.
+///
+/// # Example
+///
+/// ```
+/// use termbar::calculate_bar_width;
+///
+/// // Terminal width 80, overhead 60 -> bar width 20
+/// assert_eq!(calculate_bar_width(80, 60), 20);
+///
+/// // Terminal width 40, overhead 60 -> bar width clamped to minimum (10)
+/// assert_eq!(calculate_bar_width(40, 60), 10);
+///
+/// // Terminal width 200, overhead 60 -> bar width clamped to maximum (100)
+/// assert_eq!(calculate_bar_width(200, 60), 100);
+/// ```
+#[must_use]
+pub fn calculate_bar_width(terminal_width: u16, fixed_overhead: u16) -> u16 {
+    let available = terminal_width.saturating_sub(fixed_overhead);
+    available.clamp(MIN_BAR_WIDTH, MAX_BAR_WIDTH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_template_braces() {
+        assert_eq!(escape_template_braces("hello"), "hello");
+        assert_eq!(escape_template_braces("{test}"), "{{test}}");
+        assert_eq!(escape_template_braces("file{1}.txt"), "file{{1}}.txt");
+        assert_eq!(escape_template_braces("{}"), "{{}}");
+    }
+
+    #[test]
+    fn test_calculate_bar_width_normal() {
+        // Normal case: terminal 80, overhead 60 -> 20
+        assert_eq!(calculate_bar_width(80, 60), 20);
+    }
+
+    #[test]
+    fn test_calculate_bar_width_min_clamp() {
+        // Overhead > terminal -> clamp to MIN_BAR_WIDTH
+        assert_eq!(calculate_bar_width(40, 60), MIN_BAR_WIDTH);
+    }
+
+    #[test]
+    fn test_calculate_bar_width_max_clamp() {
+        // Wide terminal -> clamp to MAX_BAR_WIDTH
+        assert_eq!(calculate_bar_width(200, 60), MAX_BAR_WIDTH);
+    }
+
+    #[test]
+    fn test_calculate_bar_width_exact_min() {
+        // Exactly at minimum
+        assert_eq!(calculate_bar_width(70, 60), MIN_BAR_WIDTH);
+    }
+
+    #[test]
+    fn test_calculate_bar_width_exact_max() {
+        // Exactly at maximum
+        assert_eq!(calculate_bar_width(160, 60), MAX_BAR_WIDTH);
+    }
+
+    #[test]
+    fn test_constants() {
+        assert!(MIN_BAR_WIDTH < MAX_BAR_WIDTH);
+        assert!(DEFAULT_TERMINAL_WIDTH > MIN_BAR_WIDTH);
+        assert!(!PROGRESS_CHARS.is_empty());
+    }
+}

--- a/src/termbar/src/lib.rs
+++ b/src/termbar/src/lib.rs
@@ -126,6 +126,34 @@ pub fn calculate_bar_width(terminal_width: u16, fixed_overhead: u16) -> u16 {
     available.clamp(MIN_BAR_WIDTH, MAX_BAR_WIDTH)
 }
 
+/// Convert a string's length to u16, capping at [`u16::MAX`].
+///
+/// This is useful for calculating terminal display widths where string lengths
+/// need to be combined with other u16 values. Filenames longer than 65535 bytes
+/// are extremely rare in practice, so capping at u16::MAX is safe for display
+/// calculations.
+///
+/// # Arguments
+///
+/// * `s` - The string to measure.
+///
+/// # Returns
+///
+/// The string length as u16, or [`u16::MAX`] if the length exceeds u16 range.
+///
+/// # Example
+///
+/// ```
+/// use termbar::str_len_as_u16;
+///
+/// assert_eq!(str_len_as_u16("hello"), 5);
+/// assert_eq!(str_len_as_u16(""), 0);
+/// ```
+#[must_use]
+pub fn str_len_as_u16(s: &str) -> u16 {
+    u16::try_from(s.len()).unwrap_or(u16::MAX)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +203,12 @@ mod tests {
         assert!(MIN_BAR_WIDTH < MAX_BAR_WIDTH);
         assert!(DEFAULT_TERMINAL_WIDTH > MIN_BAR_WIDTH);
         assert!(!PROGRESS_CHARS.is_empty());
+    }
+
+    #[test]
+    fn test_str_len_as_u16() {
+        assert_eq!(str_len_as_u16(""), 0);
+        assert_eq!(str_len_as_u16("hello"), 5);
+        assert_eq!(str_len_as_u16("file{1}.txt"), 11);
     }
 }

--- a/src/termbar/src/lib.rs
+++ b/src/termbar/src/lib.rs
@@ -136,6 +136,8 @@ mod tests {
         assert_eq!(escape_template_braces("{test}"), "{{test}}");
         assert_eq!(escape_template_braces("file{1}.txt"), "file{{1}}.txt");
         assert_eq!(escape_template_braces("{}"), "{{}}");
+        // Empty string should return empty string
+        assert_eq!(escape_template_braces(""), "");
     }
 
     #[test]

--- a/src/termbar/src/lib.rs
+++ b/src/termbar/src/lib.rs
@@ -62,8 +62,9 @@ pub const MAX_BAR_WIDTH: u16 = 100;
 
 /// Default progress characters for smooth sub-character progress visualization.
 ///
-/// These characters provide 8 levels of progress within each character cell:
-/// `█▉▊▋▌▍▎▏  `
+/// The string contains 10 characters used by indicatif for progress rendering:
+/// - 8 partial block characters (`█▉▊▋▌▍▎▏`) for sub-character progress levels
+/// - 2 space characters for the empty/background portion of the bar
 pub const PROGRESS_CHARS: &str = "█▉▊▋▌▍▎▏  ";
 
 /// Escape braces in a string for use in indicatif templates.

--- a/src/termbar/src/style.rs
+++ b/src/termbar/src/style.rs
@@ -3,7 +3,7 @@
 //! This module provides builders for creating progress bar styles that
 //! automatically adjust to the terminal width.
 
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::ProgressStyle;
 
 use crate::error::{Result, TermbarError};
 use crate::{calculate_bar_width, escape_template_braces, PROGRESS_CHARS};
@@ -137,25 +137,6 @@ impl ProgressStyleBuilder {
             .template(&template)
             .map_err(|e| TermbarError::StyleCreation(e.to_string()))?
             .progress_chars(&self.progress_chars))
-    }
-
-    /// Apply the progress style to an existing progress bar.
-    ///
-    /// This is a convenience method for updating a progress bar's style
-    /// after a terminal resize.
-    ///
-    /// # Arguments
-    ///
-    /// * `pb` - The progress bar to update.
-    /// * `terminal_width` - The current terminal width in columns.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the progress style template is invalid.
-    pub fn apply(&self, pb: &ProgressBar, terminal_width: u16) -> Result<()> {
-        let style = self.build(terminal_width)?;
-        pb.set_style(style);
-        Ok(())
     }
 
     /// Create the template string for this style type.

--- a/src/termbar/src/style.rs
+++ b/src/termbar/src/style.rs
@@ -252,7 +252,14 @@ mod tests {
 
     /// Helper to extract bar width from a template string.
     /// Looks for pattern like `{bar:XX.` where XX is the width.
+    ///
+    /// # Safety Note
+    /// This function uses byte-offset string slicing which is safe here because
+    /// indicatif templates are always ASCII. Do not copy this pattern for
+    /// user-facing strings that may contain multi-byte UTF-8 characters.
     fn extract_bar_width(template: &str) -> Option<u16> {
+        // SAFETY: indicatif templates use ASCII-only syntax ({bar:, etc.),
+        // so byte offsets are guaranteed to be valid UTF-8 boundaries.
         let bar_start = template.find("{bar:")?;
         let after_bar = &template[bar_start + 5..];
         let dot_pos = after_bar.find('.')?;

--- a/src/termbar/src/style.rs
+++ b/src/termbar/src/style.rs
@@ -6,7 +6,7 @@
 use indicatif::ProgressStyle;
 
 use crate::error::{Result, TermbarError};
-use crate::{calculate_bar_width, escape_template_braces, str_len_as_u16, PROGRESS_CHARS};
+use crate::{calculate_bar_width, escape_template_braces, str_display_width_as_u16, PROGRESS_CHARS};
 
 /// Common format string for progress stats (bytes, percentage, speed, ETA).
 const PROGRESS_STATS_FORMAT: &str = "{bytes}/{total_bytes} ({percent}%) ({bytes_per_sec}, {eta})";
@@ -148,9 +148,9 @@ impl ProgressStyleBuilder {
                     .as_ref()
                     .map(|s| escape_template_braces(s))
                     .unwrap_or_default();
-                let filename_len = str_len_as_u16(&filename);
-                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + spaces(3) = ~60 + filename.len()
-                let overhead = 60 + filename_len;
+                let filename_display_width = str_display_width_as_u16(&filename);
+                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + spaces(3) = ~60 + filename display width
+                let overhead = 60 + filename_display_width;
                 let bar_width = calculate_bar_width(terminal_width, overhead);
                 format!(
                     "{{spinner:.green}} {} [{{bar:{}.cyan/blue}}] {}",
@@ -163,9 +163,9 @@ impl ProgressStyleBuilder {
                     .as_ref()
                     .map(|s| escape_template_braces(s))
                     .unwrap_or_default();
-                let filename_len = str_len_as_u16(&filename);
-                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + " verifying"(10) + spaces(3) = ~70 + filename.len()
-                let overhead = 70 + filename_len;
+                let filename_display_width = str_display_width_as_u16(&filename);
+                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + " verifying"(10) + spaces(3) = ~70 + filename display width
+                let overhead = 70 + filename_display_width;
                 let bar_width = calculate_bar_width(terminal_width, overhead);
                 format!(
                     "{{spinner:.yellow}} {} [{{bar:{}.yellow/dim}}] {} verifying",

--- a/src/termbar/src/style.rs
+++ b/src/termbar/src/style.rs
@@ -1,0 +1,271 @@
+//! Progress bar style builders.
+//!
+//! This module provides builders for creating progress bar styles that
+//! automatically adjust to the terminal width.
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::error::{Result, TermbarError};
+use crate::{calculate_bar_width, escape_template_braces, PROGRESS_CHARS};
+
+/// Common format string for progress stats (bytes, percentage, speed, ETA).
+const PROGRESS_STATS_FORMAT: &str = "{bytes}/{total_bytes} ({percent}%) ({bytes_per_sec}, {eta})";
+
+/// Format string for batch progress stats (bytes, speed, ETA).
+/// `{msg}` is used for file count and status (e.g., "(0/3)" or "(2/3)").
+const BATCH_PROGRESS_STATS_FORMAT: &str =
+    "{msg} {bytes}/{total_bytes} @ {bytes_per_sec} (~{eta} remaining)";
+
+/// Builder for progress bar styles with automatic width calculation.
+///
+/// This builder creates progress styles that adapt to the terminal width,
+/// ensuring the progress bar fits properly at any terminal size.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use termbar::{ProgressStyleBuilder, TerminalWidth};
+///
+/// let width = TerminalWidth::get_or_default();
+/// let style = ProgressStyleBuilder::copy("myfile.txt").build(width)?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct ProgressStyleBuilder {
+    style_type: StyleType,
+    progress_chars: String,
+    custom_filename: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum StyleType {
+    /// Copy progress style (cyan bar with spinner).
+    Copy,
+    /// Verification progress style (yellow bar with spinner).
+    Verify,
+    /// Batch progress style (blue bar with prefix).
+    Batch,
+    /// Hash progress style (cyan bar with spinner and hash prefix).
+    Hash,
+}
+
+impl ProgressStyleBuilder {
+    /// Create a progress style builder for file copy operations.
+    ///
+    /// Shows: `⠁ filename [████████░░░░] bytes/total (pct%) (speed, eta)`
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The filename to display in the progress bar.
+    #[must_use]
+    pub fn copy(filename: &str) -> Self {
+        Self {
+            style_type: StyleType::Copy,
+            progress_chars: PROGRESS_CHARS.to_string(),
+            custom_filename: Some(filename.to_string()),
+        }
+    }
+
+    /// Create a progress style builder for file verification operations.
+    ///
+    /// Shows: `⠁ filename [████████░░░░] bytes/total (pct%) (speed, eta) verifying`
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The filename to display in the progress bar.
+    #[must_use]
+    pub fn verify(filename: &str) -> Self {
+        Self {
+            style_type: StyleType::Verify,
+            progress_chars: PROGRESS_CHARS.to_string(),
+            custom_filename: Some(filename.to_string()),
+        }
+    }
+
+    /// Create a progress style builder for batch operations.
+    ///
+    /// Shows: `Batch [████████░░░░] (n/total) bytes/total @ speed (~eta remaining)`
+    #[must_use]
+    pub fn batch() -> Self {
+        Self {
+            style_type: StyleType::Batch,
+            progress_chars: PROGRESS_CHARS.to_string(),
+            custom_filename: None,
+        }
+    }
+
+    /// Create a progress style builder for file hashing operations.
+    ///
+    /// Shows: `⠁ [████████░░░░] bytes/total (pct%) (speed, eta) msg`
+    ///
+    /// This style is designed for hash operations where the filename
+    /// is shown via the progress bar message rather than the template.
+    #[must_use]
+    pub fn hash() -> Self {
+        Self {
+            style_type: StyleType::Hash,
+            progress_chars: PROGRESS_CHARS.to_string(),
+            custom_filename: None,
+        }
+    }
+
+    /// Set custom progress characters.
+    ///
+    /// The default is `█▉▊▋▌▍▎▏  ` which provides smooth sub-character progress.
+    ///
+    /// # Arguments
+    ///
+    /// * `chars` - Progress characters string for indicatif.
+    #[must_use]
+    pub fn with_progress_chars(mut self, chars: &str) -> Self {
+        self.progress_chars = chars.to_string();
+        self
+    }
+
+    /// Build the progress style for the given terminal width.
+    ///
+    /// # Arguments
+    ///
+    /// * `terminal_width` - The current terminal width in columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the progress style template is invalid.
+    pub fn build(&self, terminal_width: u16) -> Result<ProgressStyle> {
+        let template = self.create_template(terminal_width);
+
+        Ok(ProgressStyle::default_bar()
+            .template(&template)
+            .map_err(|e| TermbarError::StyleCreation(e.to_string()))?
+            .progress_chars(&self.progress_chars))
+    }
+
+    /// Apply the progress style to an existing progress bar.
+    ///
+    /// This is a convenience method for updating a progress bar's style
+    /// after a terminal resize.
+    ///
+    /// # Arguments
+    ///
+    /// * `pb` - The progress bar to update.
+    /// * `terminal_width` - The current terminal width in columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the progress style template is invalid.
+    pub fn apply(&self, pb: &ProgressBar, terminal_width: u16) -> Result<()> {
+        let style = self.build(terminal_width)?;
+        pb.set_style(style);
+        Ok(())
+    }
+
+    /// Create the template string for this style type.
+    fn create_template(&self, terminal_width: u16) -> String {
+        match &self.style_type {
+            StyleType::Copy => {
+                let filename = self
+                    .custom_filename
+                    .as_ref()
+                    .map(|s| escape_template_braces(s))
+                    .unwrap_or_default();
+                let filename_len = filename.len().min(u16::MAX as usize) as u16;
+                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + spaces(3) = ~60 + filename.len()
+                let overhead = 60 + filename_len;
+                let bar_width = calculate_bar_width(terminal_width, overhead);
+                format!(
+                    "{{spinner:.green}} {} [{{bar:{}.cyan/blue}}] {}",
+                    filename, bar_width, PROGRESS_STATS_FORMAT
+                )
+            }
+            StyleType::Verify => {
+                let filename = self
+                    .custom_filename
+                    .as_ref()
+                    .map(|s| escape_template_braces(s))
+                    .unwrap_or_default();
+                let filename_len = filename.len().min(u16::MAX as usize) as u16;
+                // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + " verifying"(10) + spaces(3) = ~70 + filename.len()
+                let overhead = 70 + filename_len;
+                let bar_width = calculate_bar_width(terminal_width, overhead);
+                format!(
+                    "{{spinner:.yellow}} {} [{{bar:{}.yellow/dim}}] {} verifying",
+                    filename, bar_width, PROGRESS_STATS_FORMAT
+                )
+            }
+            StyleType::Batch => {
+                // "Batch [bar] (99/99) 999.99 GiB/999.99 GiB @ 999.99 MiB/s (~99:99:99 remaining)" = ~85 chars overhead
+                let bar_width = calculate_bar_width(terminal_width, 85);
+                format!(
+                    "{{prefix:.bold}} [{{bar:{}.blue/dim}}] {}",
+                    bar_width, BATCH_PROGRESS_STATS_FORMAT
+                )
+            }
+            StyleType::Hash => {
+                // spinner(2) + brackets(4) + bytes/total(25) + speed/eta(35) + msg(variable) + spaces(4) = ~70 overhead
+                // We use a larger overhead to leave room for the message
+                let bar_width = calculate_bar_width(terminal_width, 70);
+                format!(
+                    "{{spinner:.green}} [{{bar:{}.cyan/blue}}] {} {{msg}}",
+                    bar_width, PROGRESS_STATS_FORMAT
+                )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_copy_style_builds() {
+        let style = ProgressStyleBuilder::copy("test.txt").build(80);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_verify_style_builds() {
+        let style = ProgressStyleBuilder::verify("test.txt").build(80);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_batch_style_builds() {
+        let style = ProgressStyleBuilder::batch().build(80);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_hash_style_builds() {
+        let style = ProgressStyleBuilder::hash().build(80);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_custom_progress_chars() {
+        let style = ProgressStyleBuilder::copy("test.txt")
+            .with_progress_chars("#>-")
+            .build(80);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_narrow_terminal() {
+        // Should still build for very narrow terminals
+        let style = ProgressStyleBuilder::copy("test.txt").build(20);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_wide_terminal() {
+        // Should still build for very wide terminals
+        let style = ProgressStyleBuilder::copy("test.txt").build(200);
+        assert!(style.is_ok());
+    }
+
+    #[test]
+    fn test_filename_with_braces() {
+        // Filenames with braces should be escaped
+        let style = ProgressStyleBuilder::copy("file{1}.txt").build(80);
+        assert!(style.is_ok());
+    }
+}

--- a/src/termbar/src/style.rs
+++ b/src/termbar/src/style.rs
@@ -6,7 +6,7 @@
 use indicatif::ProgressStyle;
 
 use crate::error::{Result, TermbarError};
-use crate::{calculate_bar_width, escape_template_braces, PROGRESS_CHARS};
+use crate::{calculate_bar_width, escape_template_braces, str_len_as_u16, PROGRESS_CHARS};
 
 /// Common format string for progress stats (bytes, percentage, speed, ETA).
 const PROGRESS_STATS_FORMAT: &str = "{bytes}/{total_bytes} ({percent}%) ({bytes_per_sec}, {eta})";
@@ -148,7 +148,7 @@ impl ProgressStyleBuilder {
                     .as_ref()
                     .map(|s| escape_template_braces(s))
                     .unwrap_or_default();
-                let filename_len = filename.len().min(u16::MAX as usize) as u16;
+                let filename_len = str_len_as_u16(&filename);
                 // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + spaces(3) = ~60 + filename.len()
                 let overhead = 60 + filename_len;
                 let bar_width = calculate_bar_width(terminal_width, overhead);
@@ -163,7 +163,7 @@ impl ProgressStyleBuilder {
                     .as_ref()
                     .map(|s| escape_template_braces(s))
                     .unwrap_or_default();
-                let filename_len = filename.len().min(u16::MAX as usize) as u16;
+                let filename_len = str_len_as_u16(&filename);
                 // spinner(2) + filename + brackets(4) + bytes(25) + speed/eta(25) + " verifying"(10) + spaces(3) = ~70 + filename.len()
                 let overhead = 70 + filename_len;
                 let bar_width = calculate_bar_width(terminal_width, overhead);

--- a/src/termbar/src/width.rs
+++ b/src/termbar/src/width.rs
@@ -207,6 +207,10 @@ impl TerminalWidthWatcher {
     /// Consider using [`spawn_sigwinch_handler_with_shutdown`](Self::spawn_sigwinch_handler_with_shutdown)
     /// for cleaner shutdown semantics. This method polls the `done` flag every 100ms,
     /// while the shutdown channel version exits immediately when signaled.
+    ///
+    /// The 100ms polling interval balances responsiveness (shutdown within 100ms)
+    /// against CPU usage (10 wakeups/second when idle). This is acceptable for
+    /// short-lived operations like file copies where the overhead is negligible.
     #[must_use]
     pub fn spawn_sigwinch_handler(&self, done: Arc<AtomicBool>) -> JoinHandle<()> {
         #[cfg(unix)]

--- a/src/termbar/src/width.rs
+++ b/src/termbar/src/width.rs
@@ -1,0 +1,213 @@
+//! Terminal width detection and monitoring.
+//!
+//! This module provides utilities for getting the current terminal width
+//! and watching for terminal resize events.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::DEFAULT_TERMINAL_WIDTH;
+
+/// Utilities for synchronous terminal width detection.
+pub struct TerminalWidth;
+
+impl TerminalWidth {
+    /// Get the current terminal width.
+    ///
+    /// Returns the terminal width in columns if it can be detected,
+    /// otherwise returns `None`.
+    #[must_use]
+    pub fn get() -> Option<u16> {
+        crossterm::terminal::size().map(|(w, _)| w).ok()
+    }
+
+    /// Get the current terminal width with a fallback.
+    ///
+    /// Returns the terminal width in columns if it can be detected,
+    /// otherwise returns the provided fallback value.
+    ///
+    /// # Arguments
+    ///
+    /// * `fallback` - The value to return if terminal width cannot be detected.
+    #[must_use]
+    pub fn get_or(fallback: u16) -> u16 {
+        Self::get().unwrap_or(fallback)
+    }
+
+    /// Get the current terminal width with the default fallback.
+    ///
+    /// Returns the terminal width in columns if it can be detected,
+    /// otherwise returns [`DEFAULT_TERMINAL_WIDTH`] (80 columns).
+    #[must_use]
+    pub fn get_or_default() -> u16 {
+        Self::get_or(DEFAULT_TERMINAL_WIDTH)
+    }
+}
+
+/// Watches for terminal width changes and notifies subscribers.
+///
+/// This struct provides an async mechanism for tracking terminal resize events
+/// using a tokio watch channel. It can optionally spawn a SIGWINCH signal handler
+/// on Unix systems.
+pub struct TerminalWidthWatcher {
+    sender: watch::Sender<u16>,
+    receiver: watch::Receiver<u16>,
+}
+
+impl TerminalWidthWatcher {
+    /// Create a new terminal width watcher.
+    ///
+    /// Initializes the watcher with the current terminal width.
+    /// The watcher does not automatically listen for resize events;
+    /// use [`with_sigwinch`](Self::with_sigwinch) for automatic resize detection.
+    #[must_use]
+    pub fn new() -> Self {
+        let initial_width = TerminalWidth::get_or_default();
+        let (sender, receiver) = watch::channel(initial_width);
+        Self { sender, receiver }
+    }
+
+    /// Create a new terminal width watcher with SIGWINCH handler (Unix only).
+    ///
+    /// This spawns a background task that listens for terminal resize signals
+    /// and updates the width automatically. The task will exit when the `done`
+    /// flag is set to `true`.
+    ///
+    /// # Arguments
+    ///
+    /// * `done` - A shared flag that signals when to stop watching for resize events.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the watcher and a handle to the background task.
+    /// The task should be awaited during cleanup.
+    #[must_use]
+    pub fn with_sigwinch(done: Arc<AtomicBool>) -> (Self, JoinHandle<()>) {
+        let watcher = Self::new();
+        let task = watcher.spawn_sigwinch_handler(done);
+        (watcher, task)
+    }
+
+    /// Spawn a SIGWINCH signal handler task.
+    ///
+    /// On Unix systems, this listens for SIGWINCH signals (terminal resize)
+    /// and updates the terminal width accordingly.
+    ///
+    /// On non-Unix systems, this returns a no-op task.
+    ///
+    /// # Arguments
+    ///
+    /// * `done` - A shared flag that signals when to stop watching for resize events.
+    #[must_use]
+    pub fn spawn_sigwinch_handler(&self, done: Arc<AtomicBool>) -> JoinHandle<()> {
+        #[cfg(unix)]
+        {
+            let sender = self.sender.clone();
+            tokio::task::spawn(async move {
+                use tokio::signal::unix::{signal, SignalKind};
+
+                let mut sigwinch = match signal(SignalKind::window_change()) {
+                    Ok(s) => s,
+                    Err(_e) => {
+                        // Non-critical: progress bar resize won't work,
+                        // but crossterm Event::Resize may still work.
+                        #[cfg(debug_assertions)]
+                        eprintln!("Debug: SIGWINCH handler setup failed: {_e}");
+                        return;
+                    }
+                };
+
+                loop {
+                    tokio::select! {
+                        _ = sigwinch.recv() => {
+                            let new_width = TerminalWidth::get_or_default();
+                            let _ = sender.send(new_width);
+                        }
+                        _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                            if done.load(Ordering::SeqCst) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            })
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = done;
+            tokio::task::spawn(async {})
+        }
+    }
+
+    /// Get a receiver for terminal width updates.
+    ///
+    /// Clone this receiver to get notified of terminal width changes.
+    #[must_use]
+    pub fn receiver(&self) -> watch::Receiver<u16> {
+        self.receiver.clone()
+    }
+
+    /// Get the current terminal width from the watcher.
+    ///
+    /// Returns the most recently observed terminal width.
+    #[must_use]
+    pub fn current_width(&self) -> u16 {
+        *self.receiver.borrow()
+    }
+
+    /// Get the sender for manual width updates.
+    ///
+    /// This is useful for integrating with other resize detection mechanisms
+    /// such as crossterm's `Event::Resize`.
+    #[must_use]
+    pub fn sender(&self) -> &watch::Sender<u16> {
+        &self.sender
+    }
+}
+
+impl Default for TerminalWidthWatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_terminal_width_get_or() {
+        // Should return something reasonable (either detected width or fallback)
+        let width = TerminalWidth::get_or(80);
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_terminal_width_get_or_default() {
+        let width = TerminalWidth::get_or_default();
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_watcher_new() {
+        let watcher = TerminalWidthWatcher::new();
+        let width = watcher.current_width();
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_watcher_sender_updates_receiver() {
+        let watcher = TerminalWidthWatcher::new();
+        let receiver = watcher.receiver();
+
+        // Update via sender
+        let _ = watcher.sender().send(120);
+
+        // Receiver should see the update
+        assert_eq!(*receiver.borrow(), 120);
+        assert_eq!(watcher.current_width(), 120);
+    }
+}

--- a/src/termbar/src/width.rs
+++ b/src/termbar/src/width.rs
@@ -110,9 +110,11 @@ impl TerminalWidthWatcher {
 
                 let mut sigwinch = match signal(SignalKind::window_change()) {
                     Ok(s) => s,
-                    Err(_) => {
+                    Err(_e) => {
                         // Non-critical: progress bar resize won't work,
                         // but crossterm Event::Resize may still work.
+                        #[cfg(debug_assertions)]
+                        eprintln!("Debug: SIGWINCH handler setup failed: {_e}");
                         return;
                     }
                 };

--- a/src/termbar/src/width.rs
+++ b/src/termbar/src/width.rs
@@ -110,11 +110,9 @@ impl TerminalWidthWatcher {
 
                 let mut sigwinch = match signal(SignalKind::window_change()) {
                     Ok(s) => s,
-                    Err(_e) => {
+                    Err(_) => {
                         // Non-critical: progress bar resize won't work,
                         // but crossterm Event::Resize may still work.
-                        #[cfg(debug_assertions)]
-                        eprintln!("Debug: SIGWINCH handler setup failed: {_e}");
                         return;
                     }
                 };


### PR DESCRIPTION
## Summary
- Create new `termbar` library crate that extracts progress bar functionality for reuse
- Migrate `prcp`, `prhash`, and `org-borg` to use the shared library
- Progress bars now dynamically adapt to terminal width instead of using hardcoded sizes

## Features
The termbar library provides:
- Terminal width detection with 80-column fallback
- Dynamic bar width calculation (clamped 10-100 chars)
- Pre-built progress styles: `copy()`, `verify()`, `batch()`, `hash()`
- Template brace escaping for filenames containing `{` or `}`
- Optional async SIGWINCH handler for terminal resize events

## Test plan
- [x] `cargo build -p termbar` - library builds
- [x] `cargo test -p termbar` - unit tests pass
- [x] `cargo build -p prcp` - prcp builds with termbar
- [x] `cargo test -p prcp` - prcp tests pass
- [x] `cargo build -p prhash` - prhash builds with termbar
- [x] `cargo test -p prhash` - prhash tests pass
- [x] `cargo build -p org-borg` - org-borg builds with termbar

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)