### PR TITLE
feat(prcp): add buffer pool optimization for parallel copy (#92)

### DIFF
--- a/src/prcp/BENCHMARKS.md
+++ b/src/prcp/BENCHMARKS.md
@@ -1,0 +1,41 @@
+# prcp Benchmarks
+
+## Buffer Pool Optimization (Issue #92)
+
+**Date:** 2025-01-14
+
+**Test Setup:**
+- Source: 10GB file (`/Volumes/SamsungSSDs/junk.bin`) on NVMe SSD
+- Destination: HDD RAID array (`/Volumes/HDDRAID/dest`)
+- Transfer type: Cross-device (parallel copy mode)
+- Test iterations: 10 runs per configuration
+
+**Results:**
+
+| Configuration | Mean Time | Std Dev | Range |
+|--------------|-----------|---------|-------|
+| Without buffer pool | 26.073s | ±2.606s | 22.782s - 29.486s |
+| With buffer pool | 24.012s | ±1.195s | 23.061s - 26.983s |
+
+**Summary:** Buffer pool is **1.09x faster** (±0.12) than allocating per chunk.
+
+**Raw hyperfine output:**
+```
+Benchmark 1: prcp /Volumes/SamsungSSDs/junk.bin /Volumes/HDDRAID/dest && rm /Volumes/HDDRAID/dest
+  Time (mean ± σ):     26.073 s ±  2.606 s    [User: 30.526 s, System: 3.960 s]
+  Range (min … max):   22.782 s … 29.486 s    10 runs
+
+Benchmark 2: prcp --buffer-pool /Volumes/SamsungSSDs/junk.bin /Volumes/HDDRAID/dest && rm /Volumes/HDDRAID/dest
+  Time (mean ± σ):     24.012 s ±  1.195 s    [User: 30.713 s, System: 3.581 s]
+  Range (min … max):   23.061 s … 26.983 s    10 runs
+
+Summary
+  prcp --buffer-pool [...] ran
+    1.09 ± 0.12 times faster than prcp [...]
+```
+
+**Notes:**
+- Buffer pool reuses buffers between reader and writer threads via a return channel
+- Pre-allocates `PARALLEL_CHANNEL_DEPTH` (4) buffers at start
+- Falls back to allocation if pool is exhausted (reader faster than writer)
+- Buffer pool is now enabled by default; use `--no-buffer-pool` to disable


### PR DESCRIPTION
## Summary

Implement buffer reuse via return channel to reduce allocation overhead in parallel copy. Pre-allocates `PARALLEL_CHANNEL_DEPTH` buffers; writer returns used buffers to reader for reuse. Falls back to allocation if pool exhausted. Benchmarking shows **1.09x speedup** on cross-device transfers (10GB NVMe→HDD RAID).

## Changes

- Add `--no-buffer-pool` flag to disable (enabled by default)
- Implement buffer return channel in `copy_parallel`
- Reader retrieves recycled buffers with 10ms timeout, falls back to allocation
- Writer returns buffers via `try_send` to avoid blocking
- Add BENCHMARKS.md with detailed test results

## Test Results

Cross-device transfer (NVMe → HDD RAID, 10GB file):
- Without pool: 26.073s ± 2.606s
- With pool: 24.012s ± 1.195s
- **Speedup: 1.09x ± 0.12**

🤖 Generated with [Claude Code](https://claude.com/claude-code)