### PR TITLE
feat(nwt): add shell integration for automatic cd into worktrees

### DIFF
--- a/src/nwt/Cargo.toml
+++ b/src/nwt/Cargo.toml
@@ -14,6 +14,7 @@ names.workspace = true
 serde.workspace = true
 toml.workspace = true
 dirs.workspace = true
+shellsetup.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Adds a `--shell-setup` flag to nwt that installs a shell function, enabling automatic `cd` into newly created worktrees. The function intelligently skips the `cd` when `--tmux` is used since the worktree opens in a new tmux window.

## Implementation

Uses the `shellsetup` library for consistent installation and updates. Includes proper exit code handling (14 for shell setup errors), comprehensive help documentation, and 3 new tests for the `--shell-setup` flag and its conflict rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)