### PR TITLE
fix(nwt,cwt): prevent shell cd error when running --help

### DIFF
--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -292,7 +292,7 @@ function wt() {
         cwt
     else
         local target=$(cwt "$@")
-        if [ $? -eq 0 ] && [ -n "$target" ]; then
+        if [ $? -eq 0 ] && [ -n "$target" ] && [ -d "$target" ]; then
             cd "$target"
         fi
     fi

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -291,9 +291,14 @@ function wt() {
         # No args: show list interactively
         cwt
     else
-        local target=$(cwt "$@")
-        if [ $? -eq 0 ] && [ -n "$target" ] && [ -d "$target" ]; then
+        local target
+        target=$(cwt "$@")
+        local exit_code=$?
+        if [ $exit_code -eq 0 ] && [ -n "$target" ] && [ -d "$target" ]; then
             cd "$target"
+        else
+            [ -n "$target" ] && echo "$target"
+            return $exit_code
         fi
     fi
 }

--- a/src/nwt/src/main.rs
+++ b/src/nwt/src/main.rs
@@ -30,7 +30,7 @@ function nwt() {
     local dir
     dir=$(command nwt "$@")
     local exit_code=$?
-    if [ $exit_code -eq 0 ] && [ -n "$dir" ]; then
+    if [ $exit_code -eq 0 ] && [ -n "$dir" ] && [ -d "$dir" ]; then
         echo "$dir"
         cd "$dir" || return 1
     else


### PR DESCRIPTION
## Summary

- Prevent shell cd errors when running `--help` on nwt/cwt by validating output is a directory before cd
- Improve cwt's wt() function to display help and error output, matching nwt() behavior

## Test Plan

- Run `nwt --help` and `wt --help` - should display help text, no cd errors
- Run `nwt -b issue-123` to create a worktree and verify normal cd behavior works
- Run `wt -f` to verify worktree navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)