### PR TITLE
feat(gr8): sort graphql rate limit to appear last in output

### DIFF
--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -5,6 +5,10 @@ use colored::Colorize;
 use serde::Deserialize;
 use std::process::Command;
 
+/// The GraphQL rate limit resource name. This is the most commonly monitored
+/// rate limit, so it's sorted to appear last in output tables for visibility.
+const GRAPHQL_RESOURCE: &str = "graphql";
+
 /// Represents a single rate limit resource with its limits and usage statistics
 #[derive(Debug, Deserialize)]
 struct RateLimit {
@@ -244,10 +248,10 @@ fn main() -> Result<()> {
         .into_iter()
         .partition(|named| named.rate_limit.remaining > 0);
 
-    // Sort each list so graphql appears last (it's the one users care about most)
+    // Sort each list so graphql appears last for visibility (most commonly monitored)
     // Uses sort_by_key: false < true in Rust, so graphql (where predicate is true) sorts last
-    available.sort_by_key(|n| n.name == "graphql");
-    exhausted.sort_by_key(|n| n.name == "graphql");
+    available.sort_by_key(|n| n.name == GRAPHQL_RESOURCE);
+    exhausted.sort_by_key(|n| n.name == GRAPHQL_RESOURCE);
 
     // Print available rate limits first (easier to scroll past)
     print_rate_limit_table("Available Rate Limits", &available);
@@ -420,12 +424,12 @@ mod tests {
             .partition(|named| named.rate_limit.remaining > 0);
 
         // Apply the same sort used in main: false < true, so graphql sorts last
-        available.sort_by_key(|n| n.name == "graphql");
+        available.sort_by_key(|n| n.name == GRAPHQL_RESOURCE);
 
         assert_eq!(
             available.last().map(|n| n.name),
-            Some("graphql"),
-            "graphql should be last in available list"
+            Some(GRAPHQL_RESOURCE),
+            "{GRAPHQL_RESOURCE} should be last in available list"
         );
     }
 
@@ -439,12 +443,12 @@ mod tests {
             .partition(|named| named.rate_limit.remaining > 0);
 
         // Apply the same sort used in main: false < true, so graphql sorts last
-        exhausted.sort_by_key(|n| n.name == "graphql");
+        exhausted.sort_by_key(|n| n.name == GRAPHQL_RESOURCE);
 
         assert_eq!(
             exhausted.last().map(|n| n.name),
-            Some("graphql"),
-            "graphql should be last in exhausted list"
+            Some(GRAPHQL_RESOURCE),
+            "{GRAPHQL_RESOURCE} should be last in exhausted list"
         );
     }
 }

--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -5,6 +5,11 @@ use colored::Colorize;
 use serde::Deserialize;
 use std::process::Command;
 
+/// The core rate limit resource name. Used in tests for consistency with other
+/// resource name constants.
+#[cfg(test)]
+const CORE_RESOURCE: &str = "core";
+
 /// The GraphQL rate limit resource name. This is the most commonly monitored
 /// rate limit, so it's sorted to appear last in output tables for visibility.
 const GRAPHQL_RESOURCE: &str = "graphql";
@@ -315,7 +320,7 @@ mod tests {
 
         // Core should be in exhausted
         assert!(
-            exhausted.iter().any(|n| n.name == "core"),
+            exhausted.iter().any(|n| n.name == CORE_RESOURCE),
             "Core (remaining=0) should be in exhausted list"
         );
 

--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -321,7 +321,7 @@ mod tests {
 
         // Graphql should be in available
         assert!(
-            available.iter().any(|n| n.name == "graphql"),
+            available.iter().any(|n| n.name == GRAPHQL_RESOURCE),
             "Graphql (remaining=100) should be in available list"
         );
 

--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -245,15 +245,9 @@ fn main() -> Result<()> {
         .partition(|named| named.rate_limit.remaining > 0);
 
     // Sort each list so graphql appears last (it's the one users care about most)
-    let graphql_last = |a: &NamedRateLimit, b: &NamedRateLimit| {
-        match (a.name == "graphql", b.name == "graphql") {
-            (true, false) => std::cmp::Ordering::Greater,
-            (false, true) => std::cmp::Ordering::Less,
-            _ => std::cmp::Ordering::Equal,
-        }
-    };
-    available.sort_by(graphql_last);
-    exhausted.sort_by(graphql_last);
+    // Uses sort_by_key: false < true in Rust, so graphql (where predicate is true) sorts last
+    available.sort_by_key(|n| n.name == "graphql");
+    exhausted.sort_by_key(|n| n.name == "graphql");
 
     // Print available rate limits first (easier to scroll past)
     print_rate_limit_table("Available Rate Limits", &available);
@@ -425,15 +419,8 @@ mod tests {
             .into_iter()
             .partition(|named| named.rate_limit.remaining > 0);
 
-        // Apply the same sort used in main
-        let graphql_last = |a: &NamedRateLimit, b: &NamedRateLimit| {
-            match (a.name == "graphql", b.name == "graphql") {
-                (true, false) => std::cmp::Ordering::Greater,
-                (false, true) => std::cmp::Ordering::Less,
-                _ => std::cmp::Ordering::Equal,
-            }
-        };
-        available.sort_by(graphql_last);
+        // Apply the same sort used in main: false < true, so graphql sorts last
+        available.sort_by_key(|n| n.name == "graphql");
 
         assert_eq!(
             available.last().map(|n| n.name),
@@ -451,15 +438,8 @@ mod tests {
             .into_iter()
             .partition(|named| named.rate_limit.remaining > 0);
 
-        // Apply the same sort used in main
-        let graphql_last = |a: &NamedRateLimit, b: &NamedRateLimit| {
-            match (a.name == "graphql", b.name == "graphql") {
-                (true, false) => std::cmp::Ordering::Greater,
-                (false, true) => std::cmp::Ordering::Less,
-                _ => std::cmp::Ordering::Equal,
-            }
-        };
-        exhausted.sort_by(graphql_last);
+        // Apply the same sort used in main: false < true, so graphql sorts last
+        exhausted.sort_by_key(|n| n.name == "graphql");
 
         assert_eq!(
             exhausted.last().map(|n| n.name),


### PR DESCRIPTION
## Summary
- Sort both available and exhausted rate limit tables so graphql always appears last
- The graphql quota is the one users care about most, but it could scroll off screen
- Added tests to verify graphql sorting behavior

## Test plan
- [x] `cargo test -p gr8` passes (13 tests)
- [x] `cargo clippy -p gr8 -- -D warnings` passes with no warnings
- [ ] Run `gr8` and verify graphql appears as the last row in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)