### PR TITLE
feat(nwt): copy untracked .env files to new worktrees

### DIFF
--- a/src/nwt/Cargo.toml
+++ b/src/nwt/Cargo.toml
@@ -18,5 +18,8 @@ shellsetup.workspace = true
 toml.workspace = true
 walkdir.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/src/nwt/Cargo.toml
+++ b/src/nwt/Cargo.toml
@@ -16,6 +16,7 @@ repowalker.workspace = true
 serde.workspace = true
 shellsetup.workspace = true
 toml.workspace = true
+walkdir.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- Add automatic copying of untracked `.env` files from the main worktree to newly created worktrees
- Preserves relative paths (e.g., `apps/web/.env.local` stays in the same location)
- Enabled by default with `--no-copy-env` flag to disable
- Configurable via `copy_env = false` in `~/.nwt.toml`
- Uses batched `git ls-files` for performance (single git call instead of per-file)
- Skips symlinks and `.git` directory

## Test plan

- [ ] Create a `.env` file in the main repo (don't track it)
- [ ] Run `nwt` to create a new worktree
- [ ] Verify `.env` was copied to the new worktree
- [ ] Test nested paths (`apps/web/.env.local`)
- [ ] Test `--no-copy-env` disables copying
- [ ] Run `cargo test -p nwt` (56 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)