### PR TITLE
fix(ic): use Kitty protocol for WezTerm and downscale large images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +156,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arbitrary"
@@ -682,6 +707,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "beta"
+version = "0.1.0"
+dependencies = [
+ "ab_glyph",
+ "anyhow",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "crossterm",
+ "flate2",
+ "image",
+ "imageproc",
+ "minijinja",
+ "portable-pty",
+ "serde",
+ "serde_json",
+ "signal-hook 0.3.18",
+ "terminal_size",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "vte",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +982,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1342,6 +1398,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 1.1.4",
@@ -1591,6 +1648,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -2053,8 +2116,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3657,6 +3722,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "imageproc"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "getrandom 0.2.17",
+ "image",
+ "itertools 0.12.1",
+ "nalgebra",
+ "num",
+ "rand 0.8.5",
+ "rand_distr",
+ "rayon",
+]
+
+[[package]]
 name = "imara-diff"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3875,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4143,7 +4235,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi 0.3.9",
 ]
 
@@ -4154,6 +4246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -4209,6 +4311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,6 +4330,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328251e58ad8e415be6198888fc207502727dc77945806421ab34f35bf012e7d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -4287,6 +4405,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "names"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,13 +4482,25 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -4441,12 +4586,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -4483,6 +4651,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4777,6 +4956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5012,6 +5200,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi 0.3.9",
+ "winreg",
+]
+
+[[package]]
 name = "portplz"
 version = "0.1.0"
 dependencies = [
@@ -5206,7 +5415,7 @@ dependencies = [
  "rand_xoshiro",
  "rayon",
  "ref-cast",
- "wide",
+ "wide 0.8.3",
 ]
 
 [[package]]
@@ -5313,6 +5522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5458,6 +5677,12 @@ dependencies = [
  "rayon",
  "rgb",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -5824,6 +6049,15 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "safe_arch"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
@@ -5978,6 +6212,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1401f562d358cdfdbdf8946e51a7871ede1db68bd0fd99bedc79e400241550"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "sf"
 version = "0.1.0"
 dependencies = [
@@ -6017,6 +6262,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -6079,6 +6334,19 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide 0.7.33",
 ]
 
 [[package]]
@@ -6376,7 +6644,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -6585,6 +6853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6592,6 +6871,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -6750,6 +7030,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tubeboard"
@@ -6939,6 +7225,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -7207,12 +7503,22 @@ dependencies = [
 
 [[package]]
 name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch 0.7.4",
+]
+
+[[package]]
+name = "wide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 0.9.3",
 ]
 
 [[package]]
@@ -7753,6 +8059,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1359,11 +1359,52 @@ fn calculate_aspect_preserving_size(
     }
 }
 
+/// Downscale an image to fit the display pixel dimensions if it exceeds them.
+///
+/// Converts character cell display dimensions to pixel dimensions using either the
+/// actual terminal pixel size (via ioctl) or estimated cell dimensions, then resizes
+/// the image if it's larger than the target. This prevents sending hundreds of megabytes
+/// of pixel data to the terminal for very large images (e.g., panoramas).
+///
+/// Returns the original image unchanged if it already fits within the target dimensions.
+fn downscale_to_display_pixels(
+    img: &DynamicImage,
+    display_width: Option<u32>,
+    display_height: Option<u32>,
+) -> DynamicImage {
+    let (target_pixel_w, target_pixel_h) = match (display_width, display_height) {
+        (Some(cols), Some(rows)) => {
+            // Try to get actual pixel dimensions per cell from the terminal
+            let (cell_w, cell_h) = if let Some((total_px_w, total_px_h)) = get_terminal_pixel_size()
+            {
+                let (term_cols, term_rows) =
+                    get_terminal_size().unwrap_or((80, 24));
+                if term_cols > 0 && term_rows > 0 {
+                    (total_px_w / term_cols, total_px_h / term_rows)
+                } else {
+                    (ESTIMATED_CELL_WIDTH_PX, ESTIMATED_CELL_HEIGHT_PX)
+                }
+            } else {
+                (ESTIMATED_CELL_WIDTH_PX, ESTIMATED_CELL_HEIGHT_PX)
+            };
+            (cols * cell_w, rows * cell_h)
+        }
+        _ => return img.clone(),
+    };
+
+    if img.width() <= target_pixel_w && img.height() <= target_pixel_h {
+        return img.clone();
+    }
+
+    img.resize(
+        target_pixel_w,
+        target_pixel_h,
+        image::imageops::FilterType::Lanczos3,
+    )
+}
+
 /// Kitty terminal display with better performance for video
 fn display_image_kitty(img: &DynamicImage, width: Option<u32>, height: Option<u32>, args: &Args) -> Result<()> {
-    // Use RGB data directly for better performance (no base64 encoding overhead)
-    let rgb_data = img.to_rgb8();
-
     // Calculate display dimensions that preserve aspect ratio
     // Terminal cells are typically ~2:1 (height:width in pixels), so we account for that
     let (display_width, display_height) = calculate_aspect_preserving_size(
@@ -1373,6 +1414,14 @@ fn display_image_kitty(img: &DynamicImage, width: Option<u32>, height: Option<u3
         height,
         args.preserve_aspect,
     );
+
+    // Downscale the image to the target pixel size before sending to avoid
+    // overwhelming the terminal with huge payloads (e.g., a 16384x8192 panorama
+    // would produce ~384MB of RGB data before base64 encoding).
+    let img = downscale_to_display_pixels(img, display_width, display_height);
+
+    // Use RGB data directly for better performance (no base64 encoding overhead)
+    let rgb_data = img.to_rgb8();
 
     // Use Kitty's more efficient graphics protocol with optimizations
     print_kitty_image(
@@ -1539,6 +1588,19 @@ fn display_image_sixel(
 
 /// Optimized iTerm2 display with reduced overhead
 fn display_image_iterm2(img: &DynamicImage, width: Option<u32>, height: Option<u32>, args: &Args) -> Result<()> {
+    // Calculate display dimensions for aspect ratio
+    let (display_width, display_height) = calculate_aspect_preserving_size(
+        img.width(),
+        img.height(),
+        width,
+        height,
+        args.preserve_aspect,
+    );
+
+    // Downscale the image to the target pixel size before encoding to avoid
+    // overwhelming the terminal with huge payloads
+    let img = downscale_to_display_pixels(img, display_width, display_height);
+
     // Use more efficient encoding for iTerm2
     // Convert to RGB first for consistency and smaller data size than RGBA
     let rgb_img = img.to_rgb8();
@@ -1553,7 +1615,7 @@ fn display_image_iterm2(img: &DynamicImage, width: Option<u32>, height: Option<u
     // Use base64 encoding
     let encoded = BASE64_STANDARD.encode(&pnm_data);
 
-    print_iterm2_image(&encoded, width, height, args.no_newline)
+    print_iterm2_image(&encoded, display_width, display_height, args.no_newline)
 }
 
 /// Optimized Kitty image printing with reduced protocol overhead

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -76,7 +76,7 @@ enum VideoControl {
 /// - iTerm2: Uses iTerm2 inline image protocol
 /// - Kitty: Uses Kitty graphics protocol (better performance for video)
 /// - Ghostty: Uses Kitty graphics protocol (better performance for video)
-/// - WezTerm: Uses iTerm2 inline image protocol
+/// - WezTerm: Uses Kitty graphics protocol
 /// - Zellij: Uses Sixel protocol (works in Zellij running inside WezTerm or other Sixel-capable terminals)
 /// - Alacritty: NOT SUPPORTED (text-only terminal, no graphics protocols)
 /// - Other terminals: Limited or no image support
@@ -413,7 +413,7 @@ fn validate_terminal_for_graphics(terminal_caps: &TerminalCapabilities, feature:
                 For {} display, please use one of these terminals:\n\
                 • iTerm2 (macOS) - supports inline images\n\
                 • Kitty - supports graphics protocol\n\
-                • WezTerm - supports iTerm2 image protocol\n\
+                • WezTerm - supports Kitty graphics protocol\n\
                 \n\
                 Alternatively, you can:\n\
                 • Extract frames using ffmpeg and view them in an image viewer\n\
@@ -427,7 +427,7 @@ fn validate_terminal_for_graphics(terminal_caps: &TerminalCapabilities, feature:
                 For {} display, please use one of these terminals:\n\
                 • iTerm2 (macOS) - supports inline images\n\
                 • Kitty - supports graphics protocol\n\
-                • WezTerm - supports iTerm2 image protocol\n\
+                • WezTerm - supports Kitty graphics protocol\n\
                 \n\
                 Current terminal: {}\n\
                 \n\
@@ -1291,7 +1291,7 @@ fn display_image(img: DynamicImage, args: &Args) -> Result<()> {
         TerminalType::Zellij => {
             display_image_sixel(&img, scaled_width, scaled_height, args)
         }
-        TerminalType::Kitty | TerminalType::Ghostty => {
+        TerminalType::Kitty | TerminalType::Ghostty | TerminalType::WezTerm => {
             display_image_kitty(&img, scaled_width, scaled_height, args)
         }
         _ => display_image_iterm2(&img, scaled_width, scaled_height, args),

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use icy_sixel::{sixel_encode, EncodeOptions};
 use image::DynamicImage;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fs;
 use std::io::{self, BufReader, Read, Write};
@@ -1285,7 +1286,7 @@ fn display_image(img: DynamicImage, args: &Args) -> Result<()> {
     };
 
     // Choose optimal display method based on terminal capabilities
-    // Check Sixel first (for Zellij), then Kitty/Ghostty, then iTerm2
+    // Check Sixel first (for Zellij), then Kitty/Ghostty/WezTerm, then iTerm2
     // Use already-detected terminal_caps to avoid redundant env var lookups
     match terminal_caps.terminal_type {
         TerminalType::Zellij => {
@@ -1359,6 +1360,29 @@ fn calculate_aspect_preserving_size(
     }
 }
 
+/// Calculate the pixel dimensions of a single terminal character cell.
+///
+/// Tries to determine actual cell dimensions via ioctl (TIOCGWINSZ). Falls back to
+/// estimated constants if the ioctl fails or the terminal reports zero dimensions.
+fn get_cell_pixel_dimensions() -> (u32, u32) {
+    if let Some((total_px_w, total_px_h)) = get_terminal_pixel_size() {
+        let (term_cols, term_rows) = get_terminal_size().unwrap_or((80, 24));
+        if term_cols > 0 && term_rows > 0 {
+            return (total_px_w / term_cols, total_px_h / term_rows);
+        }
+    }
+    (ESTIMATED_CELL_WIDTH_PX, ESTIMATED_CELL_HEIGHT_PX)
+}
+
+/// Convert character cell display dimensions to target pixel dimensions.
+///
+/// Returns `None` if either dimension is missing (meaning no downscale target can
+/// be computed). Uses actual terminal cell pixel dimensions when available, falling
+/// back to estimated constants.
+fn cells_to_pixels(cols: u32, rows: u32, cell_w: u32, cell_h: u32) -> (u32, u32) {
+    (cols * cell_w, rows * cell_h)
+}
+
 /// Downscale an image to fit the display pixel dimensions if it exceeds them.
 ///
 /// Converts character cell display dimensions to pixel dimensions using either the
@@ -1366,47 +1390,41 @@ fn calculate_aspect_preserving_size(
 /// the image if it's larger than the target. This prevents sending hundreds of megabytes
 /// of pixel data to the terminal for very large images (e.g., panoramas).
 ///
-/// Returns the original image unchanged if it already fits within the target dimensions.
-fn downscale_to_display_pixels(
-    img: &DynamicImage,
+/// Returns a borrowed reference to the original image when no downscaling is needed
+/// (dimensions unspecified or image already fits), avoiding an unnecessary clone.
+/// Returns an owned downscaled image when the original exceeds the target pixel dimensions.
+fn downscale_to_display_pixels<'a>(
+    img: &'a DynamicImage,
     display_width: Option<u32>,
     display_height: Option<u32>,
-) -> DynamicImage {
+) -> Cow<'a, DynamicImage> {
     let (target_pixel_w, target_pixel_h) = match (display_width, display_height) {
         (Some(cols), Some(rows)) => {
-            // Try to get actual pixel dimensions per cell from the terminal
-            let (cell_w, cell_h) = if let Some((total_px_w, total_px_h)) = get_terminal_pixel_size()
-            {
-                let (term_cols, term_rows) =
-                    get_terminal_size().unwrap_or((80, 24));
-                if term_cols > 0 && term_rows > 0 {
-                    (total_px_w / term_cols, total_px_h / term_rows)
-                } else {
-                    (ESTIMATED_CELL_WIDTH_PX, ESTIMATED_CELL_HEIGHT_PX)
-                }
-            } else {
-                (ESTIMATED_CELL_WIDTH_PX, ESTIMATED_CELL_HEIGHT_PX)
-            };
-            (cols * cell_w, rows * cell_h)
+            let (cell_w, cell_h) = get_cell_pixel_dimensions();
+            cells_to_pixels(cols, rows, cell_w, cell_h)
         }
-        _ => return img.clone(),
+        _ => return Cow::Borrowed(img),
     };
 
     if img.width() <= target_pixel_w && img.height() <= target_pixel_h {
-        return img.clone();
+        return Cow::Borrowed(img);
     }
 
-    img.resize(
+    Cow::Owned(img.resize(
         target_pixel_w,
         target_pixel_h,
         image::imageops::FilterType::Lanczos3,
-    )
+    ))
 }
 
-/// Kitty terminal display with better performance for video
+/// Kitty terminal display with better performance for video.
+///
+/// Also used for WezTerm and Ghostty, which support the Kitty graphics protocol.
 fn display_image_kitty(img: &DynamicImage, width: Option<u32>, height: Option<u32>, args: &Args) -> Result<()> {
-    // Calculate display dimensions that preserve aspect ratio
-    // Terminal cells are typically ~2:1 (height:width in pixels), so we account for that
+    // display_width/display_height are in terminal cells (character columns/rows).
+    // They serve two roles: (1) the Kitty protocol `c=`/`r=` display hints that tell
+    // the terminal how many cells the image should span, and (2) the downscale target
+    // converted to pixels via cell dimensions to cap the raw data we send.
     let (display_width, display_height) = calculate_aspect_preserving_size(
         img.width(),
         img.height(),
@@ -1586,9 +1604,14 @@ fn display_image_sixel(
     Ok(())
 }
 
-/// Optimized iTerm2 display with reduced overhead
+/// Optimized iTerm2 display with reduced overhead.
+///
+/// Computes aspect-preserving display dimensions and downscales the image to the
+/// target pixel size before encoding. This matches the Kitty path's behavior and
+/// prevents sending oversized payloads for very large images.
 fn display_image_iterm2(img: &DynamicImage, width: Option<u32>, height: Option<u32>, args: &Args) -> Result<()> {
-    // Calculate display dimensions for aspect ratio
+    // Calculate aspect-corrected display dimensions in terminal cells, then use them
+    // both as the iTerm2 width/height hints and the downscale target.
     let (display_width, display_height) = calculate_aspect_preserving_size(
         img.width(),
         img.height(),
@@ -1973,5 +1996,107 @@ mod tests {
         assert!(SIXEL_HORIZONTAL_MARGIN <= 1.0);
         assert!(SIXEL_VERTICAL_MARGIN > 0.5);
         assert!(SIXEL_VERTICAL_MARGIN <= 1.0);
+    }
+
+    // =========================================================================
+    // Tests for cells_to_pixels
+    // =========================================================================
+
+    #[test]
+    fn cells_to_pixels_basic() {
+        assert_eq!(cells_to_pixels(80, 24, 10, 20), (800, 480));
+    }
+
+    #[test]
+    fn cells_to_pixels_single_cell() {
+        assert_eq!(cells_to_pixels(1, 1, 10, 20), (10, 20));
+    }
+
+    #[test]
+    fn cells_to_pixels_custom_cell_dimensions() {
+        assert_eq!(cells_to_pixels(40, 12, 16, 32), (640, 384));
+    }
+
+    // =========================================================================
+    // Tests for downscale_to_display_pixels
+    // =========================================================================
+
+    /// Helper to create a test image of the given dimensions.
+    fn make_test_image(width: u32, height: u32) -> DynamicImage {
+        DynamicImage::ImageRgb8(image::RgbImage::new(width, height))
+    }
+
+    #[test]
+    fn downscale_returns_borrowed_when_no_dimensions() {
+        let img = make_test_image(100, 100);
+        let result = downscale_to_display_pixels(&img, None, None);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn downscale_returns_borrowed_when_only_width() {
+        let img = make_test_image(100, 100);
+        let result = downscale_to_display_pixels(&img, Some(50), None);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn downscale_returns_borrowed_when_only_height() {
+        let img = make_test_image(100, 100);
+        let result = downscale_to_display_pixels(&img, None, Some(50));
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn downscale_returns_borrowed_when_image_fits() {
+        // With estimated cell dimensions (10x20), 80 cols x 24 rows = 800x480 pixels.
+        // A 100x100 image fits within that, so no downscale needed.
+        // Note: in CI/test environments, get_terminal_pixel_size() returns None,
+        // so estimated constants are used.
+        let img = make_test_image(100, 100);
+        let result = downscale_to_display_pixels(&img, Some(80), Some(24));
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.width(), 100);
+        assert_eq!(result.height(), 100);
+    }
+
+    #[test]
+    fn downscale_shrinks_oversized_image() {
+        // With estimated cell dimensions (10x20), 10 cols x 5 rows = 100x100 pixels.
+        // A 500x500 image exceeds that, so it should be downscaled.
+        let img = make_test_image(500, 500);
+        let result = downscale_to_display_pixels(&img, Some(10), Some(5));
+        assert!(matches!(result, Cow::Owned(_)));
+        assert!(result.width() <= 100);
+        assert!(result.height() <= 100);
+    }
+
+    #[test]
+    fn downscale_preserves_aspect_ratio() {
+        // Wide image: 1000x200 pixels
+        // Target: 10 cols x 5 rows = 100x100 pixels (with estimated cell dims)
+        // Should downscale to fit within 100x100 while preserving 5:1 aspect ratio
+        let img = make_test_image(1000, 200);
+        let result = downscale_to_display_pixels(&img, Some(10), Some(5));
+        assert!(matches!(result, Cow::Owned(_)));
+        assert!(result.width() <= 100);
+        assert!(result.height() <= 100);
+        // Aspect ratio should be roughly maintained (5:1)
+        let aspect = result.width() as f64 / result.height() as f64;
+        assert!(
+            (aspect - 5.0).abs() < 0.5,
+            "aspect ratio {aspect} should be close to 5.0"
+        );
+    }
+
+    #[test]
+    fn downscale_handles_panoramic_image() {
+        // Very large panorama: 16384x4096 pixels
+        // Target: 80 cols x 24 rows = 800x480 pixels
+        let img = make_test_image(16384, 4096);
+        let result = downscale_to_display_pixels(&img, Some(80), Some(24));
+        assert!(matches!(result, Cow::Owned(_)));
+        assert!(result.width() <= 800);
+        assert!(result.height() <= 480);
     }
 }


### PR DESCRIPTION
## Summary

- **Switch WezTerm to Kitty graphics protocol** instead of iTerm2 inline images, fixing an issue where only one row of image data was displayed
- **Downscale large images to terminal pixel dimensions** before encoding, preventing terminals from silently dropping huge payloads (e.g., a 16384x8192 panorama that produces ~384MB of raw RGB data)
- Both Kitty and iTerm2 display paths now downscale before sending

## Test plan

- [ ] Display a large panorama image (e.g., 16384x8192) in WezTerm — should render fully instead of showing one row or nothing
- [ ] Display a normal-sized image in WezTerm — should render correctly
- [ ] Display images in Kitty/Ghostty — should still work (no regression)
- [ ] Display small GIF files — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)