### PR TITLE
fix(inscribe): improve error message when run outside a git repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,16 +1071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1449,27 +1439,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -8237,16 +8206,6 @@ dependencies = [
  "buildinfo",
  "clap",
  "get_if_addrs",
-]
-
-[[package]]
-name = "workit"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "toml_edit 0.22.27",
- "walkdir",
 ]
 
 [[package]]

--- a/src/inscribe/src/main.rs
+++ b/src/inscribe/src/main.rs
@@ -48,7 +48,7 @@ fn find_git_repository(start_path: Option<&str>) -> Result<Repository> {
     };
 
     Repository::discover(&start)
-        .with_context(|| format!("No git repository found starting from {:?}", start))
+        .with_context(|| format!("Not a git repository (or any parent up to root). inscribe must be run inside a git repository."))
 }
 
 fn check_claude_cli() -> Result<()> {


### PR DESCRIPTION
## Summary
- Replace the raw libgit2 error with a clear, user-friendly message when inscribe is run outside a git repository
- New message: "Not a git repository (or any parent up to root). inscribe must be run inside a git repository."

## Test plan
- [ ] Run `inscribe` outside a git repository and verify the friendly error message appears
- [ ] Run `inscribe` inside a git repository and verify normal operation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)