### PR TITLE
feat(portplz): hash repo root + branch to avoid port collisions

### DIFF
--- a/docs/superpowers/specs/2026-04-13-portplz-repo-root-hashing-design.md
+++ b/docs/superpowers/specs/2026-04-13-portplz-repo-root-hashing-design.md
@@ -1,0 +1,72 @@
+# portplz: Hash repo root + branch name to avoid port collisions
+
+**Issue:** #197
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Problem
+
+When multiple projects share the same branch name (typically `main`), `portplz` generates identical ports because it hashes only the branch name. This causes port collisions across unrelated projects.
+
+Current behavior:
+- `/code/project-a` on `main` -> hashes `"main"` -> port X
+- `/code/project-b` on `main` -> hashes `"main"` -> port X (collision)
+
+Worktree behavior is already correct -- worktrees of the same repo on the same branch produce the same port because they share the branch name.
+
+## Solution
+
+Always include the git repo root basename in the hash input: `repo-root-basename@branch`.
+
+### Hash input examples
+
+| Path | Branch | Hash input | Notes |
+|------|--------|------------|-------|
+| `/code/project-a` | `main` | `project-a@main` | Main repo |
+| `/code/project-b` | `main` | `project-b@main` | Different port |
+| `/code/project-a-worktrees/issue-42` | `main` | `project-a@main` | Same as main repo |
+| `/code/project-a` | `feature-x` | `project-a@feature-x` | Different branch |
+
+### Repo root discovery
+
+New function `get_repo_root_name(repo) -> Option<String>`:
+1. `repo.common_dir()` returns the shared `.git` path (consistent across worktrees)
+2. `.parent()` gives the repo root directory
+3. `.file_name()` extracts the basename
+4. Returns `None` on failure (triggers CWD basename fallback)
+
+### CLI changes
+
+- **Remove** the `--with-dir` flag entirely. It is now redundant since the repo root is always included.
+- Remove the `conflicts_with = "no_git"` constraint that was on `--with-dir`.
+- No new flags.
+
+### Hash input logic by scenario
+
+| Scenario | Hash input |
+|----------|------------|
+| Git repo found, branch available | `repo-root-basename@branch` |
+| Git repo found, detached HEAD (no branch) | repo-root-basename (no branch suffix) |
+| `--no-git` flag | CWD basename |
+| No git repo found | CWD basename |
+
+### Verbose output
+
+Update format to: `Port {port} for repo '{repo_root}' on branch '{branch}'`
+
+Fallback format (no git): `Port {port} for directory '{dirname}' (no git repo)`
+
+### Breaking changes
+
+- All git-aware port assignments change because the hash input changes from `branch` to `root@branch`.
+- `--with-dir` flag is removed. Scripts using it will error.
+- Acceptable for a personal tools repo with no external consumers.
+
+## Test plan
+
+1. Same branch + same repo root -> same port
+2. Same branch + different repo root -> different port
+3. Worktrees of the same repo on the same branch -> same port (via common_dir)
+4. Fallback to CWD basename when git repo unavailable
+5. `--no-git` uses CWD basename
+6. Detached HEAD falls back to CWD basename

--- a/plans/portplz-repo-root-hashing.md
+++ b/plans/portplz-repo-root-hashing.md
@@ -24,10 +24,10 @@ Add a `get_repo_root_name` function that extracts the repo root basename from `g
 
 ### Acceptance criteria
 
-- [ ] Same branch + same repo root -> same port
-- [ ] Same branch + different repo root -> different port
-- [ ] `get_repo_root_name` returns consistent name across worktrees (uses common_dir)
-- [ ] Fallback to CWD basename when repo root discovery fails
+- [x] Same branch + same repo root -> same port
+- [x] Same branch + different repo root -> different port
+- [x] `get_repo_root_name` returns consistent name across worktrees (uses common_dir)
+- [x] Fallback to CWD basename when repo root discovery fails
 
 ---
 
@@ -41,10 +41,10 @@ Remove the `--with-dir` CLI flag, its `conflicts_with` constraint, and all condi
 
 ### Acceptance criteria
 
-- [ ] `--with-dir` flag no longer exists in CLI struct
-- [ ] No conditional branching on `with_dir` in main logic
-- [ ] Verbose output shows repo name and branch
-- [ ] Old `--with-dir` tests removed, new verbose format tests added
+- [x] `--with-dir` flag no longer exists in CLI struct
+- [x] No conditional branching on `with_dir` in main logic
+- [x] Verbose output shows repo name and branch
+- [x] Old `--with-dir` tests removed, new verbose format tests added
 
 ---
 
@@ -58,7 +58,7 @@ Handle detached HEAD by using repo root basename without a branch suffix. Verify
 
 ### Acceptance criteria
 
-- [ ] Detached HEAD uses repo-root-basename (no branch suffix) as hash input
-- [ ] `--no-git` flag uses CWD basename
-- [ ] Non-git directory uses CWD basename
-- [ ] All edge cases have tests
+- [x] Detached HEAD uses repo-root-basename (no branch suffix) as hash input
+- [x] `--no-git` flag uses CWD basename
+- [x] Non-git directory uses CWD basename
+- [x] All edge cases have tests

--- a/plans/portplz-repo-root-hashing.md
+++ b/plans/portplz-repo-root-hashing.md
@@ -1,0 +1,64 @@
+# Plan: portplz repo-root hashing
+
+> Source PRD: docs/superpowers/specs/2026-04-13-portplz-repo-root-hashing-design.md (Issue #197)
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Hash input format**: `repo-root-basename@branch` (separator: `@`)
+- **Repo root discovery**: `gix` `common_dir()` -> `parent()` -> `file_name()`
+- **CLI surface**: remove `--with-dir`; keep `--no-git`, `--verbose`, positional `path`
+- **Port generation**: unchanged (SHA-256 -> unprivileged port range 1024-65534)
+- **Fallback**: CWD basename when git unavailable or `--no-git`
+
+---
+
+## Phase 1: Repo root hashing
+
+**User stories**: As a developer running multiple projects on `main`, I get unique ports per project without any flags.
+
+### What to build
+
+Add a `get_repo_root_name` function that extracts the repo root basename from `gix`'s `common_dir()`. Change the default hash input from `branch` to `repo-root-basename@branch`. When the repo root can't be determined but a branch is available, fall back to CWD basename as the repo identifier.
+
+### Acceptance criteria
+
+- [ ] Same branch + same repo root -> same port
+- [ ] Same branch + different repo root -> different port
+- [ ] `get_repo_root_name` returns consistent name across worktrees (uses common_dir)
+- [ ] Fallback to CWD basename when repo root discovery fails
+
+---
+
+## Phase 2: Remove --with-dir flag
+
+**User stories**: As a user, the CLI is simpler because repo identity is always included automatically.
+
+### What to build
+
+Remove the `--with-dir` CLI flag, its `conflicts_with` constraint, and all conditional logic that checked it. Update verbose output to show the repo root name: `Port {port} for repo '{root}' on branch '{branch}'`. Replace old `--with-dir` tests with tests for the new verbose format.
+
+### Acceptance criteria
+
+- [ ] `--with-dir` flag no longer exists in CLI struct
+- [ ] No conditional branching on `with_dir` in main logic
+- [ ] Verbose output shows repo name and branch
+- [ ] Old `--with-dir` tests removed, new verbose format tests added
+
+---
+
+## Phase 3: Edge case handling
+
+**User stories**: As a developer in unusual git states, I still get a reasonable port without errors.
+
+### What to build
+
+Handle detached HEAD by using repo root basename without a branch suffix. Verify that `--no-git` and non-git directories use CWD basename. Add tests for each edge case.
+
+### Acceptance criteria
+
+- [ ] Detached HEAD uses repo-root-basename (no branch suffix) as hash input
+- [ ] `--no-git` flag uses CWD basename
+- [ ] Non-git directory uses CWD basename
+- [ ] All edge cases have tests

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -15,12 +15,52 @@ struct Cli {
     #[arg(
         short,
         long,
-        help = "Print verbose output with directory name and branch"
+        help = "Print verbose output with repo/directory name and branch"
     )]
     verbose: bool,
 
     #[arg(long, help = "Disable git branch detection")]
     no_git: bool,
+}
+
+/// Describes how the port hash input was determined.
+///
+/// Each variant produces a different hash input format and verbose description.
+enum PortSource {
+    /// Git repo with a branch: hash input is `"repo_name\nbranch"`.
+    /// Uses `\n` as separator because git branch names cannot contain newlines
+    /// (per git-check-ref-format), making the hash input unambiguous even when
+    /// repo names or branch names contain `@` or other special characters.
+    GitRepo { repo_name: String, branch: String },
+    /// Git repo with detached HEAD: hash input is just `repo_name`.
+    DetachedHead { repo_name: String },
+    /// No git repo (--no-git or not a repo): hash input is `dirname`.
+    Directory { dirname: String },
+}
+
+impl PortSource {
+    fn hash_input(&self) -> String {
+        match self {
+            Self::GitRepo { repo_name, branch } => format!("{repo_name}\n{branch}"),
+            Self::DetachedHead { repo_name } => repo_name.clone(),
+            Self::Directory { dirname } => dirname.clone(),
+        }
+    }
+
+    fn verbose_description(&self, port: u16) -> String {
+        let desc = match self {
+            Self::GitRepo { repo_name, branch } => {
+                format!("repo '{repo_name}' on branch '{branch}'")
+            }
+            Self::DetachedHead { repo_name } => {
+                format!("repo '{repo_name}' (detached HEAD)")
+            }
+            Self::Directory { dirname } => {
+                format!("directory '{dirname}' (no git repo)")
+            }
+        };
+        format!("Port {port} for {desc}")
+    }
 }
 
 /// Returns the repo root directory basename, consistent across worktrees.
@@ -75,38 +115,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("Invalid path: no basename")?
         .to_string_lossy();
 
-    let (input_string, verbose_desc) = if cli.no_git {
-        (
-            basename.to_string(),
-            format!("directory '{basename}' (no git repo)"),
-        )
+    let source = if cli.no_git {
+        PortSource::Directory {
+            dirname: basename.to_string(),
+        }
     } else {
         match gix::discover(path) {
             Ok(repo) => {
-                let repo_name = get_repo_root_name(&repo)
-                    .unwrap_or_else(|| basename.to_string());
+                let repo_name =
+                    get_repo_root_name(&repo).unwrap_or_else(|| basename.to_string());
                 match get_git_branch(&repo) {
-                    Some(branch) => (
-                        format!("{repo_name}@{branch}"),
-                        format!("repo '{repo_name}' on branch '{branch}'"),
-                    ),
-                    None => (
-                        repo_name.clone(),
-                        format!("repo '{repo_name}' (detached HEAD)"),
-                    ),
+                    Some(branch) => PortSource::GitRepo { repo_name, branch },
+                    None => PortSource::DetachedHead { repo_name },
                 }
             }
-            Err(_) => (
-                basename.to_string(),
-                format!("directory '{basename}' (no git repo)"),
-            ),
+            Err(_) => PortSource::Directory {
+                dirname: basename.to_string(),
+            },
         }
     };
 
-    let port = unprivileged_port_from_string(&input_string);
+    let port = unprivileged_port_from_string(&source.hash_input());
 
     if cli.verbose {
-        println!("Port {port} for {verbose_desc}");
+        println!("{}", source.verbose_description(port));
     } else {
         println!("{port}");
     }

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -172,101 +172,53 @@ mod tests {
     }
 
     #[test]
-    fn test_same_repo_same_branch_same_port() {
-        // Same repo root + same branch -> same port
-        let port1 = unprivileged_port_from_string("project-a@main");
-        let port2 = unprivileged_port_from_string("project-a@main");
-        assert_eq!(port1, port2);
-    }
-
-    #[test]
     fn test_different_repos_same_branch_different_ports() {
-        // Different repo roots + same branch -> different ports
-        let port_a = unprivileged_port_from_string("project-a@main");
-        let port_b = unprivileged_port_from_string("project-b@main");
-        assert_ne!(port_a, port_b);
+        // Core requirement of #197: different repo roots + same branch -> different ports
+        let source_a = PortSource::GitRepo {
+            repo_name: "project-a".into(),
+            branch: "main".into(),
+        };
+        let source_b = PortSource::GitRepo {
+            repo_name: "project-b".into(),
+            branch: "main".into(),
+        };
+        assert_ne!(
+            unprivileged_port_from_string(&source_a.hash_input()),
+            unprivileged_port_from_string(&source_b.hash_input()),
+        );
     }
 
     #[test]
-    fn test_same_repo_different_branches() {
-        let main_port = unprivileged_port_from_string("project-a@main");
-        let dev_port = unprivileged_port_from_string("project-a@dev");
-        assert_ne!(main_port, dev_port);
-    }
-
-    #[test]
-    fn test_get_repo_root_name_returns_basename() {
+    fn test_get_repo_root_name_returns_valid_basename() {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let repo = gix::discover(path).expect("Should find git repo");
         let name = get_repo_root_name(&repo);
         assert!(name.is_some(), "Should find repo root name for a valid repo");
         let name = name.unwrap();
         assert!(!name.is_empty(), "Repo root name should not be empty");
-        // This repo is "tools" (or a worktree of it), so the root name should be "tools"
-        assert_eq!(name, "tools");
+        assert!(!name.contains('/'), "Should be a basename, not a path");
+        assert!(!name.contains('\\'), "Should be a basename, not a path");
     }
 
     #[test]
-    fn test_verbose_format_with_git() {
-        // Verbose output should be: "Port {port} for repo '{root}' on branch '{branch}'"
-        let repo_name = "myproject";
-        let branch = "main";
-        let input = format!("{repo_name}@{branch}");
-        let port = unprivileged_port_from_string(&input);
-        let verbose = format!("Port {port} for repo '{repo_name}' on branch '{branch}'");
-        assert!(verbose.starts_with("Port "));
-        assert!(verbose.contains("repo 'myproject'"));
-        assert!(verbose.contains("on branch 'main'"));
-    }
+    fn test_worktree_and_main_repo_share_root_name() {
+        // Discover repo from the current path (may be a worktree)
+        let worktree_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let worktree_repo = gix::discover(worktree_path).expect("Should find repo");
+        let worktree_name =
+            get_repo_root_name(&worktree_repo).expect("Should get repo root name");
 
-    #[test]
-    fn test_verbose_format_no_git() {
-        // Without git: "Port {port} for directory '{dirname}' (no git repo)"
-        let dirname = "some-dir";
-        let port = unprivileged_port_from_string(dirname);
-        let verbose = format!("Port {port} for directory '{dirname}' (no git repo)");
-        assert!(verbose.contains("directory 'some-dir'"));
-        assert!(verbose.contains("(no git repo)"));
-    }
+        // Discover repo from the main repo root (parent of common_dir)
+        let common = std::fs::canonicalize(worktree_repo.common_dir()).unwrap();
+        let main_repo_root = common.parent().unwrap();
+        let main_repo = gix::discover(main_repo_root).expect("Should find main repo");
+        let main_name =
+            get_repo_root_name(&main_repo).expect("Should get main repo root name");
 
-    #[test]
-    fn test_worktrees_share_repo_root_name() {
-        // common_dir() is the same for main repo and worktrees,
-        // so get_repo_root_name should return the same value.
-        // We test this indirectly: the hash input format repo@branch
-        // ensures worktrees of the same repo get the same port.
-        let port1 = unprivileged_port_from_string("tools@feature-x");
-        let port2 = unprivileged_port_from_string("tools@feature-x");
-        assert_eq!(port1, port2);
-    }
-
-    #[test]
-    fn test_detached_head_uses_repo_name_only() {
-        // Detached HEAD: hash input is just repo-root-basename (no @branch)
-        let detached = unprivileged_port_from_string("myproject");
-        let on_branch = unprivileged_port_from_string("myproject@main");
-        // They should differ because the input strings differ
-        assert_ne!(detached, on_branch);
-    }
-
-    #[test]
-    fn test_detached_head_verbose_format() {
-        let repo_name = "myproject";
-        let port = unprivileged_port_from_string(repo_name);
-        let verbose = format!("Port {port} for repo '{repo_name}' (detached HEAD)");
-        assert!(verbose.contains("repo 'myproject'"));
-        assert!(verbose.contains("(detached HEAD)"));
-    }
-
-    #[test]
-    fn test_no_git_uses_cwd_basename() {
-        // --no-git: hash input is just the directory basename
-        let port = unprivileged_port_from_string("my-directory");
-        let port2 = unprivileged_port_from_string("my-directory");
-        assert_eq!(port, port2);
-        // Different directory names produce different ports
-        let other = unprivileged_port_from_string("other-directory");
-        assert_ne!(port, other);
+        assert_eq!(
+            worktree_name, main_name,
+            "get_repo_root_name should return the same name from both worktree and main repo"
+        );
     }
 
     // --- PortSource tests ---

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 #[derive(Parser)]
 #[command(name = "portplz")]
 #[command(version = version_string!())]
-#[command(about = "Generate a port number from the current git branch name", long_about = None)]
+#[command(about = "Generate a port number from the git repo root and branch name", long_about = None)]
 struct Cli {
     #[arg(help = "Directory path (defaults to current directory)")]
     path: Option<String>,
@@ -21,21 +21,26 @@ struct Cli {
 
     #[arg(long, help = "Disable git branch detection")]
     no_git: bool,
-
-    #[arg(
-        long,
-        help = "Include directory name in the hash (dirname@branch)",
-        conflicts_with = "no_git"
-    )]
-    with_dir: bool,
 }
 
-fn get_git_branch(path: &Path) -> Option<String> {
-    match gix::discover(path) {
-        Ok(repo) => match repo.head() {
-            Ok(head) => head.referent_name().map(|n| n.shorten().to_string()),
-            Err(_) => None,
-        },
+/// Returns the repo root directory basename, consistent across worktrees.
+///
+/// Uses `common_dir()` which points to the shared `.git` directory,
+/// then takes the parent (repo root) and extracts its basename.
+/// For worktrees, `common_dir()` always points back to the main repo's
+/// `.git` directory, so this returns the same name regardless of which
+/// worktree you're in.
+fn get_repo_root_name(repo: &gix::Repository) -> Option<String> {
+    let common = std::fs::canonicalize(repo.common_dir()).ok()?;
+    common
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|name| name.to_string_lossy().to_string())
+}
+
+fn get_git_branch(repo: &gix::Repository) -> Option<String> {
+    match repo.head() {
+        Ok(head) => head.referent_name().map(|n| n.shorten().to_string()),
         Err(_) => None,
     }
 }
@@ -71,21 +76,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .to_string_lossy();
 
     let (input_string, verbose_desc) = if cli.no_git {
-        (basename.to_string(), format!("directory '{basename}'"))
+        (
+            basename.to_string(),
+            format!("directory '{basename}' (no git repo)"),
+        )
     } else {
-        match get_git_branch(path) {
-            Some(branch) => {
-                if cli.with_dir {
-                    (
-                        format!("{basename}@{branch}"),
-                        format!("directory '{basename}' on branch '{branch}'"),
-                    )
-                } else {
-                    let desc = format!("branch '{branch}'");
-                    (branch, desc)
+        match gix::discover(path) {
+            Ok(repo) => {
+                let repo_name = get_repo_root_name(&repo)
+                    .unwrap_or_else(|| basename.to_string());
+                match get_git_branch(&repo) {
+                    Some(branch) => (
+                        format!("{repo_name}@{branch}"),
+                        format!("repo '{repo_name}' on branch '{branch}'"),
+                    ),
+                    None => (
+                        repo_name.clone(),
+                        format!("repo '{repo_name}' (detached HEAD)"),
+                    ),
                 }
             }
-            None => (
+            Err(_) => (
                 basename.to_string(),
                 format!("directory '{basename}' (no git repo)"),
             ),
@@ -129,33 +140,100 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_only_default() {
-        // Default: hash is just the branch name
-        let port1 = unprivileged_port_from_string("main");
-        let port2 = unprivileged_port_from_string("main");
+    fn test_same_repo_same_branch_same_port() {
+        // Same repo root + same branch -> same port
+        let port1 = unprivileged_port_from_string("project-a@main");
+        let port2 = unprivileged_port_from_string("project-a@main");
         assert_eq!(port1, port2);
     }
 
     #[test]
-    fn test_with_dir_format() {
-        // --with-dir uses dirname@branch
-        let branch_only = unprivileged_port_from_string("main");
-        let with_dir = unprivileged_port_from_string("myproject@main");
-        assert_ne!(branch_only, with_dir);
+    fn test_different_repos_same_branch_different_ports() {
+        // Different repo roots + same branch -> different ports
+        let port_a = unprivileged_port_from_string("project-a@main");
+        let port_b = unprivileged_port_from_string("project-b@main");
+        assert_ne!(port_a, port_b);
     }
 
     #[test]
-    fn test_same_branch_different_dirs() {
-        // Same branch but different directory names produce different ports with --with-dir
-        let dir_a = unprivileged_port_from_string("repo-a@main");
-        let dir_b = unprivileged_port_from_string("repo-b@main");
-        assert_ne!(dir_a, dir_b);
-    }
-
-    #[test]
-    fn test_different_branches() {
-        let main_port = unprivileged_port_from_string("main");
-        let dev_port = unprivileged_port_from_string("dev");
+    fn test_same_repo_different_branches() {
+        let main_port = unprivileged_port_from_string("project-a@main");
+        let dev_port = unprivileged_port_from_string("project-a@dev");
         assert_ne!(main_port, dev_port);
+    }
+
+    #[test]
+    fn test_get_repo_root_name_returns_basename() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo = gix::discover(path).expect("Should find git repo");
+        let name = get_repo_root_name(&repo);
+        assert!(name.is_some(), "Should find repo root name for a valid repo");
+        let name = name.unwrap();
+        assert!(!name.is_empty(), "Repo root name should not be empty");
+        // This repo is "tools" (or a worktree of it), so the root name should be "tools"
+        assert_eq!(name, "tools");
+    }
+
+    #[test]
+    fn test_verbose_format_with_git() {
+        // Verbose output should be: "Port {port} for repo '{root}' on branch '{branch}'"
+        let repo_name = "myproject";
+        let branch = "main";
+        let input = format!("{repo_name}@{branch}");
+        let port = unprivileged_port_from_string(&input);
+        let verbose = format!("Port {port} for repo '{repo_name}' on branch '{branch}'");
+        assert!(verbose.starts_with("Port "));
+        assert!(verbose.contains("repo 'myproject'"));
+        assert!(verbose.contains("on branch 'main'"));
+    }
+
+    #[test]
+    fn test_verbose_format_no_git() {
+        // Without git: "Port {port} for directory '{dirname}' (no git repo)"
+        let dirname = "some-dir";
+        let port = unprivileged_port_from_string(dirname);
+        let verbose = format!("Port {port} for directory '{dirname}' (no git repo)");
+        assert!(verbose.contains("directory 'some-dir'"));
+        assert!(verbose.contains("(no git repo)"));
+    }
+
+    #[test]
+    fn test_worktrees_share_repo_root_name() {
+        // common_dir() is the same for main repo and worktrees,
+        // so get_repo_root_name should return the same value.
+        // We test this indirectly: the hash input format repo@branch
+        // ensures worktrees of the same repo get the same port.
+        let port1 = unprivileged_port_from_string("tools@feature-x");
+        let port2 = unprivileged_port_from_string("tools@feature-x");
+        assert_eq!(port1, port2);
+    }
+
+    #[test]
+    fn test_detached_head_uses_repo_name_only() {
+        // Detached HEAD: hash input is just repo-root-basename (no @branch)
+        let detached = unprivileged_port_from_string("myproject");
+        let on_branch = unprivileged_port_from_string("myproject@main");
+        // They should differ because the input strings differ
+        assert_ne!(detached, on_branch);
+    }
+
+    #[test]
+    fn test_detached_head_verbose_format() {
+        let repo_name = "myproject";
+        let port = unprivileged_port_from_string(repo_name);
+        let verbose = format!("Port {port} for repo '{repo_name}' (detached HEAD)");
+        assert!(verbose.contains("repo 'myproject'"));
+        assert!(verbose.contains("(detached HEAD)"));
+    }
+
+    #[test]
+    fn test_no_git_uses_cwd_basename() {
+        // --no-git: hash input is just the directory basename
+        let port = unprivileged_port_from_string("my-directory");
+        let port2 = unprivileged_port_from_string("my-directory");
+        assert_eq!(port, port2);
+        // Different directory names produce different ports
+        let other = unprivileged_port_from_string("other-directory");
+        assert_ne!(port, other);
     }
 }

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -236,4 +236,89 @@ mod tests {
         let other = unprivileged_port_from_string("other-directory");
         assert_ne!(port, other);
     }
+
+    // --- PortSource tests ---
+
+    #[test]
+    fn test_port_source_git_repo_hash_input() {
+        let source = PortSource::GitRepo {
+            repo_name: "myproject".into(),
+            branch: "main".into(),
+        };
+        // Separator must be \n (can't appear in git branch names)
+        assert_eq!(source.hash_input(), "myproject\nmain");
+    }
+
+    #[test]
+    fn test_port_source_detached_head_hash_input() {
+        let source = PortSource::DetachedHead {
+            repo_name: "myproject".into(),
+        };
+        assert_eq!(source.hash_input(), "myproject");
+    }
+
+    #[test]
+    fn test_port_source_directory_hash_input() {
+        let source = PortSource::Directory {
+            dirname: "some-dir".into(),
+        };
+        assert_eq!(source.hash_input(), "some-dir");
+    }
+
+    #[test]
+    fn test_port_source_verbose_git_repo() {
+        let source = PortSource::GitRepo {
+            repo_name: "myproject".into(),
+            branch: "main".into(),
+        };
+        let port = unprivileged_port_from_string(&source.hash_input());
+        assert_eq!(
+            source.verbose_description(port),
+            format!("Port {port} for repo 'myproject' on branch 'main'")
+        );
+    }
+
+    #[test]
+    fn test_port_source_verbose_detached() {
+        let source = PortSource::DetachedHead {
+            repo_name: "myproject".into(),
+        };
+        let port = unprivileged_port_from_string(&source.hash_input());
+        assert_eq!(
+            source.verbose_description(port),
+            format!("Port {port} for repo 'myproject' (detached HEAD)")
+        );
+    }
+
+    #[test]
+    fn test_port_source_verbose_directory() {
+        let source = PortSource::Directory {
+            dirname: "some-dir".into(),
+        };
+        let port = unprivileged_port_from_string(&source.hash_input());
+        assert_eq!(
+            source.verbose_description(port),
+            format!("Port {port} for directory 'some-dir' (no git repo)")
+        );
+    }
+
+    #[test]
+    fn test_separator_prevents_cross_component_collision() {
+        // Repo "a@b" on branch "c" must produce a different hash input
+        // than repo "a" on branch "b@c". With @ as separator both would
+        // be "a@b@c" — a collision. The \n separator prevents this.
+        let source_1 = PortSource::GitRepo {
+            repo_name: "a@b".into(),
+            branch: "c".into(),
+        };
+        let source_2 = PortSource::GitRepo {
+            repo_name: "a".into(),
+            branch: "b@c".into(),
+        };
+        assert_ne!(
+            source_1.hash_input(),
+            source_2.hash_input(),
+            "Different repo/branch combinations must produce different hash inputs"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Hash repo root + branch name** to generate unique ports per project, fixing port collisions when multiple repos share the same branch name (e.g. `main`). Closes #197.
- **Extract `PortSource` enum** with `hash_input()` and `verbose_description()` methods, making format logic testable without running the full CLI.
- **Use `\n` as separator** instead of `@` to prevent cross-component hash collisions (git branch names cannot contain newlines per `git-check-ref-format`).
- **Remove `--with-dir` flag** — repo root is now always included automatically.

## Test plan

- [x] Same branch + same repo root → same port
- [x] Same branch + different repo root → different port (core #197 fix)
- [x] Worktrees of same repo → same root name (real integration test via `common_dir`)
- [x] Detached HEAD → repo name only (no branch suffix)
- [x] `--no-git` / non-git directory → CWD basename fallback
- [x] Separator prevents cross-component collision (`a@b` + `c` ≠ `a` + `b@c`)
- [x] Verbose output tested through production `PortSource::verbose_description()`
- [x] 13 tests pass, 0 clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)