### PR TITLE
fix(gitrdun): write results file once per run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,16 +1071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1449,27 +1439,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2237,6 +2206,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "walkdir",

--- a/src/gitrdun/Cargo.toml
+++ b/src/gitrdun/Cargo.toml
@@ -28,6 +28,7 @@ walkdir.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/src/gitrdun/src/cli.rs
+++ b/src/gitrdun/src/cli.rs
@@ -86,3 +86,27 @@ pub struct Args {
     #[arg(value_name = "PATH")]
     pub paths: Vec<PathBuf>,
 }
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            start: "24h".to_string(),
+            end: None,
+            ignore_failures: false,
+            summary_only: false,
+            find_nested: false,
+            stats: false,
+            all: false,
+            ollama: false,
+            meta_ollama: false,
+            ollama_model: "gpt-oss".to_string(),
+            ollama_url: "http://localhost:11434".to_string(),
+            root: None,
+            output: None,
+            no_file: false,
+            filter_user: true,
+            keep_thinking: false,
+            paths: Vec::new(),
+        }
+    }
+}

--- a/src/gitrdun/src/lib.rs
+++ b/src/gitrdun/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod date;
 pub mod git;
 pub mod ollama;
+pub mod results;
 pub mod stats;
 pub mod ui;

--- a/src/gitrdun/src/main.rs
+++ b/src/gitrdun/src/main.rs
@@ -7,18 +7,18 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use tokio_util::sync::CancellationToken;
 
 mod cli;
 mod date;
 mod git;
 mod ollama;
+mod results;
 mod stats;
 mod ui;
 
 use cli::Args;
 use git::{get_git_user_email, ProgressCallback, ScanOptions, ScanProgress, SearchResult};
-use ollama::OllamaClient;
+use results::{format_results, write_output_file};
 use ui::ProgressDisplay;
 
 #[tokio::main]
@@ -154,23 +154,22 @@ async fn main() -> Result<()> {
     // Signal that scanning is complete
     progress.set_scan_complete();
 
-    // Process and display results in a separate task while UI is still running
-    let display_handle = {
+    // Format results (and run Ollama, if enabled) in a background task
+    // while the UI is still running. `format_results` is a pure function:
+    // it builds the output string but does NOT write any files.
+    let format_handle = {
         let result = Arc::clone(&search_result);
         let args = args.clone();
         let progress_clone = Arc::clone(&progress);
         let cancellation_token = progress.cancellation_token();
 
-        // We'll use spawn_blocking to avoid the nested runtime issue
         tokio::task::spawn_blocking(move || {
-            // Clone the result data to avoid holding the lock across await
             let result_data = {
                 let guard = result.lock().unwrap();
                 guard.clone()
             };
-            // Block on the async operation
             tokio::runtime::Handle::current().block_on(async move {
-                if let Err(e) = display_results(
+                format_results(
                     &result_data,
                     &args,
                     use_ollama,
@@ -178,9 +177,6 @@ async fn main() -> Result<()> {
                     cancellation_token,
                 )
                 .await
-                {
-                    eprintln!("Error displaying results: {}", e);
-                }
             })
         })
     };
@@ -188,347 +184,44 @@ async fn main() -> Result<()> {
     // Check if user cancelled
     let user_cancelled = progress.is_cancelled();
 
-    if !user_cancelled {
-        // Wait for display task to complete only if not cancelled
-        let _ = display_handle.await;
-
-        // Signal that Ollama processing is complete (if it was running)
+    // Wait for formatting to complete (only if not cancelled) and capture the buffer
+    let formatted_output: Option<String> = if user_cancelled {
+        None
+    } else {
+        let buffer = match format_handle.await {
+            Ok(Ok(buffer)) => Some(buffer),
+            Ok(Err(e)) => {
+                eprintln!("Error formatting results: {}", e);
+                None
+            }
+            Err(e) => {
+                eprintln!("Error joining format task: {}", e);
+                None
+            }
+        };
         if use_ollama {
             progress.set_ollama_complete();
         }
-    }
+        buffer
+    };
 
     // Wait for UI to finish
     let _ = ui_handle.join();
 
-    // After TUI exits, print the results to stdout (if not cancelled)
-    if !user_cancelled {
-        // Clone to avoid holding lock across await
-        let result = search_result.lock().unwrap().clone();
-        // Use a new cancellation token that won't be cancelled for final output
-        display_results(&result, &args, use_ollama, None, CancellationToken::new()).await?;
-    }
+    // After the TUI exits, print the captured output to stdout exactly
+    // once and write it to a file exactly once. Previously this block
+    // re-ran `format_results` (duplicating work and creating a second
+    // timestamped output file one second later).
+    if let Some(buffer) = formatted_output {
+        print!("{}", buffer);
+        io::stdout().flush().ok();
 
-    Ok(())
-}
-
-/// Generate an automatic filename for saving results
-fn generate_auto_filename(args: &Args) -> PathBuf {
-    let now = Local::now();
-    let timestamp = now.format("%Y-%m-%d-%H%M%S");
-    let duration_str = args.start.replace([' ', ':'], "");
-
-    let filename = if args.end.is_some() {
-        format!("gitrdun-results-{}-{}-to-end.txt", timestamp, duration_str)
-    } else {
-        format!("gitrdun-results-{}-{}.txt", timestamp, duration_str)
-    };
-
-    PathBuf::from(filename)
-}
-
-async fn display_results(
-    result: &SearchResult,
-    args: &Args,
-    use_ollama: bool,
-    progress: Option<Arc<ProgressDisplay>>,
-    cancellation_token: CancellationToken,
-) -> Result<()> {
-    // Create output buffer for file writing
-    let mut output_buffer = String::new();
-
-    // Helper function to write to buffer and optionally stdout
-    let has_progress = progress.is_some();
-    let mut write_output = |text: &str| {
-        output_buffer.push_str(text);
-        // Only print to stdout if we're not in TUI mode
-        if !has_progress {
-            print!("{}", text);
-            io::stdout().flush().unwrap();
-        }
-    };
-
-    // Print inaccessible directories if any
-    if !result.inaccessible_dirs.is_empty() && !args.ignore_failures {
-        write_output("⚠️  The following directories could not be fully accessed:\n");
-        for dir in &result.inaccessible_dirs {
-            write_output(&format!("  {}\n", dir));
-        }
-        write_output("\n");
-    }
-
-    if result.found_commits {
-        write_output("🔍 Found commits\n");
-        write_output(&format!(
-            "📅 Start date: {}\n",
-            result.threshold.format("%A, %B %d, %Y at %l:%M %p")
-        ));
-        if let Some(end) = result.end_time {
-            write_output(&format!(
-                "📅 End date: {}\n",
-                end.format("%A, %B %d, %Y at %l:%M %p")
-            ));
-        }
-        write_output(&format!(
-            "📂 Search paths: {}\n",
-            result
-                .abs_paths
-                .iter()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-        if args.all {
-            write_output("🔀 Searching across all branches\n");
-        }
-        write_output("\n");
-
-        // Calculate total commits
-        let total_commits: usize = result
-            .repositories
-            .values()
-            .map(|commits| commits.len())
-            .sum();
-
-        write_output("📊 Summary:\n");
-        write_output(&format!(
-            "   • Found {} commits across {} repositories\n\n",
-            total_commits,
-            result.repositories.len()
-        ));
-
-        // Sort repository paths for consistent output
-        let mut sorted_repo_paths: Vec<_> = result.repositories.keys().collect();
-        sorted_repo_paths.sort();
-
-        // For meta-ollama, collect all summaries
-        let mut all_summaries = Vec::new();
-
-        // Initialize Ollama client if needed
-        let ollama_client = if use_ollama {
-            Some(OllamaClient::new(args.ollama_url.clone()))
-        } else {
-            None
-        };
-
-        // Display results in sorted order
-        for repo_path in sorted_repo_paths {
-            let commits = &result.repositories[repo_path];
-            write_output(&format!(
-                "📁 {} - {} commits\n",
-                repo_path.display(),
-                commits.len()
-            ));
-
-            if let Some(client) = &ollama_client {
-                // Check if cancelled before processing
-                if cancellation_token.is_cancelled() {
-                    write_output("\n⚠️  Processing cancelled by user\n");
-                    break;
-                }
-
-                // Show commits if not summary-only
-                if !args.summary_only {
-                    for commit in commits {
-                        write_output(&format!("      • {}\n", commit.message));
-                    }
-                }
-
-                // Generate Ollama summary
-                let repo_name = repo_path.file_name().unwrap_or_default().to_string_lossy();
-                let branch_name = git::get_current_branch(repo_path);
-                let full_repo_info = format!("{} ({})", repo_path.display(), branch_name);
-                write_output(&format!(
-                    "\n🤖 Generating summary for {} with Ollama ({})...\n",
-                    repo_name, args.ollama_model
-                ));
-
-                // Update progress display with current repo
-                if let Some(progress_ref) = &progress {
-                    progress_ref.update_ollama_repo(full_repo_info.clone());
-                    progress_ref
-                        .update_ollama_status(format!("Generating summary for {}", full_repo_info));
-                }
-
-                let status_callback: Box<dyn Fn(&str) + Send + Sync> =
-                    if let Some(progress_ref) = &progress {
-                        let progress_clone = Arc::clone(progress_ref);
-                        Box::new(move |status: &str| {
-                            progress_clone.update_ollama_progress(status.to_string());
-                        })
-                    } else {
-                        Box::new(|status: &str| {
-                            print!("\r\x1b[K   ⏳ {}", status);
-                            io::stdout().flush().unwrap();
-                        })
-                    };
-
-                // Use tokio::select! to make the operation cancellable
-                tokio::select! {
-                    result = client.generate_summary(
-                        repo_path,
-                        commits,
-                        &args.ollama_model,
-                        args.keep_thinking,
-                        Some(status_callback),
-                    ) => {
-                        match result {
-                            Ok(summary) => {
-                                write_output("\n");
-                                write_output(&format!("📝 Summary for {} ({}): \n{}\n\n", repo_name, args.ollama_model, summary));
-
-                                if args.meta_ollama {
-                                    all_summaries.push(format!("Repository: {}\n{}", repo_path.display(), summary));
-                                }
-                            }
-                            Err(e) => {
-                                write_output(&format!("\n⚠️  Error generating summary: {}\n", e));
-                            }
-                        }
-                    }
-                    _ = cancellation_token.cancelled() => {
-                        write_output("\n⚠️  Summary generation cancelled\n");
-                        break;
-                    }
-                }
-            } else if !args.summary_only {
-                for commit in commits {
-                    write_output(&format!("      • {}\n", commit.message));
-                }
-                write_output("\n");
-            }
-        }
-
-        // Generate meta-summary if requested
-        if args.meta_ollama && !all_summaries.is_empty() && !cancellation_token.is_cancelled() {
-            if let Some(client) = &ollama_client {
-                write_output(&format!(
-                    "\n🔍 Generating meta-summary of all work with Ollama ({})...\n",
-                    args.ollama_model
-                ));
-
-                // Update progress display for meta-summary
-                if let Some(progress_ref) = &progress {
-                    progress_ref.update_ollama_repo("Meta-Summary".to_string());
-                    progress_ref
-                        .update_ollama_status("Generating meta-summary of all work".to_string());
-                }
-
-                let status_callback: Box<dyn Fn(&str) + Send + Sync> =
-                    if let Some(progress_ref) = &progress {
-                        let progress_clone = Arc::clone(progress_ref);
-                        Box::new(move |status: &str| {
-                            progress_clone.update_ollama_progress(status.to_string());
-                        })
-                    } else {
-                        Box::new(|status: &str| {
-                            print!("\r\x1b[K   ⏳ {}", status);
-                            io::stdout().flush().unwrap();
-                        })
-                    };
-
-                let start_duration = date::parse_duration(&args.start)?;
-
-                // Use tokio::select! to make the meta-summary cancellable
-                tokio::select! {
-                    result = client.generate_meta_summary(
-                        &all_summaries,
-                        &args.ollama_model,
-                        start_duration,
-                        args.keep_thinking,
-                        Some(status_callback),
-                    ) => {
-                        match result {
-                            Ok(meta_summary) => {
-                                write_output("\n");
-                                write_output(&format!("\n📊 Meta-Summary of All Work ({}):\n{}\n", args.ollama_model, meta_summary));
-                            }
-                            Err(e) => {
-                                write_output(&format!("\n⚠️  Error generating meta-summary: {}\n", e));
-                            }
-                        }
-                    }
-                    _ = cancellation_token.cancelled() => {
-                        write_output("\n⚠️  Meta-summary generation cancelled\n");
-                    }
-                }
-            }
-        }
-
-        // Mark Ollama as complete
-        if let Some(progress_ref) = &progress {
-            if use_ollama {
-                progress_ref.set_ollama_complete();
-            }
-        }
-    } else {
-        write_output("😴 No commits found\n");
-        write_output(&format!(
-            "   • Start date: {}\n",
-            result.threshold.format("%A, %B %d, %Y at %l:%M %p")
-        ));
-        if let Some(end) = result.end_time {
-            write_output(&format!(
-                "   • End date: {}\n",
-                end.format("%A, %B %d, %Y at %l:%M %p")
-            ));
-        }
-        write_output(&format!(
-            "   • Search paths: {}\n",
-            result
-                .abs_paths
-                .iter()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-
-    // Show stats if requested
-    if args.stats {
-        write_output("\n🔍 Git Operation Stats:\n");
-
-        if let Ok(get_git_dir_stats) = result.stats.get_git_dir.lock() {
-            write_output(&format!(
-                "   • getGitDir: {} calls, avg {:?} per call\n",
-                get_git_dir_stats.count(),
-                get_git_dir_stats.average()
-            ));
-        }
-
-        if let Ok(get_log_stats) = result.stats.get_log.lock() {
-            write_output(&format!(
-                "   • git log: {} calls, avg {:?} per call\n",
-                get_log_stats.count(),
-                get_log_stats.average()
-            ));
-        }
-
-        if let Ok(get_email_stats) = result.stats.get_email.lock() {
-            write_output(&format!(
-                "   • git config: {} calls, avg {:?} per call\n",
-                get_email_stats.count(),
-                get_email_stats.average()
-            ));
-        }
-
-        write_output("\n");
-    }
-
-    // Write to file (automatic by default, unless --no-file is specified)
-    if !args.no_file {
-        let output_file = if let Some(custom_file) = &args.output {
-            custom_file.clone()
-        } else {
-            generate_auto_filename(args)
-        };
-
-        match std::fs::write(&output_file, &output_buffer) {
-            Ok(_) => println!("📝 Results written to {}", output_file.display()),
+        match write_output_file(&args, &buffer) {
+            Ok(Some(path)) => println!("📝 Results written to {}", path.display()),
+            Ok(None) => {}
             Err(e) => println!("⚠️  Error writing to output file: {}", e),
         }
     }
 
     Ok(())
 }
-

--- a/src/gitrdun/src/main.rs
+++ b/src/gitrdun/src/main.rs
@@ -532,27 +532,3 @@ async fn display_results(
     Ok(())
 }
 
-// Implement Default for Args to support the pattern used above
-impl Default for Args {
-    fn default() -> Self {
-        Self {
-            start: "24h".to_string(),
-            end: None,
-            ignore_failures: false,
-            summary_only: false,
-            find_nested: false,
-            stats: false,
-            all: false,
-            ollama: false,
-            meta_ollama: false,
-            ollama_model: "gpt-oss".to_string(),
-            ollama_url: "http://localhost:11434".to_string(),
-            root: None,
-            output: None,
-            no_file: false,
-            filter_user: true,
-            keep_thinking: false,
-            paths: Vec::new(),
-        }
-    }
-}

--- a/src/gitrdun/src/main.rs
+++ b/src/gitrdun/src/main.rs
@@ -181,46 +181,46 @@ async fn main() -> Result<()> {
         })
     };
 
-    // Check if user cancelled
-    let user_cancelled = progress.is_cancelled();
-
-    // Wait for formatting to complete (only if not cancelled) and capture the buffer
-    let formatted_output: Option<String> = if user_cancelled {
-        None
-    } else {
-        let buffer = match format_handle.await {
-            Ok(Ok(buffer)) => Some(buffer),
-            Ok(Err(e)) => {
-                eprintln!("Error formatting results: {}", e);
-                None
-            }
-            Err(e) => {
-                eprintln!("Error joining format task: {}", e);
-                None
-            }
-        };
-        if use_ollama {
-            progress.set_ollama_complete();
-        }
-        buffer
-    };
+    // Always drive the format task to completion — even on cancel — so
+    // the spawn_blocking thread doesn't outlive main(). The buffer is
+    // discarded if the user cancelled.
+    let format_result = format_handle.await;
+    if use_ollama {
+        progress.set_ollama_complete();
+    }
 
     // Wait for UI to finish
     let _ = ui_handle.join();
+
+    // Re-sample cancellation AFTER format_handle resolves: a cancel that
+    // arrives mid-formatting should also suppress the final write.
+    if progress.is_cancelled() {
+        return Ok(());
+    }
+
+    let buffer = match format_result {
+        Ok(Ok(buffer)) => buffer,
+        Ok(Err(e)) => {
+            eprintln!("Error formatting results: {}", e);
+            return Ok(());
+        }
+        Err(e) => {
+            eprintln!("Error joining format task: {}", e);
+            return Ok(());
+        }
+    };
 
     // After the TUI exits, print the captured output to stdout exactly
     // once and write it to a file exactly once. Previously this block
     // re-ran `format_results` (duplicating work and creating a second
     // timestamped output file one second later).
-    if let Some(buffer) = formatted_output {
-        print!("{}", buffer);
-        io::stdout().flush().ok();
+    print!("{}", buffer);
+    let _ = io::stdout().flush();
 
-        match write_output_file(&args, &buffer) {
-            Ok(Some(path)) => println!("📝 Results written to {}", path.display()),
-            Ok(None) => {}
-            Err(e) => println!("⚠️  Error writing to output file: {}", e),
-        }
+    match write_output_file(&args, &buffer) {
+        Ok(Some(path)) => println!("📝 Results written to {}", path.display()),
+        Ok(None) => {}
+        Err(e) => println!("⚠️  Error writing to output file: {}", e),
     }
 
     Ok(())

--- a/src/gitrdun/src/results.rs
+++ b/src/gitrdun/src/results.rs
@@ -11,6 +11,13 @@ use crate::git::{self, SearchResult};
 use crate::ollama::OllamaClient;
 use crate::ui::ProgressDisplay;
 
+/// Message emitted when no commits match the requested window.
+///
+/// Exported so tests can pin against it without duplicating the literal
+/// — a previous inline `output.contains("No commits")` assertion was
+/// fragile to copy changes.
+pub const NO_COMMITS_MESSAGE: &str = "😴 No commits found";
+
 /// Format search results into a string buffer.
 ///
 /// This is a pure function with respect to the file system: it returns

--- a/src/gitrdun/src/results.rs
+++ b/src/gitrdun/src/results.rs
@@ -20,22 +20,21 @@ pub const NO_COMMITS_MESSAGE: &str = "😴 No commits found";
 
 /// Format search results into a string buffer.
 ///
-/// This is a pure function with respect to the file system: it returns
-/// the formatted output as a `String` without creating or modifying any
-/// files. The caller is responsible for writing the result to a file or
-/// to stdout.
+/// Pure with respect to the file system and to shared UI state: it
+/// returns the formatted output as a `String` and does not create files
+/// or flip flags on the caller-provided `ProgressDisplay`. The caller
+/// owns writing the buffer to stdout/disk and owns signalling
+/// completion (`set_ollama_complete`, etc.).
 ///
-/// When `progress` is `Some`, Ollama status updates are routed through
-/// the UI instead of being printed to stdout.
+/// When `progress` is `Some` the buffer is built silently (output is
+/// printed once by the caller after the TUI exits). When `progress` is
+/// `None` — the library-consumer / test path — each write is also
+/// streamed to stdout so callers without a TUI still see incremental
+/// output.
 ///
 /// # Errors
 ///
 /// Returns an error if duration parsing fails for the meta-summary path.
-///
-/// # Panics
-///
-/// Panics if flushing stdout fails (only when `progress` is `None`,
-/// which means output is being streamed directly to stdout).
 pub async fn format_results(
     result: &SearchResult,
     args: &Args,
@@ -50,7 +49,8 @@ pub async fn format_results(
         output_buffer.push_str(text);
         if !has_progress {
             print!("{}", text);
-            io::stdout().flush().unwrap();
+            // Ignore flush failures (e.g. closed pipe from `gitrdun | head`).
+            let _ = io::stdout().flush();
         }
     };
 
@@ -155,7 +155,7 @@ pub async fn format_results(
                     } else {
                         Box::new(|status: &str| {
                             print!("\r\x1b[K   ⏳ {}", status);
-                            io::stdout().flush().unwrap();
+                            let _ = io::stdout().flush();
                         })
                     };
 
@@ -216,7 +216,7 @@ pub async fn format_results(
                     } else {
                         Box::new(|status: &str| {
                             print!("\r\x1b[K   ⏳ {}", status);
-                            io::stdout().flush().unwrap();
+                            let _ = io::stdout().flush();
                         })
                     };
 
@@ -246,14 +246,8 @@ pub async fn format_results(
                 }
             }
         }
-
-        if let Some(progress_ref) = &progress {
-            if use_ollama {
-                progress_ref.set_ollama_complete();
-            }
-        }
     } else {
-        write_output("😴 No commits found\n");
+        write_output(&format!("{}\n", NO_COMMITS_MESSAGE));
         write_output(&format!(
             "   • Start date: {}\n",
             result.threshold.format("%A, %B %d, %Y at %l:%M %p")

--- a/src/gitrdun/src/results.rs
+++ b/src/gitrdun/src/results.rs
@@ -1,28 +1,341 @@
 use anyhow::Result;
+use chrono::Local;
+use std::io::{self, Write};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::cli::Args;
-use crate::git::SearchResult;
+use crate::date;
+use crate::git::{self, SearchResult};
+use crate::ollama::OllamaClient;
 use crate::ui::ProgressDisplay;
 
 /// Format search results into a string buffer.
 ///
-/// This is a pure function: it returns the formatted output without any
-/// file-system side effects. The caller is responsible for writing the
-/// returned string to a file and/or stdout.
+/// This is a pure function with respect to the file system: it returns
+/// the formatted output as a `String` without creating or modifying any
+/// files. The caller is responsible for writing the result to a file or
+/// to stdout.
+///
+/// When `progress` is `Some`, Ollama status updates are routed through
+/// the UI instead of being printed to stdout.
 ///
 /// # Errors
 ///
-/// Returns an error if Ollama summary generation fails and cannot be
-/// recovered from.
+/// Returns an error if duration parsing fails for the meta-summary path.
+///
+/// # Panics
+///
+/// Panics if flushing stdout fails (only when `progress` is `None`,
+/// which means output is being streamed directly to stdout).
 pub async fn format_results(
-    _result: &SearchResult,
-    _args: &Args,
-    _use_ollama: bool,
-    _progress: Option<Arc<ProgressDisplay>>,
-    _cancellation_token: CancellationToken,
+    result: &SearchResult,
+    args: &Args,
+    use_ollama: bool,
+    progress: Option<Arc<ProgressDisplay>>,
+    cancellation_token: CancellationToken,
 ) -> Result<String> {
-    // Stub - real implementation comes in the Green step.
-    Ok(String::new())
+    let mut output_buffer = String::new();
+    let has_progress = progress.is_some();
+
+    let mut write_output = |text: &str| {
+        output_buffer.push_str(text);
+        if !has_progress {
+            print!("{}", text);
+            io::stdout().flush().unwrap();
+        }
+    };
+
+    if !result.inaccessible_dirs.is_empty() && !args.ignore_failures {
+        write_output("⚠️  The following directories could not be fully accessed:\n");
+        for dir in &result.inaccessible_dirs {
+            write_output(&format!("  {}\n", dir));
+        }
+        write_output("\n");
+    }
+
+    if result.found_commits {
+        write_output("🔍 Found commits\n");
+        write_output(&format!(
+            "📅 Start date: {}\n",
+            result.threshold.format("%A, %B %d, %Y at %l:%M %p")
+        ));
+        if let Some(end) = result.end_time {
+            write_output(&format!(
+                "📅 End date: {}\n",
+                end.format("%A, %B %d, %Y at %l:%M %p")
+            ));
+        }
+        write_output(&format!(
+            "📂 Search paths: {}\n",
+            result
+                .abs_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        if args.all {
+            write_output("🔀 Searching across all branches\n");
+        }
+        write_output("\n");
+
+        let total_commits: usize = result
+            .repositories
+            .values()
+            .map(|commits| commits.len())
+            .sum();
+
+        write_output("📊 Summary:\n");
+        write_output(&format!(
+            "   • Found {} commits across {} repositories\n\n",
+            total_commits,
+            result.repositories.len()
+        ));
+
+        let mut sorted_repo_paths: Vec<_> = result.repositories.keys().collect();
+        sorted_repo_paths.sort();
+
+        let mut all_summaries = Vec::new();
+
+        let ollama_client = if use_ollama {
+            Some(OllamaClient::new(args.ollama_url.clone()))
+        } else {
+            None
+        };
+
+        for repo_path in sorted_repo_paths {
+            let commits = &result.repositories[repo_path];
+            write_output(&format!(
+                "📁 {} - {} commits\n",
+                repo_path.display(),
+                commits.len()
+            ));
+
+            if let Some(client) = &ollama_client {
+                if cancellation_token.is_cancelled() {
+                    write_output("\n⚠️  Processing cancelled by user\n");
+                    break;
+                }
+
+                if !args.summary_only {
+                    for commit in commits {
+                        write_output(&format!("      • {}\n", commit.message));
+                    }
+                }
+
+                let repo_name = repo_path.file_name().unwrap_or_default().to_string_lossy();
+                let branch_name = git::get_current_branch(repo_path);
+                let full_repo_info = format!("{} ({})", repo_path.display(), branch_name);
+                write_output(&format!(
+                    "\n🤖 Generating summary for {} with Ollama ({})...\n",
+                    repo_name, args.ollama_model
+                ));
+
+                if let Some(progress_ref) = &progress {
+                    progress_ref.update_ollama_repo(full_repo_info.clone());
+                    progress_ref
+                        .update_ollama_status(format!("Generating summary for {}", full_repo_info));
+                }
+
+                let status_callback: Box<dyn Fn(&str) + Send + Sync> =
+                    if let Some(progress_ref) = &progress {
+                        let progress_clone = Arc::clone(progress_ref);
+                        Box::new(move |status: &str| {
+                            progress_clone.update_ollama_progress(status.to_string());
+                        })
+                    } else {
+                        Box::new(|status: &str| {
+                            print!("\r\x1b[K   ⏳ {}", status);
+                            io::stdout().flush().unwrap();
+                        })
+                    };
+
+                tokio::select! {
+                    result = client.generate_summary(
+                        repo_path,
+                        commits,
+                        &args.ollama_model,
+                        args.keep_thinking,
+                        Some(status_callback),
+                    ) => {
+                        match result {
+                            Ok(summary) => {
+                                write_output("\n");
+                                write_output(&format!("📝 Summary for {} ({}): \n{}\n\n", repo_name, args.ollama_model, summary));
+
+                                if args.meta_ollama {
+                                    all_summaries.push(format!("Repository: {}\n{}", repo_path.display(), summary));
+                                }
+                            }
+                            Err(e) => {
+                                write_output(&format!("\n⚠️  Error generating summary: {}\n", e));
+                            }
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        write_output("\n⚠️  Summary generation cancelled\n");
+                        break;
+                    }
+                }
+            } else if !args.summary_only {
+                for commit in commits {
+                    write_output(&format!("      • {}\n", commit.message));
+                }
+                write_output("\n");
+            }
+        }
+
+        if args.meta_ollama && !all_summaries.is_empty() && !cancellation_token.is_cancelled() {
+            if let Some(client) = &ollama_client {
+                write_output(&format!(
+                    "\n🔍 Generating meta-summary of all work with Ollama ({})...\n",
+                    args.ollama_model
+                ));
+
+                if let Some(progress_ref) = &progress {
+                    progress_ref.update_ollama_repo("Meta-Summary".to_string());
+                    progress_ref
+                        .update_ollama_status("Generating meta-summary of all work".to_string());
+                }
+
+                let status_callback: Box<dyn Fn(&str) + Send + Sync> =
+                    if let Some(progress_ref) = &progress {
+                        let progress_clone = Arc::clone(progress_ref);
+                        Box::new(move |status: &str| {
+                            progress_clone.update_ollama_progress(status.to_string());
+                        })
+                    } else {
+                        Box::new(|status: &str| {
+                            print!("\r\x1b[K   ⏳ {}", status);
+                            io::stdout().flush().unwrap();
+                        })
+                    };
+
+                let start_duration = date::parse_duration(&args.start)?;
+
+                tokio::select! {
+                    result = client.generate_meta_summary(
+                        &all_summaries,
+                        &args.ollama_model,
+                        start_duration,
+                        args.keep_thinking,
+                        Some(status_callback),
+                    ) => {
+                        match result {
+                            Ok(meta_summary) => {
+                                write_output("\n");
+                                write_output(&format!("\n📊 Meta-Summary of All Work ({}):\n{}\n", args.ollama_model, meta_summary));
+                            }
+                            Err(e) => {
+                                write_output(&format!("\n⚠️  Error generating meta-summary: {}\n", e));
+                            }
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        write_output("\n⚠️  Meta-summary generation cancelled\n");
+                    }
+                }
+            }
+        }
+
+        if let Some(progress_ref) = &progress {
+            if use_ollama {
+                progress_ref.set_ollama_complete();
+            }
+        }
+    } else {
+        write_output("😴 No commits found\n");
+        write_output(&format!(
+            "   • Start date: {}\n",
+            result.threshold.format("%A, %B %d, %Y at %l:%M %p")
+        ));
+        if let Some(end) = result.end_time {
+            write_output(&format!(
+                "   • End date: {}\n",
+                end.format("%A, %B %d, %Y at %l:%M %p")
+            ));
+        }
+        write_output(&format!(
+            "   • Search paths: {}\n",
+            result
+                .abs_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    if args.stats {
+        write_output("\n🔍 Git Operation Stats:\n");
+
+        if let Ok(get_git_dir_stats) = result.stats.get_git_dir.lock() {
+            write_output(&format!(
+                "   • getGitDir: {} calls, avg {:?} per call\n",
+                get_git_dir_stats.count(),
+                get_git_dir_stats.average()
+            ));
+        }
+
+        if let Ok(get_log_stats) = result.stats.get_log.lock() {
+            write_output(&format!(
+                "   • git log: {} calls, avg {:?} per call\n",
+                get_log_stats.count(),
+                get_log_stats.average()
+            ));
+        }
+
+        if let Ok(get_email_stats) = result.stats.get_email.lock() {
+            write_output(&format!(
+                "   • git config: {} calls, avg {:?} per call\n",
+                get_email_stats.count(),
+                get_email_stats.average()
+            ));
+        }
+
+        write_output("\n");
+    }
+
+    Ok(output_buffer)
+}
+
+/// Generate an automatic filename for saving results.
+///
+/// The filename embeds the current local time (to the second) and the
+/// `--start` duration so multiple runs produce distinct files.
+pub fn generate_auto_filename(args: &Args) -> PathBuf {
+    let now = Local::now();
+    let timestamp = now.format("%Y-%m-%d-%H%M%S");
+    let duration_str = args.start.replace([' ', ':'], "");
+
+    let filename = if args.end.is_some() {
+        format!("gitrdun-results-{}-{}-to-end.txt", timestamp, duration_str)
+    } else {
+        format!("gitrdun-results-{}-{}.txt", timestamp, duration_str)
+    };
+
+    PathBuf::from(filename)
+}
+
+/// Write the formatted output buffer to disk according to `args`.
+///
+/// Honours `--no-file` (skip writing entirely) and `--output`
+/// (custom filename). Returns the path that was written, if any.
+///
+/// # Errors
+///
+/// Returns any I/O error from `std::fs::write`.
+pub fn write_output_file(args: &Args, content: &str) -> std::io::Result<Option<PathBuf>> {
+    if args.no_file {
+        return Ok(None);
+    }
+    let output_file = if let Some(custom_file) = &args.output {
+        custom_file.clone()
+    } else {
+        generate_auto_filename(args)
+    };
+    std::fs::write(&output_file, content)?;
+    Ok(Some(output_file))
 }

--- a/src/gitrdun/src/results.rs
+++ b/src/gitrdun/src/results.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+use crate::cli::Args;
+use crate::git::SearchResult;
+use crate::ui::ProgressDisplay;
+
+/// Format search results into a string buffer.
+///
+/// This is a pure function: it returns the formatted output without any
+/// file-system side effects. The caller is responsible for writing the
+/// returned string to a file and/or stdout.
+///
+/// # Errors
+///
+/// Returns an error if Ollama summary generation fails and cannot be
+/// recovered from.
+pub async fn format_results(
+    _result: &SearchResult,
+    _args: &Args,
+    _use_ollama: bool,
+    _progress: Option<Arc<ProgressDisplay>>,
+    _cancellation_token: CancellationToken,
+) -> Result<String> {
+    // Stub - real implementation comes in the Green step.
+    Ok(String::new())
+}

--- a/src/gitrdun/tests/integration.rs
+++ b/src/gitrdun/tests/integration.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use chrono::Duration;
-use gitrdun::{date, stats::GitStats};
+use chrono::{Duration, Local};
+use gitrdun::{cli::Args, date, git::SearchResult, results::format_results, stats::GitStats};
+use tokio_util::sync::CancellationToken;
 
 #[test]
 fn test_parse_duration() -> Result<()> {
@@ -49,6 +50,48 @@ fn test_git_stats() {
     if let Ok(email_stats) = stats.get_email.lock() {
         assert_eq!(email_stats.count(), 1);
     };
+}
+
+/// Regression test for the duplicate-results-files bug.
+///
+/// Previously, `main()` called `display_results` twice (once while the TUI
+/// was running and once after it exited). Each call wrote a timestamped
+/// output file, producing two files ~1 second apart with identical
+/// content.
+///
+/// The fix separates formatting (pure, returns a String) from file
+/// writing (side effect). `format_results` must be a pure function with
+/// no file-system side effects so the caller can control when/how many
+/// times the output is written to disk.
+#[tokio::test]
+async fn test_format_results_is_pure_and_returns_formatted_output() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let args = Args {
+        // Route auto-file writing into the temp dir (if any side effect
+        // occurs, we'll detect it here).
+        output: Some(temp_dir.path().join("should-not-exist.txt")),
+        no_file: false,
+        ..Args::default()
+    };
+    let result = SearchResult::new(Local::now(), None);
+
+    let output = format_results(&result, &args, false, None, CancellationToken::new()).await?;
+
+    assert!(
+        output.contains("No commits"),
+        "Expected formatted output to mention no commits, got: {output:?}"
+    );
+
+    let leftover_files: Vec<_> = std::fs::read_dir(temp_dir.path())?
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .collect();
+    assert!(
+        leftover_files.is_empty(),
+        "format_results must not write files; found: {leftover_files:?}"
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/gitrdun/tests/integration.rs
+++ b/src/gitrdun/tests/integration.rs
@@ -1,6 +1,14 @@
 use anyhow::Result;
 use chrono::{Duration, Local};
-use gitrdun::{cli::Args, date, git::SearchResult, results::format_results, stats::GitStats};
+use gitrdun::{
+    cli::Args,
+    date,
+    git::SearchResult,
+    results::{self, format_results},
+    stats::GitStats,
+    ui::ProgressDisplay,
+};
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 #[test]
@@ -91,6 +99,58 @@ async fn test_format_results_is_pure_and_returns_formatted_output() -> Result<()
         "format_results must not write files; found: {leftover_files:?}"
     );
 
+    Ok(())
+}
+
+/// `format_results` is a pure formatter. It must not flip shared UI state
+/// (like the `ollama_complete` flag on `ProgressDisplay`): that's the
+/// caller's responsibility. Mixing the side effect back in is what led to
+/// the duplicate-output-files bug — two code paths each thinking they
+/// "owned" the completion signal.
+#[tokio::test]
+async fn test_format_results_does_not_mutate_ollama_complete_flag() -> Result<()> {
+    let progress = Arc::new(ProgressDisplay::new(Local::now(), None, true));
+    assert!(!progress.is_ollama_complete());
+
+    // found_commits=true with no repositories enters the "found" branch
+    // but skips the Ollama loop, isolating the end-of-branch side effect.
+    let mut result = SearchResult::new(Local::now(), None);
+    result.found_commits = true;
+
+    let args = Args {
+        ollama: true,
+        ..Args::default()
+    };
+
+    format_results(
+        &result,
+        &args,
+        true,
+        Some(Arc::clone(&progress)),
+        CancellationToken::new(),
+    )
+    .await?;
+
+    assert!(
+        !progress.is_ollama_complete(),
+        "format_results must not mark ollama complete; caller owns that state transition"
+    );
+
+    Ok(())
+}
+
+/// Regression guard against phrase drift: the test above relies on the
+/// "no commits" output. Keep the assertion anchored to the exported
+/// constant so a message tweak updates both sites in one place.
+#[tokio::test]
+async fn test_no_commits_output_uses_exported_constant() -> Result<()> {
+    let args = Args::default();
+    let result = SearchResult::new(Local::now(), None);
+    let output = format_results(&result, &args, false, None, CancellationToken::new()).await?;
+    assert!(
+        output.contains(results::NO_COMMITS_MESSAGE),
+        "Expected output to contain NO_COMMITS_MESSAGE, got: {output:?}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `gitrdun` was producing two timestamped output files ~1 second apart with identical content. Root cause: `main()` called `display_results` twice (once while the TUI ran, once after it exited), and each call wrote the auto-filename file. The two writes straddled a second boundary, producing two distinct filenames.
- Split formatting from I/O: new `format_results` in `src/gitrdun/src/results.rs` is a pure function that returns the output buffer without any file-system side effects. `main.rs` now calls it once, then prints the captured buffer to stdout and writes it to disk exactly once via the new `write_output_file` helper.
- Side benefit: the second call also re-ran Ollama summary generation, which is now gone.

## Test plan

- [x] `cargo build -p gitrdun`
- [x] `cargo test -p gitrdun` — 6/6 integration tests pass, including the new regression test `test_format_results_is_pure_and_returns_formatted_output`
- [x] Red commit (`562dff3`) verified to fail before the fix with `Expected formatted output to mention no commits, got: ""`
- [x] Green commit (`4b6f936`) makes the test pass
- [x] No new clippy findings introduced (pre-existing `ui.rs` lints unchanged)
- [ ] Manual smoke: run `gitrdun --start 1h` in a repo and confirm exactly one `gitrdun-results-*.txt` file is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)