### PR TITLE
tsm: skeleton binary + safe zsh precmd hook (closes #213)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1757,12 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -3503,6 +3524,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5599,6 +5631,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7027,6 +7086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "termwiz"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7436,10 +7501,16 @@ name = "tsm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "buildinfo",
+ "chrono",
  "clap",
+ "hostname",
+ "serde_json",
+ "tempfile",
  "tsm-id",
  "tsm-jsonl",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -7689,6 +7760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7432,6 +7432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsm-id"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7432,6 +7432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buildinfo",
+ "clap",
+ "tsm-id",
+ "tsm-jsonl",
+]
+
+[[package]]
 name = "tsm-id"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7443,6 +7443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsm-jsonl"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/tsm-id/Cargo.toml
+++ b/src/tsm-id/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tsm-id"
+version = "0.1.0"
+edition.workspace = true
+description = "Session ID type for tsm: 32 lowercase hex chars (128 bits)"
+license.workspace = true
+
+[dependencies]
+hex.workspace = true
+rand.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -1,0 +1,194 @@
+//! Session ID type for tsm.
+//!
+//! A [`SessionId`] is a 128-bit identifier represented as exactly 32 lowercase
+//! hexadecimal characters. This slice covers only the random-construction path;
+//! the deterministic SHA-256 path will be added in a later issue.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+/// Number of hex characters in a [`SessionId`] (16 bytes * 2).
+const SESSION_ID_HEX_LEN: usize = 32;
+
+/// Errors produced when constructing a [`SessionId`] from an existing string.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SessionIdError {
+    /// The input was not exactly 32 characters long.
+    #[error("session id must be exactly {expected} characters, got {actual}")]
+    WrongLength {
+        /// Expected character count.
+        expected: usize,
+        /// Actual character count.
+        actual: usize,
+    },
+
+    /// The input contained an uppercase hex character; only lowercase is allowed.
+    #[error("session id must be lowercase hex; found uppercase character {0:?}")]
+    UppercaseHex(char),
+
+    /// The input contained a character outside `[0-9a-f]`.
+    #[error("session id contains non-hex character {0:?}")]
+    NonHexCharacter(char),
+}
+
+/// A 128-bit session identifier rendered as 32 lowercase hex characters.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+impl SessionId {
+    /// Construct a [`SessionId`] from 16 random bytes, hex-encoded as 32
+    /// lowercase characters.
+    pub fn random() -> Self {
+        // Stub: returns an empty string so tests fail on behavior, not symbol resolution.
+        Self(String::new())
+    }
+
+    /// Try to construct a [`SessionId`] from a pre-existing hex string.
+    ///
+    /// The input must be exactly 32 characters long and consist solely of
+    /// lowercase hex characters (`0-9`, `a-f`).
+    pub fn from_hex(s: &str) -> Result<Self, SessionIdError> {
+        // Stub: accept anything so validation tests fail on behavior.
+        Ok(Self(s.to_string()))
+    }
+
+    /// Borrow the underlying hex string.
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for SessionId {
+    type Err = SessionIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl Serialize for SessionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD_HEX: &str = "0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn random_produces_32_chars() {
+        let id = SessionId::random();
+        assert_eq!(id.as_hex().chars().count(), SESSION_ID_HEX_LEN);
+    }
+
+    #[test]
+    fn random_produces_lowercase_hex_only() {
+        let id = SessionId::random();
+        for c in id.as_hex().chars() {
+            assert!(
+                c.is_ascii_digit() || ('a'..='f').contains(&c),
+                "char {c:?} is not lowercase hex"
+            );
+        }
+    }
+
+    #[test]
+    fn two_random_calls_differ() {
+        let a = SessionId::random();
+        let b = SessionId::random();
+        assert_ne!(a, b, "two random session ids should not collide");
+    }
+
+    #[test]
+    fn from_hex_accepts_good_input() {
+        let id = SessionId::from_hex(GOOD_HEX).expect("good hex must parse");
+        assert_eq!(id.as_hex(), GOOD_HEX);
+    }
+
+    #[test]
+    fn from_hex_rejects_empty_string() {
+        let err = SessionId::from_hex("").expect_err("empty must fail");
+        assert!(matches!(err, SessionIdError::WrongLength { actual: 0, .. }));
+    }
+
+    #[test]
+    fn from_hex_rejects_31_chars() {
+        let s = "0123456789abcdef0123456789abcde";
+        let err = SessionId::from_hex(s).expect_err("31 chars must fail");
+        assert!(matches!(
+            err,
+            SessionIdError::WrongLength { actual: 31, .. }
+        ));
+    }
+
+    #[test]
+    fn from_hex_rejects_33_chars() {
+        let s = "0123456789abcdef0123456789abcdef0";
+        let err = SessionId::from_hex(s).expect_err("33 chars must fail");
+        assert!(matches!(
+            err,
+            SessionIdError::WrongLength { actual: 33, .. }
+        ));
+    }
+
+    #[test]
+    fn from_hex_rejects_uppercase() {
+        let s = "0123456789ABCDEF0123456789abcdef";
+        let err = SessionId::from_hex(s).expect_err("uppercase must fail");
+        assert!(matches!(err, SessionIdError::UppercaseHex(_)));
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex_char() {
+        let s = "0123456789abcdeg0123456789abcdef";
+        let err = SessionId::from_hex(s).expect_err("non-hex must fail");
+        assert!(matches!(err, SessionIdError::NonHexCharacter('g')));
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let id = SessionId::from_hex(GOOD_HEX).expect("good hex must parse");
+        let json = serde_json::to_string(&id).expect("serialize");
+        assert_eq!(json, format!("\"{GOOD_HEX}\""));
+        let back: SessionId = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn display_matches_as_hex() {
+        let id = SessionId::from_hex(GOOD_HEX).expect("good hex must parse");
+        assert_eq!(format!("{id}"), id.as_hex());
+    }
+
+    #[test]
+    fn from_str_agrees_with_from_hex() {
+        let via_from_str: SessionId = GOOD_HEX.parse().expect("parse");
+        let via_from_hex = SessionId::from_hex(GOOD_HEX).expect("from_hex");
+        assert_eq!(via_from_str, via_from_hex);
+    }
+}

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -42,16 +42,32 @@ impl SessionId {
     /// Construct a [`SessionId`] from 16 random bytes, hex-encoded as 32
     /// lowercase characters.
     pub fn random() -> Self {
-        // Stub: returns an empty string so tests fail on behavior, not symbol resolution.
-        Self(String::new())
+        let bytes: [u8; 16] = rand::random();
+        Self(hex::encode(bytes))
     }
 
     /// Try to construct a [`SessionId`] from a pre-existing hex string.
     ///
     /// The input must be exactly 32 characters long and consist solely of
-    /// lowercase hex characters (`0-9`, `a-f`).
+    /// lowercase hex characters (`0-9`, `a-f`). Uppercase hex is rejected
+    /// to keep the canonical representation unambiguous.
     pub fn from_hex(s: &str) -> Result<Self, SessionIdError> {
-        // Stub: accept anything so validation tests fail on behavior.
+        let actual = s.chars().count();
+        if actual != SESSION_ID_HEX_LEN {
+            return Err(SessionIdError::WrongLength {
+                expected: SESSION_ID_HEX_LEN,
+                actual,
+            });
+        }
+        for c in s.chars() {
+            if c.is_ascii_digit() || ('a'..='f').contains(&c) {
+                continue;
+            }
+            if ('A'..='F').contains(&c) {
+                return Err(SessionIdError::UppercaseHex(c));
+            }
+            return Err(SessionIdError::NonHexCharacter(c));
+        }
         Ok(Self(s.to_string()))
     }
 

--- a/src/tsm-jsonl/Cargo.toml
+++ b/src/tsm-jsonl/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tsm-jsonl"
+version = "0.1.0"
+edition.workspace = true
+description = "Header-first JSONL append and read for tsm session log files"
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"

--- a/src/tsm-jsonl/src/lib.rs
+++ b/src/tsm-jsonl/src/lib.rs
@@ -1,0 +1,423 @@
+//! Header-first JSONL append and read for tsm session log files.
+//!
+//! A tsm session log file `<session-id>.jsonl` has this structure:
+//! - Line 1: exactly one [`Header`] record (JSON object with `type: "header"`)
+//! - Lines 2..N: zero or more [`PrecmdRecord`] lines (JSON object with `type: "precmd"`)
+//!
+//! Every line is a single JSON object terminated by `\n`. UTF-8.
+
+use std::collections::BTreeMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors emitted by the tsm-jsonl crate.
+#[derive(Debug, Error)]
+pub enum JsonlError {
+    /// Underlying I/O failure.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON (de)serialization failure.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// `append_record` was called on a file that contains no header.
+    #[error("cannot append record: file has no header")]
+    MissingHeader,
+
+    /// `append_header` was called on a file that already contains data.
+    #[error("cannot append header: file already contains data")]
+    DuplicateHeader,
+
+    /// `read_all` could not parse line 1 as a [`Header`].
+    #[error("malformed first line (expected Header): {line}")]
+    MalformedFirstLine { line: String },
+
+    /// `read_all` could not parse a non-header line as a [`PrecmdRecord`].
+    #[error("malformed record on line {line_number}: {line}")]
+    MalformedRecordLine { line_number: u64, line: String },
+}
+
+/// Discriminator tag for the header record. Always serializes to `"header"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HeaderKind {
+    /// The single legal value.
+    #[serde(rename = "header")]
+    Header,
+}
+
+/// Discriminator tag for a precmd record. Always serializes to `"precmd"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrecmdKind {
+    /// The single legal value.
+    #[serde(rename = "precmd")]
+    Precmd,
+}
+
+/// Zellij session tuple stub.
+///
+/// All three fields are [`None`] outside of Zellij. Future Zellij integration will populate
+/// these from environment variables and `zellij action` queries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TupleStub {
+    /// Zellij session name, if any.
+    pub zellij_session: Option<String>,
+    /// Zellij tab name, if any.
+    pub tab: Option<String>,
+    /// Zellij pane ordinal, rendered as a string (e.g. `"1"`), if any.
+    pub pane_ordinal_str: Option<String>,
+}
+
+/// Header line written once per session log file (always line 1).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Header {
+    /// Discriminator; serialized as `type`. Always `"header"` on the wire.
+    #[serde(rename = "type")]
+    pub kind: HeaderKind,
+    /// Schema version (start at 1).
+    pub schema_version: u32,
+    /// tsm binary version string (e.g. `"0.1.0 (abc1234, clean)"`).
+    pub tsm_version: String,
+    /// Hostname.
+    pub hostname: String,
+    /// Terminal program (env `$TERM_PROGRAM` or `"unknown"`).
+    pub terminal_program: String,
+    /// Session tuple stub for this slice (Zellij integration is later).
+    pub tuple: TupleStub,
+    /// RFC3339 timestamp string for the moment this header was written.
+    pub created_at: String,
+}
+
+/// Per-prompt record written on every precmd invocation after the header.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrecmdRecord {
+    /// Discriminator; serialized as `type`. Always `"precmd"` on the wire.
+    #[serde(rename = "type")]
+    pub kind: PrecmdKind,
+    /// RFC3339 timestamp.
+    pub at: String,
+    /// Working directory at prompt return.
+    pub cwd: String,
+    /// Exit code of the just-finished command.
+    pub exit_code: i32,
+    /// Verbatim text of the last command (may be empty for the first prompt of a session).
+    pub last_command: String,
+    /// Map of env var names to values, *after* redaction (the redactor lives in `tsm record`).
+    pub env: BTreeMap<String, String>,
+    /// Sorted list of env var names whose values were redacted.
+    pub redacted_keys: Vec<String>,
+}
+
+/// Full parsed contents of a session log file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionLog {
+    /// The header on line 1.
+    pub header: Header,
+    /// All precmd records after the header, in file order.
+    pub records: Vec<PrecmdRecord>,
+}
+
+// ----- stubs (red commit): compile but do not honor invariants -----
+
+/// Append a header to `path`.
+///
+/// The file must be empty (size 0 or nonexistent). Errors if the file already has any content.
+///
+/// # Errors
+///
+/// Returns [`JsonlError::DuplicateHeader`] if `path` already has data, or [`JsonlError::Io`] /
+/// [`JsonlError::Json`] for underlying failures.
+pub fn append_header(path: &Path, header: &Header) -> Result<(), JsonlError> {
+    // STUB: does not enforce empty-file invariant.
+    let line = serde_json::to_string(header)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut buf = line.into_bytes();
+    buf.push(b'\n');
+    file.write_all(&buf)?;
+    Ok(())
+}
+
+/// Append a precmd record to `path`.
+///
+/// The file must already contain a header. Errors otherwise.
+///
+/// # Errors
+///
+/// Returns [`JsonlError::MissingHeader`] if `path` is empty or absent, or [`JsonlError::Io`] /
+/// [`JsonlError::Json`] for underlying failures.
+pub fn append_record(path: &Path, record: &PrecmdRecord) -> Result<(), JsonlError> {
+    // STUB: does not enforce header-first invariant.
+    let line = serde_json::to_string(record)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut buf = line.into_bytes();
+    buf.push(b'\n');
+    file.write_all(&buf)?;
+    Ok(())
+}
+
+/// Read an entire session log; returns the parsed header and all subsequent records.
+///
+/// # Errors
+///
+/// Returns [`JsonlError::MalformedFirstLine`] if line 1 is missing or unparseable as a
+/// [`Header`], [`JsonlError::MalformedRecordLine`] if any subsequent line cannot be parsed as a
+/// [`PrecmdRecord`], or [`JsonlError::Io`] for underlying failures.
+pub fn read_all(_path: &Path) -> Result<SessionLog, JsonlError> {
+    // STUB: returns a default-ish session log so round-trip tests fail.
+    Ok(SessionLog {
+        header: Header {
+            kind: HeaderKind::Header,
+            schema_version: 0,
+            tsm_version: String::new(),
+            hostname: String::new(),
+            terminal_program: String::new(),
+            tuple: TupleStub {
+                zellij_session: None,
+                tab: None,
+                pane_ordinal_str: None,
+            },
+            created_at: String::new(),
+        },
+        records: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn sample_header() -> Header {
+        Header {
+            kind: HeaderKind::Header,
+            schema_version: 1,
+            tsm_version: "0.1.0 (abc1234, clean)".to_string(),
+            hostname: "test-host".to_string(),
+            terminal_program: "iTerm.app".to_string(),
+            tuple: TupleStub {
+                zellij_session: None,
+                tab: None,
+                pane_ordinal_str: None,
+            },
+            created_at: "2026-05-13T12:00:00Z".to_string(),
+        }
+    }
+
+    fn sample_record(seq: u32) -> PrecmdRecord {
+        let mut env = BTreeMap::new();
+        env.insert("PATH".to_string(), format!("/usr/bin:/bin:{seq}"));
+        env.insert("HOME".to_string(), "/Users/test".to_string());
+        PrecmdRecord {
+            kind: PrecmdKind::Precmd,
+            at: format!("2026-05-13T12:00:{seq:02}Z"),
+            cwd: format!("/tmp/dir-{seq}"),
+            exit_code: 0,
+            last_command: format!("echo hello {seq}"),
+            env,
+            redacted_keys: vec!["AWS_SECRET_ACCESS_KEY".to_string()],
+        }
+    }
+
+    #[test]
+    fn append_header_to_empty_file_writes_one_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        fs::write(&path, b"").expect("create empty file");
+        let header = sample_header();
+        append_header(&path, &header).expect("append_header");
+        let contents = fs::read_to_string(&path).expect("read");
+        let expected = serde_json::to_string(&header).expect("serialize") + "\n";
+        assert_eq!(contents, expected);
+    }
+
+    #[test]
+    fn append_header_to_nonexistent_file_creates_it() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        assert!(!path.exists());
+        let header = sample_header();
+        append_header(&path, &header).expect("append_header");
+        assert!(path.exists());
+        let contents = fs::read_to_string(&path).expect("read");
+        let expected = serde_json::to_string(&header).expect("serialize") + "\n";
+        assert_eq!(contents, expected);
+    }
+
+    #[test]
+    fn append_header_to_nonempty_file_returns_duplicate_header() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        append_header(&path, &header).expect("first append_header");
+        let before = fs::read(&path).expect("read before");
+        let err = append_header(&path, &header).expect_err("second append_header must fail");
+        assert!(
+            matches!(err, JsonlError::DuplicateHeader),
+            "expected DuplicateHeader, got: {err:?}"
+        );
+        let after = fs::read(&path).expect("read after");
+        assert_eq!(before, after, "file must not be mutated");
+    }
+
+    #[test]
+    fn append_record_before_header_returns_missing_header() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let record = sample_record(1);
+        let err = append_record(&path, &record).expect_err("append_record on empty must fail");
+        assert!(
+            matches!(err, JsonlError::MissingHeader),
+            "expected MissingHeader, got: {err:?}"
+        );
+        // File must remain empty or nonexistent.
+        let exists_and_empty = !path.exists()
+            || fs::metadata(&path).expect("metadata").len() == 0;
+        assert!(exists_and_empty, "file must remain empty or absent");
+    }
+
+    #[test]
+    fn append_record_after_header_writes_one_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        let record = sample_record(1);
+        append_header(&path, &header).expect("append_header");
+        append_record(&path, &record).expect("append_record");
+        let contents = fs::read_to_string(&path).expect("read");
+        let header_line = serde_json::to_string(&header).expect("serialize header");
+        let record_line = serde_json::to_string(&record).expect("serialize record");
+        let expected = format!("{header_line}\n{record_line}\n");
+        assert_eq!(contents, expected);
+    }
+
+    #[test]
+    fn multiple_records_after_header_each_append() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        append_header(&path, &header).expect("append_header");
+        let r1 = sample_record(1);
+        let r2 = sample_record(2);
+        let r3 = sample_record(3);
+        append_record(&path, &r1).expect("append r1");
+        append_record(&path, &r2).expect("append r2");
+        append_record(&path, &r3).expect("append r3");
+        let contents = fs::read_to_string(&path).expect("read");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 4, "expected 4 lines (header + 3 records)");
+        assert_eq!(lines[0], serde_json::to_string(&header).expect("ser h"));
+        assert_eq!(lines[1], serde_json::to_string(&r1).expect("ser r1"));
+        assert_eq!(lines[2], serde_json::to_string(&r2).expect("ser r2"));
+        assert_eq!(lines[3], serde_json::to_string(&r3).expect("ser r3"));
+    }
+
+    #[test]
+    fn read_all_round_trips_header_only() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        append_header(&path, &header).expect("append_header");
+        let log = read_all(&path).expect("read_all");
+        assert_eq!(log.header, header);
+        assert!(log.records.is_empty());
+    }
+
+    #[test]
+    fn read_all_round_trips_header_and_records() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        append_header(&path, &header).expect("append_header");
+        let r1 = sample_record(1);
+        let r2 = sample_record(2);
+        let r3 = sample_record(3);
+        append_record(&path, &r1).expect("append r1");
+        append_record(&path, &r2).expect("append r2");
+        append_record(&path, &r3).expect("append r3");
+        let log = read_all(&path).expect("read_all");
+        assert_eq!(log.header, header);
+        assert_eq!(log.records, vec![r1, r2, r3]);
+    }
+
+    #[test]
+    fn read_all_on_empty_file_returns_malformed_first_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        fs::write(&path, b"").expect("write empty");
+        let err = read_all(&path).expect_err("read_all on empty must fail");
+        assert!(
+            matches!(err, JsonlError::MalformedFirstLine { .. }),
+            "expected MalformedFirstLine, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn read_all_with_garbage_first_line_returns_malformed_first_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        fs::write(&path, b"this is not json\n").expect("write garbage");
+        let err = read_all(&path).expect_err("read_all on garbage must fail");
+        match err {
+            JsonlError::MalformedFirstLine { line } => {
+                assert_eq!(line, "this is not json");
+            }
+            other => panic!("expected MalformedFirstLine, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_all_with_garbage_record_line_returns_malformed_record_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let header = sample_header();
+        let r1 = sample_record(1);
+        append_header(&path, &header).expect("append_header");
+        append_record(&path, &r1).expect("append r1");
+        // Manually append a garbage line as line 3.
+        use std::io::Write as _;
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append");
+        f.write_all(b"not a record\n").expect("write garbage");
+        drop(f);
+        let err = read_all(&path).expect_err("read_all with bad record must fail");
+        match err {
+            JsonlError::MalformedRecordLine { line_number, line } => {
+                assert_eq!(line_number, 3, "garbage is on line 3");
+                assert_eq!(line, "not a record");
+            }
+            other => panic!("expected MalformedRecordLine, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn header_wire_format_has_type_header() {
+        let header = sample_header();
+        let value = serde_json::to_value(&header).expect("to_value");
+        assert_eq!(value["type"], "header");
+    }
+
+    #[test]
+    fn precmd_wire_format_has_type_precmd() {
+        let record = sample_record(1);
+        let value = serde_json::to_value(&record).expect("to_value");
+        assert_eq!(value["type"], "precmd");
+    }
+
+    #[test]
+    fn cannot_deserialize_header_as_precmd_record() {
+        let header = sample_header();
+        let header_json = serde_json::to_string(&header).expect("serialize header");
+        let result: Result<PrecmdRecord, _> = serde_json::from_str(&header_json);
+        assert!(
+            result.is_err(),
+            "header JSON must not parse as PrecmdRecord, got: {result:?}"
+        );
+    }
+}

--- a/src/tsm-jsonl/src/lib.rs
+++ b/src/tsm-jsonl/src/lib.rs
@@ -7,8 +7,8 @@
 //! Every line is a single JSON object terminated by `\n`. UTF-8.
 
 use std::collections::BTreeMap;
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -121,7 +121,26 @@ pub struct SessionLog {
     pub records: Vec<PrecmdRecord>,
 }
 
-// ----- stubs (red commit): compile but do not honor invariants -----
+/// Returns the byte length of `path`, or `None` if the file does not exist.
+///
+/// Any I/O error other than [`NotFound`](std::io::ErrorKind::NotFound) is propagated.
+fn file_size_if_exists(path: &Path) -> Result<Option<u64>, JsonlError> {
+    match std::fs::metadata(path) {
+        Ok(meta) => Ok(Some(meta.len())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(JsonlError::Io(e)),
+    }
+}
+
+/// Serialize one record and append it (plus a trailing `\n`) to `path` in a single
+/// `write_all` call so the append stays atomic for lines ≤ `PIPE_BUF` bytes on POSIX.
+fn append_line<T: Serialize>(path: &Path, value: &T) -> Result<(), JsonlError> {
+    let mut buf = serde_json::to_vec(value)?;
+    buf.push(b'\n');
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(&buf)?;
+    Ok(())
+}
 
 /// Append a header to `path`.
 ///
@@ -132,13 +151,14 @@ pub struct SessionLog {
 /// Returns [`JsonlError::DuplicateHeader`] if `path` already has data, or [`JsonlError::Io`] /
 /// [`JsonlError::Json`] for underlying failures.
 pub fn append_header(path: &Path, header: &Header) -> Result<(), JsonlError> {
-    // STUB: does not enforce empty-file invariant.
-    let line = serde_json::to_string(header)?;
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-    let mut buf = line.into_bytes();
-    buf.push(b'\n');
-    file.write_all(&buf)?;
-    Ok(())
+    // Enforce empty-file invariant before opening for append. If the file exists with size > 0,
+    // refuse and do NOT touch it.
+    if let Some(size) = file_size_if_exists(path)? {
+        if size > 0 {
+            return Err(JsonlError::DuplicateHeader);
+        }
+    }
+    append_line(path, header)
 }
 
 /// Append a precmd record to `path`.
@@ -150,13 +170,13 @@ pub fn append_header(path: &Path, header: &Header) -> Result<(), JsonlError> {
 /// Returns [`JsonlError::MissingHeader`] if `path` is empty or absent, or [`JsonlError::Io`] /
 /// [`JsonlError::Json`] for underlying failures.
 pub fn append_record(path: &Path, record: &PrecmdRecord) -> Result<(), JsonlError> {
-    // STUB: does not enforce header-first invariant.
-    let line = serde_json::to_string(record)?;
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-    let mut buf = line.into_bytes();
-    buf.push(b'\n');
-    file.write_all(&buf)?;
-    Ok(())
+    // Header-first invariant: file must exist and be non-empty. We use the size as a cheap proxy
+    // for "has a header" — fully validating line 1 on every append would defeat the point of
+    // append-only logging. read_all enforces the structural invariant on read.
+    match file_size_if_exists(path)? {
+        Some(size) if size > 0 => append_line(path, record),
+        _ => Err(JsonlError::MissingHeader),
+    }
 }
 
 /// Read an entire session log; returns the parsed header and all subsequent records.
@@ -166,24 +186,44 @@ pub fn append_record(path: &Path, record: &PrecmdRecord) -> Result<(), JsonlErro
 /// Returns [`JsonlError::MalformedFirstLine`] if line 1 is missing or unparseable as a
 /// [`Header`], [`JsonlError::MalformedRecordLine`] if any subsequent line cannot be parsed as a
 /// [`PrecmdRecord`], or [`JsonlError::Io`] for underlying failures.
-pub fn read_all(_path: &Path) -> Result<SessionLog, JsonlError> {
-    // STUB: returns a default-ish session log so round-trip tests fail.
-    Ok(SessionLog {
-        header: Header {
-            kind: HeaderKind::Header,
-            schema_version: 0,
-            tsm_version: String::new(),
-            hostname: String::new(),
-            terminal_program: String::new(),
-            tuple: TupleStub {
-                zellij_session: None,
-                tab: None,
-                pane_ordinal_str: None,
-            },
-            created_at: String::new(),
-        },
-        records: Vec::new(),
-    })
+pub fn read_all(path: &Path) -> Result<SessionLog, JsonlError> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    // Line 1: must be a Header. An empty file yields None and is treated as MalformedFirstLine.
+    let first_line = match lines.next() {
+        Some(Ok(line)) => line,
+        Some(Err(e)) => return Err(JsonlError::Io(e)),
+        None => {
+            return Err(JsonlError::MalformedFirstLine {
+                line: String::new(),
+            });
+        }
+    };
+    let header: Header = serde_json::from_str(&first_line).map_err(|_| {
+        JsonlError::MalformedFirstLine {
+            line: first_line.clone(),
+        }
+    })?;
+
+    // Lines 2..N: each must parse as a PrecmdRecord. Track the 1-indexed line number for
+    // error reporting (line 1 = header, so the first record is line 2).
+    let mut records = Vec::new();
+    let mut line_number: u64 = 1;
+    for line_result in lines {
+        line_number = line_number.saturating_add(1);
+        let line = line_result?;
+        let record: PrecmdRecord = serde_json::from_str(&line).map_err(|_| {
+            JsonlError::MalformedRecordLine {
+                line_number,
+                line: line.clone(),
+            }
+        })?;
+        records.push(record);
+    }
+
+    Ok(SessionLog { header, records })
 }
 
 #[cfg(test)]
@@ -379,13 +419,13 @@ mod tests {
         append_header(&path, &header).expect("append_header");
         append_record(&path, &r1).expect("append r1");
         // Manually append a garbage line as line 3.
-        use std::io::Write as _;
-        let mut f = OpenOptions::new()
-            .append(true)
-            .open(&path)
-            .expect("open append");
-        f.write_all(b"not a record\n").expect("write garbage");
-        drop(f);
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("open append");
+            f.write_all(b"not a record\n").expect("write garbage");
+        }
         let err = read_all(&path).expect_err("read_all with bad record must fail");
         match err {
             JsonlError::MalformedRecordLine { line_number, line } => {

--- a/src/tsm/Cargo.toml
+++ b/src/tsm/Cargo.toml
@@ -12,8 +12,17 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 buildinfo.workspace = true
+chrono.workspace = true
 clap.workspace = true
+hostname = "0.4"
 tsm-id = { path = "../tsm-id" }
+tsm-jsonl = { path = "../tsm-jsonl" }
+wait-timeout = "0.2"
+
+[dev-dependencies]
+assert_cmd = "2"
+serde_json.workspace = true
+tempfile.workspace = true
 tsm-jsonl = { path = "../tsm-jsonl" }
 
 [lints.rust]

--- a/src/tsm/Cargo.toml
+++ b/src/tsm/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tsm"
+version = "0.1.0"
+edition.workspace = true
+description = "Terminal session manager"
+license.workspace = true
+
+[[bin]]
+name = "tsm"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+buildinfo.workspace = true
+clap.workspace = true
+tsm-id = { path = "../tsm-id" }
+tsm-jsonl = { path = "../tsm-jsonl" }
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -47,16 +47,103 @@ enum Commands {
     },
 }
 
+/// Maximum number of consecutive `tsm record` failures before the precmd
+/// hook self-disables for the current shell.
+const FAILURE_THRESHOLD: u32 = 3;
+
 /// Generate the zsh `eval`-able shell-init snippet.
 ///
-/// In the red commit this returns an obviously-broken placeholder so the
-/// behavioral test suite fails. The green commit replaces the body with the
-/// actual snippet.
-fn generate_zsh_snippet(_session_id: &SessionId) -> String {
-    String::from("# tsm placeholder\n")
+/// The emitted snippet, when sourced via `eval "$(tsm shell-init zsh)"`:
+///
+/// 1. Bails out silently if `$TSM_DISABLE` is set in the environment.
+/// 2. Runs `tsm --version` as a health check with a ~1 second timeout. On
+///    failure it prints one warning to stderr and returns without installing
+///    the hook.
+/// 3. Exports `$TSM_SESSION_ID`. The id is inlined into the snippet at print
+///    time (one fresh id per `tsm shell-init zsh` invocation). If the env var
+///    is already set on entry, the existing value is preserved.
+/// 4. Registers a `precmd` hook that backgrounds `tsm record &!`, passing
+///    `--exit-code` and `--last-command`. Before backgrounding, the hook
+///    reads `$XDG_STATE_HOME/tsm/fail-count.<shell-pid>`; if the count has
+///    reached the failure threshold it unregisters itself and emits one
+///    warning line pointing at the error log.
+/// 5. Does NOT emit any OSC pane-title sequences; pane-title work is deferred
+///    to a later slice.
+fn generate_zsh_snippet(session_id: &SessionId) -> String {
+    let id = session_id.as_hex();
+    let threshold = FAILURE_THRESHOLD;
+    format!(
+        r#"# === tsm shell integration (begin) ===
+if [[ -n "${{TSM_DISABLE-}}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# Health check: tsm --version with a ~1 second timeout. macOS does not ship
+# GNU timeout(1), so we implement the timeout inline by backgrounding the
+# health check, racing it against a sleep, and killing the loser.
+_tsm_health_check() {{
+    local _pid _watchdog _rc
+    ( tsm --version >/dev/null 2>&1 ) &
+    _pid=$!
+    ( sleep 1 && kill -TERM $_pid 2>/dev/null ) &!
+    _watchdog=$!
+    if wait $_pid 2>/dev/null; then
+        _rc=0
+    else
+        _rc=$?
+    fi
+    kill $_watchdog 2>/dev/null
+    return $_rc
+}}
+if ! _tsm_health_check; then
+    unset -f _tsm_health_check
+    print -u2 "tsm: health check failed; tsm functionality disabled for this shell"
+    return 0 2>/dev/null || exit 0
+fi
+unset -f _tsm_health_check
+
+# Export session id. The literal hex below is generated fresh by `tsm shell-init`
+# at print time, so each `eval "$(tsm shell-init zsh)"` yields a new id. If
+# TSM_SESSION_ID is already set in the environment (parent shell exported it),
+# the existing value is preserved.
+: ${{TSM_SESSION_ID:={id}}}
+export TSM_SESSION_ID
+
+typeset -g _tsm_state_dir="${{XDG_STATE_HOME:-$HOME/.local/state}}/tsm"
+typeset -g _tsm_fail_file="${{_tsm_state_dir}}/fail-count.$$"
+typeset -g _tsm_error_log="${{_tsm_state_dir}}/errors.log"
+
+_tsm_precmd() {{
+    local _last_exit=$?
+    local _last_cmd
+    _last_cmd=$(fc -ln -1 2>/dev/null) || _last_cmd=""
+
+    # Self-disable after {threshold} consecutive failures. The recorder writes
+    # this counter; we read it synchronously before dispatching the next call.
+    if [[ -r "$_tsm_fail_file" ]]; then
+        local _fc
+        _fc=$(<"$_tsm_fail_file")
+        if [[ "$_fc" -ge {threshold} ]]; then
+            add-zsh-hook -d precmd _tsm_precmd
+            rm -f "$_tsm_fail_file"
+            print -u2 "tsm: precmd hook disabled after {threshold} consecutive failures; see ${{_tsm_error_log}}"
+            return 0
+        fi
+    fi
+
+    # Dispatch recorder in the background and disown so the parent shell never
+    # waits and the prompt is not delayed.
+    {{ tsm record --exit-code "$_last_exit" --last-command "$_last_cmd" }} &!
+}}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _tsm_precmd
+# === tsm shell integration (end) ===
+"#
+    )
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let cli = Cli::parse();
     match cli.command {
         Commands::ShellInit { shell } => {
@@ -76,7 +163,6 @@ fn main() -> anyhow::Result<()> {
             // from the hot path).
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -1,0 +1,199 @@
+//! `tsm` - terminal session manager.
+//!
+//! This binary is the entry point for the tsm tool. It currently provides
+//! three subcommands:
+//!
+//! - `tsm --version` prints `tsm <version> (<short-hash>, clean|dirty)`.
+//! - `tsm shell-init <shell>` emits an eval-able shell snippet that wires up
+//!   a per-command precmd hook calling `tsm record` in the background.
+//! - `tsm record` is the precmd-time recorder; in this slice it is a stub
+//!   that accepts the same args the snippet will pass.
+
+use buildinfo::version_string;
+use clap::{Parser, Subcommand};
+use tsm_id::SessionId;
+
+/// Exit code returned when `tsm shell-init` receives an unsupported shell.
+const EXIT_UNSUPPORTED_SHELL: i32 = 2;
+
+/// Top-level CLI for `tsm`.
+#[derive(Parser)]
+#[command(name = "tsm")]
+#[command(about = "Terminal session manager")]
+#[command(version = version_string!())]
+struct Cli {
+    /// The subcommand to invoke.
+    #[command(subcommand)]
+    command: Commands,
+}
+
+/// All `tsm` subcommands.
+#[derive(Subcommand)]
+enum Commands {
+    /// Emit an eval-able shell snippet that wires up the precmd hook.
+    ShellInit {
+        /// The shell to emit integration for. Only `zsh` is supported in v1.
+        shell: String,
+    },
+    /// Record one command's metadata. Invoked by the shell precmd hook.
+    Record {
+        /// Exit status of the last command in the shell.
+        #[arg(long, allow_hyphen_values = true)]
+        exit_code: i32,
+
+        /// Verbatim text of the last command line.
+        #[arg(long, default_value = "")]
+        last_command: String,
+    },
+}
+
+/// Generate the zsh `eval`-able shell-init snippet.
+///
+/// In the red commit this returns an obviously-broken placeholder so the
+/// behavioral test suite fails. The green commit replaces the body with the
+/// actual snippet.
+fn generate_zsh_snippet(_session_id: &SessionId) -> String {
+    String::from("# tsm placeholder\n")
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::ShellInit { shell } => {
+            if shell != "zsh" {
+                eprintln!(
+                    "tsm: shell-init: only \"zsh\" is supported in v1, got: {shell}"
+                );
+                std::process::exit(EXIT_UNSUPPORTED_SHELL);
+            }
+            let session_id = SessionId::random();
+            print!("{}", generate_zsh_snippet(&session_id));
+        }
+        Commands::Record { exit_code: _, last_command: _ } => {
+            // Stub for this slice. Subagent 4 will replace this body with the
+            // real recorder. We intentionally do not write anything to stderr
+            // (per the safety policy that `tsm record` never writes to stderr
+            // from the hot path).
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fixed session ID for deterministic snippet inspection.
+    fn fixed_session_id() -> SessionId {
+        SessionId::from_hex("0123456789abcdef0123456789abcdef")
+            .expect("fixed hex is valid")
+    }
+
+    #[test]
+    fn zsh_snippet_starts_with_tsm_disable_guard() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("TSM_DISABLE"),
+            "snippet should guard on $TSM_DISABLE near the top, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_inlines_session_id() {
+        let id = fixed_session_id();
+        let s = generate_zsh_snippet(&id);
+        let hex = id.as_hex();
+        let occurrences = s.matches(hex).count();
+        assert_eq!(
+            occurrences, 1,
+            "expected session id {hex} to appear exactly once in snippet, got {occurrences}:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_uses_random_id_when_called_via_main() {
+        let a = generate_zsh_snippet(&SessionId::random());
+        let b = generate_zsh_snippet(&SessionId::random());
+        assert_ne!(
+            a, b,
+            "two snippets generated with random ids should differ"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_uses_disowned_call() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("&!"),
+            "snippet should background-disown the tsm record call with &!, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_passes_exit_code_and_last_command() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("--exit-code"),
+            "snippet should pass --exit-code to tsm record, got:\n{s}"
+        );
+        assert!(
+            s.contains("--last-command"),
+            "snippet should pass --last-command to tsm record, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_registers_precmd_hook() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("add-zsh-hook precmd"),
+            "snippet should register the precmd hook via add-zsh-hook, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_health_check_present() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("tsm --version"),
+            "snippet should perform a health check by calling tsm --version, got:\n{s}"
+        );
+        assert!(
+            s.contains("sleep 1") || s.contains("sleep 1\n") || s.contains("sleep 1 "),
+            "snippet should bound the health check with a ~1 second timeout, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_self_disables_after_3_failures() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("add-zsh-hook -d precmd"),
+            "snippet should unregister the precmd hook on repeated failure, got:\n{s}"
+        );
+        assert!(
+            s.contains('3'),
+            "snippet should reference the failure threshold of 3, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn zsh_snippet_does_not_emit_osc_sequences() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        for needle in ["\\033]", "\\x1b]", "\\e]"] {
+            assert!(
+                !s.contains(needle),
+                "snippet should not emit OSC sequences (found {needle}), got:\n{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn zsh_snippet_uses_xdg_state_home_fallback() {
+        let s = generate_zsh_snippet(&fixed_session_id());
+        assert!(
+            s.contains("${XDG_STATE_HOME:-$HOME/.local/state}"),
+            "snippet should compute state dir via XDG_STATE_HOME fallback, got:\n{s}"
+        );
+    }
+}

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -9,6 +9,8 @@
 //! - `tsm record` is the precmd-time recorder; in this slice it is a stub
 //!   that accepts the same args the snippet will pass.
 
+use std::collections::BTreeMap;
+
 use buildinfo::version_string;
 use clap::{Parser, Subcommand};
 use tsm_id::SessionId;
@@ -38,13 +40,33 @@ enum Commands {
     /// Record one command's metadata. Invoked by the shell precmd hook.
     Record {
         /// Exit status of the last command in the shell.
-        #[arg(long, allow_hyphen_values = true)]
+        #[arg(long, allow_hyphen_values = true, default_value_t = 0)]
         exit_code: i32,
 
         /// Verbatim text of the last command line.
         #[arg(long, default_value = "")]
         last_command: String,
+
+        /// Hidden: synthetic subprocess probe for the watchdog acceptance test.
+        ///
+        /// When set, the recorder skips its normal append path and instead
+        /// spawns the provided command (split on whitespace, no shell), wraps
+        /// it in the watchdog timeout, and exits 0 regardless of outcome.
+        #[arg(long, hide = true)]
+        probe_subprocess: Option<String>,
     },
+}
+
+/// Stub returning false for every input. Implemented in the green commit.
+fn is_redacted(_name: &str) -> bool {
+    false
+}
+
+/// Stub: returns env unchanged with empty `redacted_keys`. Implemented in green.
+fn redact_env(
+    env: BTreeMap<String, String>,
+) -> (BTreeMap<String, String>, Vec<String>) {
+    (env, Vec::new())
 }
 
 /// Maximum number of consecutive `tsm record` failures before the precmd
@@ -156,8 +178,12 @@ fn main() {
             let session_id = SessionId::random();
             print!("{}", generate_zsh_snippet(&session_id));
         }
-        Commands::Record { exit_code: _, last_command: _ } => {
-            // Stub for this slice. Subagent 4 will replace this body with the
+        Commands::Record {
+            exit_code: _,
+            last_command: _,
+            probe_subprocess: _,
+        } => {
+            // Stub for this slice. The green commit replaces this body with the
             // real recorder. We intentionally do not write anything to stderr
             // (per the safety policy that `tsm record` never writes to stderr
             // from the hot path).
@@ -281,5 +307,90 @@ mod tests {
             s.contains("${XDG_STATE_HOME:-$HOME/.local/state}"),
             "snippet should compute state dir via XDG_STATE_HOME fallback, got:\n{s}"
         );
+    }
+
+    // ----- redaction unit tests (red commit will see these fail against stubs) -----
+
+    #[test]
+    fn is_redacted_matches_suffix_patterns() {
+        assert!(is_redacted("AWS_SESSION_TOKEN"));
+        assert!(is_redacted("MY_API_KEY"));
+        assert!(is_redacted("DB_PASSWORD"));
+        assert!(is_redacted("OPENAI_API_KEY"));
+    }
+
+    #[test]
+    fn is_redacted_case_insensitive() {
+        assert!(is_redacted("aws_session_token"));
+        assert!(is_redacted("github_token"));
+        assert!(is_redacted("my_secret"));
+    }
+
+    #[test]
+    fn is_redacted_does_not_match_plain_names() {
+        assert!(!is_redacted("HOME"));
+        assert!(!is_redacted("PATH"));
+        assert!(!is_redacted("USER"));
+        assert!(!is_redacted("SHELL"));
+    }
+
+    #[test]
+    fn is_redacted_prefix_aws() {
+        assert!(is_redacted("AWS_REGION"));
+        assert!(is_redacted("AWS_PROFILE"));
+        assert!(is_redacted("AWS_DEFAULT_REGION"));
+    }
+
+    #[test]
+    fn is_redacted_prefix_op() {
+        assert!(is_redacted("OP_SESSION"));
+        assert!(is_redacted("OP_DEVICE"));
+    }
+
+    #[test]
+    fn is_redacted_anthropic_exact() {
+        assert!(is_redacted("ANTHROPIC_API_KEY"));
+        assert!(is_redacted("GH_TOKEN"));
+        assert!(is_redacted("GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn is_redacted_claude_prefix() {
+        assert!(is_redacted("CLAUDE_CODE_THING"));
+        assert!(is_redacted("CLAUDE_API_KEY"));
+    }
+
+    #[test]
+    fn redact_env_filters_keys_and_keeps_redacted_keys_list() {
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), "/home/x".to_string());
+        env.insert("AWS_SESSION_TOKEN".to_string(), "secret1".to_string());
+        env.insert("PATH".to_string(), "/usr/bin".to_string());
+        env.insert("MY_API_KEY".to_string(), "secret2".to_string());
+
+        let (filtered, redacted_keys) = redact_env(env);
+
+        assert!(filtered.contains_key("HOME"));
+        assert!(filtered.contains_key("PATH"));
+        assert!(!filtered.contains_key("AWS_SESSION_TOKEN"));
+        assert!(!filtered.contains_key("MY_API_KEY"));
+        assert!(redacted_keys.contains(&"AWS_SESSION_TOKEN".to_string()));
+        assert!(redacted_keys.contains(&"MY_API_KEY".to_string()));
+        assert_eq!(redacted_keys.len(), 2);
+    }
+
+    #[test]
+    fn redact_env_redacted_keys_is_sorted() {
+        let mut env = BTreeMap::new();
+        env.insert("Z_TOKEN".to_string(), "v".to_string());
+        env.insert("A_SECRET".to_string(), "v".to_string());
+        env.insert("M_PASSWORD".to_string(), "v".to_string());
+        env.insert("HOME".to_string(), "v".to_string());
+
+        let (_filtered, redacted_keys) = redact_env(env);
+        let mut sorted = redacted_keys.clone();
+        sorted.sort();
+        assert_eq!(redacted_keys, sorted, "redacted_keys must be sorted");
+        assert_eq!(redacted_keys.len(), 3);
     }
 }

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -10,13 +10,48 @@
 //!   that accepts the same args the snippet will pass.
 
 use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command as ProcCommand, Stdio};
+use std::time::Duration;
 
 use buildinfo::version_string;
+use chrono::Utc;
 use clap::{Parser, Subcommand};
 use tsm_id::SessionId;
+use tsm_jsonl::{
+    Header, HeaderKind, JsonlError, PrecmdKind, PrecmdRecord, TupleStub, append_header,
+    append_record,
+};
+use wait_timeout::ChildExt;
 
 /// Exit code returned when `tsm shell-init` receives an unsupported shell.
 const EXIT_UNSUPPORTED_SHELL: i32 = 2;
+
+/// Watchdog timeout for any subprocess the recorder spawns.
+const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Soft upper bound on the error log size in bytes; rotation kicks in above this.
+const ERROR_LOG_MAX_BYTES: u64 = 1 << 20; // 1 MiB
+
+/// Bytes kept after rotation.
+const ERROR_LOG_KEEP_BYTES: usize = 1 << 19; // 512 KiB
+
+/// Hardcoded redaction patterns. Three shapes are supported:
+/// - exact match (full uppercase name)
+/// - suffix match (`*_FOO` — `_FOO` literal suffix)
+/// - prefix match (`FOO_*` — `FOO_` literal prefix)
+///
+/// Matching is case-insensitive on the env var name (we uppercase once).
+const REDACTION_SUFFIXES: &[&str] = &["_TOKEN", "_KEY", "_SECRET", "_PASSWORD", "_PASSWD"];
+const REDACTION_PREFIXES: &[&str] = &["AWS_", "OP_", "CLAUDE_"];
+const REDACTION_EXACT: &[&str] = &[
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+];
 
 /// Top-level CLI for `tsm`.
 #[derive(Parser)]
@@ -57,16 +92,41 @@ enum Commands {
     },
 }
 
-/// Stub returning false for every input. Implemented in the green commit.
-fn is_redacted(_name: &str) -> bool {
+/// Return true if `name` matches any of the hardcoded redaction patterns.
+///
+/// Matching is case-insensitive on the env var name. The value is never
+/// inspected — pattern decisions are purely structural on the key.
+fn is_redacted(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    if REDACTION_EXACT.iter().any(|p| upper == *p) {
+        return true;
+    }
+    if REDACTION_PREFIXES.iter().any(|p| upper.starts_with(p)) {
+        return true;
+    }
+    if REDACTION_SUFFIXES.iter().any(|p| upper.ends_with(p)) {
+        return true;
+    }
     false
 }
 
-/// Stub: returns env unchanged with empty `redacted_keys`. Implemented in green.
+/// Split `env` into (kept, redacted-keys-sorted). Values for keys that match
+/// the redaction list are dropped entirely from the kept map; their names are
+/// pushed onto `redacted_keys` and the result is sorted alphabetically.
 fn redact_env(
     env: BTreeMap<String, String>,
 ) -> (BTreeMap<String, String>, Vec<String>) {
-    (env, Vec::new())
+    let mut kept = BTreeMap::new();
+    let mut redacted = Vec::new();
+    for (k, v) in env {
+        if is_redacted(&k) {
+            redacted.push(k);
+        } else {
+            kept.insert(k, v);
+        }
+    }
+    redacted.sort();
+    (kept, redacted)
 }
 
 /// Maximum number of consecutive `tsm record` failures before the precmd
@@ -165,6 +225,328 @@ add-zsh-hook precmd _tsm_precmd
     )
 }
 
+/// Resolve `$XDG_DATA_HOME` with the `$HOME/.local/share` fallback.
+fn xdg_data_home() -> Option<PathBuf> {
+    if let Ok(v) = std::env::var("XDG_DATA_HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".local").join("share"))
+}
+
+/// Resolve `$XDG_STATE_HOME` with the `$HOME/.local/state` fallback.
+fn xdg_state_home() -> Option<PathBuf> {
+    if let Ok(v) = std::env::var("XDG_STATE_HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".local").join("state"))
+}
+
+/// Compute the session log path for `<session-id>`. Creates parent dirs with
+/// mode 0700 on the `tsm/` directory.
+fn session_log_path(session_id: &SessionId) -> Option<PathBuf> {
+    let data = xdg_data_home()?;
+    let tsm_dir = data.join("tsm");
+    let sessions_dir = tsm_dir.join("sessions");
+    fs::create_dir_all(&sessions_dir).ok()?;
+    // Best-effort: tighten permissions on the tsm/ root to 0700. We don't fail
+    // if this errors — the session log is the load-bearing artifact.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(&tsm_dir) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o700);
+            let _ = fs::set_permissions(&tsm_dir, perms);
+        }
+    }
+    Some(sessions_dir.join(format!("{}.jsonl", session_id.as_hex())))
+}
+
+/// Compute the error log path. Creates parent dir if missing.
+fn error_log_path_in(state_dir: &Path) -> PathBuf {
+    let tsm_dir = state_dir.join("tsm");
+    let _ = fs::create_dir_all(&tsm_dir);
+    tsm_dir.join("errors.log")
+}
+
+/// Compute the fail-counter file path for our parent process.
+fn fail_count_path_in(state_dir: &Path) -> PathBuf {
+    let tsm_dir = state_dir.join("tsm");
+    let _ = fs::create_dir_all(&tsm_dir);
+    // On Unix `parent_id` is always available; if we're somehow init (PPID 0)
+    // we fall back to our own pid so the path is still unique.
+    let ppid = parent_pid();
+    tsm_dir.join(format!("fail-count.{ppid}"))
+}
+
+/// Return the parent process id. Falls back to our own pid if PPID is 0.
+fn parent_pid() -> u32 {
+    #[cfg(unix)]
+    {
+        let p = std::os::unix::process::parent_id();
+        if p == 0 { std::process::id() } else { p }
+    }
+    #[cfg(not(unix))]
+    {
+        std::process::id()
+    }
+}
+
+/// Truncate the error log to keep only the last `ERROR_LOG_KEEP_BYTES` bytes
+/// if it has grown past `ERROR_LOG_MAX_BYTES`. Best-effort; failures swallowed.
+fn rotate_error_log_if_needed(path: &Path) {
+    let Ok(meta) = fs::metadata(path) else { return };
+    if meta.len() <= ERROR_LOG_MAX_BYTES {
+        return;
+    }
+    // Read the tail of the file and rename a `.tmp` sibling over the original.
+    let Ok(mut f) = File::open(path) else { return };
+    let len = meta.len();
+    let keep = u64::try_from(ERROR_LOG_KEEP_BYTES).unwrap_or(0);
+    let start = len.saturating_sub(keep);
+    if f.seek(SeekFrom::Start(start)).is_err() {
+        return;
+    }
+    let mut buf = Vec::with_capacity(ERROR_LOG_KEEP_BYTES);
+    if f.read_to_end(&mut buf).is_err() {
+        return;
+    }
+    // Drop everything up to the first newline so we don't have a partial line.
+    if let Some(nl) = buf.iter().position(|b| *b == b'\n') {
+        buf.drain(..=nl);
+    }
+    let tmp = path.with_extension(format!("log.tmp.{}", std::process::id()));
+    let Ok(mut out) = File::create(&tmp) else { return };
+    if out.write_all(&buf).is_err() {
+        let _ = fs::remove_file(&tmp);
+        return;
+    }
+    let _ = fs::rename(&tmp, path);
+}
+
+/// Append `msg` to the error log at `path`, prefixed with an RFC3339 timestamp.
+/// Best-effort: any failure is silently dropped (we cannot recurse on logging).
+fn log_error_to(path: &Path, msg: &str) {
+    rotate_error_log_if_needed(path);
+    let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let ts = Utc::now().to_rfc3339();
+    let _ = writeln!(f, "{ts} {msg}");
+}
+
+/// Atomically write `value` to the fail-counter file at `path`. Uses a tmp
+/// sibling + rename so a partial write is never observed.
+fn write_fail_counter(path: &Path, value: u32) {
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    if let Ok(mut f) = File::create(&tmp) {
+        if writeln!(f, "{value}").is_ok() {
+            let _ = fs::rename(&tmp, path);
+            return;
+        }
+    }
+    let _ = fs::remove_file(&tmp);
+}
+
+/// Read the current fail counter (0 if absent or unparseable).
+fn read_fail_counter(path: &Path) -> u32 {
+    let Ok(s) = fs::read_to_string(path) else { return 0 };
+    s.trim().parse::<u32>().unwrap_or(0)
+}
+
+/// Bump the fail counter by 1, atomically.
+fn bump_fail_counter(state_dir: &Path) {
+    let path = fail_count_path_in(state_dir);
+    let v = read_fail_counter(&path).saturating_add(1);
+    write_fail_counter(&path, v);
+}
+
+/// Reset the fail counter to 0.
+fn reset_fail_counter(state_dir: &Path) {
+    let path = fail_count_path_in(state_dir);
+    write_fail_counter(&path, 0);
+}
+
+/// Run `cmd` with a watchdog timeout. On timeout, the child is killed and
+/// reaped; we return `Err(())`. We intentionally do not expose the underlying
+/// error type — the recorder swallows all subprocess errors anyway.
+fn run_with_timeout(mut cmd: ProcCommand, timeout: Duration) -> Result<(), ()> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| ())?;
+    if child.wait_timeout(timeout).map_err(|_| ())?.is_some() {
+        Ok(())
+    } else {
+        // Timeout: kill and reap. Both errors are swallowed.
+        let _ = child.kill();
+        let _ = child.wait();
+        Err(())
+    }
+}
+
+/// Parse a free-form `--probe-subprocess "/bin/sleep 5"` string into a
+/// `Command`. Whitespace-split, no shell. The first token is the program;
+/// subsequent tokens are args.
+fn parse_probe_command(spec: &str) -> Option<ProcCommand> {
+    let mut tokens = spec.split_whitespace();
+    let prog = tokens.next()?;
+    let mut cmd = ProcCommand::new(prog);
+    for arg in tokens {
+        cmd.arg(arg);
+    }
+    Some(cmd)
+}
+
+/// Build the Header used for line 1 of a fresh session log.
+fn build_header() -> Header {
+    let hostname = hostname::get().map_or_else(
+        |_| "unknown".to_string(),
+        |h| h.to_string_lossy().into_owned(),
+    );
+    let terminal_program =
+        std::env::var("TERM_PROGRAM").unwrap_or_else(|_| "unknown".to_string());
+    Header {
+        kind: HeaderKind::Header,
+        schema_version: 1,
+        tsm_version: version_string!().to_string(),
+        hostname,
+        terminal_program,
+        tuple: TupleStub {
+            zellij_session: None,
+            tab: None,
+            pane_ordinal_str: None,
+        },
+        created_at: Utc::now().to_rfc3339(),
+    }
+}
+
+/// Build a `PrecmdRecord` from the current process environment plus the
+/// caller-supplied exit code and last-command text.
+fn build_record(exit_code: i32, last_command: String) -> PrecmdRecord {
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    let (env, redacted_keys) = redact_env(env);
+    PrecmdRecord {
+        kind: PrecmdKind::Precmd,
+        at: Utc::now().to_rfc3339(),
+        cwd,
+        exit_code,
+        last_command,
+        env,
+        redacted_keys,
+    }
+}
+
+/// Append a record. If the file is empty / missing, write a header first and
+/// then retry. Handles a concurrent-writer race on the header by treating
+/// `DuplicateHeader` as success.
+fn append_record_with_header(path: &Path, record: &PrecmdRecord) -> Result<(), JsonlError> {
+    match append_record(path, record) {
+        Ok(()) => Ok(()),
+        Err(JsonlError::MissingHeader) => {
+            let header = build_header();
+            match append_header(path, &header) {
+                Ok(()) | Err(JsonlError::DuplicateHeader) => append_record(path, record),
+                Err(e) => Err(e),
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// The core of the recorder. Returns `Ok(())` on success, `Err(String)` on
+/// any internal failure (the caller logs the message and bumps the counter).
+fn do_record(
+    state_dir: &Path,
+    exit_code: i32,
+    last_command: String,
+) -> Result<(), String> {
+    let raw_id = std::env::var("TSM_SESSION_ID")
+        .map_err(|_| "record: TSM_SESSION_ID is not set".to_string())?;
+    let session_id = SessionId::from_hex(&raw_id)
+        .map_err(|e| format!("record: invalid TSM_SESSION_ID: {e}"))?;
+
+    let _ = state_dir; // path resolution for the session log uses XDG_DATA_HOME.
+    let log_path = session_log_path(&session_id)
+        .ok_or_else(|| "record: could not resolve session log path".to_string())?;
+
+    // First call: file is empty/missing → write header.
+    let first_call = match fs::metadata(&log_path) {
+        Ok(m) => m.len() == 0,
+        Err(_) => true,
+    };
+
+    if first_call {
+        let header = build_header();
+        match append_header(&log_path, &header) {
+            Ok(()) | Err(JsonlError::DuplicateHeader) => {}
+            Err(e) => return Err(format!("record: append_header failed: {e}")),
+        }
+        return Ok(());
+    }
+
+    let record = build_record(exit_code, last_command);
+    append_record_with_header(&log_path, &record)
+        .map_err(|e| format!("record: append_record failed: {e}"))?;
+    Ok(())
+}
+
+fn handle_record(
+    exit_code: i32,
+    last_command: String,
+    probe_subprocess: Option<String>,
+) {
+    let state_dir = xdg_state_home();
+    let err_log = state_dir.as_deref().map(error_log_path_in);
+
+    // Probe path: synthetic subprocess for the watchdog acceptance test. We do
+    // NOT touch the session log on this path.
+    if let Some(spec) = probe_subprocess {
+        if let Some(cmd) = parse_probe_command(&spec) {
+            if run_with_timeout(cmd, SUBPROCESS_TIMEOUT).is_err() {
+                if let Some(p) = err_log.as_deref() {
+                    log_error_to(
+                        p,
+                        &format!("record: probe subprocess timed out after 2s: {spec}"),
+                    );
+                }
+            }
+        } else if let Some(p) = err_log.as_deref() {
+            log_error_to(p, &format!("record: probe-subprocess empty: {spec}"));
+        }
+        return;
+    }
+
+    match do_record(state_dir.as_deref().unwrap_or(Path::new(".")), exit_code, last_command) {
+        Ok(()) => {
+            if let Some(dir) = state_dir.as_deref() {
+                reset_fail_counter(dir);
+            }
+        }
+        Err(msg) => {
+            if let Some(p) = err_log.as_deref() {
+                log_error_to(p, &msg);
+            }
+            if let Some(dir) = state_dir.as_deref() {
+                bump_fail_counter(dir);
+            }
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
@@ -179,14 +561,14 @@ fn main() {
             print!("{}", generate_zsh_snippet(&session_id));
         }
         Commands::Record {
-            exit_code: _,
-            last_command: _,
-            probe_subprocess: _,
+            exit_code,
+            last_command,
+            probe_subprocess,
         } => {
-            // Stub for this slice. The green commit replaces this body with the
-            // real recorder. We intentionally do not write anything to stderr
-            // (per the safety policy that `tsm record` never writes to stderr
-            // from the hot path).
+            // Safety contract: never panic, never write stderr from the hot
+            // path. Internal failures go to the error log; the fail counter
+            // ticks up; we always exit 0.
+            handle_record(exit_code, last_command, probe_subprocess);
         }
     }
 }

--- a/src/tsm/tests/record.rs
+++ b/src/tsm/tests/record.rs
@@ -1,0 +1,306 @@
+//! Integration tests for `tsm record`.
+//!
+//! Each test runs the `tsm` binary as a subprocess via `assert_cmd`, using a
+//! fresh temporary directory for `$XDG_DATA_HOME` / `$XDG_STATE_HOME` so test
+//! runs cannot pollute each other or the developer's real session log.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+use tsm_jsonl::{Header, HeaderKind, PrecmdKind, PrecmdRecord};
+
+/// Known-good 32-char lowercase hex session id used across tests.
+const TEST_SESSION_ID: &str = "0123456789abcdef0123456789abcdef";
+
+/// Path to the session log file inside a tempdir root.
+fn session_log_path(data: &TempDir, session_id: &str) -> PathBuf {
+    data.path()
+        .join("tsm")
+        .join("sessions")
+        .join(format!("{session_id}.jsonl"))
+}
+
+/// Path to the error log inside the state tempdir.
+fn error_log_path(state: &TempDir) -> PathBuf {
+    state.path().join("tsm").join("errors.log")
+}
+
+/// Path to the fail-counter for the *current* process (which is the parent of
+/// the spawned `tsm record`).
+fn fail_count_path(state: &TempDir) -> PathBuf {
+    state
+        .path()
+        .join("tsm")
+        .join(format!("fail-count.{}", std::process::id()))
+}
+
+/// Build a Command for `tsm` with `env_clear` plus the minimum env the
+/// recorder needs to run.
+fn tsm_command(data: &TempDir, state: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("tsm").expect("tsm binary");
+    cmd.env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )
+        .env("HOME", data.path())
+        .env("XDG_DATA_HOME", data.path())
+        .env("XDG_STATE_HOME", state.path());
+    cmd
+}
+
+#[test]
+fn record_first_call_writes_header() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+
+    let log_path = session_log_path(&data, TEST_SESSION_ID);
+    assert!(log_path.exists(), "session log file must exist at {log_path:?}");
+
+    let contents = fs::read_to_string(&log_path).expect("read log");
+    let first_line = contents.lines().next().expect("at least one line");
+    let header: Header =
+        serde_json::from_str(first_line).expect("line 1 must parse as Header");
+    assert!(matches!(header.kind, HeaderKind::Header));
+    assert_eq!(header.schema_version, 1);
+    assert!(!header.tsm_version.is_empty(), "tsm_version should be populated");
+}
+
+#[test]
+fn record_second_call_appends_record_after_header() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args(["record", "--exit-code", "0", "--last-command", "first"])
+        .assert()
+        .success();
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args(["record", "--exit-code", "7", "--last-command", "second"])
+        .assert()
+        .success();
+
+    let log_path = session_log_path(&data, TEST_SESSION_ID);
+    let contents = fs::read_to_string(&log_path).expect("read log");
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(lines.len(), 2, "expected exactly 2 lines, got: {contents:?}");
+
+    let header: Header =
+        serde_json::from_str(lines[0]).expect("line 1 must parse as Header");
+    assert!(matches!(header.kind, HeaderKind::Header));
+
+    let record: PrecmdRecord =
+        serde_json::from_str(lines[1]).expect("line 2 must parse as PrecmdRecord");
+    assert!(matches!(record.kind, PrecmdKind::Precmd));
+    assert_eq!(record.exit_code, 7);
+    assert_eq!(record.last_command, "second");
+}
+
+#[test]
+fn record_missing_session_id_writes_to_error_log_not_stderr() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    let output = tsm_command(&data, &state)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .output()
+        .expect("run tsm");
+
+    assert!(
+        output.stderr.is_empty(),
+        "stderr must be empty, got: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let err_path = error_log_path(&state);
+    assert!(err_path.exists(), "error log must exist at {err_path:?}");
+    let err_log = fs::read_to_string(&err_path).expect("read err log");
+    assert!(
+        err_log.to_ascii_lowercase().contains("session"),
+        "error log should mention session id: {err_log:?}"
+    );
+}
+
+#[test]
+fn record_invalid_session_id_writes_to_error_log() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", "not-hex")
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+
+    let err_path = error_log_path(&state);
+    assert!(err_path.exists(), "error log must exist");
+    let err_log = fs::read_to_string(&err_path).expect("read err log");
+    assert!(
+        err_log.to_ascii_lowercase().contains("session"),
+        "error log should mention invalid session id: {err_log:?}"
+    );
+}
+
+#[test]
+fn record_failure_increments_fail_counter() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    tsm_command(&data, &state)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+
+    let counter = fail_count_path(&state);
+    assert!(counter.exists(), "fail-count file must exist at {counter:?}");
+    let v = fs::read_to_string(&counter).expect("read counter");
+    assert_eq!(v.trim(), "1");
+
+    tsm_command(&data, &state)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+    let v = fs::read_to_string(&counter).expect("read counter");
+    assert_eq!(v.trim(), "2");
+}
+
+#[test]
+fn record_success_resets_fail_counter() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    // Pre-create a fail-count file at 2.
+    let counter = fail_count_path(&state);
+    fs::create_dir_all(counter.parent().unwrap()).expect("mkdir state/tsm");
+    fs::write(&counter, "2\n").expect("seed counter");
+
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+
+    // After success, counter must be "0" (or absent — both are acceptable).
+    if counter.exists() {
+        let v = fs::read_to_string(&counter).expect("read counter");
+        assert_eq!(
+            v.trim(),
+            "0",
+            "after success counter must be reset to 0, got {v:?}"
+        );
+    }
+}
+
+#[test]
+fn record_redacts_aws_session_token() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .env("AWS_SESSION_TOKEN", "abc-secret-do-not-leak")
+        .env("MY_API_KEY", "another-secret")
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+    // Second invocation produces a PrecmdRecord (line 2).
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .env("AWS_SESSION_TOKEN", "abc-secret-do-not-leak")
+        .env("MY_API_KEY", "another-secret")
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .assert()
+        .success();
+
+    let log_path = session_log_path(&data, TEST_SESSION_ID);
+    let contents = fs::read_to_string(&log_path).expect("read log");
+    let lines: Vec<&str> = contents.lines().collect();
+    assert!(lines.len() >= 2, "expected header + record");
+    let record: PrecmdRecord =
+        serde_json::from_str(lines[1]).expect("line 2 is PrecmdRecord");
+    assert!(
+        !record.env.contains_key("AWS_SESSION_TOKEN"),
+        "AWS_SESSION_TOKEN must be redacted out of env"
+    );
+    assert!(
+        !record.env.contains_key("MY_API_KEY"),
+        "MY_API_KEY must be redacted out of env"
+    );
+    assert!(
+        record.redacted_keys.contains(&"AWS_SESSION_TOKEN".to_string()),
+        "AWS_SESSION_TOKEN must be in redacted_keys"
+    );
+    assert!(
+        record.redacted_keys.contains(&"MY_API_KEY".to_string()),
+        "MY_API_KEY must be in redacted_keys"
+    );
+    // The secret value must never appear in the file.
+    assert!(
+        !contents.contains("abc-secret-do-not-leak"),
+        "secret value leaked into log: {contents}"
+    );
+    // Verify type-safe values exist
+    let _kv: BTreeMap<String, String> = record.env;
+}
+
+#[test]
+fn record_probe_subprocess_kills_long_running_child() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+
+    let start = Instant::now();
+    tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args([
+            "record",
+            "--exit-code",
+            "0",
+            "--last-command",
+            "probe",
+            "--probe-subprocess",
+            "/bin/sleep 5",
+        ])
+        .assert()
+        .success();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(3500),
+        "probe must time out around 2s, took {elapsed:?}"
+    );
+    assert!(
+        elapsed > Duration::from_millis(1500),
+        "probe completed suspiciously fast ({elapsed:?}); is the watchdog firing?"
+    );
+}
+
+#[test]
+fn record_writes_no_stderr_in_happy_path() {
+    let data = TempDir::new().expect("tempdir");
+    let state = TempDir::new().expect("tempdir");
+    let output = tsm_command(&data, &state)
+        .env("TSM_SESSION_ID", TEST_SESSION_ID)
+        .args(["record", "--exit-code", "0", "--last-command", "ls"])
+        .output()
+        .expect("run tsm");
+    assert!(
+        output.stderr.is_empty(),
+        "stderr must be empty in happy path, got: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Drain stdout to satisfy clippy's unused variable concerns.
+    let mut _stdout = std::io::Cursor::new(output.stdout);
+    let mut buf = String::new();
+    _stdout.read_to_string(&mut buf).expect("read stdout");
+}

--- a/src/tsm/tests/record.rs
+++ b/src/tsm/tests/record.rs
@@ -4,9 +4,7 @@
 //! fresh temporary directory for `$XDG_DATA_HOME` / `$XDG_STATE_HOME` so test
 //! runs cannot pollute each other or the developer's real session log.
 
-use std::collections::BTreeMap;
 use std::fs;
-use std::io::Read;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -251,8 +249,6 @@ fn record_redacts_aws_session_token() {
         !contents.contains("abc-secret-do-not-leak"),
         "secret value leaked into log: {contents}"
     );
-    // Verify type-safe values exist
-    let _kv: BTreeMap<String, String> = record.env;
 }
 
 #[test]
@@ -299,8 +295,4 @@ fn record_writes_no_stderr_in_happy_path() {
         "stderr must be empty in happy path, got: {:?}",
         String::from_utf8_lossy(&output.stderr)
     );
-    // Drain stdout to satisfy clippy's unused variable concerns.
-    let mut _stdout = std::io::Cursor::new(output.stdout);
-    let mut buf = String::new();
-    _stdout.read_to_string(&mut buf).expect("read stdout");
 }


### PR DESCRIPTION
Closes #213. Foundational tracer-bullet slice of PRD #204 — a working `tsm` binary that produces session JSONL logs from a real zsh shell, with all `precmd` safety defenses wired from day one. No Zellij integration yet; sessions get random `SessionId`s outside Zellij (the same path always-on outside-Zellij users will use long-term).

## Summary

Three new crates, 8 commits in strict red→green TDD pairs:

| Crate | Purpose | Tests |
|---|---|---|
| `src/tsm-id/` | `SessionId` newtype with random-construction path | 12 |
| `src/tsm-jsonl/` | Header-first JSONL append + read with invariants | 14 |
| `src/tsm/` | clap CLI binary: `--version`, `shell-init zsh`, `record` | 19 unit + 9 integration |

Behavioral coverage:
- `SessionId::random()` produces 128-bit random IDs hex-encoded; `from_hex` validates strict 32-char lowercase.
- `tsm-jsonl` enforces header-first invariant (no records without header, no duplicate headers, no record-tags as headers).
- `tsm shell-init zsh` emits a snippet with: `TSM_DISABLE` kill switch, 1s health check, fresh random `$TSM_SESSION_ID` inlined at print time, `precmd` hook dispatching `tsm record --exit-code "$?" --last-command "..." &!`, and self-disable after 3 consecutive failures via `$XDG_STATE_HOME/tsm/fail-count.$$`.
- `tsm record` writes to `$XDG_DATA_HOME/tsm/sessions/<id>.jsonl` (header first call, precmd record thereafter), redacts env keys matching `*_TOKEN`/`*_KEY`/`*_SECRET`/`*_PASSWORD`/`*_PASSWD`/`AWS_*`/`OP_*`/`GH_TOKEN`/`GITHUB_TOKEN`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`CLAUDE_*` (case-insensitive), wraps subprocesses with a 2s watchdog (via `wait-timeout`), logs errors to a size-bounded `$XDG_STATE_HOME/tsm/errors.log` (1 MiB → 512 KiB), and never writes to stderr.

## Acceptance criteria — all PASS

| # | Criterion | Status |
|---|---|---|
| 1 | `tsm --version` format `tsm 0.1.0 (abc1234, clean\|dirty)` | PASS |
| 2 | `eval "$(tsm shell-init zsh)"` produces header-first JSONL session log | PASS |
| 3 | `TSM_DISABLE=1` installs no hook, no errors | PASS |
| 4 | Missing `tsm` on PATH → exactly one warning, no further noise | PASS |
| 5a | Failing `tsm record` → zero stderr, error log entry | PASS |
| 5b | Self-disable after 3 consecutive failures | PASS |
| 6 | 5s synthetic subprocess → <50ms added to prompt return (measured ~1ms via `&!`) | PASS |
| 7 | `tsm-jsonl` unit tests cover header-first invariant, append, round-trip | PASS |
| 8 | `tsm-id` exposes `SessionId::random()` newtype | PASS |
| 9 | `cargo clippy -p tsm-id -p tsm-jsonl -p tsm -- -D warnings` + `cargo test --workspace` | PASS |

## Pre-existing lint debt (not introduced here)

`cargo clippy --workspace -- -D warnings` fails on `gitrdun`, `clipboardmon`, `termbar`, `wifiqr`, `reposize`, `tc`, `sf`, and `op-cache` — all untouched by this slice. Worth a separate cleanup PR.

## Test plan

- [x] `cargo test --workspace` (609 tests, 0 failures)
- [x] `cargo clippy -p tsm-id -p tsm-jsonl -p tsm -- -D warnings` clean
- [x] Manual end-to-end zsh integration in tempdir (header + precmd records appear)
- [x] `TSM_DISABLE=1` kill switch verified
- [x] Health-check warning fires exactly once when `tsm` not on PATH
- [x] Self-disable verified by pre-seeding `fail-count.$$=3`
- [x] `&!` dispatch latency measured sub-millisecond with 5s synthetic subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)