### PR TITLE
chore(clippy): fix all clippy warnings across the workspace

### DIFF
--- a/src/aws2env/src/main.rs
+++ b/src/aws2env/src/main.rs
@@ -54,7 +54,14 @@ fn parse_ini_file(content: &str) -> HashMap<String, HashMap<String, String>> {
         }
 
         if line.starts_with('[') && line.ends_with(']') {
-            current_section = line[1..line.len() - 1].to_string();
+            // strip_prefix/strip_suffix work at character boundaries (since the
+            // matched chars are ASCII '[' and ']') and avoid the byte-index
+            // slice that triggers clippy::string_slice on UTF-8 input.
+            current_section = line
+                .strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'))
+                .unwrap_or("")
+                .to_string();
             result
                 .entry(current_section.clone())
                 .or_insert_with(HashMap::new);

--- a/src/beta/src/export/terminal_renderer.rs
+++ b/src/beta/src/export/terminal_renderer.rs
@@ -723,13 +723,13 @@ impl TerminalState {
                     let color_index = (param - 30) as u8;
                     self.current_fg = self.theme.get_color(color_index);
                 }
-                38 => {
+                38
                     // Extended foreground color
-                    if i + 1 < param_vec.len() {
+                    if i + 1 < param_vec.len() => {
                         match param_vec[i + 1] {
-                            5 => {
+                            5
                                 // 256-color mode: ESC[38;5;n
-                                if i + 2 < param_vec.len() {
+                                if i + 2 < param_vec.len() => {
                                     let color_index = param_vec[i + 2] as u8;
                                     if (color_index as usize) < self.dynamic_palette.len() {
                                         self.current_fg =
@@ -739,33 +739,30 @@ impl TerminalState {
                                     }
                                     i += 2; // Skip the 5 and color index
                                 }
-                            }
-                            2 => {
+                            2
                                 // 24-bit RGB mode: ESC[38;2;r;g;b
-                                if i + 4 < param_vec.len() {
+                                if i + 4 < param_vec.len() => {
                                     let r = param_vec[i + 2] as u8;
                                     let g = param_vec[i + 3] as u8;
                                     let b = param_vec[i + 4] as u8;
                                     self.current_fg = (r, g, b);
                                     i += 4; // Skip the 2, r, g, b
                                 }
-                            }
                             _ => {}
                         }
                     }
-                }
                 40..=47 => {
                     // Background colors
                     let color_index = (param - 40) as u8;
                     self.current_bg = self.theme.get_color(color_index);
                 }
-                48 => {
+                48
                     // Extended background color
-                    if i + 1 < param_vec.len() {
+                    if i + 1 < param_vec.len() => {
                         match param_vec[i + 1] {
-                            5 => {
+                            5
                                 // 256-color mode: ESC[48;5;n
-                                if i + 2 < param_vec.len() {
+                                if i + 2 < param_vec.len() => {
                                     let color_index = param_vec[i + 2] as u8;
                                     if (color_index as usize) < self.dynamic_palette.len() {
                                         self.current_bg =
@@ -775,21 +772,18 @@ impl TerminalState {
                                     }
                                     i += 2; // Skip the 5 and color index
                                 }
-                            }
-                            2 => {
+                            2
                                 // 24-bit RGB mode: ESC[48;2;r;g;b
-                                if i + 4 < param_vec.len() {
+                                if i + 4 < param_vec.len() => {
                                     let r = param_vec[i + 2] as u8;
                                     let g = param_vec[i + 3] as u8;
                                     let b = param_vec[i + 4] as u8;
                                     self.current_bg = (r, g, b);
                                     i += 4; // Skip the 2, r, g, b
                                 }
-                            }
                             _ => {}
                         }
                     }
-                }
                 90..=97 => {
                     // Bright foreground colors
                     let color_index = (param - 90 + 8) as u8;
@@ -891,12 +885,11 @@ impl Perform for TerminalState {
                     self.put_char(' ');
                 }
             }
-            b'\x08' => {
+            b'\x08'
                 // Backspace
-                if self.cursor_x > 0 {
+                if self.cursor_x > 0 => {
                     self.cursor_x -= 1;
                 }
-            }
             _ => {}
         }
     }
@@ -922,10 +915,10 @@ impl Perform for TerminalState {
         let first_param = std::str::from_utf8(params[0]).unwrap_or("");
 
         match first_param {
-            "4" => {
+            "4"
                 // OSC 4 ; color_index ; color_spec ST
                 // Set/modify color palette entry
-                if params.len() >= 3 {
+                if params.len() >= 3 => {
                     if let Ok(index) = std::str::from_utf8(params[1]).unwrap_or("").parse::<u8>() {
                         let color_spec = std::str::from_utf8(params[2]).unwrap_or("");
                         if let Some(color) = self.parse_color_spec(color_spec) {
@@ -935,49 +928,44 @@ impl Perform for TerminalState {
                         }
                     }
                 }
-            }
-            "10" => {
+            "10"
                 // OSC 10 ; color_spec ST - Set text foreground color
-                if params.len() >= 2 {
+                if params.len() >= 2 => {
                     let color_spec = std::str::from_utf8(params[1]).unwrap_or("");
                     if let Some(color) = self.parse_color_spec(color_spec) {
                         self.override_fg = Some(color);
                     }
                 }
-            }
-            "11" => {
+            "11"
                 // OSC 11 ; color_spec ST - Set text background color
-                if params.len() >= 2 {
+                if params.len() >= 2 => {
                     let color_spec = std::str::from_utf8(params[1]).unwrap_or("");
                     if let Some(color) = self.parse_color_spec(color_spec) {
                         self.override_bg = Some(color);
                     }
                 }
-            }
-            "17" => {
+            "17"
                 // OSC 17 ; color_spec ST - Set selection background color
-                if params.len() >= 2 {
+                if params.len() >= 2 => {
                     let color_spec = std::str::from_utf8(params[1]).unwrap_or("");
                     if let Some(color) = self.parse_color_spec(color_spec) {
                         self.selection_bg = Some(color);
                     }
                 }
-            }
-            "19" => {
+            "19"
                 // OSC 19 ; color_spec ST - Set selection foreground color
-                if params.len() >= 2 {
+                if params.len() >= 2 => {
                     let color_spec = std::str::from_utf8(params[1]).unwrap_or("");
                     if let Some(color) = self.parse_color_spec(color_spec) {
                         self.selection_fg = Some(color);
                     }
                 }
-            }
             "52" => {
                 // OSC 52 - Clipboard operations - ignore for security
             }
-            "104" => {
+            "104"
                 // OSC 104 ; index_list ST - Reset color palette entries
-                if params.len() >= 2 {
+                if params.len() >= 2 => {
                     let indices = std::str::from_utf8(params[1]).unwrap_or("");
                     if indices.is_empty() {
                         // Reset all colors
@@ -996,7 +984,6 @@ impl Perform for TerminalState {
                         }
                     }
                 }
-            }
             "110" => {
                 // OSC 110 ST - Reset text foreground color
                 self.override_fg = None;

--- a/src/cdknuke/src/main.rs
+++ b/src/cdknuke/src/main.rs
@@ -59,15 +59,14 @@ fn main() {
         let entry_name = entry.file_name().to_string_lossy();
 
         // Check for target directories
-        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            if target_dirs.contains(&entry_name.as_ref()) {
+        if entry.file_type().is_some_and(|ft| ft.is_dir())
+            && target_dirs.contains(&entry_name.as_ref()) {
                 found_any = true;
                 println!("Removing directory: {}", entry.path().display());
                 if let Err(e) = fs::remove_dir_all(entry.path()) {
                     eprintln!("Error removing {}: {}", entry.path().display(), e);
                 }
             }
-        }
     }
 
     // Also check for cdk.out at the top level even without --hidden

--- a/src/cf/src/main.rs
+++ b/src/cf/src/main.rs
@@ -43,15 +43,11 @@ fn main() -> Result<()> {
         Some(FilterType::Suffix(suffix))
     } else if let Some(prefix) = cli.prefix {
         Some(FilterType::Prefix(prefix))
-    } else if let Some(substring) = cli.substring {
-        Some(FilterType::Substring(substring))
-    } else {
-        None
-    };
+    } else { cli.substring.map(FilterType::Substring) };
 
     let walker = FileWalker::new(cli.paths).with_filter(filter);
 
-    let mut total_count = 0u64;
+    let mut total_count = 0_u64;
 
     walker.walk(|_entry| {
         total_count += 1;

--- a/src/clipboard-random/src/main.rs
+++ b/src/clipboard-random/src/main.rs
@@ -222,13 +222,16 @@ fn generate_binary_data(bytes: usize, format: OutputFormat, dry_run: bool) -> Re
     println!("Format: {:?}", format);
     println!("Data length: {} characters", formatted_data.len());
 
-    // Show a preview of the data (first 50 characters)
-    let preview = if formatted_data.len() > 50 {
-        format!("{}...", &formatted_data[..50])
+    // Show a preview of the data (first 50 characters). Use chars().take so the
+    // truncation is safe on multi-byte UTF-8 (random text could include
+    // wide-character output in future formats).
+    let preview = if formatted_data.chars().count() > 50 {
+        let prefix: String = formatted_data.chars().take(50).collect();
+        format!("{prefix}...")
     } else {
         formatted_data
     };
-    println!("Preview: {}", preview);
+    println!("Preview: {preview}");
 
     Ok(())
 }

--- a/src/clipboardmon/src/lib.rs
+++ b/src/clipboardmon/src/lib.rs
@@ -10,7 +10,12 @@ pub trait Transformer: Send {
     /// Check if the clipboard content is relevant for this transformer
     fn is_relevant(&self, content: &str) -> bool;
 
-    /// Transform the content
+    /// Transform the content.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transformation fails (for example, an invalid
+    /// input or an external operation reported by the implementor).
     fn transform(&self, content: &str) -> Result<String, Box<dyn Error>>;
 
     /// Get the waiting message to display at startup
@@ -24,7 +29,13 @@ pub trait Transformer: Send {
     }
 }
 
-/// Monitor clipboard and apply transformations
+/// Monitor clipboard and apply transformations.
+///
+/// # Errors
+///
+/// Returns an error if the system clipboard cannot be opened, or — when the
+/// transformer rejects the current contents — if those rejection errors should
+/// be surfaced. Transient `set_text` failures are logged and the loop continues.
 pub fn monitor_clipboard<T: Transformer>(transformer: T, poll_interval: Duration) -> Result<()> {
     let mut clipboard = Clipboard::new()?;
     let mut last_seen = String::new();

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -232,8 +232,7 @@ fn find_current_worktree(worktrees: &[Worktree], repo_root: &Path) -> Option<usi
 
     worktrees.iter().position(|wt| {
         std::fs::canonicalize(&wt.path)
-            .map(|p| paths_equal(&p, &canonical))
-            .unwrap_or(false)
+            .is_ok_and(|p| paths_equal(&p, &canonical))
     })
 }
 
@@ -649,7 +648,7 @@ mod tests {
                 assert!(indices.contains(&1));
                 assert!(indices.contains(&2));
             }
-            other => panic!("Expected Multiple, got {:?}", other),
+            other => panic!("Expected Multiple, got {other:?}"),
         }
 
         // Partial path within branch name
@@ -721,14 +720,14 @@ mod tests {
                 assert!(indices.contains(&1));
                 assert!(indices.contains(&2));
             }
-            other => panic!("Expected Multiple, got {:?}", other),
+            other => panic!("Expected Multiple, got {other:?}"),
         }
         // "page" also matches both
         match find_worktree_by_name(&worktrees, "page") {
             WorktreeMatch::Multiple(indices) => {
                 assert_eq!(indices.len(), 2);
             }
-            other => panic!("Expected Multiple, got {:?}", other),
+            other => panic!("Expected Multiple, got {other:?}"),
         }
     }
 

--- a/src/diskhog/src/ui.rs
+++ b/src/diskhog/src/ui.rs
@@ -481,21 +481,33 @@ mod tests {
         const CONTENT_LINES: u16 = 2; // Line::from("") + Line::from(message)
         const MIN_REQUIRED: u16 = BORDER_LINES + CONTENT_LINES;
 
-        assert!(
-            IOPS_MESSAGE_HEIGHT >= MIN_REQUIRED,
-            "IOPS_MESSAGE_HEIGHT ({IOPS_MESSAGE_HEIGHT}) must be at least {MIN_REQUIRED} \
-             to display the status message with borders"
-        );
+        #[allow(
+            clippy::assertions_on_constants,
+            reason = "intentional change-detector test guarding the layout invariant if either constant is modified"
+        )]
+        {
+            assert!(
+                IOPS_MESSAGE_HEIGHT >= MIN_REQUIRED,
+                "IOPS_MESSAGE_HEIGHT ({IOPS_MESSAGE_HEIGHT}) must be at least {MIN_REQUIRED} \
+                 to display the status message with borders"
+            );
+        }
     }
 
     #[test]
     fn test_min_truncation_width_constant() {
         // Verify the constant is at least ellipsis width + 1
         // (need room for at least one character plus "...")
-        assert!(
-            MIN_TRUNCATION_WIDTH >= 4,
-            "MIN_TRUNCATION_WIDTH should be at least 4 (ellipsis + 1 char)"
-        );
+        #[allow(
+            clippy::assertions_on_constants,
+            reason = "intentional change-detector test guarding MIN_TRUNCATION_WIDTH if it is modified"
+        )]
+        {
+            assert!(
+                MIN_TRUNCATION_WIDTH >= 4,
+                "MIN_TRUNCATION_WIDTH should be at least 4 (ellipsis + 1 char)"
+            );
+        }
     }
 
     #[test]

--- a/src/filewalker/src/lib.rs
+++ b/src/filewalker/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(format_count(0), "0");
         assert_eq!(format_count(999), "999");
         assert_eq!(format_count(1000), "1,000");
-        assert_eq!(format_count(1234567), "1,234,567");
+        assert_eq!(format_count(1_234_567), "1,234,567");
     }
 
     #[test]
@@ -192,7 +192,7 @@ mod tests {
         assert_eq!(format_bytes(1023), "1023 B");
         assert_eq!(format_bytes(1024), "1.00 KB");
         assert_eq!(format_bytes(1536), "1.50 KB");
-        assert_eq!(format_bytes(1048576), "1.00 MB");
-        assert_eq!(format_bytes(1073741824), "1.00 GB");
+        assert_eq!(format_bytes(1_048_576), "1.00 MB");
+        assert_eq!(format_bytes(1_073_741_824), "1.00 GB");
     }
 }

--- a/src/freeport/src/main.rs
+++ b/src/freeport/src/main.rs
@@ -224,7 +224,7 @@ mod tests {
         );
         if let Some(port) = first_result {
             assert!(
-                port >= 49152 && port <= 49160,
+                (49152..=49160).contains(&port),
                 "Port {} should be in range 49152-49160",
                 port
             );
@@ -245,14 +245,14 @@ mod tests {
 
         if let Some(port) = random_result1 {
             assert!(
-                port >= 49152 && port <= 49160,
+                (49152..=49160).contains(&port),
                 "Port {} should be in range 49152-49160",
                 port
             );
         }
         if let Some(port) = random_result2 {
             assert!(
-                port >= 49152 && port <= 49160,
+                (49152..=49160).contains(&port),
                 "Port {} should be in range 49152-49160",
                 port
             );

--- a/src/gitdiggin/src/main.rs
+++ b/src/gitdiggin/src/main.rs
@@ -169,7 +169,7 @@ fn main() -> Result<()> {
 
     // Set up progress monitoring thread
     let running_clone = running.clone();
-    let pb_clone = pb.clone();
+    let pb_clone = pb;
     let dirs_checked_clone = dirs_checked.clone();
     let repos_found_clone = repos_found.clone();
     let start_time = Instant::now();
@@ -588,7 +588,7 @@ fn process_git_repo(
             Ok(())
         };
 
-    let _result = if search_all_branches {
+    if search_all_branches {
         // Search all branches
         let branches = match repo.branches(Some(BranchType::Local)) {
             Ok(branches) => branches,
@@ -654,7 +654,7 @@ fn add_matching_commit(matching_commits: &mut Vec<String>, commit: &Commit, mess
     let first_line = message.lines().next().unwrap_or("").trim();
 
     // Format the commit info
-    matching_commits.push(format!("{} {}", commit.id().to_string(), first_line));
+    matching_commits.push(format!("{} {}", commit.id(), first_line));
 }
 
 #[cfg(test)]

--- a/src/gitdiggin/src/main.rs
+++ b/src/gitdiggin/src/main.rs
@@ -15,6 +15,19 @@ use std::thread;
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
 
+/// Truncate a path-like string from the front (keeping the tail) so it fits
+/// within `max_chars` characters. Uses character counts to remain UTF-8 safe.
+fn truncate_path_tail(path: &str, max_chars: usize) -> String {
+    let char_count = path.chars().count();
+    if char_count <= max_chars {
+        return path.to_string();
+    }
+    let keep = max_chars.saturating_sub(3);
+    let skip = char_count - keep;
+    let tail: String = path.chars().skip(skip).collect();
+    format!("...{tail}")
+}
+
 /// Find the base directory of the git repository starting from current directory
 fn get_repo_base() -> Result<String> {
     match find_git_repo_repowalker() {
@@ -184,11 +197,7 @@ fn main() -> Result<()> {
                             "Directories scanned: {} | Repositories found: {} | Current: {}",
                             progress.dirs_checked,
                             progress.repos_found,
-                            if progress.current_path.len() > 38 {
-                                format!("...{}", &progress.current_path[progress.current_path.len() - 35..])
-                            } else {
-                                progress.current_path
-                            }
+                            truncate_path_tail(&progress.current_path, 38)
                         ));
                     }
                 },
@@ -379,6 +388,10 @@ fn is_ignored(entry: &DirEntry) -> bool {
 }
 
 /// Scan a path for git repositories
+#[allow(
+    clippy::too_many_arguments,
+    reason = "internal helper called from a single site; refactoring to a context struct is tracked separately"
+)]
 fn scan_path(
     path: &str,
     search_result: Arc<Mutex<SearchResult>>,

--- a/src/gitrdun/src/ollama.rs
+++ b/src/gitrdun/src/ollama.rs
@@ -386,17 +386,22 @@ fn estimate_tokens(text: &str) -> usize {
     text.len() / 4
 }
 
-/// Remove text between <think> and </think> tags
+/// Remove text between `<think>` and `</think>` tags
 fn remove_thinking_text(text: &str) -> String {
+    const OPEN: &str = "<think>";
+    const CLOSE: &str = "</think>";
+
     let mut result = text.to_string();
 
-    while let Some(start) = result.find("<think>") {
-        if let Some(end_pos) = result[start..].find("</think>") {
-            let end = start + end_pos + "</think>".len();
-            result.replace_range(start..end, "");
-        } else {
+    while let Some(start) = result.find(OPEN) {
+        // `start` was returned by str::find, so it is a valid UTF-8 boundary.
+        // Splitting at `start` lets us scan the tail half without slicing.
+        let (_, tail) = result.split_at(start);
+        let Some(end_pos) = tail.find(CLOSE) else {
             break;
-        }
+        };
+        let end = start + end_pos + CLOSE.len();
+        result.replace_range(start..end, "");
     }
 
     result

--- a/src/gitrdun/src/ui.rs
+++ b/src/gitrdun/src/ui.rs
@@ -22,6 +22,34 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
+/// Strip a trailing `.git` (and any path remnants after it) from a path-like string,
+/// returning the parent repository directory.
+fn strip_dot_git_suffix(path: &str) -> String {
+    if let Some(idx) = path.rfind(".git") {
+        // `idx` comes from str::rfind, so it is a valid UTF-8 boundary; split_at
+        // is the safe way to slice without triggering clippy::string_slice.
+        let (head, _) = path.split_at(idx);
+        head.trim_end_matches('/').to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Truncate a string to at most `max_chars` characters by trimming from the front
+/// (keeping the tail) and prefixing with `...`. Uses character (not byte) counts so
+/// it is safe for multi-byte UTF-8 input.
+fn truncate_path_tail(path: &str, max_chars: usize) -> String {
+    let char_count = path.chars().count();
+    if char_count <= max_chars {
+        return path.to_string();
+    }
+    let keep = max_chars.saturating_sub(3);
+    // Skip the leading chars to keep only the last `keep` characters.
+    let skip = char_count - keep;
+    let tail: String = path.chars().skip(skip).collect();
+    format!("...{tail}")
+}
+
 /// Simple progress display for the terminal UI
 pub struct ProgressDisplay {
     dirs_checked: Arc<AtomicUsize>,
@@ -308,26 +336,8 @@ impl ProgressDisplay {
                     "✅ Scanning complete - preparing results...".to_string()
                 } else {
                     let current_path = self.current_path.lock().clone();
-                    // Extract repo name from path if it contains .git
-                    let display_path = if current_path.contains(".git") {
-                        // Get the parent directory of .git (the actual repo)
-                        if let Some(repo_end) = current_path.rfind(".git") {
-                            current_path[..repo_end].trim_end_matches('/').to_string()
-                        } else {
-                            current_path.clone()
-                        }
-                    } else {
-                        current_path
-                    };
-
-                    let truncated_path = if display_path.len() > 60 {
-                        format!(
-                            "...{}",
-                            &display_path[display_path.len().saturating_sub(57)..]
-                        )
-                    } else {
-                        display_path
-                    };
+                    let display_path = strip_dot_git_suffix(&current_path);
+                    let truncated_path = truncate_path_tail(&display_path, 60);
                     format!("🔎 Current: {}", truncated_path)
                 };
 
@@ -429,32 +439,12 @@ impl ProgressDisplay {
             );
         } else {
             let current_path = self.current_path.lock().clone();
-
-            // Extract repo name from path if it contains .git
-            let display_path = if current_path.contains(".git") {
-                // Get the parent directory of .git (the actual repo)
-                if let Some(repo_end) = current_path.rfind(".git") {
-                    current_path[..repo_end].trim_end_matches('/').to_string()
-                } else {
-                    current_path.clone()
-                }
-            } else {
-                current_path
-            };
+            let display_path = strip_dot_git_suffix(&current_path);
+            let shown_path = truncate_path_tail(&display_path, 40);
 
             print!(
                 "\r🔍 Scanned: {} dirs, Found: {} repos, Rate: {:.1} dirs/sec, Current: {}",
-                dirs_checked,
-                repos_found,
-                scan_rate,
-                if display_path.len() > 40 {
-                    format!(
-                        "...{}",
-                        &display_path[display_path.len().saturating_sub(37)..]
-                    )
-                } else {
-                    display_path
-                }
+                dirs_checked, repos_found, scan_rate, shown_path
             );
         }
 

--- a/src/gitrdun/src/ui.rs
+++ b/src/gitrdun/src/ui.rs
@@ -317,7 +317,7 @@ impl ProgressDisplay {
                             current_path.clone()
                         }
                     } else {
-                        current_path.clone()
+                        current_path
                     };
 
                     let truncated_path = if display_path.len() > 60 {
@@ -439,7 +439,7 @@ impl ProgressDisplay {
                     current_path.clone()
                 }
             } else {
-                current_path.clone()
+                current_path
             };
 
             print!(

--- a/src/gitrdun/tests/integration.rs
+++ b/src/gitrdun/tests/integration.rs
@@ -162,7 +162,7 @@ mod cli_tests {
 
     #[test]
     fn test_cli_defaults() {
-        let args = Args::parse_from(&["gitrdun"]);
+        let args = Args::parse_from(["gitrdun"]);
 
         assert_eq!(args.start, "24h");
         assert_eq!(args.end, None);
@@ -181,7 +181,7 @@ mod cli_tests {
 
     #[test]
     fn test_cli_with_args() {
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "gitrdun",
             "--start",
             "7d",

--- a/src/glo/src/main.rs
+++ b/src/glo/src/main.rs
@@ -141,11 +141,13 @@ fn main() -> Result<()> {
     // Print the objects (largest first, limited by topCount)
     // Start from the end of the slice to get the largest objects
     let start_index = objects.len() - display_count;
-    for i in 0..display_count {
-        let obj = &objects[start_index + i];
+    for obj in objects.iter().skip(start_index).take(display_count) {
+        // git object hashes are ASCII hex, so a character-level prefix matches
+        // the historical 12-byte short hash without risking UTF-8 panics.
+        let short_hash: String = obj.hash.chars().take(12).collect();
         println!(
             "{} {} {}",
-            &obj.hash[0..12],
+            short_hash,
             human_bytes(obj.size as f64),
             obj.path
         );

--- a/src/goup/src/main.rs
+++ b/src/goup/src/main.rs
@@ -17,8 +17,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "Command failed",
         ));
     }
@@ -56,12 +55,12 @@ fn main() {
     let mut go_dirs: Vec<PathBuf> = Vec::new();
 
     // Walk through all directories and find Go projects
-    let walker = RepoWalker::new(repo_root.clone())
+    let walker = RepoWalker::new(repo_root)
         .respect_gitignore(false) // Don't respect gitignore - find ALL Go projects
         .include_hidden(true); // Include hidden directories
 
     for entry in walker.walk_with_ignore() {
-        if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
             let dir_path = entry.path();
 
             if dir_path.join("go.mod").exists() {

--- a/src/gr8/src/main.rs
+++ b/src/gr8/src/main.rs
@@ -235,8 +235,17 @@ fn predict_exhaustion(rate_limit: &RateLimit) -> ExhaustionPrediction {
         return ExhaustionPrediction::Sustainable;
     }
 
-    let time_to_exhaust_minutes = rate_limit.remaining as f64 / rate_per_minute;
-    let time_to_exhaust_seconds = (time_to_exhaust_minutes * 60.0) as i64;
+    let time_to_exhaust_minutes = f64::from(rate_limit.remaining) / rate_per_minute;
+    // Clamp before casting: the value is always non-negative (rate_per_minute > 0
+    // and remaining >= 0) and we cap at i64::MAX to ensure the cast is well
+    // defined for arbitrarily small rates.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, i64::MAX] above, so the cast is representable in i64"
+    )]
+    let time_to_exhaust_seconds =
+        (time_to_exhaust_minutes * 60.0).clamp(0.0, i64::MAX as f64) as i64;
 
     let now = Utc::now().timestamp();
     let time_until_reset = rate_limit.reset - now;

--- a/src/hexfind/src/main.rs
+++ b/src/hexfind/src/main.rs
@@ -47,6 +47,11 @@ fn main() -> Result<()> {
 
     // Open and memory map the file
     let file = File::open(&cli.file).context("Error opening file")?;
+    // SAFETY: memory-mapping a file is unsafe because the mapped region can
+    // change underneath us if the file is modified or truncated by another
+    // process. hexfind is a read-only search tool over user-supplied files; the
+    // caller accepts that risk by selecting the path, and we never write
+    // through the mapping or hand it out across thread boundaries.
     let mmap = unsafe { Mmap::map(&file)? };
 
     // Search for the pattern

--- a/src/hexfind/src/main.rs
+++ b/src/hexfind/src/main.rs
@@ -182,7 +182,7 @@ fn display_hex_dump(data: &[u8], file_offset: usize, context_bytes: usize, patte
                 let in_pattern = data_index >= pattern_pos_in_data
                     && data_index < pattern_pos_in_data + pattern_len;
 
-                let c = if byte >= 32 && byte <= 126 {
+                let c = if (32..=126).contains(&byte) {
                     byte as char
                 } else {
                     '.'

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -535,25 +535,20 @@ fn setup_video_controls(
     }
 
     // Set up raw mode for non-blocking input
-    let raw_mode = match io::stdout().into_raw_mode() {
-        Ok(raw_mode) => Some(raw_mode),
-        Err(_) => None,
-    };
+    let raw_mode = io::stdout().into_raw_mode().ok();
 
     // Spawn a thread to handle keyboard input
     let (input_tx, input_rx) = std::sync::mpsc::channel();
     let input_handle = if raw_mode.is_some() {
         Some(thread::spawn(move || {
             let stdin = io::stdin();
-            for key_result in stdin.keys() {
-                if let Ok(key) = key_result {
-                    let control = map_key_to_control(key);
-                    if let Some(ctrl) = control {
-                        let is_exit = matches!(ctrl, VideoControl::Exit);
-                        let _ = input_tx.send(ctrl);
-                        if is_exit {
-                            break;
-                        }
+            for key in stdin.keys().flatten() {
+                let control = map_key_to_control(key);
+                if let Some(ctrl) = control {
+                    let is_exit = matches!(ctrl, VideoControl::Exit);
+                    let _ = input_tx.send(ctrl);
+                    if is_exit {
+                        break;
                     }
                 }
             }
@@ -626,7 +621,7 @@ fn handle_frame_timing(
             let new_time = current_time + frames_to_skip as f64 / fps;
 
             // Try to skip the frame data in ffmpeg output
-            let mut skip_buffer = vec![0u8; frame_size];
+            let mut skip_buffer = vec![0_u8; frame_size];
             for _ in 0..frames_to_skip {
                 if reader.read_exact(&mut skip_buffer).is_err() {
                     break;
@@ -815,7 +810,7 @@ fn play_video_inner(
         let (video_width, video_height) = get_video_dimensions(file_path)?;
 
         let mut ffmpeg_child = std::process::Command::new("ffmpeg")
-            .args(&[
+            .args([
                 "-i",
                 file_path.to_str().unwrap(),
                 "-ss",
@@ -840,7 +835,7 @@ fn play_video_inner(
 
         let mut reader = BufReader::new(stdout);
         let frame_size = (video_width * video_height * 3) as usize;
-        let mut frame_buffer = vec![0u8; frame_size];
+        let mut frame_buffer = vec![0_u8; frame_size];
 
         // Read and display frames until paused, finished, or exit
         'frame_loop: loop {
@@ -1091,7 +1086,7 @@ fn get_video_dimensions(file_path: &PathBuf) -> Result<(u32, u32)> {
 
     // Use ffprobe to get video dimensions
     let output = std::process::Command::new("ffprobe")
-        .args(&[
+        .args([
             "-v",
             "quiet",
             "-select_streams",
@@ -1136,7 +1131,7 @@ fn get_video_fps(file_path: &PathBuf) -> Result<f64> {
 
     // Use ffprobe to get video frame rate
     let output = std::process::Command::new("ffprobe")
-        .args(&[
+        .args([
             "-v",
             "quiet",
             "-select_streams",
@@ -1174,7 +1169,7 @@ fn get_video_duration(file_path: &PathBuf) -> Result<f64> {
 
     // Use ffprobe to get video duration in seconds
     let output = std::process::Command::new("ffprobe")
-        .args(&[
+        .args([
             "-v",
             "quiet",
             "-select_streams",

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -329,7 +329,7 @@ fn monitor_directories(directories: &[PathBuf], args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn is_video_file(file_path: &PathBuf) -> bool {
+fn is_video_file(file_path: &Path) -> bool {
     if let Some(extension) = file_path.extension() {
         if let Some(ext_str) = extension.to_str() {
             let ext_lower = ext_str.to_lowercase();
@@ -355,7 +355,7 @@ fn is_video_file(file_path: &PathBuf) -> bool {
     }
 }
 
-fn is_image_file(file_path: &PathBuf) -> bool {
+fn is_image_file(file_path: &Path) -> bool {
     if let Some(extension) = file_path.extension() {
         if let Some(ext_str) = extension.to_str() {
             let ext_lower = ext_str.to_lowercase();
@@ -384,7 +384,7 @@ fn is_image_file(file_path: &PathBuf) -> bool {
     }
 }
 
-fn is_text_file(file_path: &PathBuf) -> bool {
+fn is_text_file(file_path: &Path) -> bool {
     // If it's not an image or video file, treat it as text
     !is_image_file(file_path) && !is_video_file(file_path)
 }
@@ -479,7 +479,7 @@ fn validate_terminal_for_graphics(
     Ok(())
 }
 
-fn display_video_from_file(file_path: &PathBuf, args: &Args) -> Result<()> {
+fn display_video_from_file(file_path: &Path, args: &Args) -> Result<()> {
     let terminal_caps = detect_terminal_capabilities();
     let transport = detect_remote_transport();
 
@@ -519,13 +519,15 @@ fn display_video_from_file(file_path: &PathBuf, args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn setup_video_controls(
-    terminal_caps: &TerminalCapabilities,
-) -> Result<(
+/// Bundle of state created by [`setup_video_controls`]: optional raw-mode
+/// guard, the channel receiving keyboard events, and the input thread handle.
+type VideoControlSetup = (
     Option<termion::raw::RawTerminal<io::Stdout>>,
     std::sync::mpsc::Receiver<VideoControl>,
     Option<thread::JoinHandle<()>>,
-)> {
+);
+
+fn setup_video_controls(terminal_caps: &TerminalCapabilities) -> Result<VideoControlSetup> {
     let supports_interactive_controls = terminal_caps.supports_raw_mode;
 
     if !supports_interactive_controls {
@@ -611,9 +613,18 @@ fn handle_frame_timing(
         thread::sleep(Duration::from_secs_f64(time_ahead));
         Ok((current_time, false))
     } else if current_time < expected_video_time && !args.do_not_drop_frames {
-        // We're behind schedule - check if we should drop frames
+        // We're behind schedule - check if we should drop frames.
+        // time_behind > 0 (from the branch condition) and fps >= 0, so the
+        // product is non-negative; clamp to u32::MAX to avoid truncation panics
+        // if it ever exceeds that bound.
         let time_behind = expected_video_time - current_time;
-        let frames_behind = (time_behind * fps) as u32;
+        let frames_behind_f = (time_behind * fps).clamp(0.0, f64::from(u32::MAX));
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "frames_behind_f is clamped to [0, u32::MAX] above"
+        )]
+        let frames_behind = frames_behind_f as u32;
 
         if frames_behind > 1 {
             // Skip frames to catch up
@@ -636,6 +647,10 @@ fn handle_frame_timing(
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "frame display needs image, args, timing, and three pieces of mutable per-call state; bundling into a struct just shifts boilerplate"
+)]
 fn process_frame_display(
     img: DynamicImage,
     args: &Args,
@@ -759,7 +774,7 @@ impl Drop for AlternateScreenGuard {
 }
 
 fn play_video_simple(
-    file_path: &PathBuf,
+    file_path: &Path,
     _frame_duration: Duration,
     args: &Args,
     duration: f64,
@@ -774,7 +789,7 @@ fn play_video_simple(
 }
 
 fn play_video_inner(
-    file_path: &PathBuf,
+    file_path: &Path,
     args: &Args,
     duration: f64,
     mut fps: f64,
@@ -1081,7 +1096,7 @@ fn rgb_data_to_image(rgb_data: &[u8], width: u32, height: u32) -> Result<Dynamic
     Ok(DynamicImage::ImageRgb8(rgb_image))
 }
 
-fn get_video_dimensions(file_path: &PathBuf) -> Result<(u32, u32)> {
+fn get_video_dimensions(file_path: &Path) -> Result<(u32, u32)> {
     ensure_ffprobe_available()?;
 
     // Use ffprobe to get video dimensions
@@ -1109,21 +1124,17 @@ fn get_video_dimensions(file_path: &PathBuf) -> Result<(u32, u32)> {
 
     let dimensions_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    // Parse "width,height" format
-    if let Some(comma_pos) = dimensions_str.find(',') {
-        let width: u32 = dimensions_str[..comma_pos]
-            .parse()
-            .context("Failed to parse video width")?;
-        let height: u32 = dimensions_str[comma_pos + 1..]
-            .parse()
-            .context("Failed to parse video height")?;
+    // Parse "width,height" format using char-based splitting for UTF-8 safety
+    if let Some((width_str, height_str)) = dimensions_str.split_once(',') {
+        let width: u32 = width_str.parse().context("Failed to parse video width")?;
+        let height: u32 = height_str.parse().context("Failed to parse video height")?;
         Ok((width, height))
     } else {
         anyhow::bail!("Invalid dimensions format from ffprobe: {}", dimensions_str);
     }
 }
 
-fn get_video_fps(file_path: &PathBuf) -> Result<f64> {
+fn get_video_fps(file_path: &Path) -> Result<f64> {
     if ensure_ffprobe_available().is_err() {
         eprintln!("Warning: ffprobe not found, using default 24 fps");
         return Ok(24.0);
@@ -1151,17 +1162,18 @@ fn get_video_fps(file_path: &PathBuf) -> Result<f64> {
 
     let fps_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    // Parse fraction like "24/1" or "30000/1001"
-    if let Some(slash_pos) = fps_str.find('/') {
-        let numerator: f64 = fps_str[..slash_pos].parse().unwrap_or(24.0);
-        let denominator: f64 = fps_str[slash_pos + 1..].parse().unwrap_or(1.0);
+    // Parse fraction like "24/1" or "30000/1001" using char-based splitting
+    // for UTF-8 safety (in practice ffprobe output is ASCII).
+    if let Some((num_str, denom_str)) = fps_str.split_once('/') {
+        let numerator: f64 = num_str.parse().unwrap_or(24.0);
+        let denominator: f64 = denom_str.parse().unwrap_or(1.0);
         Ok(numerator / denominator)
     } else {
         Ok(fps_str.parse().unwrap_or(24.0))
     }
 }
 
-fn get_video_duration(file_path: &PathBuf) -> Result<f64> {
+fn get_video_duration(file_path: &Path) -> Result<f64> {
     if ensure_ffprobe_available().is_err() {
         eprintln!("Warning: ffprobe not found, using default duration");
         return Ok(60.0); // Default to 60 seconds
@@ -1226,31 +1238,56 @@ fn draw_progress_bar(
 
     // Calculate progress
     let progress = if total_duration > 0.0 {
-        (current_time / total_duration).min(1.0).max(0.0)
+        (current_time / total_duration).clamp(0.0, 1.0)
     } else {
         0.0
     };
 
-    // Format time strings with frame numbers
-    let current_min = (current_time / 60.0) as u32;
-    let current_sec = (current_time % 60.0) as u32;
-    let current_frame = ((current_time % 1.0) * fps) as u32;
+    // Format time strings with frame numbers.
+    // Convert f64 components to u32 via a clamping helper so values that are
+    // negative (shouldn't happen but defend against ffprobe surprises) or
+    // absurdly large get pinned to the u32 range without panicking.
+    let f64_to_u32_clamped = |v: f64| -> u32 {
+        if v.is_nan() || v <= 0.0 {
+            0
+        } else if v >= f64::from(u32::MAX) {
+            u32::MAX
+        } else {
+            // SAFETY of cast: v is finite and in [0.0, u32::MAX), so truncation
+            // toward zero produces a representable u32.
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "value is bounded to [0, u32::MAX) above"
+            )]
+            let out = v as u32;
+            out
+        }
+    };
 
-    let total_min = (total_duration / 60.0) as u32;
-    let total_sec = (total_duration % 60.0) as u32;
-    let total_frame = ((total_duration % 1.0) * fps) as u32;
+    let current_min = f64_to_u32_clamped(current_time / 60.0);
+    let current_sec = f64_to_u32_clamped(current_time % 60.0);
+    let current_frame = f64_to_u32_clamped((current_time % 1.0) * fps);
+
+    let total_min = f64_to_u32_clamped(total_duration / 60.0);
+    let total_sec = f64_to_u32_clamped(total_duration % 60.0);
+    let total_frame = f64_to_u32_clamped((total_duration % 1.0) * fps);
 
     let time_str = format!(
         "{:02}:{:02}:{:02} / {:02}:{:02}:{:02}",
         current_min, current_sec, current_frame, total_min, total_sec, total_frame
     );
 
-    // Calculate available width for progress bar (leave space for time and brackets)
-    let time_len = time_str.len() as u32;
+    // Calculate available width for progress bar (leave space for time and brackets).
+    // time_str length here is a tiny ASCII string ("MM:SS:FF / MM:SS:FF" ~= 19 chars),
+    // far below u32::MAX, so the conversion cannot truncate.
+    let time_len = u32::try_from(time_str.len()).unwrap_or(u32::MAX);
     let available_width = terminal_width.saturating_sub(time_len + 4); // 4 chars for " [" and "] "
 
     if available_width > 0 {
-        let filled_chars = (progress * available_width as f64) as u32;
+        // progress is in [0.0, 1.0] (clamped above) and available_width is u32,
+        // so `progress * available_width as f64` is in [0.0, u32::MAX as f64].
+        let filled_chars = f64_to_u32_clamped(progress * f64::from(available_width));
         let empty_chars = available_width - filled_chars;
 
         // Draw the progress bar
@@ -1283,14 +1320,14 @@ fn get_terminal_size() -> Result<(u32, u32)> {
     }
 }
 
-fn display_image_from_file(file_path: &PathBuf, args: &Args) -> Result<()> {
+fn display_image_from_file(file_path: &Path, args: &Args) -> Result<()> {
     let img = image::open(file_path)
         .with_context(|| format!("Failed to open image file: {}", file_path.display()))?;
 
     display_image(img, args, args.no_newline)
 }
 
-fn display_text_file(file_path: &PathBuf) -> Result<()> {
+fn display_text_file(file_path: &Path) -> Result<()> {
     let contents = fs::read_to_string(file_path)
         .with_context(|| format!("Failed to read text file: {}", file_path.display()))?;
 
@@ -1341,13 +1378,31 @@ fn display_image(img: DynamicImage, args: &Args, no_newline: bool) -> Result<()>
         (Some(safe_width), Some(safe_height))
     };
 
-    // Apply scaling
+    // Apply scaling.
+    // args.scale is u8 in [0, 100); scale_factor is therefore in [0.0, 1.0),
+    // so `w as f32 * scale_factor` is non-negative and <= w, and a u32 input
+    // always fits in f32's value range (with possible precision loss for very
+    // large widths, which is acceptable for display scaling).
     let (scaled_width, scaled_height) = if args.scale < 100 {
-        let scale_factor = args.scale as f32 / 100.0;
-        (
-            target_width.map(|w| ((w as f32 * scale_factor) as u32).max(1)),
-            target_height.map(|h| ((h as f32 * scale_factor) as u32).max(1)),
-        )
+        let scale_factor = f32::from(args.scale) / 100.0;
+        let scale_dim = |dim: u32| -> u32 {
+            // Cast u32 -> f32 can lose precision for values above 2^24, but
+            // that's fine for image dimensions in this codebase.
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "image dimensions rarely exceed 2^24"
+            )]
+            let dim_f = dim as f32 * scale_factor;
+            // dim_f is finite and in [0.0, dim as f32], so it fits in u32.
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "dim_f is non-negative and bounded by the original u32 dimension"
+            )]
+            let scaled = dim_f as u32;
+            scaled.max(1)
+        };
+        (target_width.map(scale_dim), target_height.map(scale_dim))
     } else {
         (target_width, target_height)
     };
@@ -2392,20 +2447,20 @@ mod tests {
         assert!(fallback_aspect < 4.0);
 
         // Cell pixel estimates should be positive and reasonable
-        assert!(ESTIMATED_CELL_WIDTH_PX >= 6);
-        assert!(ESTIMATED_CELL_WIDTH_PX <= 20);
-        assert!(ESTIMATED_CELL_HEIGHT_PX >= 12);
-        assert!(ESTIMATED_CELL_HEIGHT_PX <= 40);
+        const { assert!(ESTIMATED_CELL_WIDTH_PX >= 6) };
+        const { assert!(ESTIMATED_CELL_WIDTH_PX <= 20) };
+        const { assert!(ESTIMATED_CELL_HEIGHT_PX >= 12) };
+        const { assert!(ESTIMATED_CELL_HEIGHT_PX <= 40) };
 
         // Default sixel dimensions should be reasonable screen sizes
-        assert!(DEFAULT_SIXEL_WIDTH_PX >= 640);
-        assert!(DEFAULT_SIXEL_HEIGHT_PX >= 480);
+        const { assert!(DEFAULT_SIXEL_WIDTH_PX >= 640) };
+        const { assert!(DEFAULT_SIXEL_HEIGHT_PX >= 480) };
 
         // Margins should be between 0.5 and 1.0
-        assert!(SIXEL_HORIZONTAL_MARGIN > 0.5);
-        assert!(SIXEL_HORIZONTAL_MARGIN <= 1.0);
-        assert!(SIXEL_VERTICAL_MARGIN > 0.5);
-        assert!(SIXEL_VERTICAL_MARGIN <= 1.0);
+        const { assert!(SIXEL_HORIZONTAL_MARGIN > 0.5) };
+        const { assert!(SIXEL_HORIZONTAL_MARGIN <= 1.0) };
+        const { assert!(SIXEL_VERTICAL_MARGIN > 0.5) };
+        const { assert!(SIXEL_VERTICAL_MARGIN <= 1.0) };
     }
 
     // =========================================================================

--- a/src/idear/src/main.rs
+++ b/src/idear/src/main.rs
@@ -45,13 +45,13 @@ fn main() -> Result<()> {
     };
 
     let mut found_dirs = Vec::new();
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
 
     for entry in walker {
         let entry = entry?;
 
-        if entry.file_type().is_dir() {
-            if is_idea_only_directory(entry.path())? {
+        if entry.file_type().is_dir()
+            && is_idea_only_directory(entry.path())? {
                 if cli.delete || cli.dry_run {
                     let size = calculate_dir_size(entry.path())?;
                     total_size += size;
@@ -60,7 +60,6 @@ fn main() -> Result<()> {
                     println!("{}", entry.path().display());
                 }
             }
-        }
     }
 
     if cli.delete || cli.dry_run {
@@ -119,14 +118,12 @@ fn is_idea_only_directory(dir_path: &Path) -> Result<bool> {
 }
 
 fn calculate_dir_size(dir_path: &Path) -> Result<u64> {
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
 
-    for entry in WalkDir::new(dir_path) {
-        if let Ok(entry) = entry {
-            if let Ok(metadata) = entry.metadata() {
-                if metadata.is_file() {
-                    total_size += metadata.len();
-                }
+    for entry in WalkDir::new(dir_path).into_iter().flatten() {
+        if let Ok(metadata) = entry.metadata() {
+            if metadata.is_file() {
+                total_size += metadata.len();
             }
         }
     }

--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -68,14 +68,13 @@ fn main() {
         }
 
         // Check for target directories
-        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            if target_dirs.contains(&entry_name.as_ref()) {
+        if entry.file_type().is_some_and(|ft| ft.is_dir())
+            && target_dirs.contains(&entry_name.as_ref()) {
                 println!("Removing directory: {}", entry.path().display());
                 if let Err(e) = fs::remove_dir_all(entry.path()) {
                     eprintln!("Error removing {}: {}", entry.path().display(), e);
                 }
             }
-        }
     }
 
     // Second pass: Find and remove target files
@@ -90,14 +89,13 @@ fn main() {
         let entry_name = entry.file_name().to_string_lossy();
 
         // Check for target files
-        if entry.file_type().is_some_and(|ft| ft.is_file()) {
-            if target_files.contains(&entry_name.as_ref()) {
+        if entry.file_type().is_some_and(|ft| ft.is_file())
+            && target_files.contains(&entry_name.as_ref()) {
                 println!("Removing file: {}", entry.path().display());
                 if let Err(e) = fs::remove_file(entry.path()) {
                     eprintln!("Error removing {}: {}", entry.path().display(), e);
                 }
             }
-        }
     }
 
     println!("Cleanup complete!");

--- a/src/nodeup/src/main.rs
+++ b/src/nodeup/src/main.rs
@@ -90,13 +90,13 @@ fn main() {
         println!("Using --latest flag to update to latest versions");
     }
 
-    let walker = RepoWalker::new(start_dir.clone())
+    let walker = RepoWalker::new(start_dir)
         .respect_gitignore(false) // Don't respect gitignore - find ALL Node.js projects
         .include_hidden(true); // Include hidden directories
 
     for entry in walker.walk_with_ignore() {
         // Check for directories with package.json
-        if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
             let dir_path = entry.path();
 
             // Determine package manager to use

--- a/src/nwt/src/main.rs
+++ b/src/nwt/src/main.rs
@@ -700,8 +700,11 @@ fn sanitize_for_filesystem(name: &str) -> Option<String> {
     }
 
     // Reject names that start with a dot followed by only dots and underscores
-    // (could be attempts to create hidden or traversal paths)
-    if sanitized.starts_with('.') && sanitized[1..].chars().all(|c| c == '.' || c == '_') {
+    // (could be attempts to create hidden or traversal paths). Use chars().skip(1)
+    // instead of byte indexing so the check is safe on any UTF-8 input.
+    if sanitized.starts_with('.')
+        && sanitized.chars().skip(1).all(|c| c == '.' || c == '_')
+    {
         return None;
     }
 

--- a/src/op-cache/src/lib.rs
+++ b/src/op-cache/src/lib.rs
@@ -477,6 +477,9 @@ mod tests {
         }
         let result = cache.read(&path, Some("OP_CACHE_TEST_VAR")).unwrap();
         assert_eq!(result, "from-env");
+        // SAFETY: same justification as above — this test owns the env var and
+        // runs in a single thread, so the mutation cannot race with another
+        // reader of the environment.
         unsafe {
             std::env::remove_var("OP_CACHE_TEST_VAR");
         }

--- a/src/op-cache/src/lib.rs
+++ b/src/op-cache/src/lib.rs
@@ -303,7 +303,7 @@ impl OpCache {
             NamedTempFile::new_in(self.cache_path.parent().unwrap_or_else(|| Path::new(".")))?;
         serde_json::to_writer_pretty(&tmp, cache)?;
         tmp.persist(&self.cache_path)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
 
         // Restrict permissions to owner-only since file contains secrets
         #[cfg(unix)]
@@ -373,11 +373,10 @@ fn fetch_binary_from_1password(op_path: &OpPath, output_path: &Path) -> Result<(
             ])
             .output()
         {
-            Ok(output) if output.status.success() => {
-                if output_path.exists() && output_path.metadata().map_or(false, |m| m.len() > 0) {
+            Ok(output) if output.status.success()
+                && output_path.exists() && output_path.metadata().is_ok_and(|m| m.len() > 0) => {
                     return Ok(());
                 }
-            }
             _ => {}
         }
 
@@ -424,7 +423,7 @@ mod tests {
     fn cache_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let cache_path = dir.path().join(CACHE_FILENAME);
-        let cache = OpCache::with_path(cache_path.clone());
+        let cache = OpCache::with_path(cache_path);
 
         // Empty cache
         assert!(cache.entries().unwrap().is_empty());

--- a/src/org-borg/src/github.rs
+++ b/src/org-borg/src/github.rs
@@ -5,14 +5,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 pub struct GitHubClient {
     client: reqwest::Client,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "retained for future API calls that need the raw token")]
     token: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct User {
     pub login: String,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub id: i64,
     pub name: Option<String>,
     pub email: Option<String>,
@@ -25,7 +25,7 @@ pub struct User {
 #[derive(Debug, Deserialize)]
 pub struct Organization {
     pub login: String,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub id: i64,
     pub description: Option<String>,
     pub public_repos: Option<i32>,
@@ -33,24 +33,24 @@ pub struct Organization {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Repository {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub id: i64,
     pub name: String,
     pub full_name: String,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub html_url: String,
     pub ssh_url: String,
     pub clone_url: String,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub description: Option<String>,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub fork: bool,
     pub archived: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub disabled: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub private: bool,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
     pub default_branch: Option<String>,
 }
 

--- a/src/polish/src/main.rs
+++ b/src/polish/src/main.rs
@@ -17,8 +17,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "Command failed",
         ));
     }
@@ -29,7 +28,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
 
 fn check_cargo_edit_installed() -> bool {
     Command::new("cargo")
-        .args(&["upgrade", "--help"])
+        .args(["upgrade", "--help"])
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
@@ -64,12 +63,12 @@ fn main() {
     let mut rust_dirs: Vec<PathBuf> = Vec::new();
 
     // Walk through all directories and find Rust projects
-    let walker = RepoWalker::new(repo_root.clone())
+    let walker = RepoWalker::new(repo_root)
         .respect_gitignore(false) // Don't respect gitignore - find ALL Rust projects
         .include_hidden(true); // Include hidden directories
 
     for entry in walker.walk_with_ignore() {
-        if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+        if entry.file_type().is_some_and(|ft| ft.is_dir()) {
             let dir_path = entry.path();
 
             if dir_path.join("Cargo.toml").exists() {

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -2426,7 +2426,7 @@ mod tests {
             let file = temp_dir.path().join("test.txt");
             fs::write(&file, "content").unwrap();
 
-            let result = resolve_sources(&[file.clone()], false).unwrap();
+            let result = resolve_sources(std::slice::from_ref(&file), false).unwrap();
             assert_eq!(result, vec![file]);
         }
 
@@ -2438,7 +2438,7 @@ mod tests {
             fs::write(&file, "content").unwrap();
 
             // Without --literal flag, but file exists literally
-            let result = resolve_sources(&[file.clone()], false).unwrap();
+            let result = resolve_sources(std::slice::from_ref(&file), false).unwrap();
             assert_eq!(result, vec![file]);
         }
 
@@ -2538,7 +2538,7 @@ mod tests {
             fs::write(&bracket_file, "brackets").unwrap();
 
             // When [abc].txt exists, it should be used literally, NOT expanded to a.txt, b.txt
-            let result = resolve_sources(&[bracket_file.clone()], false).unwrap();
+            let result = resolve_sources(std::slice::from_ref(&bracket_file), false).unwrap();
             assert_eq!(result, vec![bracket_file]);
         }
     }

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -1503,15 +1503,14 @@ fn read_yes_no_with_ctrlc() -> bool {
                         let _ = io::stderr().flush();
                         let _ = crossterm::terminal::enable_raw_mode();
                     }
-                    KeyCode::Backspace => {
-                        if input.pop().is_some() {
+                    KeyCode::Backspace
+                        if input.pop().is_some() => {
                             // Erase character from display
                             let _ = crossterm::terminal::disable_raw_mode();
                             eprint!("\x08 \x08"); // backspace, space, backspace
                             let _ = io::stderr().flush();
                             let _ = crossterm::terminal::enable_raw_mode();
                         }
-                    }
                     _ => {}
                 }
             }

--- a/src/rcc/src/main.rs
+++ b/src/rcc/src/main.rs
@@ -5,7 +5,6 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use buildinfo::version_string;
 use clap::Parser;
-use toml;
 use which::which;
 
 /// Rust Cross Compiler helper - simplifies cross-compilation setup

--- a/src/reposize/src/main.rs
+++ b/src/reposize/src/main.rs
@@ -4,9 +4,9 @@ use repowalker::{find_git_repo, RepoWalker};
 use std::process::exit;
 
 fn calculate_dir_size(repo_root: std::path::PathBuf) -> Result<u64, std::io::Error> {
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
 
-    let walker = RepoWalker::new(repo_root.clone())
+    let walker = RepoWalker::new(repo_root)
         .respect_gitignore(true)
         .skip_node_modules(true)
         .skip_worktrees(true);

--- a/src/repotidy/src/main.rs
+++ b/src/repotidy/src/main.rs
@@ -16,8 +16,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "Command failed",
         ));
     }
@@ -41,7 +40,7 @@ fn main() {
         }
     };
 
-    let walker = RepoWalker::new(repo_root.clone())
+    let walker = RepoWalker::new(repo_root)
         .respect_gitignore(false) // Don't respect gitignore - find ALL Go projects
         .skip_node_modules(true)
         .skip_worktrees(true)

--- a/src/rr/src/main.rs
+++ b/src/rr/src/main.rs
@@ -47,8 +47,7 @@ fn run_cargo_clean(dir: &Path, dry_run: bool) -> Result<(), std::io::Error> {
             dir.display(),
             String::from_utf8_lossy(&output.stderr).trim()
         );
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "cargo clean failed",
         ));
     }
@@ -63,14 +62,12 @@ fn calculate_target_size(dir: &Path) -> u64 {
         return 0;
     }
 
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
 
-    for entry in WalkDir::new(&target_dir) {
-        if let Ok(entry) = entry {
-            if let Ok(metadata) = entry.metadata() {
-                if metadata.is_file() {
-                    total_size += metadata.len();
-                }
+    for entry in WalkDir::new(&target_dir).into_iter().flatten() {
+        if let Ok(metadata) = entry.metadata() {
+            if metadata.is_file() {
+                total_size += metadata.len();
             }
         }
     }
@@ -122,12 +119,12 @@ fn main() {
     println!();
 
     let mut total_cleaned = 0;
-    let mut total_size_freed = 0u64;
-    let mut total_not_deleted = 0u64;
+    let mut total_size_freed = 0_u64;
+    let mut total_not_deleted = 0_u64;
     let mut projects_found = 0;
     let mut total_failed = 0;
 
-    let walker = RepoWalker::new(start_dir.clone())
+    let walker = RepoWalker::new(start_dir)
         .respect_gitignore(false) // Don't respect gitignore - find ALL Rust projects
         .skip_node_modules(true)
         .skip_worktrees(!cli.worktrees)

--- a/src/runat/src/main.rs
+++ b/src/runat/src/main.rs
@@ -139,14 +139,13 @@ fn run_app(
         if crossterm::event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 match key.code {
-                    KeyCode::Char('q') | KeyCode::Char('c') => {
+                    KeyCode::Char('q') | KeyCode::Char('c')
                         if key
                             .modifiers
                             .contains(crossterm::event::KeyModifiers::CONTROL)
-                        {
+                        => {
                             app.should_quit = true;
                         }
-                    }
                     _ => {}
                 }
             }

--- a/src/sf/src/main.rs
+++ b/src/sf/src/main.rs
@@ -43,15 +43,11 @@ fn main() -> Result<()> {
         Some(FilterType::Suffix(suffix))
     } else if let Some(prefix) = cli.prefix {
         Some(FilterType::Prefix(prefix))
-    } else if let Some(substring) = cli.substring {
-        Some(FilterType::Substring(substring))
-    } else {
-        None
-    };
+    } else { cli.substring.map(FilterType::Substring) };
 
     let walker = FileWalker::new(cli.paths).with_filter(filter);
 
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
 
     walker.walk(|entry| {
         if let Ok(metadata) = entry.metadata() {

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -478,7 +478,7 @@ alias ttv='tt --verbose'
     #[test]
     fn test_replace_block() {
         let integration = create_test_integration();
-        let old_contents = r#"# Some config
+        let old_contents = r"# Some config
 export FOO=bar
 
 # testtool - Test Tool shell integration
@@ -490,7 +490,7 @@ function tt() {
 
 # More config
 export BAZ=qux
-"#;
+";
         let result = integration.replace_block(old_contents);
 
         // Should not need warning (end marker was found)
@@ -509,7 +509,7 @@ export BAZ=qux
     #[test]
     fn test_upgrade_old_installation() {
         let integration = create_test_integration();
-        let old_contents = r#"# Some config
+        let old_contents = r"# Some config
 export FOO=bar
 
 # testtool - Test Tool shell integration
@@ -521,7 +521,7 @@ alias ttv='tt --verbose'
 
 # More config
 export BAZ=qux
-"#;
+";
         let result = integration.upgrade_old_installation(old_contents);
 
         // Should not need warning (old end marker was found)
@@ -563,7 +563,7 @@ export BAZ=qux
     #[test]
     fn test_upgrade_old_format_at_file_start() {
         let integration = create_test_integration();
-        let old_contents = r#"# testtool - Test Tool shell integration
+        let old_contents = r"# testtool - Test Tool shell integration
 # Added by: testtool --shell-setup
 function tt() {
     OLD CONTENT
@@ -572,7 +572,7 @@ alias ttv='tt --verbose'
 
 # Other config
 export PATH=/usr/bin
-"#;
+";
         let result = integration.upgrade_old_installation(old_contents);
 
         // Should not need warning (old end marker was found)
@@ -590,7 +590,7 @@ export PATH=/usr/bin
     #[test]
     fn test_upgrade_old_format_at_file_end() {
         let integration = create_test_integration();
-        let old_contents = r#"# Other config
+        let old_contents = r"# Other config
 export PATH=/usr/bin
 
 # testtool - Test Tool shell integration
@@ -598,7 +598,7 @@ export PATH=/usr/bin
 function tt() {
     OLD CONTENT
 }
-alias ttv='tt --verbose'"#;
+alias ttv='tt --verbose'";
         let result = integration.upgrade_old_installation(old_contents);
 
         // Should not need warning (old end marker was found)
@@ -616,12 +616,12 @@ alias ttv='tt --verbose'"#;
     #[test]
     fn test_upgrade_old_format_only_block() {
         let integration = create_test_integration();
-        let old_contents = r#"# testtool - Test Tool shell integration
+        let old_contents = r"# testtool - Test Tool shell integration
 # Added by: testtool --shell-setup
 function tt() {
     OLD CONTENT
 }
-alias ttv='tt --verbose'"#;
+alias ttv='tt --verbose'";
         let result = integration.upgrade_old_installation(old_contents);
 
         // Should not need warning (old end marker was found)
@@ -645,12 +645,12 @@ alias ttv='tt --verbose'"#;
         .with_old_end_marker("FIRST_MARKER")
         .with_old_end_marker("SECOND_MARKER");
 
-        let old_contents = r#"# testtool - Test Tool shell integration
+        let old_contents = r"# testtool - Test Tool shell integration
 OLD LINE 1
 FIRST_MARKER
 SHOULD_BE_PRESERVED
 SECOND_MARKER
-"#;
+";
         let result = integration.upgrade_old_installation(old_contents);
 
         // Should not need warning (old end marker was found)
@@ -695,7 +695,7 @@ export BAZ=qux
     #[test]
     fn test_replace_block_at_file_start() {
         let integration = create_test_integration();
-        let old_contents = r#"# testtool - Test Tool shell integration
+        let old_contents = r"# testtool - Test Tool shell integration
 # Added by: testtool --shell-setup
 function tt() {
     OLD CONTENT
@@ -704,7 +704,7 @@ function tt() {
 
 # Other config
 export PATH=/usr/bin
-"#;
+";
         let result = integration.replace_block(old_contents);
 
         // Should not need warning (end marker was found)
@@ -720,7 +720,7 @@ export PATH=/usr/bin
     #[test]
     fn test_replace_block_at_file_end() {
         let integration = create_test_integration();
-        let old_contents = r#"# Other config
+        let old_contents = r"# Other config
 export PATH=/usr/bin
 
 # testtool - Test Tool shell integration
@@ -728,7 +728,7 @@ export PATH=/usr/bin
 function tt() {
     OLD CONTENT
 }
-# End testtool shell integration"#;
+# End testtool shell integration";
         let result = integration.replace_block(old_contents);
 
         // Should not need warning (end marker was found)
@@ -744,12 +744,12 @@ function tt() {
     #[test]
     fn test_replace_block_only_block() {
         let integration = create_test_integration();
-        let old_contents = r#"# testtool - Test Tool shell integration
+        let old_contents = r"# testtool - Test Tool shell integration
 # Added by: testtool --shell-setup
 function tt() {
     OLD CONTENT
 }
-# End testtool shell integration"#;
+# End testtool shell integration";
         let result = integration.replace_block(old_contents);
 
         // Should not need warning (end marker was found)
@@ -801,7 +801,7 @@ export FOO=bar
     #[test]
     fn test_replace_is_idempotent() {
         let integration = create_test_integration();
-        let initial = r#"# Config
+        let initial = r"# Config
 export FOO=bar
 
 # testtool - Test Tool shell integration
@@ -812,7 +812,7 @@ function tt() {
 # End testtool shell integration
 
 export BAZ=qux
-"#;
+";
         let first_replace = integration.replace_block(initial);
         let second_replace = integration.replace_block(&first_replace.content);
 
@@ -826,7 +826,7 @@ export BAZ=qux
     #[test]
     fn test_upgrade_then_replace_is_idempotent() {
         let integration = create_test_integration();
-        let old_format = r#"# Config
+        let old_format = r"# Config
 export FOO=bar
 
 # testtool - Test Tool shell integration
@@ -837,7 +837,7 @@ function tt() {
 alias ttv='tt --verbose'
 
 export BAZ=qux
-"#;
+";
         // First upgrade from old format
         let upgraded = integration.upgrade_old_installation(old_format);
         // Then replace (simulating running --shell-setup again)
@@ -875,7 +875,7 @@ export BAZ=qux
     #[test]
     fn test_preserves_comments_around_block() {
         let integration = create_test_integration();
-        let old_contents = r#"# === MY CUSTOM SECTION ===
+        let old_contents = r"# === MY CUSTOM SECTION ===
 export FOO=bar
 # === END CUSTOM ===
 
@@ -885,7 +885,7 @@ OLD
 
 # === ANOTHER SECTION ===
 export BAZ=qux
-"#;
+";
         let result = integration.replace_block(old_contents);
 
         assert!(result.content.contains("# === MY CUSTOM SECTION ==="));
@@ -1111,14 +1111,14 @@ alias ll='ls -la'
             "\nfunction prmv() { prcp --rm; }\n",
         );
 
-        let file_with_both = r#"# cwt - Change Worktree shell integration
+        let file_with_both = r"# cwt - Change Worktree shell integration
 function wt() { OLD_CWT; }
 # End cwt shell integration
 
 # prcp - Progress Copy shell integration
 function prmv() { OLD_PRCP; }
 # End prcp shell integration
-"#;
+";
         // Replacing cwt should not affect prcp
         let after_cwt_replace = cwt.replace_block(file_with_both);
 

--- a/src/spv/src/main.rs
+++ b/src/spv/src/main.rs
@@ -887,7 +887,7 @@ mod tests {
         assert_eq!(format_memory(1024 * 1024 * 1024), "1 GiB");
 
         // Verify large values don't panic (precision is documented in the function)
-        let one_tib = 1024u64 * 1024 * 1024 * 1024;
+        let one_tib = 1024_u64 * 1024 * 1024 * 1024;
         assert_eq!(format_memory(one_tib), "1 TiB");
     }
 

--- a/src/tc/src/main.rs
+++ b/src/tc/src/main.rs
@@ -76,14 +76,12 @@ impl TokenizerModel {
 fn format_count(n: usize) -> String {
     let s = n.to_string();
     let mut result = String::new();
-    let mut count = 0;
 
-    for c in s.chars().rev() {
+    for (count, c) in s.chars().rev().enumerate() {
         if count > 0 && count % 3 == 0 {
             result.push(',');
         }
         result.push(c);
-        count += 1;
     }
 
     result.chars().rev().collect()

--- a/src/tc/src/main.rs
+++ b/src/tc/src/main.rs
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
     let tokenizer = model.get_tokenizer().context("Failed to load tokenizer")?;
 
     let mut file_counts = Vec::new();
-    let mut total_tokens = 0usize;
+    let mut total_tokens = 0_usize;
 
     // If no files specified, read from stdin
     if cli.files.is_empty() {

--- a/src/termbar/src/lib.rs
+++ b/src/termbar/src/lib.rs
@@ -391,12 +391,24 @@ fn take_chars_by_width(s: &str, max_width: usize) -> String {
 fn split_filename_extension(filename: &str) -> (&str, Option<&str>) {
     // Handle hidden files: ".bashrc" -> basename=".bashrc", ext=None
     // Handle ".hidden.txt" -> basename=".hidden", ext=Some("txt")
+    //
+    // We scan via char_indices() to find the last '.' that is *not* the leading
+    // dot of a hidden-file name. This avoids slicing strings at arbitrary byte
+    // offsets, which would panic on multi-byte UTF-8 boundaries.
 
-    let search_start = if filename.starts_with('.') { 1 } else { 0 };
+    let mut last_dot_byte: Option<usize> = None;
+    for (byte_idx, ch) in filename.char_indices() {
+        if ch == '.' && byte_idx != 0 {
+            last_dot_byte = Some(byte_idx);
+        }
+    }
 
-    if let Some(dot_pos) = filename[search_start..].rfind('.') {
-        let actual_pos = search_start + dot_pos;
-        let ext = &filename[actual_pos + 1..];
+    if let Some(actual_pos) = last_dot_byte {
+        // `actual_pos` was produced by char_indices() and points to a 1-byte
+        // ASCII '.', so split_at(actual_pos) is on a valid UTF-8 boundary and
+        // the trailing slice starts with '.' (which we skip via the `dot`).
+        let (basename, rest) = filename.split_at(actual_pos);
+        let ext = rest.strip_prefix('.').unwrap_or(rest);
         // Only treat as extension if it's non-empty and reasonable length.
         // We use chars().count() (character count) rather than display width because:
         // 1. Extension length limits are about recognizing file types, not display fitting
@@ -404,7 +416,7 @@ fn split_filename_extension(filename: &str) -> (&str, Option<&str>) {
         //    limits inconsistent (e.g., ".日本語" would be "3 chars but 6 columns")
         // 3. Character count provides predictable behavior across all scripts
         if !ext.is_empty() && ext.chars().count() <= MAX_EXTENSION_LEN {
-            return (&filename[..actual_pos], Some(ext));
+            return (basename, Some(ext));
         }
     }
 
@@ -947,10 +959,16 @@ mod tests {
     fn test_min_basename_chars_minimum_bound() {
         // Verify MIN_BASENAME_CHARS is at least 1 (mirrors compile-time assertion).
         // A value of 0 would produce truncated filenames with no visible content.
-        assert!(
-            MIN_BASENAME_CHARS >= 1,
-            "MIN_BASENAME_CHARS must be at least 1 to ensure visible content"
-        );
+        #[allow(
+            clippy::assertions_on_constants,
+            reason = "intentional change-detector test mirroring the compile-time assertion at the constant's definition"
+        )]
+        {
+            assert!(
+                MIN_BASENAME_CHARS >= 1,
+                "MIN_BASENAME_CHARS must be at least 1 to ensure visible content"
+            );
+        }
     }
 
     #[test]
@@ -1250,7 +1268,11 @@ mod tests {
         );
 
         // Verify the actual truncation produces the expected result
-        // min_with_ext = 1 + 2 + 4 = 7 for .txt
+        // min_with_ext = 1 + 2 + 4 = 7 for .txt; well within u16 range.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "min_with_ext is the sum of small constants (= 7 here) and cannot exceed u16::MAX"
+        )]
         let result = truncate_filename("longfilename.txt", min_with_ext as u16);
 
         // At min_with_ext, the result should be "l...txt" (1 basename char + ".." + ".txt")

--- a/src/tubeboard/src/main.rs
+++ b/src/tubeboard/src/main.rs
@@ -20,7 +20,7 @@ impl Transformer for TubeTransformer {
         let video_id = if url.host_str() == Some("youtu.be") {
             // Short URL format: https://youtu.be/VIDEO_ID
             url.path_segments()
-                .and_then(|segments| segments.last())
+                .and_then(|mut segments| segments.next_back())
                 .filter(|id| !id.is_empty())
                 .ok_or("No video ID in youtu.be URL")?
                 .to_string()

--- a/src/wifiqr/src/main.rs
+++ b/src/wifiqr/src/main.rs
@@ -73,8 +73,11 @@ fn generate_wifi_qr_code(
     let code = QrCode::with_error_correction_level(&wifi_string, EcLevel::H)
         .context("Failed to create QR code")?;
 
-    // Render to image - start with a reasonable base size
-    let base_size = (21 + (code.width() - 21) * 4) as u32; // Scale based on QR code version
+    // Render to image - start with a reasonable base size.
+    // QR codes have widths from 21 (version 1) to 177 (version 40), so the
+    // computed value is at most 21 + (177 - 21) * 4 = 645, well within u32.
+    let base_size = u32::try_from(21 + (code.width() - 21) * 4)
+        .context("QR base size unexpectedly exceeds u32 range")?;
     let img = code
         .render::<Rgba<u8>>()
         .quiet_zone(false)
@@ -122,12 +125,21 @@ fn add_logo_to_qr(
     // Get QR code dimensions
     let (qr_width, qr_height) = qr_image.dimensions();
 
-    // Calculate logo size (capped at 100%)
-    let logo_size_percent = logo_size_percent.min(100.0);
+    // Calculate logo size (capped at 100% and clamped non-negative so the
+    // subsequent cast cannot truncate or lose sign).
+    let logo_size_percent = logo_size_percent.clamp(0.0, 100.0);
 
     // Maximum logo size is 1/5 of QR code size
-    let max_logo_size = qr_width.min(qr_height) / 5 ;
-    let desired_logo_size = (max_logo_size as f64 * logo_size_percent / 100.0) as u32;
+    let max_logo_size = qr_width.min(qr_height) / 5;
+    let scaled = f64::from(max_logo_size) * logo_size_percent / 100.0;
+    // `scaled` is in [0, max_logo_size] (a u32 magnitude), so the as-cast is
+    // representable in u32 and non-negative.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "scaled is bounded to [0, max_logo_size] where max_logo_size is a u32 by construction"
+    )]
+    let desired_logo_size = scaled as u32;
     let desired_logo_size = desired_logo_size.max(1);
 
     // Resize logo to square

--- a/src/wifiqr/src/main.rs
+++ b/src/wifiqr/src/main.rs
@@ -126,7 +126,7 @@ fn add_logo_to_qr(
     let logo_size_percent = logo_size_percent.min(100.0);
 
     // Maximum logo size is 1/5 of QR code size
-    let max_logo_size = (qr_width.min(qr_height) / 5) as u32;
+    let max_logo_size = qr_width.min(qr_height) / 5 ;
     let desired_logo_size = (max_logo_size as f64 * logo_size_percent / 100.0) as u32;
     let desired_logo_size = desired_logo_size.max(1);
 
@@ -134,7 +134,7 @@ fn add_logo_to_qr(
     let logo_resized = resize_image(logo, desired_logo_size);
 
     // Create a new image with the QR code
-    let mut combined = qr_image.clone();
+    let mut combined = qr_image;
 
     // Calculate position to center the logo
     let x_pos = (qr_width - desired_logo_size) / 2;

--- a/src/wolly/src/main.rs
+++ b/src/wolly/src/main.rs
@@ -64,18 +64,28 @@ impl MacAddress {
         // Remove common separators
         let cleaned = s.replace([':', '-'], "");
 
-        if cleaned.len() != 12 {
+        // Operate on bytes once we have ensured the input is plain ASCII; this
+        // keeps the per-pair slicing safe across UTF-8 inputs (multi-byte chars
+        // would not be valid hex anyway, but we surface a clean error instead
+        // of panicking on a non-boundary index).
+        if !cleaned.is_ascii() {
+            bail!("MAC address must contain only ASCII hex characters");
+        }
+        let cleaned_bytes = cleaned.as_bytes();
+        if cleaned_bytes.len() != 12 {
             bail!(
                 "MAC address must be 12 hex characters (got {} characters)",
-                cleaned.len()
+                cleaned_bytes.len()
             );
         }
 
         let mut bytes = [0_u8; 6];
         for (i, byte) in bytes.iter_mut().enumerate() {
-            let hex_str = &cleaned[i * 2..i * 2 + 2];
+            // Safe: cleaned_bytes is ASCII, len == 12, and i ranges 0..6.
+            let pair = &cleaned_bytes[i * 2..i * 2 + 2];
+            let hex_str = std::str::from_utf8(pair).expect("ASCII pair is valid UTF-8");
             *byte = u8::from_str_radix(hex_str, 16)
-                .with_context(|| format!("Invalid hex in MAC address: {}", hex_str))?;
+                .with_context(|| format!("Invalid hex in MAC address: {hex_str}"))?;
         }
 
         Ok(MacAddress(bytes))
@@ -202,9 +212,10 @@ fn list_interfaces() -> Result<()> {
 /// A magic packet consists of:
 /// - 6 bytes of 0xFF
 /// - 16 repetitions of the target MAC address (6 bytes each)
+///
 /// Total: 102 bytes
 ///
-/// Returns the magic packet as a Vec<u8>
+/// Returns the magic packet as a `Vec<u8>`
 fn create_magic_packet(mac: &MacAddress) -> Vec<u8> {
     let mut packet = Vec::with_capacity(102);
 
@@ -354,12 +365,15 @@ fn main() -> Result<()> {
 
     if cli.verbose {
         println!();
-        println!("Successfully sent {} total bytes", bytes_sent);
+        println!("Successfully sent {bytes_sent} total bytes");
     } else {
+        // Use usize math to avoid a u8 overflow if ports ever grows beyond what
+        // u8 can hold. cli.count is u8 and ports.len() is at most 2 today, but
+        // there is no reason to keep the narrow type and risk silent wrap.
+        let packets_sent = usize::from(cli.count) * ports.len();
         println!(
-            "Sent {} magic packet(s) to {}",
-            cli.count * ports.len() as u8,
-            mac.format()
+            "Sent {packets_sent} magic packet(s) to {mac_fmt}",
+            mac_fmt = mac.format()
         );
     }
 
@@ -454,8 +468,8 @@ mod tests {
         assert_eq!(packet.len(), 102);
 
         // Check first 6 bytes are 0xFF
-        for i in 0..6 {
-            assert_eq!(packet[i], 0xFF, "Byte {} should be 0xFF", i);
+        for (i, byte) in packet.iter().take(6).enumerate() {
+            assert_eq!(*byte, 0xFF, "Byte {i} should be 0xFF");
         }
 
         // Check MAC address is repeated 16 times

--- a/src/wolly/src/main.rs
+++ b/src/wolly/src/main.rs
@@ -71,7 +71,7 @@ impl MacAddress {
             );
         }
 
-        let mut bytes = [0u8; 6];
+        let mut bytes = [0_u8; 6];
         for (i, byte) in bytes.iter_mut().enumerate() {
             let hex_str = &cleaned[i * 2..i * 2 + 2];
             *byte = u8::from_str_radix(hex_str, 16)

--- a/src/wu/src/main.rs
+++ b/src/wu/src/main.rs
@@ -117,8 +117,8 @@ fn print_human_readable(processes: &[ProcessInfo], verbose: bool) {
         }
     } else {
         println!(
-            "{:<8} {:<20} {:<15} {:<10} {}",
-            "PID", "NAME", "USER", "ACCESS", "FILE"
+            "{:<8} {:<20} {:<15} {:<10} FILE",
+            "PID", "NAME", "USER", "ACCESS"
         );
         println!("{}", "-".repeat(80));
 
@@ -308,7 +308,7 @@ fn get_file_users_macos(target_path: &Path) -> Result<Vec<ProcessInfo>> {
     let output = if is_dir {
         // Use +D for recursive directory search
         Command::new("lsof")
-            .args(&["+D", &target_str])
+            .args(["+D", &target_str])
             .output()
             .context("Failed to execute lsof command")?
     } else {

--- a/src/wu/src/main.rs
+++ b/src/wu/src/main.rs
@@ -142,10 +142,15 @@ fn print_human_readable(processes: &[ProcessInfo], verbose: bool) {
 }
 
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    // Compare on character counts (not bytes) and truncate via chars().take so
+    // we never slice in the middle of a multi-byte UTF-8 codepoint.
+    let char_count = s.chars().count();
+    if char_count <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let keep = max_len.saturating_sub(3);
+        let prefix: String = s.chars().take(keep).collect();
+        format!("{prefix}...")
     }
 }
 


### PR DESCRIPTION
## Summary

- Brings the workspace from **~150 clippy warnings** to **0** with `cargo clippy --all-targets --all-features` clean.
- Fixes several real UTF-8 panics hidden in path-display helpers (gitrdun, gitdiggin) where byte-indexed `&path[len-N..]` would crash on any multi-byte filename.
- Clamps previously-unbounded `f64 → u32` casts in `ic`, `gr8`, and `wifiqr` so frame-skip and time-to-exhaust counters can't silently wrap on pathological input.
- 609 tests pass before and after; no behavior changes outside the UTF-8 hardening and cast bounds noted above.

## Commits

- `7eba30c` — `cargo clippy --fix` auto-fix pass (mechanical: collapsible matches, needless raw-string hashes, redundant clones, etc.)
- `62a762a` — `ic` crate manual fixes (assertions_on_constants → `const { assert!(..) }`, &PathBuf → &Path, bounded numeric casts)
- `0f3e073` — `gitrdun` + `org-borg` (UTF-8-safe path truncation helper, dead_code allows for unsurfaced GitHub DTO fields)
- `8f5ab6f` — `termbar` + `wifiqr` + `wolly` (UTF-8 safety in filename truncation, QR base size via try_from)
- `6fbd1fb` — UTF-8-safe string slicing batch across aws2env, clipboard-random, glo, nwt, wu, gitdiggin, prcp
- `3f7a38f` — docs/casts/assertions/unsafe/loop lints across clipboardmon, diskhog, filewalker, gr8, hexfind, op-cache, tc

## Notable correctness fixes (worth a focused read)

- `src/gitrdun/src/ui.rs:315,326,437,453` — display-path truncation now uses `chars()` (was `&display_path[len-N..]`).
- `src/gitdiggin/src/main.rs:188` — same fix, same class of bug.
- `src/ic/src/main.rs:608-625` — `frames_behind = time_behind * fps` now clamped to `[0, u32::MAX]` before casting.
- `src/ic/src/main.rs:1240+` — `draw_progress_bar` clamps `f64 → u32` for minute/second/frame components.
- `src/wifiqr/src/main.rs:77` — QR base-size cast switched to `u32::try_from` so spec violations surface as errors instead of silent truncation.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo test --all` — 609 passed / 0 failed
- [ ] Manual smoke test of `ic` against a multi-byte filename
- [ ] Manual smoke test of `gitrdun` / `gitdiggin` UI against a repo path containing multi-byte characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)