### PR TITLE
tsm: deterministic Zellij tuple → SessionId (#214)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7566,6 +7566,7 @@ dependencies = [
  "tempfile",
  "tsm-id",
  "tsm-jsonl",
+ "tsm-tuple",
  "wait-timeout",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7577,7 +7577,9 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
+ "tsm-tuple",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,16 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1281,7 +1271,7 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1307,7 +1297,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1319,7 +1309,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1644,27 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cwt"
 version = "0.1.0"
 dependencies = [
@@ -1865,7 +1834,7 @@ dependencies = [
  "regex",
  "sysinfo",
  "tokio",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4069,7 +4038,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.3",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -4331,6 +4300,17 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kdl"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+dependencies = [
+ "miette",
+ "num",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -4664,6 +4644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -5992,7 +5982,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6043,7 +6033,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7072,7 +7062,7 @@ dependencies = [
  "indicatif",
  "thiserror 2.0.18",
  "tokio",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7566,6 +7556,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsm-tuple"
+version = "0.1.0"
+dependencies = [
+ "kdl",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7648,8 +7646,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8604,6 +8608,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,11 +4304,23 @@ dependencies = [
 
 [[package]]
 name = "kdl"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03e2e96c5926fe761088d66c8c2aee3a4352a2573f4eaca50043ad130af9117"
+dependencies = [
+ "miette 5.10.0",
+ "nom 7.1.3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kdl"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
 dependencies = [
- "miette",
+ "kdl 4.7.1",
+ "miette 7.6.0",
  "num",
  "winnow 0.6.24",
 ]
@@ -4648,12 +4660,35 @@ dependencies = [
 
 [[package]]
 name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7559,7 +7594,7 @@ dependencies = [
 name = "tsm-tuple"
 version = "0.1.0"
 dependencies = [
- "kdl",
+ "kdl 6.5.0",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ log = "0.4"
 env_logger = "0.11"
 
 # KDL (Zellij layout file format)
-kdl = "6"
+kdl = { version = "6", features = ["v1-fallback"] }
 
 # Misc
 tiktoken-rs = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ rodio = { version = "0.20", default-features = false, features = ["wav"] }
 log = "0.4"
 env_logger = "0.11"
 
+# KDL (Zellij layout file format)
+kdl = "6"
+
 # Misc
 tiktoken-rs = "0.5"
 num-format = "0.4"

--- a/src/tsm-id/Cargo.toml
+++ b/src/tsm-id/Cargo.toml
@@ -9,7 +9,9 @@ license.workspace = true
 hex.workspace = true
 rand.workspace = true
 serde.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
+tsm-tuple = { path = "../tsm-tuple" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -132,8 +132,26 @@ impl<'de> Deserialize<'de> for SessionId {
 /// from ever producing the same hash input by exploiting the fact that
 /// `"x" + "\0y"` and `"x\0y" + ""` have the same concatenation.
 pub(crate) fn canonical_bytes(tuple: &Tuple) -> Vec<u8> {
-    let _ = tuple;
-    todo!("canonical_bytes: implementation in green commit")
+    let session = tuple.zellij_session_name.as_ref().as_bytes();
+    let tab = tuple.tab_name.as_ref().as_bytes();
+    let ordinal = tuple.pane_ordinal_within_tab.value().to_be_bytes();
+
+    // u32 is enough for any realistic session or tab name. Names with more
+    // than 4 GiB of UTF-8 are vanishingly unlikely to exist on a Zellij
+    // tab bar, so we treat overflow as a programmer error.
+    let session_len = u32::try_from(session.len()).expect("session name fits in u32");
+    let tab_len = u32::try_from(tab.len()).expect("tab name fits in u32");
+    let ordinal_len: u32 = u32::try_from(ordinal.len()).expect("4 bytes fits in u32");
+
+    let mut out =
+        Vec::with_capacity(4 + session.len() + 4 + tab.len() + 4 + ordinal.len());
+    out.extend_from_slice(&session_len.to_be_bytes());
+    out.extend_from_slice(session);
+    out.extend_from_slice(&tab_len.to_be_bytes());
+    out.extend_from_slice(tab);
+    out.extend_from_slice(&ordinal_len.to_be_bytes());
+    out.extend_from_slice(&ordinal);
+    out
 }
 
 /// Derive a deterministic [`SessionId`] from a Zellij tuple.
@@ -144,8 +162,16 @@ pub(crate) fn canonical_bytes(tuple: &Tuple) -> Vec<u8> {
 /// The id is the first 16 bytes of `SHA-256(canonical_bytes(&tuple))`, hex
 /// encoded as 32 lowercase characters.
 pub fn session_id_from_tuple(tuple: &Tuple) -> SessionId {
-    let _ = tuple;
-    todo!("session_id_from_tuple: implementation in green commit")
+    let bytes = canonical_bytes(tuple);
+    let digest = Sha256::new().chain_update(&bytes).finalize();
+    // Take the leading 128 bits (16 bytes) of the SHA-256 output.
+    let hex = hex::encode(&digest.as_slice()[..16]);
+    // The hex crate emits lowercase 0-9a-f exclusively, so the SessionId
+    // invariants (length 32, lowercase hex only) are satisfied by
+    // construction. Re-validate through from_hex to keep all SessionId
+    // values flowing through the same gate and to surface a bug
+    // immediately if hex::encode ever changed its contract.
+    SessionId::from_hex(&hex).expect("sha256 truncated to 16 bytes is always valid hex")
 }
 
 #[cfg(test)]

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -1,14 +1,20 @@
 //! Session ID type for tsm.
 //!
 //! A [`SessionId`] is a 128-bit identifier represented as exactly 32 lowercase
-//! hexadecimal characters. This slice covers only the random-construction path;
-//! the deterministic SHA-256 path will be added in a later issue.
+//! hexadecimal characters. There are two construction paths:
+//!
+//! - [`SessionId::random`] generates a fresh random id from 16 random bytes.
+//! - [`session_id_from_tuple`] derives a stable id from a Zellij
+//!   (session-name, tab-name, pane-ordinal) tuple by length-prefixed canonical
+//!   encoding + SHA-256 truncated to its first 16 bytes.
 
 use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
+use tsm_tuple::Tuple;
 
 /// Number of hex characters in a [`SessionId`] (16 bytes * 2).
 const SESSION_ID_HEX_LEN: usize = 32;
@@ -110,11 +116,53 @@ impl<'de> Deserialize<'de> for SessionId {
     }
 }
 
+/// Encode a [`Tuple`] into its canonical, length-prefixed byte representation.
+///
+/// The encoding concatenates, in this fixed order:
+///
+/// 1. `u32::to_be_bytes(byte_len(session))` followed by the session name's
+///    UTF-8 bytes.
+/// 2. `u32::to_be_bytes(byte_len(tab))` followed by the tab name's UTF-8
+///    bytes.
+/// 3. `u32::to_be_bytes(4)` followed by `u32::to_be_bytes(ordinal)`.
+///
+/// The length prefix is the **byte length** of the following segment, not its
+/// character count. This is the input fed into SHA-256 by
+/// [`session_id_from_tuple`]; the length prefixes prevent two distinct tuples
+/// from ever producing the same hash input by exploiting the fact that
+/// `"x" + "\0y"` and `"x\0y" + ""` have the same concatenation.
+pub(crate) fn canonical_bytes(tuple: &Tuple) -> Vec<u8> {
+    let _ = tuple;
+    todo!("canonical_bytes: implementation in green commit")
+}
+
+/// Derive a deterministic [`SessionId`] from a Zellij tuple.
+///
+/// The same tuple always yields the same id; two tuples that differ in any
+/// field yield different ids with overwhelming probability.
+///
+/// The id is the first 16 bytes of `SHA-256(canonical_bytes(&tuple))`, hex
+/// encoded as 32 lowercase characters.
+pub fn session_id_from_tuple(tuple: &Tuple) -> SessionId {
+    let _ = tuple;
+    todo!("session_id_from_tuple: implementation in green commit")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tsm_tuple::{PaneOrdinal, TabName, Tuple, ZellijSessionName};
 
     const GOOD_HEX: &str = "0123456789abcdef0123456789abcdef";
+
+    /// Build a [`Tuple`] from raw strings + ordinal for KAT fixtures.
+    fn make_tuple(session: &str, tab: &str, ordinal: u32) -> Tuple {
+        Tuple {
+            zellij_session_name: ZellijSessionName::from(session.to_string()),
+            tab_name: TabName::from(tab.to_string()),
+            pane_ordinal_within_tab: PaneOrdinal::from(ordinal),
+        }
+    }
 
     #[test]
     fn random_produces_32_chars() {
@@ -206,5 +254,99 @@ mod tests {
         let via_from_str: SessionId = GOOD_HEX.parse().expect("parse");
         let via_from_hex = SessionId::from_hex(GOOD_HEX).expect("from_hex");
         assert_eq!(via_from_str, via_from_hex);
+    }
+
+    // ---------- Known-answer fixtures for session_id_from_tuple ----------
+    //
+    // Expected hex strings below were computed independently with Python
+    // (hashlib.sha256 + struct.pack('>I', ...)) against the canonical
+    // length-prefixed encoding spelled out in `canonical_bytes`. They are
+    // pasted as literals here so the test does not self-validate against the
+    // same code under test.
+
+    #[test]
+    fn kat_my_session_main_zero() {
+        let t = make_tuple("my-session", "main", 0);
+        assert_eq!(
+            session_id_from_tuple(&t).as_hex(),
+            "f429a77343e6ee531923b1e054435dcc",
+        );
+    }
+
+    #[test]
+    fn kat_dev_logs_three() {
+        let t = make_tuple("dev", "logs", 3);
+        assert_eq!(
+            session_id_from_tuple(&t).as_hex(),
+            "991dc61a48f0b5f10dcb980cc0a80e41",
+        );
+    }
+
+    #[test]
+    fn kat_multi_byte_utf8_tab_name() {
+        // "日本語" — three CJK chars, three bytes each in UTF-8.
+        let t = make_tuple("workshop", "日本語", 1);
+        assert_eq!(
+            session_id_from_tuple(&t).as_hex(),
+            "7296beed29bbd436464232eb264edf56",
+        );
+    }
+
+    #[test]
+    fn kat_embedded_nul_in_tab_name() {
+        // Embedded NUL in the tab name MUST NOT terminate the string when
+        // hashing — UTF-8 bytes are passed wholesale, length-prefixed.
+        let t = make_tuple("ci", "tab\0null", 0);
+        assert_eq!(
+            session_id_from_tuple(&t).as_hex(),
+            "e75a8cabfe8d72640b3b16c95a628bf4",
+        );
+    }
+
+    #[test]
+    fn kat_empty_session_and_tab() {
+        // Zero-length data segments must still hash, with the length-prefix
+        // being four zero bytes. This guards against accidental
+        // empty-string short-circuiting.
+        let t = make_tuple("", "", 0);
+        assert_eq!(
+            session_id_from_tuple(&t).as_hex(),
+            "56ae268ef08d7137cef01fcd73902eda",
+        );
+    }
+
+    #[test]
+    fn length_prefix_prevents_boundary_collision() {
+        // Without length-prefixing, T_A and T_B would produce identical
+        // concatenated bytes: "x" + "\0y" == "x\0y" + "". The whole point of
+        // the u32-BE length prefix is to make their canonical encodings
+        // (and therefore their session ids) differ. This is exactly the
+        // example from the PRD.
+        let a = make_tuple("x", "\u{0}y", 0);
+        let b = make_tuple("x\u{0}y", "", 0);
+        assert_ne!(
+            session_id_from_tuple(&a),
+            session_id_from_tuple(&b),
+            "length-prefix must prevent boundary collisions"
+        );
+    }
+
+    #[test]
+    fn session_id_from_tuple_is_deterministic() {
+        let t = make_tuple("repeat", "tab", 42);
+        let first = session_id_from_tuple(&t);
+        let second = session_id_from_tuple(&t);
+        assert_eq!(first, second, "the same tuple must always hash to the same id");
+    }
+
+    #[test]
+    fn canonical_bytes_matches_hand_computed_layout() {
+        // Hand-built reference for ("a", "bc", 7):
+        //   [0,0,0,1] 'a' [0,0,0,2] 'b' 'c' [0,0,0,4] [0,0,0,7]
+        let t = make_tuple("a", "bc", 7);
+        let expected: Vec<u8> = vec![
+            0, 0, 0, 1, b'a', 0, 0, 0, 2, b'b', b'c', 0, 0, 0, 4, 0, 0, 0, 7,
+        ];
+        assert_eq!(canonical_bytes(&t), expected);
     }
 }

--- a/src/tsm-tuple/Cargo.toml
+++ b/src/tsm-tuple/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tsm-tuple"
+version = "0.1.0"
+edition.workspace = true
+description = "Pure derivation of the Zellij (session, tab, pane-ordinal) tuple from env + layout"
+license.workspace = true
+
+[dependencies]
+kdl.workspace = true
+thiserror.workspace = true
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"

--- a/src/tsm-tuple/src/lib.rs
+++ b/src/tsm-tuple/src/lib.rs
@@ -29,8 +29,12 @@
 //!
 //! # Format support
 //!
-//! The parser accepts the subset of Zellij's `session-layout.kdl` format
-//! that is observably stable across recent releases:
+//! Zellij currently emits **KDL v1** for `session-layout.kdl`, but the wider
+//! Rust ecosystem is migrating to KDL v2. This crate enables `kdl`'s
+//! `v1-fallback` feature, so documents are parsed as v2 first and re-parsed
+//! as v1 on failure — either dialect is accepted, with the same surface
+//! semantics. The parser accepts the subset of Zellij's `session-layout.kdl`
+//! format that is observably stable across recent releases:
 //!
 //! ```kdl
 //! layout {
@@ -67,6 +71,7 @@
 
 use std::fmt;
 
+use kdl::{KdlDocument, KdlNode};
 use thiserror::Error;
 
 /// Human-readable summary of the ordinal-assignment policy used by
@@ -207,6 +212,205 @@ pub enum TupleError {
 /// Returns a typed [`TupleError`] when the layout cannot be parsed, contains
 /// no tabs, has no pane matching `env.zellij_pane_id`, the matching tab is
 /// nameless, or the same pane id appears in more than one place.
-pub fn derive_tuple(_env: &Env, _layout: &LayoutText) -> Result<Tuple, TupleError> {
-    todo!("derive_tuple — implemented in green slice (#214)")
+pub fn derive_tuple(env: &Env, layout: &LayoutText) -> Result<Tuple, TupleError> {
+    let doc: KdlDocument = layout
+        .0
+        .parse()
+        .map_err(|e: kdl::KdlError| TupleError::LayoutParse(e.to_string()))?;
+
+    // Collect tabs. The document may be wrapped in a top-level `layout { ... }`
+    // node, or it may contain `tab` nodes directly.
+    let tabs: Vec<&KdlNode> = collect_tabs(&doc);
+    if tabs.is_empty() {
+        return Err(TupleError::NoTabs);
+    }
+
+    // For every tab, run a fresh walker and record any ordinals at which the
+    // target pane id was matched. Multiple matches across tabs (or within a
+    // single tab) constitute an ambiguous layout.
+    let mut matches: Vec<(&KdlNode, u32)> = Vec::new();
+    for tab in &tabs {
+        let mut walker = TabWalker::new(&env.zellij_pane_id);
+        walker.walk_tab(tab);
+        for ord in walker.matched_ordinals {
+            matches.push((tab, ord));
+        }
+    }
+
+    if matches.len() > 1 {
+        return Err(TupleError::AmbiguousPaneId {
+            pane_id: env.zellij_pane_id.clone(),
+        });
+    }
+
+    let (tab, ordinal) = matches
+        .into_iter()
+        .next()
+        .ok_or_else(|| TupleError::PaneNotFound {
+            pane_id: env.zellij_pane_id.clone(),
+        })?;
+
+    let tab_name = tab_name_of(tab).ok_or_else(|| TupleError::TabNameMissing {
+        pane_id: env.zellij_pane_id.clone(),
+    })?;
+
+    Ok(Tuple {
+        zellij_session_name: ZellijSessionName(env.zellij_session_name.clone()),
+        tab_name: TabName(tab_name),
+        pane_ordinal_within_tab: PaneOrdinal(ordinal),
+    })
+}
+
+/// Find all `tab` nodes in the document. Tolerates both
+/// `layout { tab ...; tab ...; }` and bare top-level `tab` nodes.
+fn collect_tabs(doc: &KdlDocument) -> Vec<&KdlNode> {
+    let mut out = Vec::new();
+    for node in doc.nodes() {
+        match node.name().value() {
+            "tab" => out.push(node),
+            "layout" => {
+                if let Some(children) = node.children() {
+                    for inner in children.nodes() {
+                        if inner.name().value() == "tab" {
+                            out.push(inner);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Extract the `name=` attribute of a tab node, if present.
+fn tab_name_of(tab: &KdlNode) -> Option<String> {
+    tab.entries()
+        .iter()
+        .find(|e| e.name().map(kdl::KdlIdentifier::value) == Some("name"))
+        .and_then(|e| e.value().as_string().map(String::from))
+}
+
+/// Walks a single tab and records ordinals + which ordinals matched the
+/// caller's target pane id.
+struct TabWalker<'a> {
+    target_pane_id: &'a str,
+    next_ordinal: u32,
+    matched_ordinals: Vec<u32>,
+}
+
+impl<'a> TabWalker<'a> {
+    fn new(target_pane_id: &'a str) -> Self {
+        Self {
+            target_pane_id,
+            next_ordinal: 0,
+            matched_ordinals: Vec::new(),
+        }
+    }
+
+    fn walk_tab(&mut self, tab: &KdlNode) {
+        let Some(children) = tab.children() else {
+            return;
+        };
+
+        // First pass: tiled panes. Recurse into every direct `pane` child.
+        for node in children.nodes() {
+            if node.name().value() == "pane" {
+                self.visit_pane(node);
+            }
+        }
+
+        // Second pass: floating panes, appended after tiled.
+        for node in children.nodes() {
+            if node.name().value() == "floating_panes" {
+                if let Some(fc) = node.children() {
+                    for inner in fc.nodes() {
+                        if inner.name().value() == "pane" {
+                            self.visit_pane(inner);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Visit one pane. Decides whether it is a plugin pane (skip),
+    /// a container (recurse without ordinaling), or a terminal pane
+    /// (assign ordinal, possibly recording a match).
+    fn visit_pane(&mut self, pane: &KdlNode) {
+        if is_plugin_pane(pane) {
+            return;
+        }
+
+        if let Some(children) = pane.children() {
+            // A pane with `pane` child nodes is a container. Walk in
+            // document order; non-`pane` children (e.g. comments, future
+            // metadata) are skipped without affecting numbering.
+            let has_pane_child = children
+                .nodes()
+                .iter()
+                .any(|n| n.name().value() == "pane");
+
+            if has_pane_child {
+                for inner in children.nodes() {
+                    if inner.name().value() == "pane" {
+                        self.visit_pane(inner);
+                    }
+                }
+                return;
+            }
+            // Otherwise treat as a terminal pane (children are some
+            // non-pane block other than `plugin`, which was caught above).
+        }
+
+        // Terminal pane (tiled, floating, or suppressed — all ordinaled).
+        let ordinal = self.next_ordinal;
+        self.next_ordinal += 1;
+
+        if let Some(id) = pane_id_string(pane) {
+            if id == self.target_pane_id {
+                self.matched_ordinals.push(ordinal);
+            }
+        }
+    }
+}
+
+/// A pane is a plugin pane if either:
+/// - it has an attribute named `plugin`, or
+/// - it has a child node named `plugin`.
+fn is_plugin_pane(pane: &KdlNode) -> bool {
+    let has_plugin_attr = pane
+        .entries()
+        .iter()
+        .any(|e| e.name().map(kdl::KdlIdentifier::value) == Some("plugin"));
+    if has_plugin_attr {
+        return true;
+    }
+    if let Some(children) = pane.children() {
+        if children
+            .nodes()
+            .iter()
+            .any(|n| n.name().value() == "plugin")
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Stringify the `id=` attribute on a pane, regardless of whether KDL parsed
+/// it as integer or string.
+fn pane_id_string(pane: &KdlNode) -> Option<String> {
+    let entry = pane
+        .entries()
+        .iter()
+        .find(|e| e.name().map(kdl::KdlIdentifier::value) == Some("id"))?;
+    let v = entry.value();
+    if let Some(s) = v.as_string() {
+        return Some(s.to_string());
+    }
+    if let Some(i) = v.as_integer() {
+        return Some(i.to_string());
+    }
+    None
 }

--- a/src/tsm-tuple/src/lib.rs
+++ b/src/tsm-tuple/src/lib.rs
@@ -1,0 +1,212 @@
+//! Pure derivation of the Zellij (session, tab, pane-ordinal) tuple from
+//! environment values plus a Zellij `session-layout.kdl` document.
+//!
+//! This crate is intentionally I/O-free: callers are responsible for reading
+//! `$ZELLIJ_SESSION_NAME`, `$ZELLIJ_PANE_ID`, and the layout file from disk,
+//! then handing the strings to [`derive_tuple`]. The function returns a typed
+//! [`Tuple`] suitable for hashing into a deterministic session id.
+//!
+//! # Locked-down ordinal policy
+//!
+//! Within a single tab, terminal panes are assigned monotonically-increasing
+//! [`PaneOrdinal`] values starting at `0`, in the following order
+//! (also captured in [`POLICY`] for runtime / debugging surfaces):
+//!
+//! 1. Walk the tab's tiled pane tree depth-first, left-to-right
+//!    (the order children appear in the KDL document).
+//! 2. **Plugin panes are skipped entirely.** A pane with a `plugin { ... }`
+//!    child node, or with a `plugin` attribute, has no shell and therefore
+//!    no ordinal. Its sub-tree (typically empty) is not recursed into.
+//! 3. **Suppressed panes are included in tree-DFS position.** A pane with
+//!    `suppressed=true` is still a terminal pane and still receives an
+//!    ordinal at the moment it is visited by the DFS.
+//! 4. **Container panes do not get an ordinal.** A `pane` node that has
+//!    child `pane` nodes (regardless of `split_direction=`) is a tiling
+//!    container; only its leaf descendants are ordinaled.
+//! 5. **Floating panes are appended after all tiled panes** within the same
+//!    tab, walking the contents of the `floating_panes { ... }` block in
+//!    document order.
+//!
+//! # Format support
+//!
+//! The parser accepts the subset of Zellij's `session-layout.kdl` format
+//! that is observably stable across recent releases:
+//!
+//! ```kdl
+//! layout {
+//!     tab name="editor" focus=true {
+//!         pane split_direction="vertical" {
+//!             pane id=1 command="nvim"
+//!             pane id=2 cwd="/tmp"
+//!         }
+//!         floating_panes {
+//!             pane id=99 x=10 y=10 width=80 height=24
+//!         }
+//!     }
+//!     tab name="logs" {
+//!         pane id=3
+//!         pane id=4 suppressed=true
+//!     }
+//! }
+//! ```
+//!
+//! Specifically:
+//!
+//! - The top-level wrapper may be `layout { ... }`. If the document instead
+//!   contains bare `tab` nodes, they are accepted as siblings.
+//! - `tab name="<utf8>" { ... }` defines a tab. Additional attributes such as
+//!   `focus=true` are tolerated and ignored.
+//! - `pane` defines either a terminal pane (leaf) or a container.
+//!   Attributes such as `id=<n>`, `command=...`, `cwd=...`,
+//!   `split_direction=...`, and `borderless=true` are tolerated.
+//! - `pane id=N` matches `$ZELLIJ_PANE_ID` by **string equality** on `N`.
+//! - `pane { plugin { ... } }` and `pane plugin="..."` mark plugin panes
+//!   (skipped, never ordinaled).
+//! - `pane suppressed=true` marks a suppressed terminal pane (ordinaled).
+//! - `floating_panes { pane ...; pane ...; }` is walked AFTER the tiled tree.
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Human-readable summary of the ordinal-assignment policy used by
+/// [`derive_tuple`]. Suitable for printing from `tsm doctor`.
+pub const POLICY: &str = "\
+tiled panes ordinaled depth-first left-to-right; \
+plugin panes skipped; \
+suppressed panes ordinaled at their tree position; \
+floating panes appended after all tiled panes in document order";
+
+/// Zellij session name (`$ZELLIJ_SESSION_NAME`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ZellijSessionName(String);
+
+impl From<String> for ZellijSessionName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl AsRef<str> for ZellijSessionName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ZellijSessionName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Zellij tab name (the `name=` attribute on a `tab` node).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TabName(String);
+
+impl From<String> for TabName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl AsRef<str> for TabName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TabName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Stable ordinal of a terminal pane within its enclosing tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PaneOrdinal(u32);
+
+impl PaneOrdinal {
+    /// The underlying integer value.
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for PaneOrdinal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The full coordinate that deterministically identifies a Zellij pane
+/// across resurrections of the same session.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Tuple {
+    /// The Zellij session that the pane belongs to.
+    pub zellij_session_name: ZellijSessionName,
+    /// The tab the pane lives in, by its `name=` attribute.
+    pub tab_name: TabName,
+    /// Stable ordinal of the pane within its tab (see [`POLICY`]).
+    pub pane_ordinal_within_tab: PaneOrdinal,
+}
+
+/// Inputs sampled from the Zellij environment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Env {
+    /// Value of `$ZELLIJ_SESSION_NAME`.
+    pub zellij_session_name: String,
+    /// Value of `$ZELLIJ_PANE_ID`, matched against `pane id=...` in the layout.
+    pub zellij_pane_id: String,
+}
+
+/// Raw text of a Zellij `session-layout.kdl` document.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LayoutText(pub String);
+
+/// Errors produced by [`derive_tuple`].
+#[derive(Debug, Error)]
+pub enum TupleError {
+    /// The KDL document failed to parse.
+    #[error("layout failed to parse as KDL: {0}")]
+    LayoutParse(String),
+
+    /// The layout contained no `tab` nodes at all.
+    #[error("layout contains no tabs")]
+    NoTabs,
+
+    /// No `tab` in the layout contains a pane whose `id=` matches the
+    /// environment's `$ZELLIJ_PANE_ID`.
+    #[error("no terminal pane matched ZELLIJ_PANE_ID={pane_id:?}")]
+    PaneNotFound {
+        /// The pane id that failed to match.
+        pane_id: String,
+    },
+
+    /// The tab that contains the matching pane has no `name=` attribute.
+    #[error("tab containing pane id {pane_id:?} has no name= attribute")]
+    TabNameMissing {
+        /// The pane id whose tab was nameless.
+        pane_id: String,
+    },
+
+    /// More than one pane in the layout shares the same `id=`.
+    #[error("layout contains duplicate pane id {pane_id:?}")]
+    AmbiguousPaneId {
+        /// The duplicated pane id.
+        pane_id: String,
+    },
+}
+
+/// Derive a [`Tuple`] for the pane identified by `env` using the supplied
+/// layout text.
+///
+/// This function is pure — it performs no I/O. All inputs are passed in.
+///
+/// # Errors
+///
+/// Returns a typed [`TupleError`] when the layout cannot be parsed, contains
+/// no tabs, has no pane matching `env.zellij_pane_id`, the matching tab is
+/// nameless, or the same pane id appears in more than one place.
+pub fn derive_tuple(_env: &Env, _layout: &LayoutText) -> Result<Tuple, TupleError> {
+    todo!("derive_tuple — implemented in green slice (#214)")
+}

--- a/src/tsm-tuple/src/lib.rs
+++ b/src/tsm-tuple/src/lib.rs
@@ -137,6 +137,12 @@ impl PaneOrdinal {
     }
 }
 
+impl From<u32> for PaneOrdinal {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
 impl fmt::Display for PaneOrdinal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/src/tsm-tuple/tests/fixtures/floating_panes.kdl
+++ b/src/tsm-tuple/tests/fixtures/floating_panes.kdl
@@ -1,0 +1,10 @@
+layout {
+    tab name="main" {
+        pane id=10
+        pane id=11
+        floating_panes {
+            pane id=20 x=10 y=10 width=80 height=24
+            pane id=21 x=15 y=15 width=80 height=24
+        }
+    }
+}

--- a/src/tsm-tuple/tests/fixtures/nested_split.kdl
+++ b/src/tsm-tuple/tests/fixtures/nested_split.kdl
@@ -1,0 +1,18 @@
+layout {
+    tab name="deep" {
+        pane split_direction="vertical" {
+            pane split_direction="horizontal" {
+                pane id=50
+                pane id=51
+            }
+            pane id=52
+        }
+        pane split_direction="horizontal" {
+            pane id=53
+            pane split_direction="vertical" {
+                pane id=54
+                pane id=55
+            }
+        }
+    }
+}

--- a/src/tsm-tuple/tests/fixtures/plugin_panes.kdl
+++ b/src/tsm-tuple/tests/fixtures/plugin_panes.kdl
@@ -1,0 +1,11 @@
+layout {
+    tab name="mixed" {
+        pane id=30
+        pane {
+            plugin location="zellij:status-bar"
+        }
+        pane id=31
+        pane id=32 plugin="zellij:tab-bar"
+        pane id=33
+    }
+}

--- a/src/tsm-tuple/tests/fixtures/simple_two_tabs.kdl
+++ b/src/tsm-tuple/tests/fixtures/simple_two_tabs.kdl
@@ -1,0 +1,10 @@
+layout {
+    tab name="editor" focus=true {
+        pane id=1 command="nvim"
+        pane id=2 cwd="/tmp"
+    }
+    tab name="logs" {
+        pane id=3
+        pane id=4
+    }
+}

--- a/src/tsm-tuple/tests/fixtures/suppressed_panes.kdl
+++ b/src/tsm-tuple/tests/fixtures/suppressed_panes.kdl
@@ -1,0 +1,7 @@
+layout {
+    tab name="work" {
+        pane id=40
+        pane id=41 suppressed=true
+        pane id=42
+    }
+}

--- a/src/tsm-tuple/tests/ordinal_fixtures.rs
+++ b/src/tsm-tuple/tests/ordinal_fixtures.rs
@@ -1,0 +1,156 @@
+//! Golden-file tests that pin the locked-down ordinal policy for tsm-tuple.
+
+use tsm_tuple::{derive_tuple, Env, LayoutText, TupleError};
+
+const SESSION: &str = "fixture-session";
+
+fn load(fixture: &str) -> LayoutText {
+    let path = format!(
+        "{}/tests/fixtures/{}.kdl",
+        env!("CARGO_MANIFEST_DIR"),
+        fixture
+    );
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!("failed to read fixture {path:?}: {e}");
+    });
+    LayoutText(text)
+}
+
+fn env(pane_id: &str) -> Env {
+    Env {
+        zellij_session_name: SESSION.to_string(),
+        zellij_pane_id: pane_id.to_string(),
+    }
+}
+
+fn expect_tuple(fixture: &str, pane_id: &str, expected_tab: &str, expected_ordinal: u32) {
+    let layout = load(fixture);
+    let tup = derive_tuple(&env(pane_id), &layout)
+        .unwrap_or_else(|e| panic!("derive_tuple failed for {fixture}/pane {pane_id}: {e}"));
+    assert_eq!(
+        tup.zellij_session_name.as_ref(),
+        SESSION,
+        "session name should round-trip"
+    );
+    assert_eq!(
+        tup.tab_name.as_ref(),
+        expected_tab,
+        "tab name mismatch for {fixture}/pane {pane_id}"
+    );
+    assert_eq!(
+        tup.pane_ordinal_within_tab.value(),
+        expected_ordinal,
+        "ordinal mismatch for {fixture}/pane {pane_id}"
+    );
+}
+
+#[test]
+fn simple_two_tabs_assigns_ordinals_per_tab() {
+    expect_tuple("simple_two_tabs", "1", "editor", 0);
+    expect_tuple("simple_two_tabs", "2", "editor", 1);
+    expect_tuple("simple_two_tabs", "3", "logs", 0);
+    expect_tuple("simple_two_tabs", "4", "logs", 1);
+}
+
+#[test]
+fn floating_panes_are_appended_after_tiled_panes() {
+    // Tiled first.
+    expect_tuple("floating_panes", "10", "main", 0);
+    expect_tuple("floating_panes", "11", "main", 1);
+    // Floating panes get ordinals AFTER the tiled tree.
+    expect_tuple("floating_panes", "20", "main", 2);
+    expect_tuple("floating_panes", "21", "main", 3);
+}
+
+#[test]
+fn plugin_panes_are_skipped_entirely() {
+    // pane 30 is the first terminal pane.
+    expect_tuple("plugin_panes", "30", "mixed", 0);
+    // pane 31 follows a skipped `pane { plugin { ... } }`.
+    expect_tuple("plugin_panes", "31", "mixed", 1);
+    // pane 33 follows a skipped `pane plugin="..."`.
+    expect_tuple("plugin_panes", "33", "mixed", 2);
+
+    // Plugin panes themselves must NOT match.
+    let layout = load("plugin_panes");
+    let err = derive_tuple(&env("32"), &layout)
+        .expect_err("plugin pane should not be findable as a terminal pane");
+    assert!(matches!(err, TupleError::PaneNotFound { .. }));
+}
+
+#[test]
+fn suppressed_panes_keep_their_tree_dfs_ordinal() {
+    expect_tuple("suppressed_panes", "40", "work", 0);
+    // The suppressed pane is counted at its document position.
+    expect_tuple("suppressed_panes", "41", "work", 1);
+    expect_tuple("suppressed_panes", "42", "work", 2);
+}
+
+#[test]
+fn nested_split_uses_depth_first_left_to_right_order() {
+    expect_tuple("nested_split", "50", "deep", 0);
+    expect_tuple("nested_split", "51", "deep", 1);
+    expect_tuple("nested_split", "52", "deep", 2);
+    expect_tuple("nested_split", "53", "deep", 3);
+    expect_tuple("nested_split", "54", "deep", 4);
+    expect_tuple("nested_split", "55", "deep", 5);
+}
+
+#[test]
+fn missing_pane_returns_pane_not_found() {
+    let layout = load("simple_two_tabs");
+    let err = derive_tuple(&env("9999"), &layout).expect_err("unknown pane id must error");
+    match err {
+        TupleError::PaneNotFound { pane_id } => assert_eq!(pane_id, "9999"),
+        other => panic!("expected PaneNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_layout_returns_no_tabs() {
+    let layout = LayoutText("layout {\n}\n".to_string());
+    let err = derive_tuple(&env("1"), &layout).expect_err("no tabs should fail");
+    assert!(matches!(err, TupleError::NoTabs));
+}
+
+#[test]
+fn unparseable_layout_returns_layout_parse_error() {
+    let layout = LayoutText("this is { not valid kdl ".to_string());
+    let err = derive_tuple(&env("1"), &layout).expect_err("garbage must fail to parse");
+    assert!(matches!(err, TupleError::LayoutParse(_)));
+}
+
+#[test]
+fn ambiguous_pane_id_is_rejected() {
+    let layout = LayoutText(
+        "layout {\n  tab name=\"a\" {\n    pane id=7\n  }\n  tab name=\"b\" {\n    pane id=7\n  }\n}\n"
+            .to_string(),
+    );
+    let err = derive_tuple(&env("7"), &layout).expect_err("duplicate id must fail");
+    match err {
+        TupleError::AmbiguousPaneId { pane_id } => assert_eq!(pane_id, "7"),
+        other => panic!("expected AmbiguousPaneId, got {other:?}"),
+    }
+}
+
+#[test]
+fn tab_without_name_yields_tab_name_missing() {
+    let layout = LayoutText(
+        "layout {\n  tab {\n    pane id=42\n  }\n}\n".to_string(),
+    );
+    let err = derive_tuple(&env("42"), &layout).expect_err("nameless tab must fail");
+    match err {
+        TupleError::TabNameMissing { pane_id } => assert_eq!(pane_id, "42"),
+        other => panic!("expected TabNameMissing, got {other:?}"),
+    }
+}
+
+#[test]
+fn utf8_tab_name_is_preserved() {
+    let layout = LayoutText(
+        "layout {\n  tab name=\"日本語 🎉 café\" {\n    pane id=1\n  }\n}\n".to_string(),
+    );
+    let tup = derive_tuple(&env("1"), &layout).expect("multi-byte tab name should parse");
+    assert_eq!(tup.tab_name.as_ref(), "日本語 🎉 café");
+    assert_eq!(tup.pane_ordinal_within_tab.value(), 0);
+}

--- a/src/tsm/Cargo.toml
+++ b/src/tsm/Cargo.toml
@@ -17,13 +17,16 @@ clap.workspace = true
 hostname = "0.4"
 tsm-id = { path = "../tsm-id" }
 tsm-jsonl = { path = "../tsm-jsonl" }
+tsm-tuple = { path = "../tsm-tuple" }
 wait-timeout = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
 serde_json.workspace = true
 tempfile.workspace = true
+tsm-id = { path = "../tsm-id" }
 tsm-jsonl = { path = "../tsm-jsonl" }
+tsm-tuple = { path = "../tsm-tuple" }
 
 [lints.rust]
 unsafe_code = "deny"

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -286,7 +286,6 @@ fn zellij_session_layout_path(session: &str) -> Option<PathBuf> {
 
 /// Read Zellij session + pane env vars. Returns `None` when either is missing
 /// or empty.
-#[allow(dead_code)]
 fn read_zellij_env() -> Option<TupleEnv> {
     let session = std::env::var("ZELLIJ_SESSION_NAME").ok()?;
     if session.is_empty() {
@@ -317,7 +316,6 @@ fn read_zellij_env() -> Option<TupleEnv> {
 /// because it runs from `tsm shell-init zsh` where a stderr write would
 /// disrupt the user's shell startup. The `tsm doctor` subcommand surfaces
 /// the same information through a structured report instead.
-#[allow(dead_code)]
 fn try_derive_zellij_session_id() -> Option<SessionId> {
     let env = read_zellij_env()?;
     let layout_path = zellij_session_layout_path(&env.zellij_session_name)?;
@@ -879,7 +877,16 @@ fn main() {
                 );
                 std::process::exit(EXIT_UNSUPPORTED_SHELL);
             }
-            let session_id = SessionId::random();
+            // Inside Zellij with a readable session-layout.kdl, derive a
+            // deterministic SessionId from the (session, tab, pane-ordinal)
+            // tuple so resurrecting the pane yields the same id. Anywhere
+            // else we fall back to a random id; this includes derivation
+            // errors, which are surfaced through `tsm doctor` rather than
+            // stderr-from-shell-init.
+            let session_id = match try_derive_zellij_session_id() {
+                Some(id) => id,
+                None => SessionId::random(),
+            };
             print!("{}", generate_zsh_snippet(&session_id));
         }
         Commands::Doctor => {

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -72,6 +72,9 @@ enum Commands {
         /// The shell to emit integration for. Only `zsh` is supported in v1.
         shell: String,
     },
+    /// Print a diagnostic report about the Zellij environment and derived
+    /// session id. Exit code is always 0; failures are part of the report.
+    Doctor,
     /// Record one command's metadata. Invoked by the shell precmd hook.
     Record {
         /// Exit status of the last command in the shell.
@@ -559,6 +562,9 @@ fn main() {
             }
             let session_id = SessionId::random();
             print!("{}", generate_zsh_snippet(&session_id));
+        }
+        Commands::Doctor => {
+            // Stub for red phase: emits nothing so the doctor tests fail.
         }
         Commands::Record {
             exit_code,

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -10,6 +10,7 @@
 //!   that accepts the same args the snippet will pass.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -19,11 +20,12 @@ use std::time::Duration;
 use buildinfo::version_string;
 use chrono::Utc;
 use clap::{Parser, Subcommand};
-use tsm_id::SessionId;
+use tsm_id::{SessionId, session_id_from_tuple};
 use tsm_jsonl::{
     Header, HeaderKind, JsonlError, PrecmdKind, PrecmdRecord, TupleStub, append_header,
     append_record,
 };
+use tsm_tuple::{Env as TupleEnv, LayoutText, Tuple, TupleError, derive_tuple};
 use wait_timeout::ChildExt;
 
 /// Exit code returned when `tsm shell-init` receives an unsupported shell.
@@ -250,6 +252,323 @@ fn xdg_state_home() -> Option<PathBuf> {
     std::env::var("HOME")
         .ok()
         .map(|h| PathBuf::from(h).join(".local").join("state"))
+}
+
+/// Resolve the Zellij cache directory. Resolution order:
+///
+/// 1. `$ZELLIJ_CACHE_DIR`
+/// 2. `$XDG_CACHE_HOME/zellij`
+/// 3. `$HOME/.cache/zellij`
+///
+/// Returns `None` when none of the above can be determined.
+fn zellij_cache_dir() -> Option<PathBuf> {
+    if let Ok(v) = std::env::var("ZELLIJ_CACHE_DIR") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v));
+        }
+    }
+    if let Ok(v) = std::env::var("XDG_CACHE_HOME") {
+        if !v.is_empty() {
+            return Some(PathBuf::from(v).join("zellij"));
+        }
+    }
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".cache").join("zellij"))
+}
+
+/// Compute the path to the active `session-layout.kdl` for the given Zellij
+/// session, joining the cache dir with `<session>/session-layout.kdl`. Returns
+/// `None` when no cache dir can be resolved.
+fn zellij_session_layout_path(session: &str) -> Option<PathBuf> {
+    zellij_cache_dir().map(|d| d.join(session).join("session-layout.kdl"))
+}
+
+/// Read Zellij session + pane env vars. Returns `None` when either is missing
+/// or empty.
+#[allow(dead_code)]
+fn read_zellij_env() -> Option<TupleEnv> {
+    let session = std::env::var("ZELLIJ_SESSION_NAME").ok()?;
+    if session.is_empty() {
+        return None;
+    }
+    let pane = std::env::var("ZELLIJ_PANE_ID").ok()?;
+    if pane.is_empty() {
+        return None;
+    }
+    Some(TupleEnv {
+        zellij_session_name: session,
+        zellij_pane_id: pane,
+    })
+}
+
+/// Attempt to derive a deterministic [`SessionId`] from the current process
+/// environment + on-disk Zellij `session-layout.kdl`.
+///
+/// Returns `None` when:
+///
+/// - either `ZELLIJ_SESSION_NAME` or `ZELLIJ_PANE_ID` is missing/empty
+///   (outside-Zellij path),
+/// - the layout file can't be located or read, or
+/// - the layout can't produce a tuple (parse error, no tabs, missing pane,
+///   etc — see [`TupleError`]).
+///
+/// This function is silent on failure: it MUST NOT print or log anything,
+/// because it runs from `tsm shell-init zsh` where a stderr write would
+/// disrupt the user's shell startup. The `tsm doctor` subcommand surfaces
+/// the same information through a structured report instead.
+#[allow(dead_code)]
+fn try_derive_zellij_session_id() -> Option<SessionId> {
+    let env = read_zellij_env()?;
+    let layout_path = zellij_session_layout_path(&env.zellij_session_name)?;
+    let layout_text = fs::read_to_string(&layout_path).ok()?;
+    let tuple = derive_tuple(&env, &LayoutText(layout_text)).ok()?;
+    Some(session_id_from_tuple(&tuple))
+}
+
+/// Pretty-format a derived [`Tuple`] for diagnostic output (`tsm doctor`).
+///
+/// Format: `(session=<name>, tab=<name>, ordinal=<N>)`.
+fn format_tuple(tuple: &Tuple) -> String {
+    format!(
+        "(session={}, tab={}, ordinal={})",
+        tuple.zellij_session_name,
+        tuple.tab_name,
+        tuple.pane_ordinal_within_tab,
+    )
+}
+
+/// One observation row in the doctor report's "Layout file" section.
+struct LayoutObservation {
+    /// The resolved path, or `None` when the cache directory could not be
+    /// determined at all (`$HOME` unset and no `$ZELLIJ_CACHE_DIR`).
+    path: Option<PathBuf>,
+    /// Whether the file exists on disk.
+    exists: bool,
+    /// File size in bytes; `None` when the file doesn't exist or stat failed.
+    bytes: Option<u64>,
+    /// File contents, if readable.
+    contents: Option<String>,
+}
+
+/// Observe the layout file on disk for the doctor report. Pushes a
+/// `layout file not found at ...` warning to `warnings` when the resolved
+/// path does not exist.
+fn observe_layout(session: &str, warnings: &mut Vec<String>) -> LayoutObservation {
+    let mut obs = LayoutObservation {
+        path: zellij_session_layout_path(session),
+        exists: false,
+        bytes: None,
+        contents: None,
+    };
+    if let Some(p) = obs.path.as_deref() {
+        if let Ok(meta) = fs::metadata(p) {
+            obs.exists = true;
+            obs.bytes = Some(meta.len());
+            obs.contents = fs::read_to_string(p).ok();
+        } else {
+            obs.exists = false;
+            warnings.push(format!("layout file not found at {}", p.display()));
+        }
+    }
+    obs
+}
+
+/// Tuple-derivation step of the doctor report. Returns a (status, detail,
+/// tuple) triple and may push extra warnings.
+fn derive_for_doctor(
+    session_env: Option<&str>,
+    pane_env: Option<&str>,
+    layout: &LayoutObservation,
+    warnings: &mut Vec<String>,
+) -> (String, String, Option<Tuple>) {
+    let (Some(session), Some(pane)) = (session_env, pane_env) else {
+        return (
+            "skipped".to_string(),
+            "outside Zellij — random id path".to_string(),
+            None,
+        );
+    };
+    let Some(text) = layout.contents.as_deref() else {
+        return (
+            "skipped".to_string(),
+            "layout file unreadable or missing".to_string(),
+            None,
+        );
+    };
+    let env_inputs = TupleEnv {
+        zellij_session_name: session.to_string(),
+        zellij_pane_id: pane.to_string(),
+    };
+    match derive_tuple(&env_inputs, &LayoutText(text.to_string())) {
+        Ok(t) => {
+            let pretty = format_tuple(&t);
+            ("ok".to_string(), pretty, Some(t))
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if matches!(&e, TupleError::AmbiguousPaneId { .. }) {
+                warnings.push("pane id is ambiguous in layout".to_string());
+            }
+            warnings.push(format!("tuple derivation failed: {msg}"));
+            ("error".to_string(), msg, None)
+        }
+    }
+}
+
+/// Aggregated inputs to [`render_doctor_report`].
+struct DoctorReport<'a> {
+    session_display: &'a str,
+    pane_display: &'a str,
+    layout: &'a LayoutObservation,
+    status: &'a str,
+    detail: &'a str,
+    id_source: &'a str,
+    id_value: &'a str,
+    warnings: &'a [String],
+}
+
+/// Render the structured doctor report to a `String`. The output is plain
+/// text designed to be readable by humans and parse-friendly for tests.
+fn render_doctor_report(report: &DoctorReport<'_>) -> String {
+    let DoctorReport {
+        session_display,
+        pane_display,
+        layout,
+        status,
+        detail,
+        id_source,
+        id_value,
+        warnings,
+    } = *report;
+    let path_display = layout
+        .path
+        .as_deref()
+        .map_or_else(|| "(unresolved)".to_string(), |p| p.display().to_string());
+    let exists_display = if layout.path.is_none() {
+        "-"
+    } else if layout.exists {
+        "yes"
+    } else {
+        "no"
+    };
+    let bytes_display = layout
+        .bytes
+        .map_or_else(|| "-".to_string(), |b| b.to_string());
+
+    let mut out = String::new();
+    let _ = writeln!(out, "tsm doctor");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Zellij environment:");
+    let _ = writeln!(out, "  ZELLIJ_SESSION_NAME = {session_display}");
+    let _ = writeln!(out, "  ZELLIJ_PANE_ID      = {pane_display}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Layout file:");
+    let _ = writeln!(out, "  path     = {path_display}");
+    let _ = writeln!(out, "  exists   = {exists_display}");
+    let _ = writeln!(out, "  bytes    = {bytes_display}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Tuple derivation:");
+    let _ = writeln!(out, "  status   = {status}");
+    let _ = writeln!(out, "  detail   = {detail}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Session id:");
+    let _ = writeln!(out, "  source   = {id_source}");
+    let _ = writeln!(out, "  value    = {id_value}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Warnings:");
+    if warnings.is_empty() {
+        let _ = writeln!(out, "  none");
+    } else {
+        for w in warnings {
+            let _ = writeln!(out, "  {w}");
+        }
+    }
+    out
+}
+
+/// Compute the `(source, value)` pair for the "Session id" section of the
+/// report. `source` is one of `deterministic`, `random`, or `none`.
+fn session_id_for_doctor(
+    derived: Option<&Tuple>,
+    in_zellij: bool,
+) -> (String, String) {
+    if let Some(t) = derived {
+        (
+            "deterministic".to_string(),
+            session_id_from_tuple(t).as_hex().to_string(),
+        )
+    } else if in_zellij {
+        // We're inside Zellij but failed somewhere. The runtime fallback in
+        // main() would have used a random id, but reporting the actual hex
+        // would lie about determinism — emit `none` instead.
+        ("none".to_string(), "-".to_string())
+    } else {
+        ("random".to_string(), "-".to_string())
+    }
+}
+
+/// Render the `tsm doctor` report to stdout. Always exits 0 on the caller's
+/// behalf — every failure shows up in the report rather than as an error.
+fn handle_doctor() {
+    let mut warnings: Vec<String> = Vec::new();
+    let session_env = std::env::var("ZELLIJ_SESSION_NAME").ok();
+    let pane_env = std::env::var("ZELLIJ_PANE_ID").ok();
+    let session_set = session_env.as_deref().is_some_and(|v| !v.is_empty());
+    let pane_set = pane_env.as_deref().is_some_and(|v| !v.is_empty());
+
+    let session_display = if session_set {
+        session_env.clone().unwrap_or_default()
+    } else {
+        "(unset)".to_string()
+    };
+    let pane_display = if pane_set {
+        pane_env.clone().unwrap_or_default()
+    } else {
+        "(unset)".to_string()
+    };
+
+    if session_set != pane_set {
+        warnings.push(
+            "ZELLIJ_SESSION_NAME is set but ZELLIJ_PANE_ID is not (or vice versa)"
+                .to_string(),
+        );
+    }
+
+    let layout = if session_set {
+        observe_layout(session_env.as_deref().unwrap_or(""), &mut warnings)
+    } else {
+        LayoutObservation {
+            path: None,
+            exists: false,
+            bytes: None,
+            contents: None,
+        }
+    };
+
+    let session_for_derive = if session_set { session_env.as_deref() } else { None };
+    let pane_for_derive = if pane_set { pane_env.as_deref() } else { None };
+    let (status, detail, derived_tuple) = derive_for_doctor(
+        session_for_derive,
+        pane_for_derive,
+        &layout,
+        &mut warnings,
+    );
+
+    let (id_source, id_value) =
+        session_id_for_doctor(derived_tuple.as_ref(), session_set && pane_set);
+
+    let out = render_doctor_report(&DoctorReport {
+        session_display: &session_display,
+        pane_display: &pane_display,
+        layout: &layout,
+        status: &status,
+        detail: &detail,
+        id_source: &id_source,
+        id_value: &id_value,
+        warnings: &warnings,
+    });
+    print!("{out}");
 }
 
 /// Compute the session log path for `<session-id>`. Creates parent dirs with
@@ -564,7 +883,7 @@ fn main() {
             print!("{}", generate_zsh_snippet(&session_id));
         }
         Commands::Doctor => {
-            // Stub for red phase: emits nothing so the doctor tests fail.
+            handle_doctor();
         }
         Commands::Record {
             exit_code,

--- a/src/tsm/tests/doctor.rs
+++ b/src/tsm/tests/doctor.rs
@@ -1,0 +1,178 @@
+//! Integration tests for `tsm doctor`.
+//!
+//! Each test invokes the `tsm` binary as a subprocess with a controlled HOME
+//! and `XDG_CACHE_HOME` so test runs cannot pollute each other or read the
+//! developer's real Zellij cache.
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+use tsm_id::session_id_from_tuple;
+use tsm_tuple::{Env, LayoutText, derive_tuple};
+
+/// Build a `Command` for `tsm doctor` with `env_clear` and a controlled HOME +
+/// `XDG_CACHE_HOME` so it can never read the user's real Zellij cache.
+fn tsm_doctor(home: &TempDir, cache: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("tsm").expect("tsm binary");
+    cmd.env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )
+        .env("HOME", home.path())
+        .env("XDG_CACHE_HOME", cache.path());
+    cmd
+}
+
+/// Path inside `cache` where Zellij would write `session-layout.kdl` for
+/// `session`. Creates the parent directory if missing.
+fn write_layout(cache: &TempDir, session: &str, body: &str) -> PathBuf {
+    let dir = cache.path().join(session);
+    fs::create_dir_all(&dir).expect("mkdir session dir");
+    let path = dir.join("session-layout.kdl");
+    fs::write(&path, body).expect("write layout fixture");
+    path
+}
+
+#[test]
+fn doctor_runs_with_no_zellij_env_and_emits_structured_sections() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+
+    let output = tsm_doctor(&home, &cache)
+        .env_remove("ZELLIJ_SESSION_NAME")
+        .env_remove("ZELLIJ_PANE_ID")
+        .env_remove("ZELLIJ_CACHE_DIR")
+        .arg("doctor")
+        .output()
+        .expect("run tsm doctor");
+    assert!(
+        output.status.success(),
+        "tsm doctor must exit 0, got {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(stdout.contains("tsm doctor"), "header line missing: {stdout}");
+    assert!(stdout.contains("Zellij environment:"), "Zellij section missing: {stdout}");
+    assert!(stdout.contains("ZELLIJ_SESSION_NAME = (unset)"), "expected unset session name marker: {stdout}");
+    assert!(stdout.contains("ZELLIJ_PANE_ID      = (unset)"), "expected unset pane id marker: {stdout}");
+    assert!(stdout.contains("Layout file:"), "Layout file section missing: {stdout}");
+    assert!(stdout.contains("Tuple derivation:"), "Tuple derivation section missing: {stdout}");
+    assert!(stdout.contains("Session id:"), "Session id section missing: {stdout}");
+    assert!(stdout.contains("source   = random"), "expected source = random for outside-Zellij: {stdout}");
+    assert!(stdout.contains("Warnings:"), "Warnings section missing: {stdout}");
+}
+
+#[test]
+fn doctor_warns_about_lopsided_zellij_env() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+
+    let output = tsm_doctor(&home, &cache)
+        .env("ZELLIJ_SESSION_NAME", "lopsided")
+        .env_remove("ZELLIJ_PANE_ID")
+        .env_remove("ZELLIJ_CACHE_DIR")
+        .arg("doctor")
+        .output()
+        .expect("run tsm doctor");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        stdout.contains("ZELLIJ_SESSION_NAME is set but ZELLIJ_PANE_ID is not"),
+        "expected lopsided-env warning, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn doctor_warns_when_layout_file_missing() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+
+    let output = tsm_doctor(&home, &cache)
+        .env("ZELLIJ_SESSION_NAME", "ghost")
+        .env("ZELLIJ_PANE_ID", "1")
+        .env_remove("ZELLIJ_CACHE_DIR")
+        // ZELLIJ_CACHE_DIR is unset, so doctor will resolve via XDG_CACHE_HOME.
+        .arg("doctor")
+        .output()
+        .expect("run tsm doctor");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        stdout.contains("layout file not found"),
+        "expected layout-not-found warning, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("exists   = no"),
+        "expected exists = no, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn doctor_derives_tuple_and_session_id_with_real_layout() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+
+    let layout_body = r#"layout {
+    tab name="editor" focus=true {
+        pane id=1 command="nvim"
+        pane id=2 cwd="/tmp"
+    }
+    tab name="logs" {
+        pane id=3
+        pane id=4
+    }
+}
+"#;
+    let layout_path = write_layout(&cache, "my-session", layout_body);
+
+    // Compute expected session id via the same pure path.
+    let env_inputs = Env {
+        zellij_session_name: "my-session".to_string(),
+        zellij_pane_id: "2".to_string(),
+    };
+    let tuple = derive_tuple(&env_inputs, &LayoutText(layout_body.to_string()))
+        .expect("fixture must derive");
+    let expected_id = session_id_from_tuple(&tuple).as_hex().to_string();
+
+    let output = tsm_doctor(&home, &cache)
+        .env("ZELLIJ_SESSION_NAME", "my-session")
+        .env("ZELLIJ_PANE_ID", "2")
+        .env("ZELLIJ_CACHE_DIR", cache.path())
+        .arg("doctor")
+        .output()
+        .expect("run tsm doctor");
+    assert!(
+        output.status.success(),
+        "tsm doctor exit status: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        stdout.contains(&format!("path     = {}", layout_path.display())),
+        "expected layout path line for {layout_path:?}, got:\n{stdout}"
+    );
+    assert!(stdout.contains("exists   = yes"), "expected exists = yes: {stdout}");
+    assert!(stdout.contains("status   = ok"), "expected status = ok: {stdout}");
+    assert!(
+        stdout.contains("(session=my-session, tab=editor, ordinal=1)"),
+        "expected pretty tuple, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("source   = deterministic"),
+        "expected source = deterministic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("value    = {expected_id}")),
+        "expected session id {expected_id}, got:\n{stdout}"
+    );
+    // Happy path should emit no warnings.
+    assert!(
+        stdout.contains("Warnings:\n  none"),
+        "expected no warnings, got:\n{stdout}"
+    );
+}

--- a/src/tsm/tests/shell_init.rs
+++ b/src/tsm/tests/shell_init.rs
@@ -2,7 +2,7 @@
 //!
 //! When invoked inside a Zellij pane (with `ZELLIJ_SESSION_NAME` and
 //! `ZELLIJ_PANE_ID` set and a readable `session-layout.kdl` on disk),
-//! `tsm shell-init zsh` must inline a **deterministic** SessionId derived
+//! `tsm shell-init zsh` must inline a **deterministic** `SessionId` derived
 //! from the Zellij tuple — not the random fallback. Outside Zellij, the
 //! random fallback path is used and the deterministic id from the same
 //! tuple must not appear in the output.

--- a/src/tsm/tests/shell_init.rs
+++ b/src/tsm/tests/shell_init.rs
@@ -1,0 +1,151 @@
+//! Integration tests for the `tsm shell-init zsh` Zellij branch.
+//!
+//! When invoked inside a Zellij pane (with `ZELLIJ_SESSION_NAME` and
+//! `ZELLIJ_PANE_ID` set and a readable `session-layout.kdl` on disk),
+//! `tsm shell-init zsh` must inline a **deterministic** SessionId derived
+//! from the Zellij tuple — not the random fallback. Outside Zellij, the
+//! random fallback path is used and the deterministic id from the same
+//! tuple must not appear in the output.
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+use tsm_id::session_id_from_tuple;
+use tsm_tuple::{Env, LayoutText, derive_tuple};
+
+const LAYOUT_BODY: &str = r#"layout {
+    tab name="editor" focus=true {
+        pane id=1 command="nvim"
+        pane id=42 cwd="/tmp"
+    }
+    tab name="logs" {
+        pane id=99
+    }
+}
+"#;
+
+/// Build a `tsm shell-init zsh` command with `env_clear` plus a controlled
+/// HOME and `XDG_CACHE_HOME`.
+fn shell_init(home: &TempDir, cache: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("tsm").expect("tsm binary");
+    cmd.env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )
+        .env("HOME", home.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .args(["shell-init", "zsh"]);
+    cmd
+}
+
+/// Write a Zellij layout fixture into `<cache>/<session>/session-layout.kdl`.
+fn write_layout_fixture(cache: &TempDir, session: &str, body: &str) -> PathBuf {
+    let dir = cache.path().join(session);
+    fs::create_dir_all(&dir).expect("mkdir session dir");
+    let path = dir.join("session-layout.kdl");
+    fs::write(&path, body).expect("write layout fixture");
+    path
+}
+
+/// Compute the deterministic session id for the supplied tuple via the pure
+/// `tsm-id` API — this is what the binary should embed in the snippet.
+fn expected_deterministic_id(session: &str, pane: &str, layout: &str) -> String {
+    let env = Env {
+        zellij_session_name: session.to_string(),
+        zellij_pane_id: pane.to_string(),
+    };
+    let tuple = derive_tuple(&env, &LayoutText(layout.to_string()))
+        .expect("fixture must derive");
+    session_id_from_tuple(&tuple).as_hex().to_string()
+}
+
+#[test]
+fn shell_init_uses_deterministic_id_when_inside_zellij() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+    write_layout_fixture(&cache, "live-session", LAYOUT_BODY);
+
+    let expected = expected_deterministic_id("live-session", "42", LAYOUT_BODY);
+
+    let output = shell_init(&home, &cache)
+        .env("ZELLIJ_SESSION_NAME", "live-session")
+        .env("ZELLIJ_PANE_ID", "42")
+        .env("ZELLIJ_CACHE_DIR", cache.path())
+        .output()
+        .expect("run tsm shell-init zsh");
+    assert!(
+        output.status.success(),
+        "shell-init must succeed: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        stdout.contains(&expected),
+        "emitted snippet must contain deterministic id {expected}:\n{stdout}"
+    );
+    // It should appear exactly once (in the `TSM_SESSION_ID=` line).
+    assert_eq!(
+        stdout.matches(&expected).count(),
+        1,
+        "deterministic id should appear exactly once in the snippet:\n{stdout}"
+    );
+}
+
+#[test]
+fn shell_init_uses_random_id_outside_zellij() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+    // Still write the fixture so we can compute its deterministic id and
+    // assert it is NOT present in the outside-Zellij snippet.
+    write_layout_fixture(&cache, "live-session", LAYOUT_BODY);
+    let deterministic = expected_deterministic_id("live-session", "42", LAYOUT_BODY);
+
+    let output = shell_init(&home, &cache)
+        .env_remove("ZELLIJ_SESSION_NAME")
+        .env_remove("ZELLIJ_PANE_ID")
+        .env_remove("ZELLIJ_CACHE_DIR")
+        .output()
+        .expect("run tsm shell-init zsh");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        !stdout.contains(&deterministic),
+        "outside Zellij the deterministic id {deterministic} must not appear (we should use a random id):\n{stdout}"
+    );
+}
+
+#[test]
+fn shell_init_falls_back_to_random_when_layout_file_missing() {
+    let home = TempDir::new().expect("tempdir");
+    let cache = TempDir::new().expect("tempdir");
+    // ZELLIJ_SESSION_NAME / ZELLIJ_PANE_ID are set but no fixture is written.
+    let deterministic = expected_deterministic_id("ghost", "1", LAYOUT_BODY);
+
+    let output = shell_init(&home, &cache)
+        .env("ZELLIJ_SESSION_NAME", "ghost")
+        .env("ZELLIJ_PANE_ID", "1")
+        .env("ZELLIJ_CACHE_DIR", cache.path())
+        .output()
+        .expect("run tsm shell-init zsh");
+    assert!(
+        output.status.success(),
+        "shell-init must remain silent and exit 0 on failure to derive: {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Failure to derive MUST NOT write to stderr (would break the user's shell).
+    assert!(
+        output.stderr.is_empty(),
+        "shell-init must not write to stderr on derive failure: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        !stdout.contains(&deterministic),
+        "deterministic id must not appear when layout file is missing: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #214. Implements the deterministic-id slice of the tsm PRD: same Zellij pane → same `SessionId` across resurrections.

- New pure crate **`tsm-tuple`**: parses `session-layout.kdl`, walks the active tab's pane tree depth-first, and returns `Tuple { zellij_session_name, tab_name, pane_ordinal_within_tab }` for the pane whose `id=` matches `$ZELLIJ_PANE_ID`.
- **Pane ordinal policy** (locked down in this slice and documented in `tsm-tuple`'s module docs / `POLICY` constant):
  - **Plugin panes** are skipped entirely (no shell → no ordinal).
  - **Suppressed panes** are included in their tree-DFS position.
  - **Floating panes** are appended after all tiled panes within the same tab (in DFS order through `floating_panes { … }`), so adding/removing a float doesn't shift tiled ordinals.
- **`tsm-id`** gains `session_id_from_tuple(&Tuple) -> SessionId`. Canonical encoding is `u32-BE-length-prefixed` segments — `(name_bytes, tab_bytes, ordinal_u32_be)` — fed to SHA-256, first 128 bits hex-encoded. Length-prefixing is what makes `("x", "\0y", 0)` and `("x\0y", "", 0)` provably non-colliding.
- **`tsm shell-init zsh`** now derives the deterministic id when both `$ZELLIJ_SESSION_NAME` and `$ZELLIJ_PANE_ID` are set and the layout file is readable — silently falling back to a random id otherwise (no stderr noise at shell init).
- **`tsm doctor`** prints a structured plain-text diagnostic report: Zellij env vars, layout path + existence, tuple-derivation status, derived SessionId, and any warnings (lopsided env, missing layout, parse error, ambiguous pane id).

Built TDD-first: each crate / change shipped as a red commit (failing tests with stubbed behavior) then a green commit (implementation), no combined commits. Eight commits total.

KDL parser is `kdl = "6"` with the `v1-fallback` feature, since Zellij still emits KDL v1 (`focus=true` etc.) while v2 (`focus=#true`) is the kdl-rs default.

## Test plan

- [x] `cargo test --workspace` — green (zero failures across all crates)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `tsm-tuple` integration tests cover floating, suppressed, plugin, nested-split, and multi-tab fixtures
- [x] `tsm-id` ships 5 known-answer SHA-256 fixtures (ASCII, different ordinal, multi-byte UTF-8 tab name `日本語`, embedded `\0` in tab name, empty session+tab) plus a length-prefix collision test and a determinism test
- [x] `tsm doctor` integration tests cover: outside-Zellij, lopsided env vars, layout-missing, and end-to-end (fixture layout → derived tuple → deterministic id)
- [x] `tsm shell-init` integration test asserts deterministic id is inlined when env+layout are present, and that the deterministic id is NOT inlined when env vars are absent
- [ ] Manual smoke test inside a real Zellij session: `tsm doctor` shows the same SessionId before and after `zellij kill-session && zellij attach <name>` with unchanged layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)