### PR TITLE
feat(gsw): compact git status watch for viddy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,8 @@ dependencies = [
  "clap",
  "colored",
  "tempfile",
+ "terminal_size",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,16 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1641,27 +1631,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3429,6 +3398,17 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "gsw"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buildinfo",
+ "clap",
+ "colored",
+ "tempfile",
 ]
 
 [[package]]

--- a/src/gsw/Cargo.toml
+++ b/src/gsw/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gsw"
+version = "0.1.0"
+edition.workspace = true
+description = "Compact git status watch — one-shot pretty output of branch state for viddy"
+
+[[bin]]
+name = "gsw"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+buildinfo.workspace = true
+clap.workspace = true
+colored.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/src/gsw/Cargo.toml
+++ b/src/gsw/Cargo.toml
@@ -13,6 +13,8 @@ anyhow.workspace = true
 buildinfo.workspace = true
 clap.workspace = true
 colored.workspace = true
+terminal_size.workspace = true
+unicode-width.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -21,13 +21,31 @@ pub enum AgeDim {
 /// - `< 60m`              → `Nm`
 /// - `< 24h`              → `Nh`
 /// - everything else      → `Nd`
-pub fn format_age(_age: Duration) -> String {
-    String::from("TODO")
+pub fn format_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 60 * 60 {
+        format!("{}m", secs / 60)
+    } else if secs < 60 * 60 * 24 {
+        format!("{}h", secs / (60 * 60))
+    } else {
+        format!("{}d", secs / (60 * 60 * 24))
+    }
 }
 
 /// Classify an age into a display brightness bucket.
-pub fn age_dim_level(_age: Duration) -> AgeDim {
-    AgeDim::Fresh
+pub fn age_dim_level(age: Duration) -> AgeDim {
+    let secs = age.as_secs();
+    if secs < 60 * 5 {
+        AgeDim::Fresh
+    } else if secs < 60 * 60 {
+        AgeDim::Recent
+    } else if secs < 60 * 60 * 24 {
+        AgeDim::Aging
+    } else {
+        AgeDim::Stale
+    }
 }
 
 #[cfg(test)]

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -1,0 +1,1 @@
+//! Format durations as short human strings and pick a dim level by age.

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -1,1 +1,76 @@
 //! Format durations as short human strings and pick a dim level by age.
+
+use std::time::Duration;
+
+/// How "fresh" an age is — drives display brightness.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AgeDim {
+    /// `< 5m` — bright.
+    Fresh,
+    /// `< 1h` — normal.
+    Recent,
+    /// `< 1d` — dim.
+    Aging,
+    /// `>= 1d` — very dim.
+    Stale,
+}
+
+/// Format a duration like `30s`, `5m`, `2h`, `3d`. Always 1–3 chars + unit.
+///
+/// - `< 60s`              → `Ns`
+/// - `< 60m`              → `Nm`
+/// - `< 24h`              → `Nh`
+/// - everything else      → `Nd`
+pub fn format_age(_age: Duration) -> String {
+    String::from("TODO")
+}
+
+/// Classify an age into a display brightness bucket.
+pub fn age_dim_level(_age: Duration) -> AgeDim {
+    AgeDim::Fresh
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_seconds_below_a_minute() {
+        assert_eq!(format_age(Duration::from_secs(0)), "0s");
+        assert_eq!(format_age(Duration::from_secs(30)), "30s");
+        assert_eq!(format_age(Duration::from_secs(59)), "59s");
+    }
+
+    #[test]
+    fn format_minutes_below_an_hour() {
+        assert_eq!(format_age(Duration::from_secs(60)), "1m");
+        assert_eq!(format_age(Duration::from_secs(60 * 5)), "5m");
+        assert_eq!(format_age(Duration::from_secs(60 * 59)), "59m");
+    }
+
+    #[test]
+    fn format_hours_below_a_day() {
+        assert_eq!(format_age(Duration::from_secs(60 * 60)), "1h");
+        assert_eq!(format_age(Duration::from_secs(60 * 60 * 2)), "2h");
+        assert_eq!(format_age(Duration::from_secs(60 * 60 * 23)), "23h");
+    }
+
+    #[test]
+    fn format_days_and_above() {
+        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24)), "1d");
+        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 3)), "3d");
+        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 365)), "365d");
+    }
+
+    #[test]
+    fn dim_level_buckets_by_boundary() {
+        assert_eq!(age_dim_level(Duration::from_secs(0)), AgeDim::Fresh);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 5 - 1)), AgeDim::Fresh);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 5)), AgeDim::Recent);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 60 - 1)), AgeDim::Recent);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 60)), AgeDim::Aging);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24 - 1)), AgeDim::Aging);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24)), AgeDim::Stale);
+        assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24 * 30)), AgeDim::Stale);
+    }
+}

--- a/src/gsw/src/bar.rs
+++ b/src/gsw/src/bar.rs
@@ -19,7 +19,11 @@ pub fn render_bar(value: u32, max: u32, width: usize) -> String {
     let clamped = value.min(max);
     let ratio = f64::from(clamped) / f64::from(max);
     // Total eighth-cells to fill across the bar.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "ratio is clamped to [0,1], so the result fits in usize for any sensible width",
+    )]
     let total_eighths = (ratio * (width as f64) * 8.0).round() as usize;
     let full_cells = (total_eighths / 8).min(width);
     let partial = total_eighths % 8;

--- a/src/gsw/src/bar.rs
+++ b/src/gsw/src/bar.rs
@@ -1,0 +1,1 @@
+//! Render a magnitude bar using 8-level Unicode block characters.

--- a/src/gsw/src/bar.rs
+++ b/src/gsw/src/bar.rs
@@ -12,9 +12,32 @@ const EIGHTHS: [char; 9] = [EMPTY, '▏', '▎', '▍', '▌', '▋', '▊', '�
 /// - When `value >= max`, the bar is fully filled.
 /// - Fractional fill is approximated to the nearest eighth, so a value at
 ///   90% of max produces ~5 full cells and one ~3/8-filled cell at width 6.
-pub fn render_bar(_value: u32, _max: u32, width: usize) -> String {
-    // Stub: returns wrong fixed shape so tests fail behaviorally.
-    EMPTY.to_string().repeat(width)
+pub fn render_bar(value: u32, max: u32, width: usize) -> String {
+    if max == 0 || width == 0 {
+        return EMPTY.to_string().repeat(width);
+    }
+    let clamped = value.min(max);
+    let ratio = f64::from(clamped) / f64::from(max);
+    // Total eighth-cells to fill across the bar.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let total_eighths = (ratio * (width as f64) * 8.0).round() as usize;
+    let full_cells = (total_eighths / 8).min(width);
+    let partial = total_eighths % 8;
+    let mut result = String::with_capacity(width * 4);
+    for _ in 0..full_cells {
+        result.push('█');
+    }
+    if full_cells < width && partial > 0 {
+        result.push(EIGHTHS[partial]);
+        for _ in (full_cells + 1)..width {
+            result.push(EMPTY);
+        }
+    } else {
+        for _ in full_cells..width {
+            result.push(EMPTY);
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/src/gsw/src/bar.rs
+++ b/src/gsw/src/bar.rs
@@ -1,1 +1,70 @@
 //! Render a magnitude bar using 8-level Unicode block characters.
+
+/// Empty cell — Unicode light shade.
+const EMPTY: char = '░';
+
+/// Eighth-filled block characters, indexed 0..=8 (0 = empty, 8 = full).
+const EIGHTHS: [char; 9] = [EMPTY, '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
+
+/// Render a bar of `width` cells showing `value` scaled against `max`.
+///
+/// - When `max == 0`, the bar is all empty cells.
+/// - When `value >= max`, the bar is fully filled.
+/// - Fractional fill is approximated to the nearest eighth, so a value at
+///   90% of max produces ~5 full cells and one ~3/8-filled cell at width 6.
+pub fn render_bar(_value: u32, _max: u32, width: usize) -> String {
+    // Stub: returns wrong fixed shape so tests fail behaviorally.
+    EMPTY.to_string().repeat(width)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_value_renders_all_empty() {
+        assert_eq!(render_bar(0, 10, 6), "░░░░░░");
+    }
+
+    #[test]
+    fn value_equal_to_max_fills_bar() {
+        assert_eq!(render_bar(10, 10, 6), "██████");
+    }
+
+    #[test]
+    fn value_above_max_clamps_to_full() {
+        assert_eq!(render_bar(20, 10, 6), "██████");
+    }
+
+    #[test]
+    fn half_value_fills_half_bar() {
+        // ratio 0.5 → 0.5*6*8 = 24 eighths → 3 full + 0 partial
+        assert_eq!(render_bar(5, 10, 6), "███░░░");
+    }
+
+    #[test]
+    fn small_value_renders_fractional_cell() {
+        // ratio 0.1 → 0.1*6*8 = 4.8 ≈ 5 eighths → 0 full + 5/8 partial
+        assert_eq!(render_bar(1, 10, 6), "▋░░░░░");
+    }
+
+    #[test]
+    fn near_full_renders_partial_at_end() {
+        // ratio 0.9 → 0.9*6*8 = 43.2 ≈ 43 eighths → 5 full + 3/8 partial
+        assert_eq!(render_bar(9, 10, 6), "█████▍");
+    }
+
+    #[test]
+    fn zero_max_renders_all_empty() {
+        // Defensive: no division by zero, no panic.
+        assert_eq!(render_bar(0, 0, 6), "░░░░░░");
+        assert_eq!(render_bar(5, 0, 6), "░░░░░░");
+    }
+
+    #[test]
+    fn respects_requested_width() {
+        assert_eq!(render_bar(10, 10, 3), "███");
+        assert_eq!(render_bar(0, 10, 3), "░░░");
+        assert_eq!(render_bar(10, 10, 10), "██████████");
+    }
+}

--- a/src/gsw/src/git.rs
+++ b/src/gsw/src/git.rs
@@ -45,14 +45,131 @@ pub struct NumStat {
 /// Input is a single string with `\0`-separated records (the `-z` form).
 /// For renames/copies the new path and original path are split by `\0`
 /// within the entry, which is why we consume two records for a type-2 entry.
-pub fn parse_status(_input: &str) -> Vec<FileEntry> {
-    // Stub.
-    vec![FileEntry {
-        path: String::from("TODO"),
+pub fn parse_status(input: &str) -> Vec<FileEntry> {
+    let pieces: Vec<&str> = input.split('\0').filter(|s| !s.is_empty()).collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < pieces.len() {
+        let piece = pieces[i];
+        let (type_ch, rest) = split_first(piece);
+        match type_ch {
+            Some('1') => {
+                if let Some(rest) = rest.strip_prefix(' ') {
+                    parse_ordinary_entry(rest, None, &mut out);
+                }
+                i += 1;
+            }
+            Some('2') => {
+                let orig = pieces.get(i + 1).map(|s| (*s).to_string());
+                if let Some(rest) = rest.strip_prefix(' ') {
+                    parse_rename_entry(rest, orig, &mut out);
+                }
+                i += 2;
+            }
+            Some('u') => {
+                if let Some(rest) = rest.strip_prefix(' ') {
+                    parse_unmerged_entry(rest, &mut out);
+                }
+                i += 1;
+            }
+            Some('?') => {
+                if let Some(path) = rest.strip_prefix(' ') {
+                    let status = if path.ends_with('/') {
+                        FileStatus::UntrackedDir
+                    } else {
+                        FileStatus::Untracked
+                    };
+                    out.push(FileEntry {
+                        path: path.to_string(),
+                        orig_path: None,
+                        status,
+                        staged: false,
+                    });
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    out
+}
+
+fn split_first(s: &str) -> (Option<char>, &str) {
+    let mut chars = s.chars();
+    let first = chars.next();
+    (first, chars.as_str())
+}
+
+fn parse_ordinary_entry(rest: &str, orig: Option<String>, out: &mut Vec<FileEntry>) {
+    // <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>
+    let parts: Vec<&str> = rest.splitn(8, ' ').collect();
+    if parts.len() < 8 {
+        return;
+    }
+    emit_xy(parts[0], parts[7], orig, out);
+}
+
+fn parse_rename_entry(rest: &str, orig: Option<String>, out: &mut Vec<FileEntry>) {
+    // <XY> <sub> <mH> <mI> <mW> <hH> <hI> <Xscore> <path>
+    let parts: Vec<&str> = rest.splitn(9, ' ').collect();
+    if parts.len() < 9 {
+        return;
+    }
+    emit_xy(parts[0], parts[8], orig, out);
+}
+
+fn parse_unmerged_entry(rest: &str, out: &mut Vec<FileEntry>) {
+    // <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
+    let parts: Vec<&str> = rest.splitn(10, ' ').collect();
+    if parts.len() < 10 {
+        return;
+    }
+    out.push(FileEntry {
+        path: parts[9].to_string(),
         orig_path: None,
-        status: FileStatus::Modified,
+        status: FileStatus::Conflicted,
         staged: false,
-    }]
+    });
+}
+
+fn emit_xy(xy: &str, path: &str, orig: Option<String>, out: &mut Vec<FileEntry>) {
+    let mut xy_chars = xy.chars();
+    let x = xy_chars.next().unwrap_or('.');
+    let y = xy_chars.next().unwrap_or('.');
+    if let Some(status) = char_to_status(x) {
+        out.push(FileEntry {
+            path: path.to_string(),
+            orig_path: orig.clone(),
+            status,
+            staged: true,
+        });
+    }
+    if let Some(status) = char_to_status(y) {
+        // The worktree side of a rename is just an edit on the new path,
+        // not a rename itself — drop orig_path for non-rename statuses.
+        let orig_for_y = match status {
+            FileStatus::Renamed | FileStatus::Copied => orig,
+            _ => None,
+        };
+        out.push(FileEntry {
+            path: path.to_string(),
+            orig_path: orig_for_y,
+            status,
+            staged: false,
+        });
+    }
+}
+
+fn char_to_status(c: char) -> Option<FileStatus> {
+    match c {
+        'M' => Some(FileStatus::Modified),
+        'A' => Some(FileStatus::Added),
+        'D' => Some(FileStatus::Deleted),
+        'R' => Some(FileStatus::Renamed),
+        'C' => Some(FileStatus::Copied),
+        'T' => Some(FileStatus::TypeChange),
+        _ => None,
+    }
 }
 
 /// Parse the output of `git diff [--cached] --numstat -z`.
@@ -60,18 +177,38 @@ pub fn parse_status(_input: &str) -> Vec<FileEntry> {
 /// Returns a map from path to its [`NumStat`]. Renames in `-z` numstat
 /// emit three NUL-separated tokens: `adds\tdels\t\0origPath\0newPath`,
 /// and we key the result on the new path.
-pub fn parse_numstat(_input: &str) -> HashMap<String, NumStat> {
-    // Stub.
-    let mut m = HashMap::new();
-    m.insert(
-        String::from("TODO"),
-        NumStat {
-            adds: 0,
-            dels: 0,
-            binary: false,
-        },
-    );
-    m
+pub fn parse_numstat(input: &str) -> HashMap<String, NumStat> {
+    let pieces: Vec<&str> = input.split('\0').filter(|s| !s.is_empty()).collect();
+    let mut out = HashMap::new();
+    let mut i = 0;
+    while i < pieces.len() {
+        let header = pieces[i];
+        let mut tabs = header.split('\t');
+        let adds_str = tabs.next().unwrap_or("");
+        let dels_str = tabs.next().unwrap_or("");
+        let path_part = tabs.next().unwrap_or("");
+        let (binary, adds, dels) = if adds_str == "-" && dels_str == "-" {
+            (true, 0, 0)
+        } else {
+            (
+                false,
+                adds_str.parse::<u32>().unwrap_or(0),
+                dels_str.parse::<u32>().unwrap_or(0),
+            )
+        };
+        let (path, step) = if path_part.is_empty() {
+            // Rename: next is origPath, then newPath. Key on newPath.
+            let new_path = pieces.get(i + 2).map_or(String::new(), |s| (*s).to_string());
+            (new_path, 3)
+        } else {
+            (path_part.to_string(), 1)
+        };
+        if !path.is_empty() {
+            out.insert(path, NumStat { adds, dels, binary });
+        }
+        i += step;
+    }
+    out
 }
 
 #[cfg(test)]

--- a/src/gsw/src/git.rs
+++ b/src/gsw/src/git.rs
@@ -1,1 +1,284 @@
 //! Parse `git status --porcelain=v2 -z` and `git diff --numstat -z` output.
+
+use std::collections::HashMap;
+
+/// What kind of change a [`FileEntry`] represents.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum FileStatus {
+    Modified,
+    Added,
+    Deleted,
+    Renamed,
+    Copied,
+    TypeChange,
+    Untracked,
+    UntrackedDir,
+    Conflicted,
+}
+
+/// One row in the rendered output.
+///
+/// A file with both staged and unstaged changes produces two entries —
+/// that mirrors how `git status` displays it and what the user wants to see.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FileEntry {
+    pub path: String,
+    /// Set for renames/copies; this is the pre-rename path.
+    pub orig_path: Option<String>,
+    pub status: FileStatus,
+    /// True when the change is in the index (staged), false when only in the worktree.
+    pub staged: bool,
+}
+
+/// Adds/deletes for a single file, from `git diff --numstat`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct NumStat {
+    pub adds: u32,
+    pub dels: u32,
+    /// Binary files report `-`/`-` in numstat; we surface that here so render
+    /// can show `bin` instead of an empty bar.
+    pub binary: bool,
+}
+
+/// Parse the output of `git status --porcelain=v2 -z`.
+///
+/// Input is a single string with `\0`-separated records (the `-z` form).
+/// For renames/copies the new path and original path are split by `\0`
+/// within the entry, which is why we consume two records for a type-2 entry.
+pub fn parse_status(_input: &str) -> Vec<FileEntry> {
+    // Stub.
+    vec![FileEntry {
+        path: String::from("TODO"),
+        orig_path: None,
+        status: FileStatus::Modified,
+        staged: false,
+    }]
+}
+
+/// Parse the output of `git diff [--cached] --numstat -z`.
+///
+/// Returns a map from path to its [`NumStat`]. Renames in `-z` numstat
+/// emit three NUL-separated tokens: `adds\tdels\t\0origPath\0newPath`,
+/// and we key the result on the new path.
+pub fn parse_numstat(_input: &str) -> HashMap<String, NumStat> {
+    // Stub.
+    let mut m = HashMap::new();
+    m.insert(
+        String::from("TODO"),
+        NumStat {
+            adds: 0,
+            dels: 0,
+            binary: false,
+        },
+    );
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        path: &str,
+        status: FileStatus,
+        staged: bool,
+        orig: Option<&str>,
+    ) -> FileEntry {
+        FileEntry {
+            path: path.to_string(),
+            orig_path: orig.map(String::from),
+            status,
+            staged,
+        }
+    }
+
+    // ---- parse_status ----
+
+    #[test]
+    fn status_empty_input_yields_nothing() {
+        assert_eq!(parse_status(""), Vec::<FileEntry>::new());
+    }
+
+    #[test]
+    fn status_single_unstaged_modification() {
+        // XY = ".M" → only worktree changed
+        let input = "1 .M N... 100644 100644 100644 a b src/foo.rs\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("src/foo.rs", FileStatus::Modified, false, None)],
+        );
+    }
+
+    #[test]
+    fn status_single_staged_addition() {
+        // XY = "A." → only index changed
+        let input = "1 A. N... 000000 100644 100644 a b src/new.rs\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("src/new.rs", FileStatus::Added, true, None)],
+        );
+    }
+
+    #[test]
+    fn status_both_staged_and_unstaged_splits_into_two_entries() {
+        // XY = "MM" → modified in index AND in worktree
+        let input = "1 MM N... 100644 100644 100644 a b src/baz.rs\0";
+        assert_eq!(
+            parse_status(input),
+            vec![
+                entry("src/baz.rs", FileStatus::Modified, true, None),
+                entry("src/baz.rs", FileStatus::Modified, false, None),
+            ],
+        );
+    }
+
+    #[test]
+    fn status_staged_deletion() {
+        let input = "1 D. N... 100644 000000 000000 a b gone.txt\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("gone.txt", FileStatus::Deleted, true, None)],
+        );
+    }
+
+    #[test]
+    fn status_rename_emits_single_entry_with_orig_path() {
+        // Type 2: "R." with score, then path NUL origPath NUL
+        let input = "2 R. N... 100644 100644 100644 a b R100 src/new.rs\0src/old.rs\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("src/new.rs", FileStatus::Renamed, true, Some("src/old.rs"))],
+        );
+    }
+
+    #[test]
+    fn status_conflict_renders_as_conflicted() {
+        let input = "u UU N... 100644 100644 100644 100644 a b c src/clash.rs\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("src/clash.rs", FileStatus::Conflicted, false, None)],
+        );
+    }
+
+    #[test]
+    fn status_untracked_file() {
+        let input = "? scratch.txt\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("scratch.txt", FileStatus::Untracked, false, None)],
+        );
+    }
+
+    #[test]
+    fn status_untracked_directory_keeps_trailing_slash() {
+        let input = "? new-folder/\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("new-folder/", FileStatus::UntrackedDir, false, None)],
+        );
+    }
+
+    #[test]
+    fn status_path_with_spaces_handled() {
+        let input = "1 .M N... 100644 100644 100644 a b a path with spaces.txt\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry(
+                "a path with spaces.txt",
+                FileStatus::Modified,
+                false,
+                None,
+            )],
+        );
+    }
+
+    #[test]
+    fn status_multiple_entries_in_order() {
+        let input = "1 .M N... 100644 100644 100644 a b a.rs\0\
+                     1 A. N... 000000 100644 100644 a b b.rs\0\
+                     ? c.txt\0";
+        assert_eq!(
+            parse_status(input),
+            vec![
+                entry("a.rs", FileStatus::Modified, false, None),
+                entry("b.rs", FileStatus::Added, true, None),
+                entry("c.txt", FileStatus::Untracked, false, None),
+            ],
+        );
+    }
+
+    #[test]
+    fn status_ignored_entries_are_dropped() {
+        // '!' entries should not surface.
+        let input = "! target/build.log\0? real.txt\0";
+        assert_eq!(
+            parse_status(input),
+            vec![entry("real.txt", FileStatus::Untracked, false, None)],
+        );
+    }
+
+    // ---- parse_numstat ----
+
+    #[test]
+    fn numstat_empty_input() {
+        assert_eq!(parse_numstat(""), HashMap::new());
+    }
+
+    #[test]
+    fn numstat_simple_adds_and_dels() {
+        // -z numstat format: "adds\tdels\tpath\0"
+        let input = "12\t3\tsrc/foo.rs\0";
+        let result = parse_numstat(input);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.get("src/foo.rs"),
+            Some(&NumStat {
+                adds: 12,
+                dels: 3,
+                binary: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn numstat_binary_files_marked() {
+        let input = "-\t-\tassets/logo.png\0";
+        let result = parse_numstat(input);
+        assert_eq!(
+            result.get("assets/logo.png"),
+            Some(&NumStat {
+                adds: 0,
+                dels: 0,
+                binary: true,
+            }),
+        );
+    }
+
+    #[test]
+    fn numstat_rename_keyed_on_new_path() {
+        // Rename in -z numstat: "adds\tdels\t\0origPath\0newPath\0"
+        let input = "5\t2\t\0src/old.rs\0src/new.rs\0";
+        let result = parse_numstat(input);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.get("src/new.rs"),
+            Some(&NumStat {
+                adds: 5,
+                dels: 2,
+                binary: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn numstat_multiple_entries() {
+        let input = "1\t1\ta.rs\0\
+                     20\t5\tb.rs\0\
+                     -\t-\timg.png\0";
+        let result = parse_numstat(input);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.get("a.rs").map(|n| n.adds), Some(1));
+        assert_eq!(result.get("b.rs").map(|n| n.adds), Some(20));
+        assert_eq!(result.get("img.png").map(|n| n.binary), Some(true));
+    }
+}

--- a/src/gsw/src/git.rs
+++ b/src/gsw/src/git.rs
@@ -1,0 +1,1 @@
+//! Parse `git status --porcelain=v2 -z` and `git diff --numstat -z` output.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -8,7 +8,7 @@ use buildinfo::version_string;
 use clap::Parser;
 
 use crate::git::{parse_numstat, parse_status, FileEntry, NumStat};
-use crate::render::{render, RenderOptions};
+use crate::render::{default_max_files, render, RenderOptions};
 use crate::snapshot::build_snapshot;
 
 mod age;
@@ -88,13 +88,13 @@ fn main() -> Result<()> {
         &ages,
     );
 
-    let terminal_width = terminal_size::terminal_size()
-        .map_or(80, |(w, _)| usize::from(w.0));
+    let (terminal_width, terminal_height) = terminal_size::terminal_size()
+        .map_or((80, 24), |(w, h)| (usize::from(w.0), h.0));
 
     let opts = RenderOptions {
         terminal_width,
         bar_width: cli.bar_width,
-        max_files: cli.max_files,
+        max_files: cli.max_files.or(Some(default_max_files(terminal_height))),
     };
 
     println!("{}", render(&snapshot, &opts));

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -5,6 +5,7 @@ mod age;
 mod bar;
 mod git;
 mod render;
+mod snapshot;
 
 #[derive(Parser)]
 #[command(name = "gsw")]

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -1,5 +1,15 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+use anyhow::{bail, Context, Result};
 use buildinfo::version_string;
 use clap::Parser;
+
+use crate::git::{parse_numstat, parse_status, FileEntry, NumStat};
+use crate::render::{render, RenderOptions};
+use crate::snapshot::build_snapshot;
 
 mod age;
 mod bar;
@@ -26,7 +36,7 @@ struct Cli {
     #[arg(long)]
     base: Option<String>,
 
-    /// Maximum number of file rows to show (default: fit terminal).
+    /// Maximum number of file rows to show (default: unlimited).
     #[arg(long)]
     max_files: Option<usize>,
 
@@ -35,7 +45,124 @@ struct Cli {
     bar_width: usize,
 }
 
-fn main() -> anyhow::Result<()> {
-    let _cli = Cli::parse();
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    if cli.no_color {
+        colored::control::set_override(false);
+    }
+
+    let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"])
+        .context("not inside a git repository")?
+        .trim()
+        .to_string();
+
+    let base = cli.base.unwrap_or_else(|| resolve_base_ref().unwrap_or_else(|_| "HEAD".to_string()));
+
+    let commits_ahead = run_git(&["rev-list", "--count", &format!("{base}..HEAD")])
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+
+    let last_commit_age = last_commit_age().unwrap_or(Duration::ZERO);
+
+    let status_raw = run_git(&["status", "--porcelain=v2", "-z"])?;
+    let entries = parse_status(&status_raw);
+
+    let staged_numstat = run_git(&["diff", "--cached", "--numstat", "-z"])
+        .map(|s| parse_numstat(&s))
+        .unwrap_or_default();
+    let unstaged_numstat = run_git(&["diff", "--numstat", "-z"])
+        .map(|s| parse_numstat(&s))
+        .unwrap_or_default();
+
+    let ages = collect_ages(&entries);
+
+    let snapshot = build_snapshot(
+        branch,
+        base,
+        commits_ahead,
+        last_commit_age,
+        entries,
+        &staged_numstat,
+        &unstaged_numstat,
+        &ages,
+    );
+
+    let terminal_width = terminal_size::terminal_size()
+        .map_or(80, |(w, _)| usize::from(w.0));
+
+    let opts = RenderOptions {
+        terminal_width,
+        bar_width: cli.bar_width,
+        max_files: cli.max_files,
+    };
+
+    println!("{}", render(&snapshot, &opts));
     Ok(())
 }
+
+/// Run `git` with the given args and return captured stdout as UTF-8.
+fn run_git(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("invoking `git {}`", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "`git {}` exited with status {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Pick the first base ref that actually resolves: `main`, then `master`,
+/// then whatever `origin/HEAD` points to.
+fn resolve_base_ref() -> Result<String> {
+    for candidate in ["main", "master"] {
+        if run_git(&["rev-parse", "--verify", "--quiet", candidate]).is_ok() {
+            return Ok(candidate.to_string());
+        }
+    }
+    if let Ok(out) = run_git(&["symbolic-ref", "refs/remotes/origin/HEAD"]) {
+        let trimmed = out.trim();
+        if let Some(name) = trimmed.strip_prefix("refs/remotes/origin/") {
+            return Ok(format!("origin/{name}"));
+        }
+    }
+    Ok("HEAD".to_string())
+}
+
+/// How long ago the current HEAD commit was authored.
+fn last_commit_age() -> Result<Duration> {
+    let raw = run_git(&["log", "-1", "--format=%ct"])?;
+    let secs: u64 = raw.trim().parse().unwrap_or(0);
+    let when = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+    Ok(SystemTime::now().duration_since(when).unwrap_or(Duration::ZERO))
+}
+
+/// Get mtime ages for each entry's path, where the path still exists on disk.
+fn collect_ages(entries: &[FileEntry]) -> HashMap<String, Duration> {
+    let now = SystemTime::now();
+    let mut out = HashMap::with_capacity(entries.len());
+    for e in entries {
+        if out.contains_key(&e.path) {
+            continue;
+        }
+        let path = Path::new(&e.path);
+        let Ok(meta) = std::fs::metadata(path) else {
+            continue;
+        };
+        let Ok(mtime) = meta.modified() else {
+            continue;
+        };
+        let elapsed = now.duration_since(mtime).unwrap_or(Duration::ZERO);
+        out.insert(e.path.clone(), elapsed);
+    }
+    out
+}
+
+// Silence: NumStat is only constructed inside parse_numstat / tests.
+const _: fn() -> NumStat = || NumStat::default();

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, SystemTime};
 use anyhow::{bail, Context, Result};
 use buildinfo::version_string;
 use clap::Parser;
+use colored::Colorize;
 
 use crate::git::{parse_numstat, parse_status, FileEntry, NumStat};
 use crate::render::{default_max_files, render, RenderOptions};
@@ -49,6 +50,11 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     if cli.no_color {
         colored::control::set_override(false);
+    }
+
+    if !inside_git_repo() {
+        println!("{}", "gsw • not a git repository".dimmed());
+        return Ok(());
     }
 
     let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"])
@@ -99,6 +105,14 @@ fn main() -> Result<()> {
 
     println!("{}", render(&snapshot, &opts));
     Ok(())
+}
+
+/// True if the current working directory is inside a git work tree.
+fn inside_git_repo() -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .is_ok_and(|o| o.status.success())
 }
 
 /// Run `git` with the given args and return captured stdout as UTF-8.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -1,0 +1,40 @@
+use buildinfo::version_string;
+use clap::Parser;
+
+mod age;
+mod bar;
+mod git;
+mod render;
+
+#[derive(Parser)]
+#[command(name = "gsw")]
+#[command(version = version_string!())]
+#[command(
+    about = "Compact git status watch — one-shot pretty output for use with viddy",
+    long_about = "Prints a compact, color-coded view of the current branch's state: \
+                  commits ahead of the base branch, last-commit age, and a per-file \
+                  list showing a magnitude bar, +/- counts, and recency. Designed to \
+                  be run repeatedly under `viddy`."
+)]
+struct Cli {
+    /// Strip ANSI color codes from output.
+    #[arg(long)]
+    no_color: bool,
+
+    /// Base ref to compare against (default: main, then master, then origin/HEAD).
+    #[arg(long)]
+    base: Option<String>,
+
+    /// Maximum number of file rows to show (default: fit terminal).
+    #[arg(long)]
+    max_files: Option<usize>,
+
+    /// Width of the magnitude bar in cells.
+    #[arg(long, default_value_t = 6)]
+    bar_width: usize,
+}
+
+fn main() -> anyhow::Result<()> {
+    let _cli = Cli::parse();
+    Ok(())
+}

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -2,6 +2,11 @@
 
 use std::time::Duration;
 
+use colored::{ColoredString, Colorize};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::age::{age_dim_level, format_age, AgeDim};
+use crate::bar::render_bar;
 use crate::git::FileStatus;
 
 /// Everything render() needs to draw one frame.
@@ -37,10 +42,305 @@ pub struct RenderOptions {
     pub max_files: Option<usize>,
 }
 
+/// Width of the "+adds" / "-dels" / age column fields.
+const ADDS_FIELD: usize = 5;
+const DELS_FIELD: usize = 4;
+const AGE_FIELD: usize = 4;
+
+/// Visible separator characters between columns.
+const SEP_PATH_BAR: usize = 0;
+const SEP_BAR_ADDS: usize = 2;
+const SEP_ADDS_DELS: usize = 1;
+const SEP_DELS_AGE: usize = 3;
+
 /// Produce the colored, multi-line frame.
-pub fn render(_snapshot: &Snapshot, _opts: &RenderOptions) -> String {
-    // Stub.
-    String::from("TODO")
+pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(render_header(snapshot));
+    lines.push(render_separator(opts.terminal_width));
+
+    let display_count = opts
+        .max_files
+        .unwrap_or(usize::MAX)
+        .min(snapshot.files.len());
+    let max_change = snapshot
+        .files
+        .iter()
+        .map(|e| e.adds.saturating_add(e.dels))
+        .max()
+        .unwrap_or(0)
+        .max(1);
+    let path_width = compute_path_width(opts);
+
+    for entry in snapshot.files.iter().take(display_count) {
+        lines.push(render_row(entry, opts, max_change, path_width));
+    }
+
+    let hidden = snapshot.files.len() - display_count;
+    if hidden > 0 {
+        lines.push(
+            format!("  +{hidden} more file{}", if hidden == 1 { "" } else { "s" })
+                .dimmed()
+                .to_string(),
+        );
+    }
+
+    lines.join("\n")
+}
+
+fn compute_path_width(opts: &RenderOptions) -> usize {
+    // Layout overhead per row: icon(1) + letter(1) + " "(1) + bar(N) + seps + fields.
+    let overhead = 3
+        + opts.bar_width
+        + SEP_PATH_BAR
+        + SEP_BAR_ADDS
+        + ADDS_FIELD
+        + SEP_ADDS_DELS
+        + DELS_FIELD
+        + SEP_DELS_AGE
+        + AGE_FIELD;
+    opts.terminal_width.saturating_sub(overhead).max(8)
+}
+
+fn render_header(snap: &Snapshot) -> String {
+    let commit_word = if snap.commits_ahead == 1 { "commit" } else { "commits" };
+    let age = format_age_detailed(snap.last_commit_age);
+    let header = format!(
+        "gsw • {branch} • {n} {word} ahead of {base} • last commit {age} ago",
+        branch = snap.branch,
+        n = snap.commits_ahead,
+        word = commit_word,
+        base = snap.base,
+        age = age,
+    );
+    header.bold().to_string()
+}
+
+fn render_separator(width: usize) -> String {
+    "─".repeat(width).dimmed().to_string()
+}
+
+fn render_row(
+    entry: &RenderEntry,
+    opts: &RenderOptions,
+    max_change: u32,
+    path_width: usize,
+) -> String {
+    let (icon, letter) = icon_and_letter(entry);
+
+    let path_display_raw = match &entry.orig_path {
+        Some(orig) => format!("{orig} → {new}", new = entry.path),
+        None => entry.path.clone(),
+    };
+    let path_truncated = truncate_left(&path_display_raw, path_width);
+    let path_padded = pad_right(&path_truncated, path_width);
+
+    let icon_str = colorize_icon(icon, entry);
+    let letter_str = colorize_letter(letter, entry);
+    let path_str = colorize_path(&path_padded, entry);
+
+    // Untracked files get a stripped-down row — no bar, no counts.
+    if matches!(
+        entry.status,
+        FileStatus::Untracked | FileStatus::UntrackedDir
+    ) {
+        let age = entry.age.map(format_age).unwrap_or_default();
+        let age_field = format!("{age:>width$}", width = AGE_FIELD);
+        let age_str = colorize_age(&age_field, entry.age);
+        return format!("{icon_str}{letter_str} {path_str}{age_str}");
+    }
+
+    let bar_raw = if entry.binary {
+        center("bin", opts.bar_width)
+    } else {
+        render_bar(entry.adds.saturating_add(entry.dels), max_change, opts.bar_width)
+    };
+    let bar_str = colorize_bar(&bar_raw, entry);
+
+    let adds_raw = if entry.adds > 0 {
+        format!("+{}", entry.adds)
+    } else {
+        String::new()
+    };
+    let dels_raw = if entry.dels > 0 {
+        format!("-{}", entry.dels)
+    } else {
+        String::new()
+    };
+    let adds_field = format!("{adds_raw:>width$}", width = ADDS_FIELD);
+    let dels_field = format!("{dels_raw:>width$}", width = DELS_FIELD);
+
+    let adds_str = if entry.adds > 0 {
+        adds_field.green().to_string()
+    } else {
+        adds_field
+    };
+    let dels_str = if entry.dels > 0 {
+        dels_field.red().to_string()
+    } else {
+        dels_field
+    };
+
+    let age_raw = entry.age.map(format_age).unwrap_or_else(|| String::from("—"));
+    let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
+    let age_str = colorize_age(&age_field, entry.age);
+
+    let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
+    let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);
+    let sep_dels_age = " ".repeat(SEP_DELS_AGE);
+
+    format!(
+        "{icon_str}{letter_str} {path_str}{bar_str}{sep_bar_adds}{adds_str}{sep_adds_dels}{dels_str}{sep_dels_age}{age_str}",
+    )
+}
+
+fn icon_and_letter(entry: &RenderEntry) -> (char, char) {
+    let icon = match entry.status {
+        FileStatus::Conflicted => '!',
+        FileStatus::Untracked | FileStatus::UntrackedDir => '?',
+        _ if entry.staged => '●',
+        _ => '○',
+    };
+    let letter = match entry.status {
+        FileStatus::Modified => 'M',
+        FileStatus::Added => 'A',
+        FileStatus::Deleted => 'D',
+        FileStatus::Renamed => 'R',
+        FileStatus::Copied => 'C',
+        FileStatus::TypeChange => 'T',
+        FileStatus::Untracked | FileStatus::UntrackedDir => '?',
+        FileStatus::Conflicted => 'U',
+    };
+    (icon, letter)
+}
+
+fn colorize_icon(icon: char, entry: &RenderEntry) -> ColoredString {
+    let s = icon.to_string();
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        _ if entry.staged => s.green(),
+        _ => s.yellow(),
+    }
+}
+
+fn colorize_letter(letter: char, entry: &RenderEntry) -> ColoredString {
+    let s = letter.to_string();
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        FileStatus::Added => s.green().bold(),
+        FileStatus::Deleted => s.red().bold(),
+        FileStatus::Renamed | FileStatus::Copied => s.magenta().bold(),
+        _ => s.bold(),
+    }
+}
+
+fn colorize_path(path: &str, entry: &RenderEntry) -> ColoredString {
+    match entry.status {
+        FileStatus::Conflicted => path.red(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => path.cyan().dimmed(),
+        _ if entry.staged => path.normal().dimmed(),
+        _ => path.yellow(),
+    }
+}
+
+fn colorize_bar(bar: &str, entry: &RenderEntry) -> ColoredString {
+    if entry.binary {
+        bar.dimmed()
+    } else if matches!(entry.status, FileStatus::Conflicted) {
+        bar.red()
+    } else {
+        bar.cyan()
+    }
+}
+
+fn colorize_age(text: &str, age: Option<Duration>) -> ColoredString {
+    let Some(age) = age else {
+        return text.dimmed();
+    };
+    match age_dim_level(age) {
+        AgeDim::Fresh => text.bold(),
+        AgeDim::Recent => text.normal(),
+        AgeDim::Aging => text.dimmed(),
+        AgeDim::Stale => text.dimmed(),
+    }
+}
+
+/// Pad `s` on the right with spaces until its display width reaches `width`.
+fn pad_right(s: &str, width: usize) -> String {
+    let current = UnicodeWidthStr::width(s);
+    if current >= width {
+        s.to_string()
+    } else {
+        let mut result = String::with_capacity(s.len() + (width - current));
+        result.push_str(s);
+        for _ in 0..(width - current) {
+            result.push(' ');
+        }
+        result
+    }
+}
+
+/// Truncate `s` from the left to fit within `max_width` display columns,
+/// prefixing with `…` when truncation happens. UTF-8 safe.
+fn truncate_left(s: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+    let ellipsis_width = 1usize;
+    let target = max_width.saturating_sub(ellipsis_width);
+    let chars: Vec<char> = s.chars().collect();
+    let mut acc = 0usize;
+    let mut start = chars.len();
+    for (i, c) in chars.iter().enumerate().rev() {
+        let cw = UnicodeWidthChar::width(*c).unwrap_or(0);
+        if acc + cw > target {
+            break;
+        }
+        acc += cw;
+        start = i;
+    }
+    let mut result = String::from("…");
+    for c in &chars[start..] {
+        result.push(*c);
+    }
+    result
+}
+
+/// Center `text` within `width` display columns, padding with spaces.
+fn center(text: &str, width: usize) -> String {
+    let text_w = UnicodeWidthStr::width(text);
+    if text_w >= width {
+        return text.to_string();
+    }
+    let total_pad = width - text_w;
+    let left = total_pad / 2;
+    let right = total_pad - left;
+    let mut result = String::with_capacity(width);
+    for _ in 0..left {
+        result.push(' ');
+    }
+    result.push_str(text);
+    for _ in 0..right {
+        result.push(' ');
+    }
+    result
+}
+
+/// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.
+fn format_age_detailed(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
+    }
 }
 
 #[cfg(test)]
@@ -53,7 +353,6 @@ mod tests {
         let mut in_escape = false;
         for c in s.chars() {
             if in_escape {
-                // CSI terminator is any byte in 0x40..=0x7E.
                 if (0x40..=0x7E).contains(&(c as u32)) {
                     in_escape = false;
                 }
@@ -144,7 +443,6 @@ mod tests {
         assert!(row.contains("+12"), "row should include +adds: {row}");
         assert!(row.contains("-3"), "row should include -dels: {row}");
         assert!(row.contains("30s"), "row should include age: {row}");
-        // Staged → filled-circle icon.
         assert!(row.contains('●'), "row should use ● for staged: {row}");
         assert!(row.contains('M'), "row should include status letter: {row}");
     }
@@ -166,7 +464,6 @@ mod tests {
         let row = out.lines().nth(2).unwrap_or("");
         assert!(row.contains('?'), "untracked should use ? icon: {row}");
         assert!(row.contains("scratch.txt"));
-        // No counts, no bar — the bar block chars should not appear.
         assert!(
             !row.contains('█') && !row.contains('░'),
             "untracked row should not include a bar: {row}",
@@ -252,10 +549,8 @@ mod tests {
 
     #[test]
     fn utf8_path_truncation_does_not_panic() {
-        // Japanese (each char is 3 bytes UTF-8 but display width 2)
         let path = "日本語/とても/長い/ファイル名.rs".to_string();
         let snap = snap_with(vec![entry(&path, FileStatus::Modified, true, 1, 0)]);
-        // Narrow width to force truncation through multi-byte chars.
         let out = render(
             &snap,
             &RenderOptions {
@@ -265,7 +560,6 @@ mod tests {
             },
         );
         let stripped = strip_ansi(&out);
-        // Must contain SOME suffix of the file name.
         assert!(stripped.contains(".rs"));
     }
 
@@ -283,7 +577,6 @@ mod tests {
                 max_files: Some(3),
             },
         ));
-        // Three file rows, then "+7 more".
         assert!(out.contains("f0.rs"));
         assert!(out.contains("f2.rs"));
         assert!(!out.contains("f3.rs"), "files past the limit should be hidden");

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -608,4 +608,43 @@ mod tests {
         );
         assert!(big_filled >= 6, "biggest change should fill the bar: {big_row}");
     }
+
+    #[test]
+    fn detailed_age_seconds_only() {
+        assert_eq!(format_age_detailed(Duration::from_secs(0)), "0s");
+        assert_eq!(format_age_detailed(Duration::from_secs(5)), "5s");
+        assert_eq!(format_age_detailed(Duration::from_secs(59)), "59s");
+    }
+
+    #[test]
+    fn detailed_age_minutes_and_seconds() {
+        assert_eq!(format_age_detailed(Duration::from_secs(60)), "1m0s");
+        assert_eq!(format_age_detailed(Duration::from_secs(5 * 60 + 23)), "5m23s");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(59 * 60 + 59)),
+            "59m59s",
+        );
+    }
+
+    #[test]
+    fn detailed_age_hours_and_minutes() {
+        assert_eq!(format_age_detailed(Duration::from_secs(60 * 60)), "1h0m");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(2 * 3600 + 14 * 60)),
+            "2h14m",
+        );
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(23 * 3600 + 59 * 60)),
+            "23h59m",
+        );
+    }
+
+    #[test]
+    fn detailed_age_days_and_hours() {
+        assert_eq!(format_age_detailed(Duration::from_secs(86400)), "1d0h");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(3 * 86400 + 12 * 3600)),
+            "3d12h",
+        );
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1,0 +1,1 @@
+//! Assemble a Snapshot into a colored, compact text block.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1,1 +1,318 @@
-//! Assemble a Snapshot into a colored, compact text block.
+//! Assemble a [`Snapshot`] into a colored, compact text block.
+
+use std::time::Duration;
+
+use crate::git::FileStatus;
+
+/// Everything render() needs to draw one frame.
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    pub branch: String,
+    pub base: String,
+    pub commits_ahead: u32,
+    pub last_commit_age: Duration,
+    pub files: Vec<RenderEntry>,
+}
+
+/// One file row in the frame.
+#[derive(Debug, Clone)]
+pub struct RenderEntry {
+    pub path: String,
+    /// Pre-rename path, when applicable.
+    pub orig_path: Option<String>,
+    pub status: FileStatus,
+    pub staged: bool,
+    pub adds: u32,
+    pub dels: u32,
+    pub binary: bool,
+    /// File mtime age. `None` for deleted files / untracked dirs we won't stat.
+    pub age: Option<Duration>,
+}
+
+/// Options driving layout.
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    pub terminal_width: usize,
+    pub bar_width: usize,
+    pub max_files: Option<usize>,
+}
+
+/// Produce the colored, multi-line frame.
+pub fn render(_snapshot: &Snapshot, _opts: &RenderOptions) -> String {
+    // Stub.
+    String::from("TODO")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drop ANSI CSI sequences so tests can match on the visible glyphs.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut in_escape = false;
+        for c in s.chars() {
+            if in_escape {
+                // CSI terminator is any byte in 0x40..=0x7E.
+                if (0x40..=0x7E).contains(&(c as u32)) {
+                    in_escape = false;
+                }
+                continue;
+            }
+            if c == '\x1b' {
+                in_escape = true;
+                continue;
+            }
+            out.push(c);
+        }
+        out
+    }
+
+    fn opts() -> RenderOptions {
+        RenderOptions {
+            terminal_width: 80,
+            bar_width: 6,
+            max_files: None,
+        }
+    }
+
+    fn snap_with(files: Vec<RenderEntry>) -> Snapshot {
+        Snapshot {
+            branch: "gsv".into(),
+            base: "main".into(),
+            commits_ahead: 3,
+            last_commit_age: Duration::from_secs(5 * 60 + 23),
+            files,
+        }
+    }
+
+    fn entry(
+        path: &str,
+        status: FileStatus,
+        staged: bool,
+        adds: u32,
+        dels: u32,
+    ) -> RenderEntry {
+        RenderEntry {
+            path: path.into(),
+            orig_path: None,
+            status,
+            staged,
+            adds,
+            dels,
+            binary: false,
+            age: Some(Duration::from_secs(30)),
+        }
+    }
+
+    #[test]
+    fn header_mentions_branch_commits_and_age() {
+        let out = strip_ansi(&render(&snap_with(vec![]), &opts()));
+        let header_line = out.lines().next().unwrap_or("");
+        assert!(
+            header_line.contains("gsv"),
+            "header should mention branch: {header_line}",
+        );
+        assert!(
+            header_line.contains("3 commits ahead of main"),
+            "header should mention commit count and base: {header_line}",
+        );
+        assert!(
+            header_line.contains("5m23s"),
+            "header should mention last-commit age: {header_line}",
+        );
+    }
+
+    #[test]
+    fn single_commit_uses_singular_word() {
+        let mut s = snap_with(vec![]);
+        s.commits_ahead = 1;
+        let out = strip_ansi(&render(&s, &opts()));
+        let header_line = out.lines().next().unwrap_or("");
+        assert!(
+            header_line.contains("1 commit ahead of main"),
+            "expected singular 'commit': {header_line}",
+        );
+    }
+
+    #[test]
+    fn staged_modified_file_renders_full_row() {
+        let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, true, 12, 3)]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains("src/foo.rs"), "row should include path: {row}");
+        assert!(row.contains("+12"), "row should include +adds: {row}");
+        assert!(row.contains("-3"), "row should include -dels: {row}");
+        assert!(row.contains("30s"), "row should include age: {row}");
+        // Staged → filled-circle icon.
+        assert!(row.contains('●'), "row should use ● for staged: {row}");
+        assert!(row.contains('M'), "row should include status letter: {row}");
+    }
+
+    #[test]
+    fn unstaged_file_uses_open_circle_icon() {
+        let snap = snap_with(vec![entry("a.rs", FileStatus::Modified, false, 1, 0)]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains('○'), "row should use ○ for unstaged: {row}");
+    }
+
+    #[test]
+    fn untracked_file_uses_question_icon_and_no_bar() {
+        let mut e = entry("scratch.txt", FileStatus::Untracked, false, 0, 0);
+        e.age = Some(Duration::from_secs(10));
+        let snap = snap_with(vec![e]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains('?'), "untracked should use ? icon: {row}");
+        assert!(row.contains("scratch.txt"));
+        // No counts, no bar — the bar block chars should not appear.
+        assert!(
+            !row.contains('█') && !row.contains('░'),
+            "untracked row should not include a bar: {row}",
+        );
+    }
+
+    #[test]
+    fn untracked_directory_keeps_trailing_slash() {
+        let snap = snap_with(vec![entry(
+            "new-folder/",
+            FileStatus::UntrackedDir,
+            false,
+            0,
+            0,
+        )]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(
+            row.contains("new-folder/"),
+            "untracked dir should show trailing slash: {row}",
+        );
+    }
+
+    #[test]
+    fn binary_file_replaces_bar_with_bin_marker() {
+        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+        e.binary = true;
+        let snap = snap_with(vec![e]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains("bin"), "binary file should show 'bin': {row}");
+        assert!(
+            !row.contains('█'),
+            "binary file should not show bar fill: {row}",
+        );
+    }
+
+    #[test]
+    fn renamed_file_shows_old_arrow_new_on_one_line() {
+        let mut e = entry("src/new.rs", FileStatus::Renamed, true, 5, 2);
+        e.orig_path = Some("src/old.rs".into());
+        let snap = snap_with(vec![e]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains("src/old.rs"), "rename should show old path: {row}");
+        assert!(row.contains("src/new.rs"), "rename should show new path: {row}");
+        assert!(row.contains('→'), "rename should use arrow: {row}");
+    }
+
+    #[test]
+    fn conflict_uses_bang_icon() {
+        let snap = snap_with(vec![entry(
+            "src/clash.rs",
+            FileStatus::Conflicted,
+            false,
+            5,
+            5,
+        )]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains('!'), "conflict should use ! icon: {row}");
+    }
+
+    #[test]
+    fn long_path_truncated_from_left_with_ellipsis() {
+        let long_path = format!("{}/end.rs", "a/very/long/path".repeat(10));
+        let snap = snap_with(vec![entry(&long_path, FileStatus::Modified, true, 1, 0)]);
+        let out = strip_ansi(&render(
+            &snap,
+            &RenderOptions {
+                terminal_width: 60,
+                bar_width: 6,
+                max_files: None,
+            },
+        ));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(row.contains('…'), "long path should be truncated: {row}");
+        assert!(
+            row.contains("end.rs"),
+            "filename end should be preserved: {row}",
+        );
+    }
+
+    #[test]
+    fn utf8_path_truncation_does_not_panic() {
+        // Japanese (each char is 3 bytes UTF-8 but display width 2)
+        let path = "日本語/とても/長い/ファイル名.rs".to_string();
+        let snap = snap_with(vec![entry(&path, FileStatus::Modified, true, 1, 0)]);
+        // Narrow width to force truncation through multi-byte chars.
+        let out = render(
+            &snap,
+            &RenderOptions {
+                terminal_width: 40,
+                bar_width: 6,
+                max_files: None,
+            },
+        );
+        let stripped = strip_ansi(&out);
+        // Must contain SOME suffix of the file name.
+        assert!(stripped.contains(".rs"));
+    }
+
+    #[test]
+    fn max_files_truncates_and_shows_more_footer() {
+        let files: Vec<RenderEntry> = (0..10)
+            .map(|i| entry(&format!("f{i}.rs"), FileStatus::Modified, true, 1, 0))
+            .collect();
+        let snap = snap_with(files);
+        let out = strip_ansi(&render(
+            &snap,
+            &RenderOptions {
+                terminal_width: 80,
+                bar_width: 6,
+                max_files: Some(3),
+            },
+        ));
+        // Three file rows, then "+7 more".
+        assert!(out.contains("f0.rs"));
+        assert!(out.contains("f2.rs"));
+        assert!(!out.contains("f3.rs"), "files past the limit should be hidden");
+        assert!(
+            out.contains("7 more"),
+            "footer should report hidden count: {out}",
+        );
+    }
+
+    #[test]
+    fn bar_scales_to_max_change_in_snapshot() {
+        let big = entry("big.rs", FileStatus::Modified, true, 100, 0);
+        let small = entry("small.rs", FileStatus::Modified, true, 1, 0);
+        let snap = snap_with(vec![big, small]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let big_row = out
+            .lines()
+            .find(|l| l.contains("big.rs"))
+            .unwrap_or_default();
+        let small_row = out
+            .lines()
+            .find(|l| l.contains("small.rs"))
+            .unwrap_or_default();
+        let big_filled = big_row.matches('█').count();
+        let small_filled = small_row.matches('█').count();
+        assert!(
+            big_filled > small_filled,
+            "big-change row should have more full cells than small: big={big_filled}, small={small_filled}",
+        );
+        assert!(big_filled >= 6, "biggest change should fill the bar: {big_row}");
+    }
+}

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -329,6 +329,16 @@ fn center(text: &str, width: usize) -> String {
     result
 }
 
+/// Pick a sensible default file-row limit for the given terminal height.
+///
+/// Reserves space for our own header, separator, and a potential `+N more`
+/// footer (plus one row of breathing room for whatever shell/viddy chrome
+/// sits above us). Always returns at least 1.
+pub fn default_max_files(_terminal_height: u16) -> usize {
+    // Stub: return a wrong fixed value so behavioral tests fail.
+    999
+}
+
 /// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.
 fn format_age_detailed(age: Duration) -> String {
     let secs = age.as_secs();
@@ -637,6 +647,22 @@ mod tests {
             format_age_detailed(Duration::from_secs(23 * 3600 + 59 * 60)),
             "23h59m",
         );
+    }
+
+    #[test]
+    fn default_max_files_reserves_room_for_chrome() {
+        // Reserve 4 rows for header, separator, footer, and breathing room.
+        assert_eq!(default_max_files(24), 20);
+        assert_eq!(default_max_files(50), 46);
+        assert_eq!(default_max_files(10), 6);
+    }
+
+    #[test]
+    fn default_max_files_never_returns_zero() {
+        assert_eq!(default_max_files(0), 1);
+        assert_eq!(default_max_files(1), 1);
+        assert_eq!(default_max_files(4), 1);
+        assert_eq!(default_max_files(5), 1);
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -334,9 +334,8 @@ fn center(text: &str, width: usize) -> String {
 /// Reserves space for our own header, separator, and a potential `+N more`
 /// footer (plus one row of breathing room for whatever shell/viddy chrome
 /// sits above us). Always returns at least 1.
-pub fn default_max_files(_terminal_height: u16) -> usize {
-    // Stub: return a wrong fixed value so behavioral tests fail.
-    999
+pub fn default_max_files(terminal_height: u16) -> usize {
+    usize::from(terminal_height.saturating_sub(4)).max(1)
 }
 
 /// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -289,10 +289,10 @@ fn truncate_left(s: &str, max_width: usize) -> String {
     if UnicodeWidthStr::width(s) <= max_width {
         return s.to_string();
     }
-    let ellipsis_width = 1usize;
+    let ellipsis_width = 1_usize;
     let target = max_width.saturating_sub(ellipsis_width);
     let chars: Vec<char> = s.chars().collect();
-    let mut acc = 0usize;
+    let mut acc = 0_usize;
     let mut start = chars.len();
     for (i, c) in chars.iter().enumerate().rev() {
         let cw = UnicodeWidthChar::width(*c).unwrap_or(0);

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::git::{FileEntry, FileStatus, NumStat};
+use crate::git::{FileEntry, NumStat};
 use crate::render::{RenderEntry, Snapshot};
 
 /// Assemble a [`Snapshot`] from parsed git outputs.
@@ -20,25 +20,43 @@ pub fn build_snapshot(
     unstaged_numstat: &HashMap<String, NumStat>,
     ages: &HashMap<String, Duration>,
 ) -> Snapshot {
-    let _ = (
-        &status_entries,
-        staged_numstat,
-        unstaged_numstat,
-        ages,
-    );
-    // Stub: return an empty file list to fail the substance tests.
+    let files = status_entries
+        .into_iter()
+        .map(|e| {
+            let side = if e.staged {
+                staged_numstat
+            } else {
+                unstaged_numstat
+            };
+            let (adds, dels, binary) = side
+                .get(&e.path)
+                .map_or((0, 0, false), |n| (n.adds, n.dels, n.binary));
+            let age = ages.get(&e.path).copied();
+            RenderEntry {
+                path: e.path,
+                orig_path: e.orig_path,
+                status: e.status,
+                staged: e.staged,
+                adds,
+                dels,
+                binary,
+                age,
+            }
+        })
+        .collect();
     Snapshot {
         branch,
         base,
         commits_ahead,
         last_commit_age,
-        files: vec![],
+        files,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git::FileStatus;
 
     fn ns(adds: u32, dels: u32) -> NumStat {
         NumStat {
@@ -297,19 +315,3 @@ mod tests {
     }
 }
 
-// Tests above must remain failing until build_snapshot is implemented.
-// The stub returns an empty `files` so substance assertions fail
-// behaviorally, not at compile time.
-#[allow(dead_code)]
-fn _ensure_render_entry_constructible_for_tests() -> RenderEntry {
-    RenderEntry {
-        path: String::new(),
-        orig_path: None,
-        status: FileStatus::Modified,
-        staged: false,
-        adds: 0,
-        dels: 0,
-        binary: false,
-        age: None,
-    }
-}

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -1,0 +1,315 @@
+//! Combine parsed git data + filesystem ages into a [`Snapshot`].
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::git::{FileEntry, FileStatus, NumStat};
+use crate::render::{RenderEntry, Snapshot};
+
+/// Assemble a [`Snapshot`] from parsed git outputs.
+///
+/// `staged_numstat` and `unstaged_numstat` are keyed on the post-rename path.
+/// `ages` maps file path → mtime age; missing entries become `None`.
+pub fn build_snapshot(
+    branch: String,
+    base: String,
+    commits_ahead: u32,
+    last_commit_age: Duration,
+    status_entries: Vec<FileEntry>,
+    staged_numstat: &HashMap<String, NumStat>,
+    unstaged_numstat: &HashMap<String, NumStat>,
+    ages: &HashMap<String, Duration>,
+) -> Snapshot {
+    let _ = (
+        &status_entries,
+        staged_numstat,
+        unstaged_numstat,
+        ages,
+    );
+    // Stub: return an empty file list to fail the substance tests.
+    Snapshot {
+        branch,
+        base,
+        commits_ahead,
+        last_commit_age,
+        files: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ns(adds: u32, dels: u32) -> NumStat {
+        NumStat {
+            adds,
+            dels,
+            binary: false,
+        }
+    }
+
+    fn binstat() -> NumStat {
+        NumStat {
+            adds: 0,
+            dels: 0,
+            binary: true,
+        }
+    }
+
+    #[test]
+    fn header_fields_pass_through() {
+        let snap = build_snapshot(
+            "gsv".into(),
+            "main".into(),
+            5,
+            Duration::from_secs(120),
+            vec![],
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(snap.branch, "gsv");
+        assert_eq!(snap.base, "main");
+        assert_eq!(snap.commits_ahead, 5);
+        assert_eq!(snap.last_commit_age, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn staged_entry_picks_staged_numstat() {
+        let entries = vec![FileEntry {
+            path: "src/foo.rs".into(),
+            orig_path: None,
+            status: FileStatus::Modified,
+            staged: true,
+        }];
+        let mut staged = HashMap::new();
+        staged.insert("src/foo.rs".to_string(), ns(10, 2));
+        let mut unstaged = HashMap::new();
+        unstaged.insert("src/foo.rs".to_string(), ns(99, 99));
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &staged,
+            &unstaged,
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files.len(), 1);
+        assert_eq!(snap.files[0].adds, 10);
+        assert_eq!(snap.files[0].dels, 2);
+        assert!(snap.files[0].staged);
+    }
+
+    #[test]
+    fn unstaged_entry_picks_unstaged_numstat() {
+        let entries = vec![FileEntry {
+            path: "src/foo.rs".into(),
+            orig_path: None,
+            status: FileStatus::Modified,
+            staged: false,
+        }];
+        let mut staged = HashMap::new();
+        staged.insert("src/foo.rs".to_string(), ns(99, 99));
+        let mut unstaged = HashMap::new();
+        unstaged.insert("src/foo.rs".to_string(), ns(7, 1));
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &staged,
+            &unstaged,
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files.len(), 1);
+        assert_eq!(snap.files[0].adds, 7);
+        assert_eq!(snap.files[0].dels, 1);
+        assert!(!snap.files[0].staged);
+    }
+
+    #[test]
+    fn binary_flag_propagates() {
+        let entries = vec![FileEntry {
+            path: "img.png".into(),
+            orig_path: None,
+            status: FileStatus::Modified,
+            staged: true,
+        }];
+        let mut staged = HashMap::new();
+        staged.insert("img.png".to_string(), binstat());
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &staged,
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files.len(), 1);
+        assert!(snap.files[0].binary);
+        assert_eq!(snap.files[0].adds, 0);
+        assert_eq!(snap.files[0].dels, 0);
+    }
+
+    #[test]
+    fn age_lookup_by_path() {
+        let entries = vec![FileEntry {
+            path: "src/foo.rs".into(),
+            orig_path: None,
+            status: FileStatus::Modified,
+            staged: false,
+        }];
+        let mut ages = HashMap::new();
+        ages.insert("src/foo.rs".to_string(), Duration::from_secs(45));
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &HashMap::new(),
+            &HashMap::new(),
+            &ages,
+        );
+        assert_eq!(snap.files[0].age, Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn missing_age_is_none() {
+        let entries = vec![FileEntry {
+            path: "src/foo.rs".into(),
+            orig_path: None,
+            status: FileStatus::Modified,
+            staged: false,
+        }];
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files[0].age, None);
+    }
+
+    #[test]
+    fn rename_info_preserved() {
+        let entries = vec![FileEntry {
+            path: "src/new.rs".into(),
+            orig_path: Some("src/old.rs".into()),
+            status: FileStatus::Renamed,
+            staged: true,
+        }];
+        let mut staged = HashMap::new();
+        staged.insert("src/new.rs".to_string(), ns(5, 2));
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &staged,
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files[0].path, "src/new.rs");
+        assert_eq!(snap.files[0].orig_path.as_deref(), Some("src/old.rs"));
+    }
+
+    #[test]
+    fn both_sides_become_two_render_entries() {
+        // A file modified in both index and worktree shows up as two FileEntry rows.
+        let entries = vec![
+            FileEntry {
+                path: "src/foo.rs".into(),
+                orig_path: None,
+                status: FileStatus::Modified,
+                staged: true,
+            },
+            FileEntry {
+                path: "src/foo.rs".into(),
+                orig_path: None,
+                status: FileStatus::Modified,
+                staged: false,
+            },
+        ];
+        let mut staged = HashMap::new();
+        staged.insert("src/foo.rs".to_string(), ns(10, 0));
+        let mut unstaged = HashMap::new();
+        unstaged.insert("src/foo.rs".to_string(), ns(0, 3));
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &staged,
+            &unstaged,
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files.len(), 2);
+        let staged_row = snap.files.iter().find(|e| e.staged).unwrap();
+        let unstaged_row = snap.files.iter().find(|e| !e.staged).unwrap();
+        assert_eq!(staged_row.adds, 10);
+        assert_eq!(staged_row.dels, 0);
+        assert_eq!(unstaged_row.adds, 0);
+        assert_eq!(unstaged_row.dels, 3);
+    }
+
+    #[test]
+    fn untracked_entries_keep_status_and_skip_numstat() {
+        let entries = vec![FileEntry {
+            path: "scratch.txt".into(),
+            orig_path: None,
+            status: FileStatus::Untracked,
+            staged: false,
+        }];
+
+        let snap = build_snapshot(
+            "x".into(),
+            "main".into(),
+            0,
+            Duration::ZERO,
+            entries,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(snap.files.len(), 1);
+        assert!(matches!(snap.files[0].status, FileStatus::Untracked));
+        assert_eq!(snap.files[0].adds, 0);
+        assert_eq!(snap.files[0].dels, 0);
+    }
+}
+
+// Tests above must remain failing until build_snapshot is implemented.
+// The stub returns an empty `files` so substance assertions fail
+// behaviorally, not at compile time.
+#[allow(dead_code)]
+fn _ensure_render_entry_constructible_for_tests() -> RenderEntry {
+    RenderEntry {
+        path: String::new(),
+        orig_path: None,
+        status: FileStatus::Modified,
+        staged: false,
+        adds: 0,
+        dels: 0,
+        binary: false,
+        age: None,
+    }
+}

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -10,6 +10,10 @@ use crate::render::{RenderEntry, Snapshot};
 ///
 /// `staged_numstat` and `unstaged_numstat` are keyed on the post-rename path.
 /// `ages` maps file path → mtime age; missing entries become `None`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "build_snapshot fans in five distinct inputs; grouping them obscures rather than clarifies",
+)]
 pub fn build_snapshot(
     branch: String,
     base: String,

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -92,6 +92,32 @@ fn shows_untracked_file() {
 }
 
 #[test]
+fn outside_git_repo_prints_friendly_header_and_exits_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Deliberately no `git init`. Set GIT_CEILING_DIRECTORIES so git won't
+    // walk upward into whatever happens to be above /tmp on this host.
+    let parent = dir.path().parent().unwrap_or(Path::new("/"));
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .env("GIT_CEILING_DIRECTORIES", parent)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(
+        output.status.success(),
+        "gsw should exit 0 outside a repo: stderr = {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("not a git repository"),
+        "expected a friendly header outside a repo: {stdout}",
+    );
+}
+
+#[test]
 fn shows_untracked_directory_with_slash() {
     let dir = setup_repo();
     fs::create_dir(dir.path().join("new-dir")).unwrap();

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -1,0 +1,105 @@
+//! End-to-end: drive the real `gsw` binary against a fresh temp git repo.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        // Make sure user/email config from $HOME doesn't bleed in.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .status()
+        .expect("failed to invoke git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn run_gsw(dir: &Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .current_dir(dir)
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(
+        output.status.success(),
+        "gsw exited non-zero: stderr = {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn setup_repo() -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    run_git(p, &["init", "-q", "-b", "main"]);
+    run_git(p, &["config", "user.email", "test@example.com"]);
+    run_git(p, &["config", "user.name", "Test"]);
+    run_git(p, &["config", "commit.gpgsign", "false"]);
+    fs::write(p.join("a.txt"), "initial\n").unwrap();
+    run_git(p, &["add", "a.txt"]);
+    run_git(p, &["commit", "-q", "-m", "initial"]);
+    dir
+}
+
+#[test]
+fn shows_branch_and_header() {
+    let dir = setup_repo();
+    let out = run_gsw(dir.path());
+    assert!(
+        out.contains("main"),
+        "output should include the branch name: {out}",
+    );
+    assert!(
+        out.contains("commit"),
+        "output should include a commit-count phrase: {out}",
+    );
+}
+
+#[test]
+fn shows_staged_modification() {
+    let dir = setup_repo();
+    fs::write(dir.path().join("a.txt"), "changed line one\nchanged line two\n").unwrap();
+    run_git(dir.path(), &["add", "a.txt"]);
+
+    let out = run_gsw(dir.path());
+    assert!(out.contains("a.txt"), "should mention a.txt: {out}");
+    // Staged modification → filled circle icon.
+    assert!(out.contains('●'), "should mark staged with ●: {out}");
+}
+
+#[test]
+fn shows_unstaged_modification() {
+    let dir = setup_repo();
+    fs::write(dir.path().join("a.txt"), "edited\n").unwrap();
+
+    let out = run_gsw(dir.path());
+    assert!(out.contains("a.txt"));
+    assert!(out.contains('○'), "should mark unstaged with ○: {out}");
+}
+
+#[test]
+fn shows_untracked_file() {
+    let dir = setup_repo();
+    fs::write(dir.path().join("new.txt"), "hello\n").unwrap();
+
+    let out = run_gsw(dir.path());
+    assert!(out.contains("new.txt"), "should list untracked file: {out}");
+    assert!(out.contains('?'), "should mark untracked with ?: {out}");
+}
+
+#[test]
+fn shows_untracked_directory_with_slash() {
+    let dir = setup_repo();
+    fs::create_dir(dir.path().join("new-dir")).unwrap();
+    fs::write(dir.path().join("new-dir").join("inside.txt"), "x\n").unwrap();
+
+    let out = run_gsw(dir.path());
+    assert!(
+        out.contains("new-dir/"),
+        "untracked dir should show with trailing slash: {out}",
+    );
+}


### PR DESCRIPTION
## Summary
- New `gsw` crate at `src/gsw/`: one-shot, color-coded git status frame designed for `viddy` panes — replaces my dual viddy setup (`git log | head` + `git status`) with a single, denser command.
- Per-file rows show staged/unstaged/untracked/conflict icon, a cyan magnitude bar scaled to the largest change, `+adds`/`-dels`, and an mtime-based recency column that dims with age. Renames render as `old → new`; binary files show a centered `bin` marker instead of a bar; untracked directories keep their trailing slash.
- Header line replaces the commits/age viddy line: branch, commits ahead of base (auto-resolved `main` → `master` → `origin/HEAD`), and the last-commit age in `Nm Ns` form.
- `--max-files` defaults to `terminal_height - 4` so a busy branch fits a small viddy pane; explicit `--max-files N` overrides. Outside a git repo, prints a single dimmed `not a git repository` line and exits 0 instead of erroring under viddy.
- 58 unit + 6 integration tests, all green. Each behavioral unit built with strict red → green commits per `TESTING.md`.

## Test plan
- [ ] `cargo test -p gsw` — 64 tests pass
- [ ] `cargo clippy -p gsw --all-targets` — no warnings
- [ ] `cargo run --release -p gsw -- --version` shows `gsw <ver> (<hash>, clean/dirty)`
- [ ] `viddy 'cargo run --release -p gsw'` in a real working tree with staged, unstaged, untracked, renamed, and binary files — verify icons, colors, bar scaling, age dimming, rename arrow
- [ ] `gsw` outside any git repo — prints friendly header, exits 0
- [ ] Run in a tall vs. short pane — confirm `--max-files` default leaves room for the `+N more files` footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)