### PR TITLE
gsw: compact one-shot git status display for viddy

### DIFF
--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -34,6 +34,20 @@ pub fn format_age(age: Duration) -> String {
     }
 }
 
+/// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.
+pub fn format_age_detailed(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else if secs < 86400 {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
+    }
+}
+
 /// Classify an age into a display brightness bucket.
 pub fn age_dim_level(age: Duration) -> AgeDim {
     let secs = age.as_secs();
@@ -78,6 +92,45 @@ mod tests {
         assert_eq!(format_age(Duration::from_secs(60 * 60 * 24)), "1d");
         assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 3)), "3d");
         assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 365)), "365d");
+    }
+
+    #[test]
+    fn detailed_age_seconds_only() {
+        assert_eq!(format_age_detailed(Duration::from_secs(0)), "0s");
+        assert_eq!(format_age_detailed(Duration::from_secs(5)), "5s");
+        assert_eq!(format_age_detailed(Duration::from_secs(59)), "59s");
+    }
+
+    #[test]
+    fn detailed_age_minutes_and_seconds() {
+        assert_eq!(format_age_detailed(Duration::from_secs(60)), "1m0s");
+        assert_eq!(format_age_detailed(Duration::from_secs(5 * 60 + 23)), "5m23s");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(59 * 60 + 59)),
+            "59m59s",
+        );
+    }
+
+    #[test]
+    fn detailed_age_hours_and_minutes() {
+        assert_eq!(format_age_detailed(Duration::from_secs(60 * 60)), "1h0m");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(2 * 3600 + 14 * 60)),
+            "2h14m",
+        );
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(23 * 3600 + 59 * 60)),
+            "23h59m",
+        );
+    }
+
+    #[test]
+    fn detailed_age_days_and_hours() {
+        assert_eq!(format_age_detailed(Duration::from_secs(86400)), "1d0h");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(3 * 86400 + 12 * 3600)),
+            "3d12h",
+        );
     }
 
     #[test]

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -15,26 +15,7 @@ pub enum AgeDim {
     Stale,
 }
 
-/// Format a duration like `30s`, `5m`, `2h`, `3d`. Always 1–3 chars + unit.
-///
-/// - `< 60s`              → `Ns`
-/// - `< 60m`              → `Nm`
-/// - `< 24h`              → `Nh`
-/// - everything else      → `Nd`
-pub fn format_age(age: Duration) -> String {
-    let secs = age.as_secs();
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 60 * 60 {
-        format!("{}m", secs / 60)
-    } else if secs < 60 * 60 * 24 {
-        format!("{}h", secs / (60 * 60))
-    } else {
-        format!("{}d", secs / (60 * 60 * 24))
-    }
-}
-
-/// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.
+/// Format a duration with two units, e.g. `5m23s`, `2h14m`, `3d12h`.
 pub fn format_age_detailed(age: Duration) -> String {
     let secs = age.as_secs();
     if secs < 60 {
@@ -65,34 +46,6 @@ pub fn age_dim_level(age: Duration) -> AgeDim {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn format_seconds_below_a_minute() {
-        assert_eq!(format_age(Duration::from_secs(0)), "0s");
-        assert_eq!(format_age(Duration::from_secs(30)), "30s");
-        assert_eq!(format_age(Duration::from_secs(59)), "59s");
-    }
-
-    #[test]
-    fn format_minutes_below_an_hour() {
-        assert_eq!(format_age(Duration::from_secs(60)), "1m");
-        assert_eq!(format_age(Duration::from_secs(60 * 5)), "5m");
-        assert_eq!(format_age(Duration::from_secs(60 * 59)), "59m");
-    }
-
-    #[test]
-    fn format_hours_below_a_day() {
-        assert_eq!(format_age(Duration::from_secs(60 * 60)), "1h");
-        assert_eq!(format_age(Duration::from_secs(60 * 60 * 2)), "2h");
-        assert_eq!(format_age(Duration::from_secs(60 * 60 * 23)), "23h");
-    }
-
-    #[test]
-    fn format_days_and_above() {
-        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24)), "1d");
-        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 3)), "3d");
-        assert_eq!(format_age(Duration::from_secs(60 * 60 * 24 * 365)), "365d");
-    }
 
     #[test]
     fn detailed_age_seconds_only() {

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
         .trim()
         .to_string();
 
-    let base = cli.base.unwrap_or_else(|| resolve_base_ref().unwrap_or_else(|_| "HEAD".to_string()));
+    let base = cli.base.unwrap_or_else(resolve_base_ref);
 
     let commits_ahead = run_git(&["rev-list", "--count", &format!("{base}..HEAD")])
         .ok()
@@ -133,20 +133,21 @@ fn run_git(args: &[&str]) -> Result<String> {
 }
 
 /// Pick the first base ref that actually resolves: `main`, then `master`,
-/// then whatever `origin/HEAD` points to.
-fn resolve_base_ref() -> Result<String> {
+/// then whatever `origin/HEAD` points to. Falls back to `HEAD` so the
+/// commits-ahead count degrades gracefully to zero.
+fn resolve_base_ref() -> String {
     for candidate in ["main", "master"] {
         if run_git(&["rev-parse", "--verify", "--quiet", candidate]).is_ok() {
-            return Ok(candidate.to_string());
+            return candidate.to_string();
         }
     }
     if let Ok(out) = run_git(&["symbolic-ref", "refs/remotes/origin/HEAD"]) {
         let trimmed = out.trim();
         if let Some(name) = trimmed.strip_prefix("refs/remotes/origin/") {
-            return Ok(format!("origin/{name}"));
+            return format!("origin/{name}");
         }
     }
-    Ok("HEAD".to_string())
+    "HEAD".to_string()
 }
 
 /// How long ago the current HEAD commit was authored.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -8,7 +8,7 @@ use buildinfo::version_string;
 use clap::Parser;
 use colored::Colorize;
 
-use crate::git::{parse_numstat, parse_status, FileEntry, NumStat};
+use crate::git::{parse_numstat, parse_status, FileEntry};
 use crate::render::{default_max_files, render, RenderOptions};
 use crate::snapshot::build_snapshot;
 
@@ -177,6 +177,3 @@ fn collect_ages(entries: &[FileEntry]) -> HashMap<String, Duration> {
     }
     out
 }
-
-// Silence: NumStat is only constructed inside parse_numstat / tests.
-const _: fn() -> NumStat = || NumStat::default();

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
     }
 
     let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"])
-        .context("not inside a git repository")?
+        .context("failed to read HEAD ref")?
         .trim()
         .to_string();
 

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -108,11 +108,21 @@ fn main() -> Result<()> {
 }
 
 /// True if the current working directory is inside a git work tree.
+///
+/// `git rev-parse --is-inside-work-tree` returns status 0 with stdout
+/// `false` for bare repos, so we have to inspect the output, not just
+/// the exit code.
 fn inside_git_repo() -> bool {
-    Command::new("git")
+    let Ok(output) = Command::new("git")
         .args(["rev-parse", "--is-inside-work-tree"])
         .output()
-        .is_ok_and(|o| o.status.success())
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout).trim() == "true"
 }
 
 /// Run `git` with the given args and return captured stdout as UTF-8.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -466,6 +466,28 @@ mod tests {
     }
 
     #[test]
+    fn untracked_row_aligns_age_column_with_normal_rows() {
+        let modified = entry("file.rs", FileStatus::Modified, false, 5, 2);
+        let mut untracked = entry("scratch.txt", FileStatus::Untracked, false, 0, 0);
+        untracked.age = Some(Duration::from_secs(30));
+        let snap = snap_with(vec![modified, untracked]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let mod_row = out
+            .lines()
+            .find(|l| l.contains("file.rs"))
+            .expect("modified row");
+        let untr_row = out
+            .lines()
+            .find(|l| l.contains("scratch.txt"))
+            .expect("untracked row");
+        assert_eq!(
+            UnicodeWidthStr::width(mod_row),
+            UnicodeWidthStr::width(untr_row),
+            "untracked row should pad to same total width so age columns align:\n  mod:   {mod_row:?}\n  untr:  {untr_row:?}",
+        );
+    }
+
+    #[test]
     fn untracked_directory_keeps_trailing_slash() {
         let snap = snap_with(vec![entry(
             "new-folder/",

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use colored::{ColoredString, Colorize};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::age::{age_dim_level, format_age, AgeDim};
+use crate::age::{age_dim_level, format_age, format_age_detailed, AgeDim};
 use crate::bar::render_bar;
 use crate::git::FileStatus;
 
@@ -338,20 +338,6 @@ pub fn default_max_files(terminal_height: u16) -> usize {
     usize::from(terminal_height.saturating_sub(4)).max(1)
 }
 
-/// Like [`format_age`] but spells out two units, e.g. `5m23s` or `2h14m`.
-fn format_age_detailed(age: Duration) -> String {
-    let secs = age.as_secs();
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 3600 {
-        format!("{}m{}s", secs / 60, secs % 60)
-    } else if secs < 86400 {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
-    } else {
-        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -619,36 +605,6 @@ mod tests {
     }
 
     #[test]
-    fn detailed_age_seconds_only() {
-        assert_eq!(format_age_detailed(Duration::from_secs(0)), "0s");
-        assert_eq!(format_age_detailed(Duration::from_secs(5)), "5s");
-        assert_eq!(format_age_detailed(Duration::from_secs(59)), "59s");
-    }
-
-    #[test]
-    fn detailed_age_minutes_and_seconds() {
-        assert_eq!(format_age_detailed(Duration::from_secs(60)), "1m0s");
-        assert_eq!(format_age_detailed(Duration::from_secs(5 * 60 + 23)), "5m23s");
-        assert_eq!(
-            format_age_detailed(Duration::from_secs(59 * 60 + 59)),
-            "59m59s",
-        );
-    }
-
-    #[test]
-    fn detailed_age_hours_and_minutes() {
-        assert_eq!(format_age_detailed(Duration::from_secs(60 * 60)), "1h0m");
-        assert_eq!(
-            format_age_detailed(Duration::from_secs(2 * 3600 + 14 * 60)),
-            "2h14m",
-        );
-        assert_eq!(
-            format_age_detailed(Duration::from_secs(23 * 3600 + 59 * 60)),
-            "23h59m",
-        );
-    }
-
-    #[test]
     fn default_max_files_reserves_room_for_chrome() {
         // Reserve 4 rows for header, separator, footer, and breathing room.
         assert_eq!(default_max_files(24), 20);
@@ -664,12 +620,4 @@ mod tests {
         assert_eq!(default_max_files(5), 1);
     }
 
-    #[test]
-    fn detailed_age_days_and_hours() {
-        assert_eq!(format_age_detailed(Duration::from_secs(86400)), "1d0h");
-        assert_eq!(
-            format_age_detailed(Duration::from_secs(3 * 86400 + 12 * 3600)),
-            "3d12h",
-        );
-    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -613,6 +613,32 @@ mod tests {
     }
 
     #[test]
+    fn max_files_zero_means_unlimited() {
+        let files: Vec<RenderEntry> = (0..5)
+            .map(|i| entry(&format!("f{i}.rs"), FileStatus::Modified, true, 1, 0))
+            .collect();
+        let snap = snap_with(files);
+        let out = strip_ansi(&render(
+            &snap,
+            &RenderOptions {
+                terminal_width: 80,
+                bar_width: 6,
+                max_files: Some(0),
+            },
+        ));
+        for i in 0..5 {
+            assert!(
+                out.contains(&format!("f{i}.rs")),
+                "every file should appear when max_files=0 means unlimited: {out}",
+            );
+        }
+        assert!(
+            !out.contains("more file"),
+            "no 'more files' footer when nothing is hidden: {out}",
+        );
+    }
+
+    #[test]
     fn bar_scales_to_max_change_in_snapshot() {
         let big = entry("big.rs", FileStatus::Modified, true, 100, 0);
         let small = entry("small.rs", FileStatus::Modified, true, 1, 0);

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -58,8 +58,10 @@ const SEP_DELS_AGE: usize = 3;
 pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     let mut lines = Vec::new();
 
-    lines.push(render_header(snapshot));
-    lines.push(render_separator(opts.terminal_width));
+    let header_plain = header_text(snapshot);
+    let header_width = UnicodeWidthStr::width(header_plain.as_str());
+    lines.push(header_plain.bold().to_string());
+    lines.push(render_separator(header_width));
 
     let display_count = match opts.max_files {
         Some(0) | None => snapshot.files.len(),
@@ -104,18 +106,16 @@ fn compute_path_width(opts: &RenderOptions) -> usize {
     opts.terminal_width.saturating_sub(overhead).max(8)
 }
 
-fn render_header(snap: &Snapshot) -> String {
+fn header_text(snap: &Snapshot) -> String {
     let commit_word = if snap.commits_ahead == 1 { "commit" } else { "commits" };
     let age = format_age_detailed(snap.last_commit_age);
-    let header = format!(
+    format!(
         "gsw • {branch} • {n} {word} ahead of {base} • last commit {age} ago",
         branch = snap.branch,
         n = snap.commits_ahead,
         word = commit_word,
         base = snap.base,
-        age = age,
-    );
-    header.bold().to_string()
+    )
 }
 
 fn render_separator(width: usize) -> String {

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -413,6 +413,22 @@ mod tests {
     }
 
     #[test]
+    fn separator_matches_header_visible_width() {
+        // If the separator is wider than the header line, resizing the
+        // terminal smaller wraps it onto the next line. Size it to match.
+        let snap = snap_with(vec![]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let mut lines = out.lines();
+        let header = lines.next().expect("header line");
+        let sep = lines.next().expect("separator line");
+        assert_eq!(
+            UnicodeWidthStr::width(header),
+            UnicodeWidthStr::width(sep),
+            "separator width should match header width\n  header: {header:?}\n  sep:    {sep:?}",
+        );
+    }
+
+    #[test]
     fn header_mentions_branch_commits_and_age() {
         let out = strip_ansi(&render(&snap_with(vec![]), &opts()));
         let header_line = out.lines().next().unwrap_or("");

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use colored::{ColoredString, Colorize};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::age::{age_dim_level, format_age, format_age_detailed, AgeDim};
+use crate::age::{age_dim_level, format_age_detailed, AgeDim};
 use crate::bar::render_bar;
 use crate::git::FileStatus;
 
@@ -45,7 +45,8 @@ pub struct RenderOptions {
 /// Width of the "+adds" / "-dels" / age column fields.
 const ADDS_FIELD: usize = 5;
 const DELS_FIELD: usize = 4;
-const AGE_FIELD: usize = 4;
+/// Wide enough for `59m59s`, `23h59m`, `99d23h`. Older files overflow slightly.
+const AGE_FIELD: usize = 6;
 
 /// Visible separator characters between columns.
 const SEP_PATH_BAR: usize = 0;
@@ -90,8 +91,8 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
 }
 
 fn compute_path_width(opts: &RenderOptions) -> usize {
-    // Layout overhead per row: icon(1) + letter(1) + " "(1) + bar(N) + seps + fields.
-    let overhead = 3
+    // Layout overhead per row: icon(1) + " "(1) + letter(1) + " "(1) + bar(N) + seps + fields.
+    let overhead = 4
         + opts.bar_width
         + SEP_PATH_BAR
         + SEP_BAR_ADDS
@@ -154,10 +155,10 @@ fn render_row(
             + DELS_FIELD
             + SEP_DELS_AGE;
         let gutter = " ".repeat(gutter_width);
-        let age = entry.age.map(format_age).unwrap_or_default();
+        let age = entry.age.map(format_age_detailed).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
         let age_str = colorize_age(&age_field, entry.age);
-        return format!("{icon_str}{letter_str} {path_str}{gutter}{age_str}");
+        return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
     }
 
     let bar_raw = if entry.binary {
@@ -191,7 +192,10 @@ fn render_row(
         dels_field
     };
 
-    let age_raw = entry.age.map(format_age).unwrap_or_else(|| String::from("—"));
+    let age_raw = entry
+        .age
+        .map(format_age_detailed)
+        .unwrap_or_else(|| String::from("—"));
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
     let age_str = colorize_age(&age_field, entry.age);
 
@@ -200,7 +204,7 @@ fn render_row(
     let sep_dels_age = " ".repeat(SEP_DELS_AGE);
 
     format!(
-        "{icon_str}{letter_str} {path_str}{bar_str}{sep_bar_adds}{adds_str}{sep_adds_dels}{dels_str}{sep_dels_age}{age_str}",
+        "{icon_str} {letter_str} {path_str}{bar_str}{sep_bar_adds}{adds_str}{sep_adds_dels}{dels_str}{sep_dels_age}{age_str}",
     )
 }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -77,7 +77,7 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
         lines.push(render_row(entry, opts, max_change, path_width));
     }
 
-    let hidden = snapshot.files.len() - display_count;
+    let hidden = snapshot.files.len().saturating_sub(display_count);
     if hidden > 0 {
         lines.push(
             format!("  +{hidden} more file{}", if hidden == 1 { "" } else { "s" })

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -60,10 +60,10 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     lines.push(render_header(snapshot));
     lines.push(render_separator(opts.terminal_width));
 
-    let display_count = opts
-        .max_files
-        .unwrap_or(usize::MAX)
-        .min(snapshot.files.len());
+    let display_count = match opts.max_files {
+        Some(0) | None => snapshot.files.len(),
+        Some(n) => n.min(snapshot.files.len()),
+    };
     let max_change = snapshot
         .files
         .iter()

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -140,15 +140,24 @@ fn render_row(
     let letter_str = colorize_letter(letter, entry);
     let path_str = colorize_path(&path_padded, entry);
 
-    // Untracked files get a stripped-down row — no bar, no counts.
+    // Untracked files get a stripped-down row — no bar, no counts — but
+    // pad the gutter where bar/adds/dels would be so the age column still
+    // lines up with normal rows above and below it.
     if matches!(
         entry.status,
         FileStatus::Untracked | FileStatus::UntrackedDir
     ) {
+        let gutter_width = opts.bar_width
+            + SEP_BAR_ADDS
+            + ADDS_FIELD
+            + SEP_ADDS_DELS
+            + DELS_FIELD
+            + SEP_DELS_AGE;
+        let gutter = " ".repeat(gutter_width);
         let age = entry.age.map(format_age).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
         let age_str = colorize_age(&age_field, entry.age);
-        return format!("{icon_str}{letter_str} {path_str}{age_str}");
+        return format!("{icon_str}{letter_str} {path_str}{gutter}{age_str}");
     }
 
     let bar_raw = if entry.binary {

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -452,6 +452,47 @@ mod tests {
     }
 
     #[test]
+    fn row_has_space_between_icon_and_status_letter() {
+        let snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(
+            row.contains("● M "),
+            "icon and letter should be separated by a space: {row}",
+        );
+    }
+
+    #[test]
+    fn untracked_row_has_space_between_icon_and_status_letter() {
+        let snap = snap_with(vec![entry(
+            "scratch.txt",
+            FileStatus::Untracked,
+            false,
+            0,
+            0,
+        )]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(
+            row.contains("? ? "),
+            "untracked icon and letter should also be space-separated: {row}",
+        );
+    }
+
+    #[test]
+    fn per_file_age_uses_detailed_two_unit_format() {
+        let mut e = entry("file.rs", FileStatus::Modified, true, 1, 0);
+        e.age = Some(Duration::from_secs(5 * 60 + 23));
+        let snap = snap_with(vec![e]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(
+            row.contains("5m23s"),
+            "per-file age should match the header's two-unit format: {row}",
+        );
+    }
+
+    #[test]
     fn unstaged_file_uses_open_circle_icon() {
         let snap = snap_with(vec![entry("a.rs", FileStatus::Modified, false, 1, 0)]);
         let out = strip_ansi(&render(&snap, &opts()));

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -118,6 +118,31 @@ fn outside_git_repo_prints_friendly_header_and_exits_zero() {
 }
 
 #[test]
+fn bare_repo_prints_friendly_header_and_exits_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A bare repo has no working tree, so gsw can't render a per-file view.
+    // It should bail out cleanly the same way it does outside any repo.
+    run_git(dir.path(), &["init", "--bare", "-q"]);
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(
+        output.status.success(),
+        "gsw should exit 0 in a bare repo: stderr = {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("not a git repository"),
+        "expected a friendly header in a bare repo: {stdout}",
+    );
+}
+
+#[test]
 fn shows_untracked_directory_with_slash() {
     let dir = setup_repo();
     fs::create_dir(dir.path().join("new-dir")).unwrap();


### PR DESCRIPTION
## Summary

- New \`gsw\` crate (\`src/gsw/\`): one-shot, colored, viddy-friendly snapshot of the current branch — commits ahead of base, last-commit age, and a per-file list with a magnitude bar, +/- counts, and recency. Built strictly red→green TDD throughout.
- Layout polish from code review: space between status icon and status letter, two-unit age format (\`5m23s\`) in the per-file column, separator sized to the header (no more wrap when the terminal narrows).
- Robustness from code review: bare-repo and outside-of-repo are both detected and produce a friendly one-line header (exit 0) instead of an error; \`--max-files 0\` means unlimited.

## Test plan

- [x] \`cargo test -p gsw\` — 63 unit + 7 integration, all passing
- [x] \`cargo clippy -p gsw --all-targets\` — clean
- [ ] Manual: run \`viddy -d -- gsw\` in a dirty repo and confirm the separator no longer wraps on terminal resize
- [ ] Manual: run inside a bare repo and confirm friendly \"not a git repository\" header
- [ ] Manual: \`gsw --max-files 0\` shows all files, no \"+N more\" footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)