### PR TITLE
gsw: fix age column showing em-dash on every row from a subdirectory

### DIFF
--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime};
 
@@ -81,7 +81,10 @@ fn main() -> Result<()> {
         .map(|s| parse_numstat(&s))
         .unwrap_or_default();
 
-    let ages = collect_ages(&entries);
+    let repo_root = run_git(&["rev-parse", "--show-toplevel"])
+        .ok()
+        .map(|s| PathBuf::from(s.trim()));
+    let ages = collect_ages(&entries, repo_root.as_deref());
 
     let snapshot = build_snapshot(
         branch,
@@ -169,15 +172,23 @@ fn last_commit_age() -> Result<Duration> {
 }
 
 /// Get mtime ages for each entry's path, where the path still exists on disk.
-fn collect_ages(entries: &[FileEntry]) -> HashMap<String, Duration> {
+///
+/// `repo_root` anchors the lookup: `git status --porcelain=v2 -z` reports
+/// paths relative to the repo root, not the cwd, so resolving against the
+/// cwd misses every file when gsw runs from a subdirectory. Falls back to
+/// cwd-relative resolution when the root can't be determined.
+fn collect_ages(entries: &[FileEntry], repo_root: Option<&Path>) -> HashMap<String, Duration> {
     let now = SystemTime::now();
     let mut out = HashMap::with_capacity(entries.len());
     for e in entries {
         if out.contains_key(&e.path) {
             continue;
         }
-        let path = Path::new(&e.path);
-        let Ok(meta) = std::fs::metadata(path) else {
+        let full = match repo_root {
+            Some(root) => root.join(&e.path),
+            None => PathBuf::from(&e.path),
+        };
+        let Ok(meta) = std::fs::metadata(&full) else {
             continue;
         };
         let Ok(mtime) = meta.modified() else {

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -192,10 +192,7 @@ fn render_row(
         dels_field
     };
 
-    let age_raw = entry
-        .age
-        .map(format_age_detailed)
-        .unwrap_or_else(|| String::from("—"));
+    let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
     let age_str = colorize_age(&age_field, entry.age);
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -731,6 +731,24 @@ mod tests {
     }
 
     #[test]
+    fn missing_age_renders_as_blank_not_emdash() {
+        // The em-dash placeholder visually drifts past the terminal edge in
+        // some font/terminal combos (zellij + certain fonts render em-dash
+        // wider than unicode-width reports). Leave the age column empty
+        // when we don't have an mtime — the row already shows `D` / `?` /
+        // etc. to explain why.
+        let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
+        e.age = None;
+        let snap = snap_with(vec![e]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let row = out.lines().nth(2).unwrap_or("");
+        assert!(
+            !row.contains('\u{2014}'),
+            "no-age row should not include an em-dash placeholder: {row}",
+        );
+    }
+
+    #[test]
     fn default_max_files_never_returns_zero() {
         assert_eq!(default_max_files(0), 1);
         assert_eq!(default_max_files(1), 1);

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -143,6 +143,39 @@ fn bare_repo_prints_friendly_header_and_exits_zero() {
 }
 
 #[test]
+fn shows_age_for_modified_file_when_run_from_subdir() {
+    // git status --porcelain=v2 -z reports paths relative to the repo root,
+    // not the cwd. If gsw resolves those paths against cwd, every fs::metadata
+    // lookup fails when gsw runs from a subdirectory — every age becomes None
+    // and the row collapses to a placeholder. Make sure gsw resolves paths
+    // against the repo root so ages still appear from a subdirectory.
+    let dir = setup_repo();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("a.txt"), "edited from sub\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .current_dir(dir.path().join("sub"))
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let out = String::from_utf8_lossy(&output.stdout);
+
+    let row = out
+        .lines()
+        .find(|l| l.contains("a.txt"))
+        .unwrap_or_else(|| panic!("expected a row for a.txt: {out}"));
+    assert!(
+        !row.contains('\u{2014}'),
+        "modified file should show an age, not the em-dash placeholder: {row}",
+    );
+    assert!(
+        row.contains('s') || row.contains('m') || row.contains('h') || row.contains('d'),
+        "modified file row should include a duration suffix (s/m/h/d): {row}",
+    );
+}
+
+#[test]
 fn shows_untracked_directory_with_slash() {
     let dir = setup_repo();
     fs::create_dir(dir.path().join("new-dir")).unwrap();


### PR DESCRIPTION
## Summary

- Fix `gsw` so the per-file age column actually shows mtimes when run from a subdirectory of the worktree (the common case under `viddy`). `git status --porcelain=v2 -z` reports paths relative to the repo root, but `collect_ages` was resolving them against the cwd, so every `fs::metadata` lookup missed → every row collapsed to the `—` placeholder.
- Drop the `—` placeholder entirely. When age is `None` (now only deleted files), leave the age column blank. The row already carries `D` / `?` / etc. to explain the absence, and the em-dash visually rendered past its unicode-width of 1 in some terminal/font combos (notably zellij), pushing the dash onto a wrapped second line.

## Test plan

- [x] `cargo test -p gsw` — all 61 unit tests + 8 integration tests pass, including the new `shows_age_for_modified_file_when_run_from_subdir` integration test and the new `missing_age_renders_as_blank_not_emdash` render unit test
- [x] `cargo clippy -p gsw --all-targets -- -D warnings` — clean
- [x] Visual smoke test: ran release `gsw` from `src/gsw/` after modifying files at the repo root and at the subdir — each row now shows a real age (`0s`, `25s`, `21s`) instead of `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)