### PR TITLE
gsw: respect COLUMNS env and preserve colors under viddy

### DIFF
--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -44,6 +44,47 @@ struct Cli {
     /// Width of the magnitude bar in cells.
     #[arg(long, default_value_t = 6)]
     bar_width: usize,
+
+    /// Columns to subtract from the detected terminal width. Useful when a
+    /// wrapping TUI (e.g. viddy) eats a column for its own chrome that the
+    /// child process can't see.
+    #[arg(long, default_value_t = 0)]
+    width_offset: usize,
+}
+
+/// Decide the effective terminal width gsw should render for.
+///
+/// - When stdout is a TTY, trust `tty_width` directly (interactive use).
+/// - When stdout is *not* a TTY but `COLUMNS` is set in env, a watch-like
+///   wrapper (e.g. viddy) is framing us. Viddy reports the full terminal
+///   width via `COLUMNS` but renders into a content area that's one column
+///   narrower (its scroll indicator). So we use `columns_env - 1`.
+/// - Otherwise fall back to 80 columns.
+///
+/// `width_offset` always stacks on top, and the result is at least 1.
+fn effective_terminal_width(
+    _tty_width: Option<usize>,
+    _columns_env: Option<usize>,
+    _stdout_is_tty: bool,
+    _width_offset: usize,
+) -> usize {
+    // RED stub — green commit replaces this with real behavior.
+    80
+}
+
+/// Should `colored::control::set_override(true)` be called?
+///
+/// True only when output is captured by a watch-like wrapper (stdout is not
+/// a TTY *and* `COLUMNS` is set in env), and the user has not asked to
+/// suppress colors via `NO_COLOR`. The wrapper renders the captured bytes
+/// inside its own TTY-backed UI, so colors should pass through.
+fn should_force_colors(
+    _stdout_is_tty: bool,
+    _columns_env_present: bool,
+    _no_color_env: bool,
+) -> bool {
+    // RED stub — green commit replaces this with real behavior.
+    false
 }
 
 fn main() -> Result<()> {
@@ -169,6 +210,73 @@ fn last_commit_age() -> Result<Duration> {
     let secs: u64 = raw.trim().parse().unwrap_or(0);
     let when = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
     Ok(SystemTime::now().duration_since(when).unwrap_or(Duration::ZERO))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn width_uses_columns_minus_one_when_stdout_not_tty() {
+        // viddy case: pipes captured, COLUMNS exported.
+        assert_eq!(effective_terminal_width(None, Some(120), false, 0), 119);
+    }
+
+    #[test]
+    fn width_uses_tty_width_when_stdout_is_tty() {
+        // Interactive: trust the ioctl-reported width, not the env.
+        assert_eq!(effective_terminal_width(Some(200), None, true, 0), 200);
+    }
+
+    #[test]
+    fn width_ignores_columns_when_stdout_is_tty() {
+        // If a shell leaked COLUMNS into our env but we have a real TTY,
+        // the TTY measurement wins.
+        assert_eq!(effective_terminal_width(Some(200), Some(120), true, 0), 200);
+    }
+
+    #[test]
+    fn width_falls_back_to_eighty_when_no_signal() {
+        // Piped to a plain file with no COLUMNS in env: nothing to go on.
+        assert_eq!(effective_terminal_width(None, None, false, 0), 80);
+    }
+
+    #[test]
+    fn width_offset_stacks_on_top_of_detection() {
+        assert_eq!(effective_terminal_width(Some(200), None, true, 3), 197);
+        // 120 (COLUMNS) - 1 (scroll bar) - 2 (offset) = 117
+        assert_eq!(effective_terminal_width(None, Some(120), false, 2), 117);
+    }
+
+    #[test]
+    fn width_never_drops_below_one() {
+        // A pathologically large offset should clamp to 1, not underflow.
+        assert_eq!(effective_terminal_width(Some(10), None, true, 999), 1);
+    }
+
+    #[test]
+    fn force_colors_when_piped_to_wrapper_with_columns_env() {
+        assert!(should_force_colors(false, true, false));
+    }
+
+    #[test]
+    fn no_force_colors_when_interactive() {
+        // TTY → let colored auto-detect (it will say yes anyway).
+        assert!(!should_force_colors(true, true, false));
+        assert!(!should_force_colors(true, false, false));
+    }
+
+    #[test]
+    fn no_force_colors_when_piped_without_columns_env() {
+        // Plain pipe to file: respect the colored crate's default (off).
+        assert!(!should_force_colors(false, false, false));
+    }
+
+    #[test]
+    fn no_force_colors_when_no_color_env_set() {
+        // Honor https://no-color.org even when under viddy.
+        assert!(!should_force_colors(false, true, true));
+    }
 }
 
 /// Get mtime ages for each entry's path, where the path still exists on disk.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime};
@@ -63,13 +64,16 @@ struct Cli {
 ///
 /// `width_offset` always stacks on top, and the result is at least 1.
 fn effective_terminal_width(
-    _tty_width: Option<usize>,
-    _columns_env: Option<usize>,
-    _stdout_is_tty: bool,
-    _width_offset: usize,
+    tty_width: Option<usize>,
+    columns_env: Option<usize>,
+    stdout_is_tty: bool,
+    width_offset: usize,
 ) -> usize {
-    // RED stub — green commit replaces this with real behavior.
-    80
+    let base = match (stdout_is_tty, columns_env) {
+        (false, Some(cols)) => cols.saturating_sub(1),
+        _ => tty_width.unwrap_or(80),
+    };
+    base.saturating_sub(width_offset).max(1)
 }
 
 /// Should `colored::control::set_override(true)` be called?
@@ -79,18 +83,29 @@ fn effective_terminal_width(
 /// suppress colors via `NO_COLOR`. The wrapper renders the captured bytes
 /// inside its own TTY-backed UI, so colors should pass through.
 fn should_force_colors(
-    _stdout_is_tty: bool,
-    _columns_env_present: bool,
-    _no_color_env: bool,
+    stdout_is_tty: bool,
+    columns_env_present: bool,
+    no_color_env: bool,
 ) -> bool {
-    // RED stub — green commit replaces this with real behavior.
-    false
+    !stdout_is_tty && columns_env_present && !no_color_env
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    let stdout_is_tty = std::io::stdout().is_terminal();
+    let columns_env: Option<usize> = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    let no_color_env = std::env::var_os("NO_COLOR").is_some();
+
     if cli.no_color {
         colored::control::set_override(false);
+    } else if should_force_colors(stdout_is_tty, columns_env.is_some(), no_color_env) {
+        // A watch-like wrapper (e.g. viddy) is rendering our output inside
+        // its own TTY-backed UI. The colored crate would otherwise strip
+        // colors because our stdout is a pipe.
+        colored::control::set_override(true);
     }
 
     if !inside_git_repo() {
@@ -138,8 +153,11 @@ fn main() -> Result<()> {
         &ages,
     );
 
-    let (terminal_width, terminal_height) = terminal_size::terminal_size()
-        .map_or((80, 24), |(w, h)| (usize::from(w.0), h.0));
+    let tty_size = terminal_size::terminal_size().map(|(w, h)| (usize::from(w.0), h.0));
+    let tty_width = tty_size.map(|(w, _)| w);
+    let terminal_height = tty_size.map_or(24, |(_, h)| h);
+    let terminal_width =
+        effective_terminal_width(tty_width, columns_env, stdout_is_tty, cli.width_offset);
 
     let opts = RenderOptions {
         terminal_width,
@@ -212,6 +230,35 @@ fn last_commit_age() -> Result<Duration> {
     Ok(SystemTime::now().duration_since(when).unwrap_or(Duration::ZERO))
 }
 
+/// Get mtime ages for each entry's path, where the path still exists on disk.
+///
+/// `repo_root` anchors the lookup: `git status --porcelain=v2 -z` reports
+/// paths relative to the repo root, not the cwd, so resolving against the
+/// cwd misses every file when gsw runs from a subdirectory. Falls back to
+/// cwd-relative resolution when the root can't be determined.
+fn collect_ages(entries: &[FileEntry], repo_root: Option<&Path>) -> HashMap<String, Duration> {
+    let now = SystemTime::now();
+    let mut out = HashMap::with_capacity(entries.len());
+    for e in entries {
+        if out.contains_key(&e.path) {
+            continue;
+        }
+        let full = match repo_root {
+            Some(root) => root.join(&e.path),
+            None => PathBuf::from(&e.path),
+        };
+        let Ok(meta) = std::fs::metadata(&full) else {
+            continue;
+        };
+        let Ok(mtime) = meta.modified() else {
+            continue;
+        };
+        let elapsed = now.duration_since(mtime).unwrap_or(Duration::ZERO);
+        out.insert(e.path.clone(), elapsed);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,33 +324,4 @@ mod tests {
         // Honor https://no-color.org even when under viddy.
         assert!(!should_force_colors(false, true, true));
     }
-}
-
-/// Get mtime ages for each entry's path, where the path still exists on disk.
-///
-/// `repo_root` anchors the lookup: `git status --porcelain=v2 -z` reports
-/// paths relative to the repo root, not the cwd, so resolving against the
-/// cwd misses every file when gsw runs from a subdirectory. Falls back to
-/// cwd-relative resolution when the root can't be determined.
-fn collect_ages(entries: &[FileEntry], repo_root: Option<&Path>) -> HashMap<String, Duration> {
-    let now = SystemTime::now();
-    let mut out = HashMap::with_capacity(entries.len());
-    for e in entries {
-        if out.contains_key(&e.path) {
-            continue;
-        }
-        let full = match repo_root {
-            Some(root) => root.join(&e.path),
-            None => PathBuf::from(&e.path),
-        };
-        let Ok(meta) = std::fs::metadata(&full) else {
-            continue;
-        };
-        let Ok(mtime) = meta.modified() else {
-            continue;
-        };
-        let elapsed = now.duration_since(mtime).unwrap_or(Duration::ZERO);
-        out.insert(e.path.clone(), elapsed);
-    }
-    out
 }

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -187,3 +187,107 @@ fn shows_untracked_directory_with_slash() {
         "untracked dir should show with trailing slash: {out}",
     );
 }
+
+/// Stage a deeply-nested file under a long path so the rendered row's
+/// path column is wide enough that narrow terminals will visibly truncate
+/// it with `…`. Untracked nested dirs would otherwise collapse to their
+/// topmost segment in `git status` output and defeat the test.
+fn make_long_staged(dir: &Path) -> String {
+    let rel = "a/very/long/path/to/deeply/nested/file.txt";
+    let full = dir.join(rel);
+    fs::create_dir_all(full.parent().unwrap()).unwrap();
+    fs::write(&full, "x\n").unwrap();
+    run_git(dir, &["add", rel]);
+    rel.to_string()
+}
+
+#[test]
+fn columns_env_with_piped_stdout_narrows_width_and_preserves_colors() {
+    // Simulate viddy: stdout is captured (no TTY) and the wrapper exports
+    // its terminal's width via COLUMNS. gsw should use COLUMNS-1 (reserving
+    // one cell for the wrapper's scroll bar) and force colors through.
+    let dir = setup_repo();
+    make_long_staged(dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .env("COLUMNS", "50")
+        // Make the test independent of the host's NO_COLOR / CLICOLOR setup.
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR")
+        .env_remove("CLICOLOR_FORCE")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(
+        output.status.success(),
+        "gsw exited non-zero: stderr = {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let raw = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        raw.contains('\u{1b}'),
+        "expected ANSI color escapes when COLUMNS is set: {raw:?}",
+    );
+    assert!(
+        raw.contains('…'),
+        "long path should be left-truncated to fit COLUMNS-1: {raw:?}",
+    );
+}
+
+#[test]
+fn columns_env_ignored_when_no_color_env_is_set() {
+    // NO_COLOR must win even when we'd otherwise force colors on under
+    // a watch wrapper. https://no-color.org/
+    let dir = setup_repo();
+    make_long_staged(dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .env("COLUMNS", "50")
+        .env("NO_COLOR", "1")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let raw = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !raw.contains('\u{1b}'),
+        "NO_COLOR=1 should suppress colors even under a watch wrapper: {raw:?}",
+    );
+}
+
+#[test]
+fn width_offset_flag_narrows_render() {
+    // With a fixed COLUMNS, --width-offset should subtract that many cells
+    // on top of the auto-detection, narrowing the file-row path column
+    // enough to force ellipsis truncation.
+    let dir = setup_repo();
+    make_long_staged(dir.path());
+
+    let baseline = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .env("COLUMNS", "80")
+        .current_dir(dir.path())
+        .output()
+        .expect("baseline gsw failed");
+    assert!(baseline.status.success());
+    let baseline_str = String::from_utf8_lossy(&baseline.stdout);
+    assert!(
+        !baseline_str.contains('…'),
+        "baseline width should fit the long path without truncation: {baseline_str}",
+    );
+
+    let with_offset = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .arg("--width-offset")
+        .arg("30")
+        .env("COLUMNS", "80")
+        .current_dir(dir.path())
+        .output()
+        .expect("offset gsw failed");
+    assert!(with_offset.status.success());
+    let offset_str = String::from_utf8_lossy(&with_offset.stdout);
+    assert!(
+        offset_str.contains('…'),
+        "--width-offset 30 should narrow render enough to truncate path: {offset_str}",
+    );
+}


### PR DESCRIPTION
## Summary
- Auto-detect viddy / watch-like wrappers via `COLUMNS` env + non-TTY stdout, and render at `COLUMNS - 1` so the wrapper's scroll indicator doesn't eat content from the right edge.
- Force `colored` on through the pipe in the same condition so the wrapper's TTY-backed UI receives our colors (`NO_COLOR` still wins).
- Add `--width-offset N` as a manual escape hatch for wrappers that don't export `COLUMNS`.

## Test plan
- [ ] `viddy gsw` renders the full width without wrapping the rightmost column
- [ ] Colors are visible in the viddy display
- [ ] `NO_COLOR=1 viddy gsw` strips colors as expected
- [ ] `viddy 'gsw --width-offset 1'` narrows the render by one more cell
- [ ] Plain `gsw` in an interactive terminal is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)