### PR TITLE
gsw: append git log oneline section so `viddy gsw` shows status + history

### DIFF
--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -163,6 +163,7 @@ fn main() -> Result<()> {
         terminal_width,
         bar_width: cli.bar_width,
         max_files: cli.max_files.or(Some(default_max_files(terminal_height))),
+        log_lines: 0,
     };
 
     println!("{}", render(&snapshot, &opts));

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use crate::git::{parse_numstat, parse_status, FileEntry};
-use crate::render::{default_max_files, render, RenderOptions};
+use crate::render::{default_max_files, render, LogEntry, RenderOptions};
 use crate::snapshot::build_snapshot;
 
 mod age;
@@ -51,6 +51,15 @@ struct Cli {
     /// child process can't see.
     #[arg(long, default_value_t = 0)]
     width_offset: usize,
+
+    /// Number of recent commits to show in the `git log --oneline`-style
+    /// section appended after the file list.
+    #[arg(long, default_value_t = 20)]
+    log_lines: usize,
+
+    /// Disable the recent-commit section entirely.
+    #[arg(long)]
+    no_log: bool,
 }
 
 /// Decide the effective terminal width gsw should render for.
@@ -142,7 +151,7 @@ fn main() -> Result<()> {
         .map(|s| PathBuf::from(s.trim()));
     let ages = collect_ages(&entries, repo_root.as_deref());
 
-    let snapshot = build_snapshot(
+    let mut snapshot = build_snapshot(
         branch,
         base,
         commits_ahead,
@@ -153,17 +162,26 @@ fn main() -> Result<()> {
         &ages,
     );
 
+    let log_lines = if cli.no_log { 0 } else { cli.log_lines };
+    snapshot.log = fetch_log(log_lines);
+
     let tty_size = terminal_size::terminal_size().map(|(w, h)| (usize::from(w.0), h.0));
     let tty_width = tty_size.map(|(w, _)| w);
     let terminal_height = tty_size.map_or(24, |(_, h)| h);
     let terminal_width =
         effective_terminal_width(tty_width, columns_env, stdout_is_tty, cli.width_offset);
 
+    // Reserve room for the log section so the file list shrinks instead of
+    // pushing log rows off the bottom under viddy.
+    let log_reserve = if log_lines == 0 { 0 } else { 1 + log_lines };
+    let files_height =
+        terminal_height.saturating_sub(u16::try_from(log_reserve).unwrap_or(u16::MAX));
+
     let opts = RenderOptions {
         terminal_width,
         bar_width: cli.bar_width,
-        max_files: cli.max_files.or(Some(default_max_files(terminal_height))),
-        log_lines: 0,
+        max_files: cli.max_files.or(Some(default_max_files(files_height))),
+        log_lines,
     };
 
     println!("{}", render(&snapshot, &opts));
@@ -221,6 +239,30 @@ fn resolve_base_ref() -> String {
         }
     }
     "HEAD".to_string()
+}
+
+/// Fetch the `n` most recent commits as (short-hash, subject) pairs.
+///
+/// Returns an empty list when `n == 0` or git fails (e.g. no commits yet).
+/// Uses `%h %s` and splits on the first space — git short hashes never
+/// contain spaces, so the split is unambiguous.
+fn fetch_log(n: usize) -> Vec<LogEntry> {
+    if n == 0 {
+        return Vec::new();
+    }
+    let n_arg = format!("-n{n}");
+    let Ok(out) = run_git(&["log", &n_arg, "--pretty=format:%h %s"]) else {
+        return Vec::new();
+    };
+    out.lines()
+        .filter_map(|line| {
+            let (hash, subject) = line.split_once(' ')?;
+            Some(LogEntry {
+                hash: hash.to_string(),
+                subject: subject.to_string(),
+            })
+        })
+        .collect()
 }
 
 /// How long ago the current HEAD commit was authored.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -101,7 +101,12 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     }
 
     if opts.log_lines > 0 && !snapshot.log.is_empty() {
-        lines.push(render_separator(header_width));
+        // When there are no file rows above us, the post-header separator
+        // already sits directly above the log section; adding another would
+        // produce a double rule with nothing between them.
+        if !snapshot.files.is_empty() {
+            lines.push(render_separator(header_width));
+        }
         for entry in snapshot.log.iter().take(opts.log_lines) {
             lines.push(render_log_row(entry, opts.terminal_width));
         }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -17,6 +17,15 @@ pub struct Snapshot {
     pub commits_ahead: u32,
     pub last_commit_age: Duration,
     pub files: Vec<RenderEntry>,
+    /// Most recent commits, newest first. Empty when not requested.
+    pub log: Vec<LogEntry>,
+}
+
+/// One recent-commit row.
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub hash: String,
+    pub subject: String,
 }
 
 /// One file row in the frame.
@@ -40,6 +49,8 @@ pub struct RenderOptions {
     pub terminal_width: usize,
     pub bar_width: usize,
     pub max_files: Option<usize>,
+    /// Maximum recent-commit rows to render. 0 disables the log section.
+    pub log_lines: usize,
 }
 
 /// Width of the "+adds" / "-dels" / age column fields.
@@ -377,6 +388,7 @@ mod tests {
             terminal_width: 80,
             bar_width: 6,
             max_files: None,
+            log_lines: 0,
         }
     }
 
@@ -387,6 +399,7 @@ mod tests {
             commits_ahead: 3,
             last_commit_age: Duration::from_secs(5 * 60 + 23),
             files,
+            log: vec![],
         }
     }
 
@@ -621,6 +634,7 @@ mod tests {
                 terminal_width: 60,
                 bar_width: 6,
                 max_files: None,
+                log_lines: 0,
             },
         ));
         let row = out.lines().nth(2).unwrap_or("");
@@ -641,6 +655,7 @@ mod tests {
                 terminal_width: 40,
                 bar_width: 6,
                 max_files: None,
+                log_lines: 0,
             },
         );
         let stripped = strip_ansi(&out);
@@ -659,6 +674,7 @@ mod tests {
                 terminal_width: 80,
                 bar_width: 6,
                 max_files: Some(3),
+                log_lines: 0,
             },
         ));
         assert!(out.contains("f0.rs"));
@@ -682,6 +698,7 @@ mod tests {
                 terminal_width: 80,
                 bar_width: 6,
                 max_files: Some(0),
+                log_lines: 0,
             },
         ));
         for i in 0..5 {
@@ -753,4 +770,116 @@ mod tests {
         assert_eq!(default_max_files(5), 1);
     }
 
+    #[test]
+    fn log_section_renders_hash_and_subject() {
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![
+            LogEntry {
+                hash: "abc1234".into(),
+                subject: "first commit subject".into(),
+            },
+            LogEntry {
+                hash: "def5678".into(),
+                subject: "second commit subject".into(),
+            },
+        ];
+        let mut o = opts();
+        o.log_lines = 10;
+        let out = strip_ansi(&render(&snap, &o));
+        assert!(out.contains("abc1234"), "first hash should appear: {out}");
+        assert!(
+            out.contains("first commit subject"),
+            "first subject should appear: {out}",
+        );
+        assert!(out.contains("def5678"), "second hash should appear: {out}");
+        assert!(
+            out.contains("second commit subject"),
+            "second subject should appear: {out}",
+        );
+    }
+
+    #[test]
+    fn log_section_caps_at_log_lines() {
+        let mut snap = snap_with(vec![]);
+        snap.log = (0..30)
+            .map(|i| LogEntry {
+                hash: format!("h{i:06}"),
+                subject: format!("subj {i}"),
+            })
+            .collect();
+        let mut o = opts();
+        o.log_lines = 5;
+        let out = strip_ansi(&render(&snap, &o));
+        assert!(out.contains("h000000"), "first entry shown: {out}");
+        assert!(out.contains("h000004"), "fifth entry shown: {out}");
+        assert!(
+            !out.contains("h000005"),
+            "sixth entry hidden by log_lines limit: {out}",
+        );
+    }
+
+    #[test]
+    fn log_lines_zero_disables_section() {
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![LogEntry {
+            hash: "abc1234".into(),
+            subject: "first".into(),
+        }];
+        let mut o = opts();
+        o.log_lines = 0;
+        let out = strip_ansi(&render(&snap, &o));
+        assert!(
+            !out.contains("abc1234"),
+            "log_lines=0 disables log section: {out}",
+        );
+    }
+
+    #[test]
+    fn log_row_truncates_long_subject_to_fit_terminal_width() {
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![LogEntry {
+            hash: "abc1234".into(),
+            subject: "really long subject ".repeat(20),
+        }];
+        let mut o = opts();
+        o.log_lines = 1;
+        o.terminal_width = 40;
+        let out = strip_ansi(&render(&snap, &o));
+        let log_line = out
+            .lines()
+            .find(|l| l.contains("abc1234"))
+            .expect("log line should appear");
+        let w = UnicodeWidthStr::width(log_line);
+        assert!(
+            w <= 40,
+            "log row width {w} should not exceed terminal_width=40: {log_line:?}",
+        );
+        assert!(
+            log_line.contains('…'),
+            "truncated subject should end with ellipsis: {log_line:?}",
+        );
+    }
+
+    #[test]
+    fn log_section_has_separator_before_entries() {
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![LogEntry {
+            hash: "abc1234".into(),
+            subject: "first".into(),
+        }];
+        let mut o = opts();
+        o.log_lines = 5;
+        let out = strip_ansi(&render(&snap, &o));
+        let lines: Vec<&str> = out.lines().collect();
+        let log_idx = lines
+            .iter()
+            .position(|l| l.contains("abc1234"))
+            .expect("log row should appear");
+        assert!(log_idx >= 1, "log row should be preceded by other lines");
+        let preceding = lines[log_idx - 1];
+        assert!(
+            preceding.chars().all(|c| c == '─' || c.is_whitespace()),
+            "line before log section should be a ─ separator: {preceding:?}",
+        );
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -100,7 +100,24 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
         );
     }
 
+    if opts.log_lines > 0 && !snapshot.log.is_empty() {
+        lines.push(render_separator(header_width));
+        for entry in snapshot.log.iter().take(opts.log_lines) {
+            lines.push(render_log_row(entry, opts.terminal_width));
+        }
+    }
+
     lines.join("\n")
+}
+
+fn render_log_row(entry: &LogEntry, width: usize) -> String {
+    let hash_width = UnicodeWidthStr::width(entry.hash.as_str());
+    let sep = "  ";
+    let sep_width = sep.chars().count();
+    let subject_budget = width.saturating_sub(hash_width + sep_width);
+    let subject = truncate_right(&entry.subject, subject_budget);
+    let hash_str = entry.hash.yellow().to_string();
+    format!("{hash_str}{sep}{subject}")
 }
 
 fn compute_path_width(opts: &RenderOptions) -> usize {
@@ -302,6 +319,28 @@ fn pad_right(s: &str, width: usize) -> String {
         }
         result
     }
+}
+
+/// Truncate `s` from the right to fit within `max_width` display columns,
+/// suffixing with `…` when truncation happens. UTF-8 safe.
+fn truncate_right(s: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+    let ellipsis_width = 1_usize;
+    let target = max_width.saturating_sub(ellipsis_width);
+    let mut acc = 0_usize;
+    let mut result = String::new();
+    for c in s.chars() {
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if acc + cw > target {
+            break;
+        }
+        acc += cw;
+        result.push(c);
+    }
+    result.push('…');
+    result
 }
 
 /// Truncate `s` from the left to fit within `max_width` display columns,

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -900,6 +900,36 @@ mod tests {
     }
 
     #[test]
+    fn empty_file_list_collapses_to_single_separator_before_log() {
+        // When there are no staged/unstaged files, the post-header separator
+        // already sits directly above the log section, so the additional
+        // pre-log separator just creates a double rule with nothing between
+        // them. Collapse to a single ─ line.
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![
+            LogEntry {
+                hash: "abc1234".into(),
+                subject: "first".into(),
+            },
+            LogEntry {
+                hash: "def5678".into(),
+                subject: "second".into(),
+            },
+        ];
+        let mut o = opts();
+        o.log_lines = 5;
+        let out = strip_ansi(&render(&snap, &o));
+        let separator_count = out
+            .lines()
+            .filter(|l| !l.is_empty() && l.chars().all(|c| c == '─'))
+            .count();
+        assert_eq!(
+            separator_count, 1,
+            "expected exactly one separator when file list is empty:\n{out}",
+        );
+    }
+
+    #[test]
     fn log_section_has_separator_before_entries() {
         let mut snap = snap_with(vec![]);
         snap.log = vec![LogEntry {

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -54,6 +54,7 @@ pub fn build_snapshot(
         commits_ahead,
         last_commit_age,
         files,
+        log: Vec::new(),
     }
 }
 

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -256,6 +256,68 @@ fn columns_env_ignored_when_no_color_env_is_set() {
 }
 
 #[test]
+fn shows_recent_commit_subject_in_log_section() {
+    // By default gsw should append a `git log --oneline`-style block so
+    // `viddy gsw` shows recent commits alongside status. The setup repo has
+    // one commit with subject "initial".
+    let dir = setup_repo();
+    let out = run_gsw(dir.path());
+    assert!(
+        out.contains("initial"),
+        "default output should include the recent commit subject: {out}",
+    );
+}
+
+#[test]
+fn no_log_flag_suppresses_log_section() {
+    let dir = setup_repo();
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .args(["--no-color", "--no-log"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !out.contains("initial"),
+        "--no-log should hide the log section: {out}",
+    );
+}
+
+#[test]
+fn log_lines_flag_caps_visible_commits() {
+    let dir = setup_repo();
+    // Add several commits so we can verify --log-lines actually caps.
+    for i in 0..5 {
+        fs::write(dir.path().join("a.txt"), format!("rev {i}\n")).unwrap();
+        run_git(dir.path(), &["add", "a.txt"]);
+        run_git(
+            dir.path(),
+            &["commit", "-q", "-m", &format!("rev-{i}-subject")],
+        );
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .args(["--no-color", "--log-lines", "2"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        out.contains("rev-4-subject"),
+        "newest commit should be visible with --log-lines 2: {out}",
+    );
+    assert!(
+        out.contains("rev-3-subject"),
+        "second-newest commit should be visible with --log-lines 2: {out}",
+    );
+    assert!(
+        !out.contains("rev-2-subject"),
+        "third-newest commit should be hidden by --log-lines 2: {out}",
+    );
+}
+
+#[test]
 fn width_offset_flag_narrows_render() {
     // With a fixed COLUMNS, --width-offset should subtract that many cells
     // on top of the auto-detection, narrowing the file-row path column


### PR DESCRIPTION
## Summary
- Append a `git log --oneline`-style block after the file list so `viddy gsw` renders status and recent history in a single frame.
- New CLI flags: `--log-lines N` (default 20) and `--no-log`. File-row budget shrinks by `1 + log_lines` so the log section never gets pushed off the bottom under viddy.
- Collapse the pre-log separator when there are no staged/unstaged files (avoids a doubled ─ rule directly under the header).

## Test plan
- [x] `cargo test -p gsw` — 76 unit + 14 integration tests pass
- [x] `cargo clippy -p gsw --all-targets -- -D warnings` — clean
- [x] Manual: `gsw` in a dirty repo shows files + log; `gsw --no-log` suppresses the log; `gsw --log-lines 3` caps to 3 commits; `gsw` in a clean repo shows one separator (not two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)