### PR TITLE
gsw: append commit age to log rows in detailed format

### DIFF
--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -241,25 +241,32 @@ fn resolve_base_ref() -> String {
     "HEAD".to_string()
 }
 
-/// Fetch the `n` most recent commits as (short-hash, subject) pairs.
+/// Fetch the `n` most recent commits as (short-hash, age, subject) records.
 ///
 /// Returns an empty list when `n == 0` or git fails (e.g. no commits yet).
-/// Uses `%h %s` and splits on the first space — git short hashes never
-/// contain spaces, so the split is unambiguous.
+/// Uses `%h %ct %s` and splits on the first two spaces — the hash never
+/// contains spaces and `%ct` is a bare unix timestamp, so the splits are
+/// unambiguous. The subject keeps any internal spaces.
 fn fetch_log(n: usize) -> Vec<LogEntry> {
     if n == 0 {
         return Vec::new();
     }
     let n_arg = format!("-n{n}");
-    let Ok(out) = run_git(&["log", &n_arg, "--pretty=format:%h %s"]) else {
+    let Ok(out) = run_git(&["log", &n_arg, "--pretty=format:%h %ct %s"]) else {
         return Vec::new();
     };
+    let now = SystemTime::now();
     out.lines()
         .filter_map(|line| {
-            let (hash, subject) = line.split_once(' ')?;
+            let (hash, rest) = line.split_once(' ')?;
+            let (ct_str, subject) = rest.split_once(' ')?;
+            let secs: u64 = ct_str.parse().ok()?;
+            let when = SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+            let age = now.duration_since(when).unwrap_or(Duration::ZERO);
             Some(LogEntry {
                 hash: hash.to_string(),
                 subject: subject.to_string(),
+                age,
             })
         })
         .collect()

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -26,6 +26,9 @@ pub struct Snapshot {
 pub struct LogEntry {
     pub hash: String,
     pub subject: String,
+    /// How long ago this commit was authored. Same `Duration` shape as the
+    /// per-file age column so the two render in identical units.
+    pub age: Duration,
 }
 
 /// One file row in the frame.
@@ -116,13 +119,26 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
 }
 
 fn render_log_row(entry: &LogEntry, width: usize) -> String {
+    // Layout: `{hash}  {subject…}   {age}` — the rightmost AGE_FIELD cells
+    // hold the right-aligned age, matching the file-row age column exactly.
+    // The subject is padded to fill the gap so the age column lines up.
     let hash_width = UnicodeWidthStr::width(entry.hash.as_str());
-    let sep = "  ";
-    let sep_width = sep.chars().count();
-    let subject_budget = width.saturating_sub(hash_width + sep_width);
-    let subject = truncate_right(&entry.subject, subject_budget);
+    let hash_sep = "  ";
+    let hash_sep_width = hash_sep.chars().count();
+    let sep_to_age = " ".repeat(SEP_DELS_AGE);
+
+    let subject_budget = width
+        .saturating_sub(hash_width + hash_sep_width + SEP_DELS_AGE + AGE_FIELD)
+        .max(1);
+    let subject_truncated = truncate_right(&entry.subject, subject_budget);
+    let subject_padded = pad_right(&subject_truncated, subject_budget);
+
+    let age_raw = format_age_detailed(entry.age);
+    let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
+    let age_str = colorize_age(&age_field, Some(entry.age));
+
     let hash_str = entry.hash.yellow().to_string();
-    format!("{hash_str}{sep}{subject}")
+    format!("{hash_str}{hash_sep}{subject_padded}{sep_to_age}{age_str}")
 }
 
 fn compute_path_width(opts: &RenderOptions) -> usize {
@@ -814,18 +830,20 @@ mod tests {
         assert_eq!(default_max_files(5), 1);
     }
 
+    fn log_entry(hash: &str, subject: &str, age_secs: u64) -> LogEntry {
+        LogEntry {
+            hash: hash.into(),
+            subject: subject.into(),
+            age: Duration::from_secs(age_secs),
+        }
+    }
+
     #[test]
     fn log_section_renders_hash_and_subject() {
         let mut snap = snap_with(vec![]);
         snap.log = vec![
-            LogEntry {
-                hash: "abc1234".into(),
-                subject: "first commit subject".into(),
-            },
-            LogEntry {
-                hash: "def5678".into(),
-                subject: "second commit subject".into(),
-            },
+            log_entry("abc1234", "first commit subject", 30),
+            log_entry("def5678", "second commit subject", 60),
         ];
         let mut o = opts();
         o.log_lines = 10;
@@ -845,10 +863,11 @@ mod tests {
     #[test]
     fn log_section_caps_at_log_lines() {
         let mut snap = snap_with(vec![]);
-        snap.log = (0..30)
+        snap.log = (0..30_u64)
             .map(|i| LogEntry {
                 hash: format!("h{i:06}"),
                 subject: format!("subj {i}"),
+                age: Duration::from_secs(i * 60),
             })
             .collect();
         let mut o = opts();
@@ -865,10 +884,7 @@ mod tests {
     #[test]
     fn log_lines_zero_disables_section() {
         let mut snap = snap_with(vec![]);
-        snap.log = vec![LogEntry {
-            hash: "abc1234".into(),
-            subject: "first".into(),
-        }];
+        snap.log = vec![log_entry("abc1234", "first", 0)];
         let mut o = opts();
         o.log_lines = 0;
         let out = strip_ansi(&render(&snap, &o));
@@ -884,6 +900,7 @@ mod tests {
         snap.log = vec![LogEntry {
             hash: "abc1234".into(),
             subject: "really long subject ".repeat(20),
+            age: Duration::from_secs(30),
         }];
         let mut o = opts();
         o.log_lines = 1;
@@ -912,14 +929,8 @@ mod tests {
         // them. Collapse to a single ─ line.
         let mut snap = snap_with(vec![]);
         snap.log = vec![
-            LogEntry {
-                hash: "abc1234".into(),
-                subject: "first".into(),
-            },
-            LogEntry {
-                hash: "def5678".into(),
-                subject: "second".into(),
-            },
+            log_entry("abc1234", "first", 0),
+            log_entry("def5678", "second", 60),
         ];
         let mut o = opts();
         o.log_lines = 5;
@@ -935,12 +946,52 @@ mod tests {
     }
 
     #[test]
+    fn log_row_renders_age_in_detailed_format() {
+        let mut snap = snap_with(vec![]);
+        snap.log = vec![log_entry("abc1234", "subject", 5 * 60 + 23)];
+        let mut o = opts();
+        o.log_lines = 1;
+        let out = strip_ansi(&render(&snap, &o));
+        let log_line = out
+            .lines()
+            .find(|l| l.contains("abc1234"))
+            .expect("log row should appear");
+        assert!(
+            log_line.contains("5m23s"),
+            "log row should include the commit age in the two-unit format: {log_line:?}",
+        );
+    }
+
+    #[test]
+    fn log_row_age_column_aligns_with_file_row_age_column() {
+        // The age column on a log row should occupy the same rightmost
+        // AGE_FIELD cells as the file rows, so the two stacked sections
+        // align cleanly under viddy.
+        let file = entry("file.rs", FileStatus::Modified, true, 1, 0);
+        let mut snap = snap_with(vec![file]);
+        snap.log = vec![log_entry("abc1234", "subject", 5 * 60 + 23)];
+        let mut o = opts();
+        o.log_lines = 1;
+        let out = strip_ansi(&render(&snap, &o));
+        let file_row = out
+            .lines()
+            .find(|l| l.contains("file.rs"))
+            .expect("file row should appear");
+        let log_line = out
+            .lines()
+            .find(|l| l.contains("abc1234"))
+            .expect("log row should appear");
+        assert_eq!(
+            UnicodeWidthStr::width(file_row.trim_end()),
+            UnicodeWidthStr::width(log_line.trim_end()),
+            "file row and log row should occupy the same width so age columns align:\n  file: {file_row:?}\n  log:  {log_line:?}",
+        );
+    }
+
+    #[test]
     fn log_section_has_separator_before_entries() {
         let mut snap = snap_with(vec![]);
-        snap.log = vec![LogEntry {
-            hash: "abc1234".into(),
-            subject: "first".into(),
-        }];
+        snap.log = vec![log_entry("abc1234", "first", 0)];
         let mut o = opts();
         o.log_lines = 5;
         let out = strip_ansi(&render(&snap, &o));

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -285,6 +285,38 @@ fn no_log_flag_suppresses_log_section() {
 }
 
 #[test]
+fn log_row_ends_with_commit_age_in_detailed_format() {
+    // Each rendered log row should end with the commit age in the same
+    // two-unit format the file rows and the header use (e.g. `0s`, `5m23s`,
+    // `2h14m`, `3d12h`). The "initial" commit is freshly minted, so its row
+    // should end with a digit followed by `s`/`m`/`h`/`d`.
+    let dir = setup_repo();
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .args(["--no-color", "--log-lines", "1"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let out = String::from_utf8_lossy(&output.stdout);
+    let log_line = out
+        .lines()
+        .find(|l| l.contains("initial"))
+        .expect("log row should appear");
+    let trimmed = log_line.trim_end();
+    let chars: Vec<char> = trimmed.chars().collect();
+    let last = chars.last().copied().unwrap_or(' ');
+    let prev = chars.iter().rev().nth(1).copied().unwrap_or(' ');
+    assert!(
+        matches!(last, 's' | 'm' | 'h' | 'd'),
+        "log row should end with an age unit (s/m/h/d): {log_line:?}",
+    );
+    assert!(
+        prev.is_ascii_digit(),
+        "log row age unit should be preceded by a digit: {log_line:?}",
+    );
+}
+
+#[test]
 fn log_lines_flag_caps_visible_commits() {
     let dir = setup_repo();
     // Add several commits so we can verify --log-lines actually caps.


### PR DESCRIPTION
## Summary
- Append commit age (e.g., `2 hours ago`) to each git log row in `gsw`'s detailed format so `viddy gsw` surfaces how stale each commit is at a glance.
- Built test-first: red commit asserts log rows end with the age; green commit wires the rendering through.

## Test plan
- [x] `cargo test -p gsw` (integration test asserts log rows end with commit age)
- [ ] `gsw` in a repo with recent commits shows ages on each log line
- [ ] `viddy gsw` still renders correctly with the appended ages

🤖 Generated with [Claude Code](https://claude.com/claude-code)