### PR TITLE
gsw: leave one cell of safety margin on direct TTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,16 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1641,27 +1631,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -64,12 +64,16 @@ struct Cli {
 
 /// Decide the effective terminal width gsw should render for.
 ///
-/// - When stdout is a TTY, trust `tty_width` directly (interactive use).
-/// - When stdout is *not* a TTY but `COLUMNS` is set in env, a watch-like
-///   wrapper (e.g. viddy) is framing us. Viddy reports the full terminal
-///   width via `COLUMNS` but renders into a content area that's one column
-///   narrower (its scroll indicator). So we use `columns_env - 1`.
-/// - Otherwise fall back to 80 columns.
+/// Always leaves one cell of margin against the detected column count:
+/// - Direct TTY: rendering a row exactly `cols` cells wide collides with
+///   DECAWM auto-wrap quirks and right-edge chrome (scrollbars, padding)
+///   on many terminals, pushing the last glyph onto the next line. The
+///   margin keeps the rightmost cell empty.
+/// - Watch-like wrapper (stdout not a TTY but `COLUMNS` set, e.g. viddy):
+///   `COLUMNS` reports the full terminal width but the wrapper renders
+///   into a content area one column narrower (its scroll indicator).
+/// - Fallback (no signal): treat the implicit 80-column default the same
+///   way for consistency.
 ///
 /// `width_offset` always stacks on top, and the result is at least 1.
 fn effective_terminal_width(
@@ -78,11 +82,14 @@ fn effective_terminal_width(
     stdout_is_tty: bool,
     width_offset: usize,
 ) -> usize {
-    let base = match (stdout_is_tty, columns_env) {
-        (false, Some(cols)) => cols.saturating_sub(1),
+    let detected = match (stdout_is_tty, columns_env) {
+        (false, Some(cols)) => cols,
         _ => tty_width.unwrap_or(80),
     };
-    base.saturating_sub(width_offset).max(1)
+    detected
+        .saturating_sub(1)
+        .saturating_sub(width_offset)
+        .max(1)
 }
 
 /// Should `colored::control::set_override(true)` be called?
@@ -366,27 +373,31 @@ mod tests {
 
     #[test]
     fn width_uses_tty_width_when_stdout_is_tty() {
-        // Interactive: trust the ioctl-reported width, not the env.
-        assert_eq!(effective_terminal_width(Some(200), None, true, 0), 200);
+        // Interactive: trust the ioctl-reported width, not the env — but
+        // still subtract the one-cell safety margin.
+        assert_eq!(effective_terminal_width(Some(200), None, true, 0), 199);
     }
 
     #[test]
     fn width_ignores_columns_when_stdout_is_tty() {
         // If a shell leaked COLUMNS into our env but we have a real TTY,
         // the TTY measurement wins.
-        assert_eq!(effective_terminal_width(Some(200), Some(120), true, 0), 200);
+        assert_eq!(effective_terminal_width(Some(200), Some(120), true, 0), 199);
     }
 
     #[test]
-    fn width_falls_back_to_eighty_when_no_signal() {
-        // Piped to a plain file with no COLUMNS in env: nothing to go on.
-        assert_eq!(effective_terminal_width(None, None, false, 0), 80);
+    fn width_falls_back_to_eighty_minus_margin_when_no_signal() {
+        // Piped to a plain file with no COLUMNS in env: nothing to go on,
+        // so fall back to the 80-column default. The safety margin still
+        // applies so the fallback matches the detected paths.
+        assert_eq!(effective_terminal_width(None, None, false, 0), 79);
     }
 
     #[test]
     fn width_offset_stacks_on_top_of_detection() {
-        assert_eq!(effective_terminal_width(Some(200), None, true, 3), 197);
-        // 120 (COLUMNS) - 1 (scroll bar) - 2 (offset) = 117
+        // 200 (TTY) - 1 (safety margin) - 3 (offset) = 196
+        assert_eq!(effective_terminal_width(Some(200), None, true, 3), 196);
+        // 120 (COLUMNS) - 1 (safety margin) - 2 (offset) = 117
         assert_eq!(effective_terminal_width(None, Some(120), false, 2), 117);
     }
 

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -354,6 +354,17 @@ mod tests {
     }
 
     #[test]
+    fn width_leaves_safety_margin_when_stdout_is_tty() {
+        // Direct TTY: terminal_size reports the full column count, but if
+        // gsw renders a row exactly that many cells wide, terminals with
+        // auto-wrap (DECAWM) or right-edge chrome (scrollbars, padding)
+        // push the rightmost glyph onto the next line — the user sees the
+        // last character of the age column wrap. Leave one cell of margin,
+        // matching the viddy path so direct and viddy renderings agree.
+        assert_eq!(effective_terminal_width(Some(200), None, true, 0), 199);
+    }
+
+    #[test]
     fn width_uses_tty_width_when_stdout_is_tty() {
         // Interactive: trust the ioctl-reported width, not the env.
         assert_eq!(effective_terminal_width(Some(200), None, true, 0), 200);


### PR DESCRIPTION
## Summary
- Reserve one trailing cell in direct-TTY width so wide rows can't wrap into a second visible line
- Cargo.lock: drop stale claude-usage and csv entries

## Test plan
- [ ] cargo build
- [ ] Run gsw in a terminal at a narrow width and confirm rows fit on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)