### PR TITLE
gsw: show upstream ahead/behind in header when branch tracks a remote

### DIFF
--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use crate::git::{parse_numstat, parse_status, FileEntry};
-use crate::render::{plan_section_caps, render, LogEntry, RenderOptions};
+use crate::render::{plan_section_caps, render, LogEntry, RenderOptions, UpstreamStatus};
 use crate::snapshot::build_snapshot;
 
 mod age;
@@ -172,6 +172,8 @@ fn main() -> Result<()> {
     let log_lines = if cli.no_log { 0 } else { cli.log_lines };
     snapshot.log = fetch_log(log_lines);
 
+    snapshot.upstream = detect_upstream();
+
     let tty_size = terminal_size::terminal_size().map(|(w, h)| (usize::from(w.0), h.0));
     let tty_width = tty_size.map(|(w, _)| w);
     let terminal_height = tty_size.map_or(24, |(_, h)| h);
@@ -272,6 +274,44 @@ fn resolve_base_ref() -> String {
         }
     }
     "HEAD".to_string()
+}
+
+/// Resolve the current branch's upstream tracking ref and count how many
+/// commits HEAD is ahead of and behind it.
+///
+/// Returns `None` when the branch has no upstream configured (a brand-new
+/// local branch that's never been pushed, a detached HEAD, etc.) — gsw
+/// hides the upstream field entirely in that case rather than fabricating
+/// a zero count for a tracking branch that doesn't exist.
+///
+/// Counts use `git rev-list --left-right --count <upstream>...HEAD`,
+/// which emits `<behind>\t<ahead>` in a single git invocation. The
+/// three-dot range produces the symmetric difference, so the left side
+/// is "in upstream but not HEAD" (i.e. how far behind we are) and the
+/// right side is "in HEAD but not upstream" (how far ahead).
+fn detect_upstream() -> Option<UpstreamStatus> {
+    let name = run_git(&["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+        .ok()?
+        .trim()
+        .to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let counts = run_git(&[
+        "rev-list",
+        "--left-right",
+        "--count",
+        &format!("{name}...HEAD"),
+    ])
+    .ok()?;
+    let mut parts = counts.split_whitespace();
+    let behind: u32 = parts.next()?.parse().ok()?;
+    let ahead: u32 = parts.next()?.parse().ok()?;
+    Some(UpstreamStatus {
+        name,
+        ahead,
+        behind,
+    })
 }
 
 /// Fetch the `n` most recent commits as (short-hash, age, subject) records.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -290,13 +290,10 @@ fn resolve_base_ref() -> String {
 /// is "in upstream but not HEAD" (i.e. how far behind we are) and the
 /// right side is "in HEAD but not upstream" (how far ahead).
 fn detect_upstream() -> Option<UpstreamStatus> {
-    let name = run_git(&["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+    let name = run_git(&["rev-parse", "--abbrev-ref", "@{upstream}"])
         .ok()?
         .trim()
         .to_string();
-    if name.is_empty() {
-        return None;
-    }
     let counts = run_git(&[
         "rev-list",
         "--left-right",

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -181,8 +181,13 @@ fn header_text(snap: &Snapshot) -> String {
     let age = snap
         .last_commit_age
         .map_or_else(|| "?".to_string(), format_age_detailed);
+    let upstream_field = snap
+        .upstream
+        .as_ref()
+        .map(|u| format!(" • ↑{ahead} ↓{behind} {name}", ahead = u.ahead, behind = u.behind, name = u.name))
+        .unwrap_or_default();
     format!(
-        "gsw • {branch} • {n} {word} ahead of {base} • last commit {age} ago",
+        "gsw • {branch} • {n} {word} ahead of {base}{upstream_field} • last commit {age} ago",
         branch = snap.branch,
         n = snap.commits_ahead,
         word = commit_word,

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -19,6 +19,20 @@ pub struct Snapshot {
     pub files: Vec<RenderEntry>,
     /// Most recent commits, newest first. Empty when not requested.
     pub log: Vec<LogEntry>,
+    /// Upstream tracking branch status (ahead/behind). `None` when the
+    /// current branch has no configured upstream.
+    pub upstream: Option<UpstreamStatus>,
+}
+
+/// State of the local branch relative to its upstream tracking ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamStatus {
+    /// Short upstream name, e.g. `origin/gsw-origin`.
+    pub name: String,
+    /// Commits on HEAD not yet on the upstream.
+    pub ahead: u32,
+    /// Commits on the upstream not yet on HEAD.
+    pub behind: u32,
 }
 
 /// One recent-commit row.
@@ -500,6 +514,7 @@ mod tests {
             last_commit_age: Some(Duration::from_secs(5 * 60 + 23)),
             files,
             log: vec![],
+            upstream: None,
         }
     }
 
@@ -1101,6 +1116,70 @@ mod tests {
         assert!(
             !aging.style.contains(Styles::Italic),
             "Aging should not be italicized",
+        );
+    }
+
+    #[test]
+    fn header_includes_upstream_arrows_and_name_when_set() {
+        // When the current branch has an upstream tracking ref, the header
+        // should report how far ahead/behind we are of it, alongside the
+        // existing base-branch comparison. Using arrows keeps the field
+        // compact for the viddy header line.
+        let mut snap = snap_with(vec![]);
+        snap.upstream = Some(UpstreamStatus {
+            name: "origin/gsv".into(),
+            ahead: 2,
+            behind: 1,
+        });
+        let out = strip_ansi(&render(&snap, &opts()));
+        let header = out.lines().next().unwrap_or("");
+        assert!(
+            header.contains("origin/gsv"),
+            "header should name the upstream tracking branch: {header}",
+        );
+        assert!(
+            header.contains("↑2"),
+            "header should show commits-ahead count with ↑: {header}",
+        );
+        assert!(
+            header.contains("↓1"),
+            "header should show commits-behind count with ↓: {header}",
+        );
+    }
+
+    #[test]
+    fn header_shows_zero_ahead_zero_behind_when_in_sync_with_upstream() {
+        // Predictable shape: even when ahead/behind are both 0, render the
+        // arrows so the eye can scan a column of values under viddy without
+        // the field appearing/disappearing.
+        let mut snap = snap_with(vec![]);
+        snap.upstream = Some(UpstreamStatus {
+            name: "origin/main".into(),
+            ahead: 0,
+            behind: 0,
+        });
+        let out = strip_ansi(&render(&snap, &opts()));
+        let header = out.lines().next().unwrap_or("");
+        assert!(
+            header.contains("↑0") && header.contains("↓0"),
+            "header should still show ↑0 ↓0 when in sync: {header}",
+        );
+        assert!(
+            header.contains("origin/main"),
+            "header should name the upstream even when in sync: {header}",
+        );
+    }
+
+    #[test]
+    fn header_omits_upstream_field_when_no_upstream() {
+        // No upstream configured: the header should not include the arrows
+        // at all, and certainly not invent an "origin/…" name.
+        let snap = snap_with(vec![]);
+        let out = strip_ansi(&render(&snap, &opts()));
+        let header = out.lines().next().unwrap_or("");
+        assert!(
+            !header.contains('↑') && !header.contains('↓'),
+            "header should not show upstream arrows without an upstream: {header}",
         );
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -184,7 +184,7 @@ fn header_text(snap: &Snapshot) -> String {
     let upstream_field = snap
         .upstream
         .as_ref()
-        .map(|u| format!(" • ↑{ahead} ↓{behind} {name}", ahead = u.ahead, behind = u.behind, name = u.name))
+        .map(|u| format!(" • ↑{} ↓{} {}", u.ahead, u.behind, u.name))
         .unwrap_or_default();
     format!(
         "gsw • {branch} • {n} {word} ahead of {base}{upstream_field} • last commit {age} ago",

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -55,6 +55,7 @@ pub fn build_snapshot(
         last_commit_age,
         files,
         log: Vec::new(),
+        upstream: None,
     }
 }
 

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -350,6 +350,79 @@ fn log_lines_flag_caps_visible_commits() {
 }
 
 #[test]
+fn shows_upstream_ahead_and_behind_counts_when_branch_tracks_remote() {
+    // End-to-end: a repo whose local branch tracks an upstream should have
+    // gsw report ↑M ↓N <upstream> in the header. Set up a bare repo to act
+    // as the remote, push the initial commit, then create divergence by
+    // landing a commit on the "remote" side (via a second clone) and another
+    // commit on the local side. The local branch ends up 1 ahead and 1
+    // behind its upstream.
+    let dir = setup_repo();
+    let local = dir.path();
+
+    let remote_dir = tempfile::tempdir().expect("remote tempdir");
+    let remote = remote_dir.path();
+    run_git(remote, &["init", "--bare", "-q", "-b", "main"]);
+
+    run_git(local, &["remote", "add", "origin", remote.to_str().unwrap()]);
+    run_git(local, &["push", "-q", "-u", "origin", "main"]);
+
+    // Land a "remote" commit by cloning the bare repo, committing there,
+    // and pushing back. This is what would normally happen when a teammate
+    // pushes while you've been working locally.
+    let other_dir = tempfile::tempdir().expect("other tempdir");
+    let other = other_dir.path();
+    run_git(other, &["clone", "-q", remote.to_str().unwrap(), "."]);
+    run_git(other, &["config", "user.email", "other@example.com"]);
+    run_git(other, &["config", "user.name", "Other"]);
+    run_git(other, &["config", "commit.gpgsign", "false"]);
+    fs::write(other.join("b.txt"), "from other\n").unwrap();
+    run_git(other, &["add", "b.txt"]);
+    run_git(other, &["commit", "-q", "-m", "remote-side commit"]);
+    run_git(other, &["push", "-q", "origin", "main"]);
+
+    // Now make a local commit so we're both ahead AND behind the upstream
+    // without ever fetching the remote-side change.
+    fs::write(local.join("c.txt"), "local only\n").unwrap();
+    run_git(local, &["add", "c.txt"]);
+    run_git(local, &["commit", "-q", "-m", "local-side commit"]);
+
+    // Fetch so the tracking ref knows about the remote-side commit, but
+    // don't merge. Now `git rev-list --left-right --count @{u}...HEAD`
+    // reports 1 behind, 1 ahead.
+    run_git(local, &["fetch", "-q"]);
+
+    let out = run_gsw(local);
+    let header = out.lines().next().unwrap_or("");
+    assert!(
+        header.contains("origin/main"),
+        "header should name the upstream tracking branch: {header}",
+    );
+    assert!(
+        header.contains("↑1"),
+        "header should show 1 commit ahead of upstream: {header}",
+    );
+    assert!(
+        header.contains("↓1"),
+        "header should show 1 commit behind upstream: {header}",
+    );
+}
+
+#[test]
+fn omits_upstream_field_when_branch_has_no_remote() {
+    // No `git remote add`, no `git push -u`. The branch has no upstream
+    // configured, so gsw should not invent one or print arrows for a
+    // nonexistent tracking ref.
+    let dir = setup_repo();
+    let out = run_gsw(dir.path());
+    let header = out.lines().next().unwrap_or("");
+    assert!(
+        !header.contains('↑') && !header.contains('↓'),
+        "header should not show upstream arrows when no upstream exists: {header}",
+    );
+}
+
+#[test]
 fn width_offset_flag_narrows_render() {
     // With a fixed COLUMNS, --width-offset should subtract that many cells
     // on top of the auto-detection, narrowing the file-row path column


### PR DESCRIPTION
## Summary
- Adds `↑M ↓N <upstream-name>` to the gsw header between the base-branch comparison and the last-commit-age field whenever the current branch has a configured upstream tracking ref.
- Field is omitted entirely on local-only branches and detached HEAD, so brand-new worktree branches still render a clean header.
- Counts come from a single `git rev-list --left-right --count <upstream>...HEAD` call; the upstream name comes from `git rev-parse --abbrev-ref @{upstream}`.

## Test plan
- [x] `cargo test -p gsw` — 91 unit + 17 integration tests pass, including the new `header_includes_upstream_arrows_and_name_when_set`, `header_shows_zero_ahead_zero_behind_when_in_sync_with_upstream`, `header_omits_upstream_field_when_no_upstream`, `shows_upstream_ahead_and_behind_counts_when_branch_tracks_remote`, and `omits_upstream_field_when_branch_has_no_remote` cases
- [x] `cargo clippy -p gsw --tests --bins -- -D warnings` clean
- [x] Smoke test in `/Volumes/SamsungSSDs/code/tools` (main branch tracks `origin/main`): header reads `gsw • main • 0 commits ahead of main • ↑0 ↓0 origin/main • last commit 6d13h ago`
- [x] Smoke test in this worktree (`gsw-origin`, no upstream): header omits the upstream field

🤖 Generated with [Claude Code](https://claude.com/claude-code)