### PR TITLE
gsw: fade commit-log rows from bright to dark as commits age (24-bit)

### DIFF
--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -43,6 +43,30 @@ pub fn age_dim_level(age: Duration) -> AgeDim {
     }
 }
 
+/// Minimum fraction of base brightness retained at the stale boundary and
+/// beyond. The fade approaches this floor so commits never disappear into
+/// the background.
+pub const FADE_FLOOR: f32 = 0.30;
+
+/// Continuous fade factor in `[0.0, 1.0]` for a commit `age`.
+///
+/// `0.0` means use the full base color; `1.0` means use the dark floor.
+/// Piecewise-linear across the same boundaries as [`age_dim_level`] so the
+/// per-minute change is visible inside Fresh and Recent (the buckets a user
+/// is most likely to be staring at while working), while the long tail
+/// across Aging still fades visibly over tens of minutes.
+pub fn age_fade_factor(_age: Duration) -> f32 {
+    0.0
+}
+
+/// Linearly interpolate `base` toward a dark floor by `factor` in `[0,1]`.
+///
+/// `factor = 0` returns `base` unchanged; `factor = 1` returns
+/// `base * FADE_FLOOR` (rounded). Out-of-range factors are clamped.
+pub fn fade_rgb(base: (u8, u8, u8), _factor: f32) -> (u8, u8, u8) {
+    base
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,5 +120,128 @@ mod tests {
         assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24 - 1)), AgeDim::Aging);
         assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24)), AgeDim::Stale);
         assert_eq!(age_dim_level(Duration::from_secs(60 * 60 * 24 * 30)), AgeDim::Stale);
+    }
+
+    #[test]
+    fn fade_factor_is_zero_at_age_zero() {
+        // A just-authored commit should display at full base brightness.
+        assert!(
+            (age_fade_factor(Duration::from_secs(0)) - 0.0).abs() < 1e-6,
+            "factor at age=0 should be exactly 0.0",
+        );
+    }
+
+    #[test]
+    fn fade_factor_reaches_one_at_stale_boundary() {
+        // At and beyond the 24h stale boundary the gradient should hit its
+        // floor — i.e. factor = 1.0 — so further aging doesn't keep darkening.
+        let day = Duration::from_secs(60 * 60 * 24);
+        assert!(
+            (age_fade_factor(day) - 1.0).abs() < 1e-6,
+            "factor at 24h should be 1.0, was {}",
+            age_fade_factor(day),
+        );
+        let week = Duration::from_secs(60 * 60 * 24 * 7);
+        assert!(
+            (age_fade_factor(week) - 1.0).abs() < 1e-6,
+            "factor past 24h should clamp at 1.0, was {}",
+            age_fade_factor(week),
+        );
+    }
+
+    #[test]
+    fn fade_factor_increases_with_age() {
+        // The user requested visible darkening per minute. Walk minute by
+        // minute through the Fresh and Recent buckets and confirm every step
+        // strictly increases — that's what "every minute they get a little
+        // darker" requires.
+        let mut prev = age_fade_factor(Duration::from_secs(0));
+        for m in 1..=70_u64 {
+            let next = age_fade_factor(Duration::from_secs(m * 60));
+            assert!(
+                next > prev,
+                "factor must strictly increase between minute {} and {}: prev={prev} next={next}",
+                m - 1,
+                m,
+            );
+            prev = next;
+        }
+    }
+
+    #[test]
+    fn fade_factor_visible_step_per_minute_in_fresh_and_recent() {
+        // The fade has to actually move enough per minute to be perceptible.
+        // With a base channel of 200 and a floor of 30%, the available range
+        // is 140 RGB units; a 1 RGB-unit minimum step requires the factor to
+        // advance by >= 1/140 ≈ 0.007 per minute somewhere in the Fresh and
+        // Recent buckets. This guards against a future "stretch the gradient
+        // over 24h" change that would silently make per-minute changes
+        // invisible to the eye.
+        for m in 0..60_u64 {
+            let a = age_fade_factor(Duration::from_secs(m * 60));
+            let b = age_fade_factor(Duration::from_secs((m + 1) * 60));
+            if m < 5 {
+                assert!(
+                    b - a >= 0.01,
+                    "fresh-bucket step too small at minute {m}: {a} -> {b}",
+                );
+            } else {
+                assert!(
+                    b - a >= 0.001,
+                    "recent-bucket step too small at minute {m}: {a} -> {b}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fade_rgb_returns_base_at_zero() {
+        // factor=0 means "no fade applied" — color comes out untouched.
+        let base = (200, 150, 50);
+        assert_eq!(fade_rgb(base, 0.0), base);
+    }
+
+    #[test]
+    fn fade_rgb_hits_floor_at_factor_one() {
+        // factor=1 should scale every channel to FADE_FLOOR * base, rounded.
+        let base: (u8, u8, u8) = (200, 100, 50);
+        let (r, g, b) = fade_rgb(base, 1.0);
+        let expect = |c: u8| (f32::from(c) * FADE_FLOOR).round() as u8;
+        assert_eq!(
+            (r, g, b),
+            (expect(base.0), expect(base.1), expect(base.2)),
+            "factor=1 should scale every channel by FADE_FLOOR",
+        );
+    }
+
+    #[test]
+    fn fade_rgb_is_monotonic_per_channel() {
+        // Each channel must monotonically decrease as factor grows — no
+        // bumps, no overshoots. We sample a representative non-grey base so
+        // any per-channel logic error (e.g. swapping channels) would show.
+        let base = (255, 215, 80);
+        let mut prev = fade_rgb(base, 0.0);
+        for step in 1..=10 {
+            let factor = step as f32 / 10.0;
+            let now = fade_rgb(base, factor);
+            assert!(
+                now.0 <= prev.0 && now.1 <= prev.1 && now.2 <= prev.2,
+                "channels must not brighten as factor increases ({prev:?} -> {now:?} at factor={factor})",
+            );
+            prev = now;
+        }
+    }
+
+    #[test]
+    fn fade_rgb_clamps_out_of_range_factors() {
+        // Defensive: callers might hand in factors slightly outside [0,1]
+        // through floating-point drift. We should clamp, not blow past the
+        // floor (which would let colors disappear) or back past the base.
+        let base = (200, 100, 50);
+        let below = fade_rgb(base, -0.5);
+        let above = fade_rgb(base, 1.5);
+        assert_eq!(below, base, "negative factor should clamp to base");
+        let floored = fade_rgb(base, 1.0);
+        assert_eq!(above, floored, "factor > 1 should clamp to the floor color");
     }
 }

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -55,16 +55,46 @@ pub const FADE_FLOOR: f32 = 0.30;
 /// per-minute change is visible inside Fresh and Recent (the buckets a user
 /// is most likely to be staring at while working), while the long tail
 /// across Aging still fades visibly over tens of minutes.
-pub fn age_fade_factor(_age: Duration) -> f32 {
-    0.0
+pub fn age_fade_factor(age: Duration) -> f32 {
+    // Bucket boundaries in seconds — match `age_dim_level` exactly so the
+    // gradient lines up with the existing Fresh/Recent/Aging/Stale model.
+    const FRESH_END: f32 = (60 * 5) as f32;
+    const RECENT_END: f32 = (60 * 60) as f32;
+    const AGING_END: f32 = (60 * 60 * 24) as f32;
+    // Factor checkpoints at each boundary. Front-loaded so Fresh and Recent
+    // get a perceptible per-minute step before the long Aging tail.
+    const F_FRESH: f32 = 0.00;
+    const F_RECENT: f32 = 0.15;
+    const F_AGING: f32 = 0.50;
+    const F_STALE: f32 = 1.00;
+
+    let secs = age.as_secs_f32();
+    if secs <= 0.0 {
+        F_FRESH
+    } else if secs < FRESH_END {
+        lerp(F_FRESH, F_RECENT, secs / FRESH_END)
+    } else if secs < RECENT_END {
+        lerp(F_RECENT, F_AGING, (secs - FRESH_END) / (RECENT_END - FRESH_END))
+    } else if secs < AGING_END {
+        lerp(F_AGING, F_STALE, (secs - RECENT_END) / (AGING_END - RECENT_END))
+    } else {
+        F_STALE
+    }
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
 }
 
 /// Linearly interpolate `base` toward a dark floor by `factor` in `[0,1]`.
 ///
 /// `factor = 0` returns `base` unchanged; `factor = 1` returns
 /// `base * FADE_FLOOR` (rounded). Out-of-range factors are clamped.
-pub fn fade_rgb(base: (u8, u8, u8), _factor: f32) -> (u8, u8, u8) {
-    base
+pub fn fade_rgb(base: (u8, u8, u8), factor: f32) -> (u8, u8, u8) {
+    let f = factor.clamp(0.0, 1.0);
+    let scale = 1.0 - f * (1.0 - FADE_FLOOR);
+    let scl = |c: u8| (f32::from(c) * scale).round().clamp(0.0, 255.0) as u8;
+    (scl(base.0), scl(base.1), scl(base.2))
 }
 
 #[cfg(test)]

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -93,6 +93,13 @@ fn lerp(a: f32, b: f32, t: f32) -> f32 {
 pub fn fade_rgb(base: (u8, u8, u8), factor: f32) -> (u8, u8, u8) {
     let f = factor.clamp(0.0, 1.0);
     let scale = 1.0 - f * (1.0 - FADE_FLOOR);
+    // The cast is bounded: `scale` is in [FADE_FLOOR, 1.0] and `c` is u8, so
+    // the product is in [0, 255]; the explicit clamp is belt-and-braces.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "value is clamped to [0.0, 255.0] before the cast"
+    )]
     let scl = |c: u8| (f32::from(c) * scale).round().clamp(0.0, 255.0) as u8;
     (scl(base.0), scl(base.1), scl(base.2))
 }
@@ -236,6 +243,11 @@ mod tests {
         // factor=1 should scale every channel to FADE_FLOOR * base, rounded.
         let base: (u8, u8, u8) = (200, 100, 50);
         let (r, g, b) = fade_rgb(base, 1.0);
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "c is u8 and FADE_FLOOR is in (0, 1), so the product is in [0, 255]"
+        )]
         let expect = |c: u8| (f32::from(c) * FADE_FLOOR).round() as u8;
         assert_eq!(
             (r, g, b),

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -113,8 +113,10 @@ fn should_force_colors(
 /// var, is treated as "no truecolor" and the renderer falls back to the
 /// eight-color path. Comparison is case-insensitive.
 fn truecolor_supported(colorterm_env: Option<&str>) -> bool {
-    let _ = colorterm_env;
-    false
+    matches!(
+        colorterm_env.map(str::to_ascii_lowercase).as_deref(),
+        Some("truecolor" | "24bit")
+    )
 }
 
 fn main() -> Result<()> {
@@ -125,6 +127,12 @@ fn main() -> Result<()> {
         .ok()
         .and_then(|s| s.parse().ok());
     let no_color_env = std::env::var_os("NO_COLOR").is_some();
+    let colorterm_env = std::env::var("COLORTERM").ok();
+    // If the user asked for `--no-color` we disable the gradient too — a
+    // 24-bit gradient would re-enable colours the user just opted out of.
+    let truecolor = !cli.no_color
+        && !no_color_env
+        && truecolor_supported(colorterm_env.as_deref());
 
     if cli.no_color {
         colored::control::set_override(false);
@@ -228,7 +236,7 @@ fn main() -> Result<()> {
         bar_width: cli.bar_width,
         max_files: file_cap_opt,
         log_lines: log_cap,
-        truecolor: false,
+        truecolor,
     };
 
     println!("{}", render(&snapshot, &opts));

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -119,6 +119,25 @@ fn truecolor_supported(colorterm_env: Option<&str>) -> bool {
     )
 }
 
+/// Resolve the effective truecolor setting from CLI flags, env, and detection.
+///
+/// Priority, highest first:
+///   1. `--no-color` or `NO_COLOR` → false (kills all color)
+///   2. `--no-truecolor` → false (force the 8-color path)
+///   3. `--truecolor` → true (force the gradient regardless of detection)
+///   4. otherwise, auto-detect via `COLORTERM`
+fn effective_truecolor(
+    cli_no_color: bool,
+    cli_force_truecolor: bool,
+    cli_force_no_truecolor: bool,
+    no_color_env: bool,
+    colorterm_env: Option<&str>,
+) -> bool {
+    // Stub: ignore the CLI overrides so the new tests can fail on behavior.
+    let _ = (cli_force_truecolor, cli_force_no_truecolor);
+    !cli_no_color && !no_color_env && truecolor_supported(colorterm_env)
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -539,5 +558,47 @@ mod tests {
         assert!(!truecolor_supported(Some("1")));
         assert!(!truecolor_supported(Some("xterm-256color")));
         assert!(!truecolor_supported(Some("")));
+    }
+
+    // --- --truecolor / --no-truecolor override --------------------------
+
+    #[test]
+    fn truecolor_flag_forces_on_when_env_unset() {
+        // The escape hatch: some terminals support 24-bit color but don't
+        // export COLORTERM (or strip it through wrappers like cargo run /
+        // viddy). `--truecolor` lets the user assert capability directly.
+        assert!(effective_truecolor(false, true, false, false, None));
+    }
+
+    #[test]
+    fn truecolor_flag_forces_on_when_env_unrecognized() {
+        // Same escape hatch when COLORTERM is set to something we don't
+        // know how to interpret.
+        assert!(effective_truecolor(false, true, false, false, Some("1")));
+    }
+
+    #[test]
+    fn no_truecolor_flag_forces_off_even_with_colorterm() {
+        // Symmetric escape hatch: users on truecolor terminals can opt
+        // back to the legacy 8-color path (e.g. screen-recording, or just
+        // preferring the look).
+        assert!(!effective_truecolor(false, false, true, false, Some("truecolor")));
+    }
+
+    #[test]
+    fn no_color_beats_truecolor_flag() {
+        // `--no-color` / `$NO_COLOR` mean "no colors at all" — overriding
+        // them with `--truecolor` would re-enable the very thing the user
+        // opted out of. Honor the opt-out.
+        assert!(!effective_truecolor(true, true, false, false, Some("truecolor")));
+        assert!(!effective_truecolor(false, true, false, true, Some("truecolor")));
+    }
+
+    #[test]
+    fn truecolor_auto_uses_colorterm_when_no_flags() {
+        // No CLI overrides → fall back to the existing COLORTERM detection.
+        assert!(effective_truecolor(false, false, false, false, Some("truecolor")));
+        assert!(!effective_truecolor(false, false, false, false, None));
+        assert!(!effective_truecolor(false, false, false, false, Some("xterm-256color")));
     }
 }

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -106,6 +106,17 @@ fn should_force_colors(
     !stdout_is_tty && columns_env_present && !no_color_env
 }
 
+/// Does the active terminal advertise 24-bit color support?
+///
+/// We trust the `COLORTERM` env var (the de facto signal) — the canonical
+/// values are `truecolor` and `24bit`. Anything else, including a missing
+/// var, is treated as "no truecolor" and the renderer falls back to the
+/// eight-color path. Comparison is case-insensitive.
+fn truecolor_supported(colorterm_env: Option<&str>) -> bool {
+    let _ = colorterm_env;
+    false
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -483,5 +494,42 @@ mod tests {
     #[test]
     fn parse_log_line_drops_empty_lines() {
         assert!(parse_log_line("", SystemTime::now()).is_none());
+    }
+
+    #[test]
+    fn truecolor_supported_when_colorterm_is_truecolor() {
+        assert!(truecolor_supported(Some("truecolor")));
+    }
+
+    #[test]
+    fn truecolor_supported_when_colorterm_is_24bit() {
+        assert!(truecolor_supported(Some("24bit")));
+    }
+
+    #[test]
+    fn truecolor_supported_is_case_insensitive() {
+        // Some terminals export uppercase or mixed-case values. Treat them
+        // as equivalent so we don't accidentally fall back on, say, gnome's
+        // "Truecolor".
+        assert!(truecolor_supported(Some("TrueColor")));
+        assert!(truecolor_supported(Some("TRUECOLOR")));
+        assert!(truecolor_supported(Some("24BIT")));
+    }
+
+    #[test]
+    fn truecolor_not_supported_when_colorterm_missing() {
+        // No COLORTERM at all — typical for old terminals or shells that
+        // strip it. Stay safe: assume 8-color until told otherwise.
+        assert!(!truecolor_supported(None));
+    }
+
+    #[test]
+    fn truecolor_not_supported_for_unknown_colorterm_value() {
+        // COLORTERM is set but to something we don't recognize (some
+        // terminals export "1" or vendor-specific strings). Don't guess —
+        // fall back to the 8-color path.
+        assert!(!truecolor_supported(Some("1")));
+        assert!(!truecolor_supported(Some("xterm-256color")));
+        assert!(!truecolor_supported(Some("")));
     }
 }

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -60,6 +60,17 @@ struct Cli {
     /// Disable the recent-commit section entirely.
     #[arg(long)]
     no_log: bool,
+
+    /// Force the 24-bit truecolor commit-log gradient on, regardless of
+    /// what `COLORTERM` says. Useful when a wrapper (cargo run, viddy)
+    /// strips the env var or your terminal doesn't export it.
+    #[arg(long, conflicts_with = "no_truecolor")]
+    truecolor: bool,
+
+    /// Force the 24-bit truecolor commit-log gradient off, falling back
+    /// to the 8-color path even on a terminal that supports truecolor.
+    #[arg(long, conflicts_with = "truecolor")]
+    no_truecolor: bool,
 }
 
 /// Decide the effective terminal width gsw should render for.
@@ -133,9 +144,13 @@ fn effective_truecolor(
     no_color_env: bool,
     colorterm_env: Option<&str>,
 ) -> bool {
-    // Stub: ignore the CLI overrides so the new tests can fail on behavior.
-    let _ = (cli_force_truecolor, cli_force_no_truecolor);
-    !cli_no_color && !no_color_env && truecolor_supported(colorterm_env)
+    if cli_no_color || no_color_env || cli_force_no_truecolor {
+        false
+    } else if cli_force_truecolor {
+        true
+    } else {
+        truecolor_supported(colorterm_env)
+    }
 }
 
 fn main() -> Result<()> {
@@ -147,11 +162,13 @@ fn main() -> Result<()> {
         .and_then(|s| s.parse().ok());
     let no_color_env = std::env::var_os("NO_COLOR").is_some();
     let colorterm_env = std::env::var("COLORTERM").ok();
-    // If the user asked for `--no-color` we disable the gradient too — a
-    // 24-bit gradient would re-enable colours the user just opted out of.
-    let truecolor = !cli.no_color
-        && !no_color_env
-        && truecolor_supported(colorterm_env.as_deref());
+    let truecolor = effective_truecolor(
+        cli.no_color,
+        cli.truecolor,
+        cli.no_truecolor,
+        no_color_env,
+        colorterm_env.as_deref(),
+    );
 
     if cli.no_color {
         colored::control::set_override(false);

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -217,6 +217,7 @@ fn main() -> Result<()> {
         bar_width: cli.bar_width,
         max_files: file_cap_opt,
         log_lines: log_cap,
+        truecolor: false,
     };
 
     println!("{}", render(&snapshot, &opts));

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use colored::{ColoredString, Colorize};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::age::{age_dim_level, format_age_detailed, AgeDim};
+use crate::age::{age_dim_level, age_fade_factor, fade_rgb, format_age_detailed, AgeDim};
 use crate::bar::render_bar;
 use crate::git::FileStatus;
 
@@ -128,7 +128,7 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
             lines.push(render_separator(header_width));
         }
         for entry in snapshot.log.iter().take(opts.log_lines) {
-            lines.push(render_log_row(entry, opts.terminal_width));
+            lines.push(render_log_row(entry, opts.terminal_width, opts.truecolor));
         }
     }
 
@@ -138,7 +138,7 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
 /// Visible gap between the short hash and the subject in a log row.
 const LOG_HASH_SUBJECT_SEP: &str = "  ";
 
-fn render_log_row(entry: &LogEntry, width: usize) -> String {
+fn render_log_row(entry: &LogEntry, width: usize, truecolor: bool) -> String {
     // Layout: `{hash}  {subject…}   {age}` — the rightmost AGE_FIELD cells
     // hold the right-aligned age, matching the file-row age column exactly.
     // The subject is padded to fill the gap so the age column lines up.
@@ -154,10 +154,11 @@ fn render_log_row(entry: &LogEntry, width: usize) -> String {
 
     let age_raw = format_age_detailed(entry.age);
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
-    let age_str = colorize_age(&age_field, Some(entry.age));
 
-    let hash_str = entry.hash.yellow().to_string();
-    format!("{hash_str}{LOG_HASH_SUBJECT_SEP}{subject_padded}{sep_to_age}{age_str}")
+    let hash_str = colorize_log_hash(&entry.hash, entry.age, truecolor);
+    let subject_str = colorize_log_subject(&subject_padded, entry.age, truecolor);
+    let age_str = colorize_log_age(&age_field, entry.age, truecolor);
+    format!("{hash_str}{LOG_HASH_SUBJECT_SEP}{subject_str}{sep_to_age}{age_str}")
 }
 
 /// Total width of everything to the right of the path column: the bar plus
@@ -368,18 +369,41 @@ const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
 /// With `truecolor`, the hash starts at [`LOG_HASH_BASE_RGB`] and fades
 /// toward the dark floor as `age` grows. Without, falls back to the
 /// legacy ANSI yellow so eight-color terminals still get a coloured hash.
-fn colorize_log_hash(hash: &str, _age: Duration, _truecolor: bool) -> ColoredString {
-    hash.yellow()
+fn colorize_log_hash(hash: &str, age: Duration, truecolor: bool) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(LOG_HASH_BASE_RGB, age_fade_factor(age));
+        hash.truecolor(r, g, b)
+    } else {
+        hash.yellow()
+    }
 }
 
 /// Color the subject line for a commit-log row.
-fn colorize_log_subject(subject: &str, _age: Duration, _truecolor: bool) -> ColoredString {
-    subject.normal()
+///
+/// With `truecolor`, the subject fades from a near-white base toward the
+/// dark floor. Without, falls back to the same Aging/Stale dim styling as
+/// the file-row age column, so the row still gets quieter as it ages.
+fn colorize_log_subject(subject: &str, age: Duration, truecolor: bool) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(LOG_SUBJECT_BASE_RGB, age_fade_factor(age));
+        subject.truecolor(r, g, b)
+    } else {
+        match age_dim_level(age) {
+            AgeDim::Fresh | AgeDim::Recent => subject.normal(),
+            AgeDim::Aging => subject.dimmed(),
+            AgeDim::Stale => subject.dimmed().italic(),
+        }
+    }
 }
 
 /// Color the right-aligned age column for a commit-log row.
-fn colorize_log_age(text: &str, age: Duration, _truecolor: bool) -> ColoredString {
-    colorize_age(text, Some(age))
+fn colorize_log_age(text: &str, age: Duration, truecolor: bool) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(LOG_AGE_BASE_RGB, age_fade_factor(age));
+        text.truecolor(r, g, b)
+    } else {
+        colorize_age(text, Some(age))
+    }
 }
 
 /// Pad `s` on the right with spaces until its display width reaches `width`.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1401,4 +1401,21 @@ mod tests {
         };
         assert!(hr < fr, "hour-old age column should be darker than fresh: {fr} -> {hr}");
     }
+
+    #[test]
+    fn fallback_stale_subject_is_not_italic() {
+        // User feedback: italics on old subjects looks weird and out of
+        // place. The fallback path should still dim stale subjects (so
+        // age is conveyed at all) but without leaning the text.
+        use colored::Styles;
+        let stale = colorize_log_subject(
+            "an old subject",
+            Duration::from_secs(60 * 60 * 24 * 7),
+            false,
+        );
+        assert!(
+            !stale.style.contains(Styles::Italic),
+            "stale subjects should be dimmed but not italicized in fallback mode",
+        );
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -364,6 +364,16 @@ const LOG_SUBJECT_BASE_RGB: (u8, u8, u8) = (220, 220, 220);
 /// Base RGB for the commit-log age column.
 const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
 
+/// Apply the age-driven truecolor fade to `s`, starting from `base`.
+///
+/// Shared by every truecolor commit-log colorizer so the fade math lives
+/// in exactly one place — keeps the per-column functions to a single
+/// readable `if truecolor { fade } else { fallback }` shape.
+fn fade_truecolor(s: &str, age: Duration, base: (u8, u8, u8)) -> ColoredString {
+    let (r, g, b) = fade_rgb(base, age_fade_factor(age));
+    s.truecolor(r, g, b)
+}
+
 /// Color the short hash for a commit-log row.
 ///
 /// With `truecolor`, the hash starts at [`LOG_HASH_BASE_RGB`] and fades
@@ -371,8 +381,7 @@ const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
 /// legacy ANSI yellow so eight-color terminals still get a coloured hash.
 fn colorize_log_hash(hash: &str, age: Duration, truecolor: bool) -> ColoredString {
     if truecolor {
-        let (r, g, b) = fade_rgb(LOG_HASH_BASE_RGB, age_fade_factor(age));
-        hash.truecolor(r, g, b)
+        fade_truecolor(hash, age, LOG_HASH_BASE_RGB)
     } else {
         hash.yellow()
     }
@@ -385,8 +394,7 @@ fn colorize_log_hash(hash: &str, age: Duration, truecolor: bool) -> ColoredStrin
 /// the file-row age column, so the row still gets quieter as it ages.
 fn colorize_log_subject(subject: &str, age: Duration, truecolor: bool) -> ColoredString {
     if truecolor {
-        let (r, g, b) = fade_rgb(LOG_SUBJECT_BASE_RGB, age_fade_factor(age));
-        subject.truecolor(r, g, b)
+        fade_truecolor(subject, age, LOG_SUBJECT_BASE_RGB)
     } else {
         match age_dim_level(age) {
             AgeDim::Fresh | AgeDim::Recent => subject.normal(),
@@ -398,8 +406,7 @@ fn colorize_log_subject(subject: &str, age: Duration, truecolor: bool) -> Colore
 /// Color the right-aligned age column for a commit-log row.
 fn colorize_log_age(text: &str, age: Duration, truecolor: bool) -> ColoredString {
     if truecolor {
-        let (r, g, b) = fade_rgb(LOG_AGE_BASE_RGB, age_fade_factor(age));
-        text.truecolor(r, g, b)
+        fade_truecolor(text, age, LOG_AGE_BASE_RGB)
     } else {
         colorize_age(text, Some(age))
     }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1340,23 +1340,29 @@ mod tests {
         let Some(Color::TrueColor { r, g, b }) = cs.fgcolor else {
             panic!("expected TrueColor under truecolor=true");
         };
-        // LOG_HASH_BASE_RGB is (255, 215, 0). With FADE_FLOOR=0.30 the
-        // minimum red is ~76, green ~64, blue 0.
+        // Derive the per-channel floor from the live base RGB so this
+        // test asserts the invariant ("no channel drops below its
+        // FADE_FLOOR fraction") rather than hardcoding numbers tied to
+        // today's choice of LOG_HASH_BASE_RGB. If the base later gains
+        // a non-zero blue, the test still checks the right bound.
         #[allow(
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss,
-            reason = "255 * 0.30 ≈ 76, well within u8 range"
+            reason = "u8 × FADE_FLOOR ∈ [0, 1] stays in [0, 255]"
         )]
-        let min_red = (255.0 * FADE_FLOOR).round() as u8;
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "215 * 0.30 ≈ 64, well within u8 range"
-        )]
-        let min_green = (215.0 * FADE_FLOOR).round() as u8;
+        let floor_of = |c: u8| (f32::from(c) * FADE_FLOOR).round() as u8;
+        let (base_r, base_g, base_b) = LOG_HASH_BASE_RGB;
+        let min_r = floor_of(base_r);
+        let min_g = floor_of(base_g);
+        let min_b = floor_of(base_b);
+        // .saturating_sub(1) absorbs one RGB-unit of rounding drift at
+        // the fade-curve boundary; the test still fails if any channel
+        // drops meaningfully below its computed floor.
         assert!(
-            r >= min_red.saturating_sub(1) && g >= min_green.saturating_sub(1) && b == 0,
-            "channels must not drop below the floor: ({r},{g},{b}) min=({min_red},{min_green},0)",
+            r >= min_r.saturating_sub(1)
+                && g >= min_g.saturating_sub(1)
+                && b >= min_b.saturating_sub(1),
+            "channels must not drop below the floor: actual=({r},{g},{b}) min=({min_r},{min_g},{min_b}) base=({base_r},{base_g},{base_b})",
         );
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -390,8 +390,7 @@ fn colorize_log_subject(subject: &str, age: Duration, truecolor: bool) -> Colore
     } else {
         match age_dim_level(age) {
             AgeDim::Fresh | AgeDim::Recent => subject.normal(),
-            AgeDim::Aging => subject.dimmed(),
-            AgeDim::Stale => subject.dimmed().italic(),
+            AgeDim::Aging | AgeDim::Stale => subject.dimmed(),
         }
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -68,6 +68,10 @@ pub struct RenderOptions {
     pub max_files: Option<usize>,
     /// Maximum recent-commit rows to render. 0 disables the log section.
     pub log_lines: usize,
+    /// When true, the commit-log rows fade from a bright base color toward
+    /// a dark floor as commits age, using 24-bit (truecolor) ANSI. When
+    /// false, log rows use the same 8-color/dim styling as everything else.
+    pub truecolor: bool,
 }
 
 /// Width of the "+adds" / "-dels" / age column fields.
@@ -350,6 +354,34 @@ fn colorize_age(text: &str, age: Option<Duration>) -> ColoredString {
     }
 }
 
+/// Base RGB for commit-log hashes when truecolor fading is on. Picked to
+/// match the perceptual feel of the legacy `yellow()` ANSI hash without
+/// depending on a specific terminal palette.
+const LOG_HASH_BASE_RGB: (u8, u8, u8) = (255, 215, 0);
+/// Base RGB for commit-log subjects — a near-white that fades visibly.
+const LOG_SUBJECT_BASE_RGB: (u8, u8, u8) = (220, 220, 220);
+/// Base RGB for the commit-log age column.
+const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
+
+/// Color the short hash for a commit-log row.
+///
+/// With `truecolor`, the hash starts at [`LOG_HASH_BASE_RGB`] and fades
+/// toward the dark floor as `age` grows. Without, falls back to the
+/// legacy ANSI yellow so eight-color terminals still get a coloured hash.
+fn colorize_log_hash(hash: &str, _age: Duration, _truecolor: bool) -> ColoredString {
+    hash.yellow()
+}
+
+/// Color the subject line for a commit-log row.
+fn colorize_log_subject(subject: &str, _age: Duration, _truecolor: bool) -> ColoredString {
+    subject.normal()
+}
+
+/// Color the right-aligned age column for a commit-log row.
+fn colorize_log_age(text: &str, age: Duration, _truecolor: bool) -> ColoredString {
+    colorize_age(text, Some(age))
+}
+
 /// Pad `s` on the right with spaces until its display width reaches `width`.
 fn pad_right(s: &str, width: usize) -> String {
     let current = UnicodeWidthStr::width(s);
@@ -508,6 +540,7 @@ mod tests {
             bar_width: 6,
             max_files: None,
             log_lines: 0,
+            truecolor: false,
         }
     }
 
@@ -755,6 +788,7 @@ mod tests {
                 bar_width: 6,
                 max_files: None,
                 log_lines: 0,
+                truecolor: false,
             },
         ));
         let row = out.lines().nth(2).unwrap_or("");
@@ -776,6 +810,7 @@ mod tests {
                 bar_width: 6,
                 max_files: None,
                 log_lines: 0,
+                truecolor: false,
             },
         );
         let stripped = strip_ansi(&out);
@@ -795,6 +830,7 @@ mod tests {
                 bar_width: 6,
                 max_files: Some(3),
                 log_lines: 0,
+                truecolor: false,
             },
         ));
         assert!(out.contains("f0.rs"));
@@ -819,6 +855,7 @@ mod tests {
                 bar_width: 6,
                 max_files: Some(0),
                 log_lines: 0,
+                truecolor: false,
             },
         ));
         for i in 0..5 {
@@ -1206,5 +1243,128 @@ mod tests {
             preceding.chars().all(|c| c == '─' || c.is_whitespace()),
             "line before log section should be a ─ separator: {preceding:?}",
         );
+    }
+
+    // --- truecolor commit-log fade ---------------------------------------
+    //
+    // These tests inspect the `ColoredString::fgcolor` field directly rather
+    // than rendering to ANSI. The `colored` crate gates ANSI emission on a
+    // process-global override that races with parallel tests; reading the
+    // typed color avoids that entirely (same pattern as
+    // `stale_age_renders_differently_from_aging` above).
+
+    #[test]
+    fn log_hash_uses_truecolor_when_enabled() {
+        // With truecolor on, a fresh commit's hash must be coloured with a
+        // 24-bit RGB value (not the legacy `Color::Yellow`), so the gradient
+        // has somewhere to fade *from*.
+        use colored::Color;
+        let cs = colorize_log_hash("abc1234", Duration::from_secs(0), true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor when truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn log_hash_falls_back_to_yellow_without_truecolor() {
+        // Without truecolor, the legacy 8-colour yellow must still come
+        // through — otherwise we silently drop hash colouring on terminals
+        // that can't render 24-bit RGB.
+        use colored::Color;
+        let cs = colorize_log_hash("abc1234", Duration::from_secs(0), false);
+        assert_eq!(cs.fgcolor, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn log_hash_darkens_with_age_under_truecolor() {
+        // The core gradient property: an hour-old commit's hash must come
+        // out darker (lower channel values) than a fresh commit's hash on
+        // every channel.
+        use colored::Color;
+        let fresh = colorize_log_hash("abc1234", Duration::from_secs(0), true);
+        let hour = colorize_log_hash("abc1234", Duration::from_secs(60 * 60), true);
+        let (Some(Color::TrueColor { r: fr, g: fg, b: fb }), Some(Color::TrueColor { r: hr, g: hg, b: hb })) =
+            (fresh.fgcolor, hour.fgcolor)
+        else {
+            panic!("both should be TrueColor under truecolor=true");
+        };
+        assert!(
+            hr < fr && hg <= fg && hb <= fb,
+            "hour-old hash should be darker than fresh: fresh=({fr},{fg},{fb}) hour=({hr},{hg},{hb})",
+        );
+    }
+
+    #[test]
+    fn log_hash_stays_above_floor_when_very_old() {
+        // The fade must never reach pure black — a week-old commit should
+        // still be readable, which means every channel stays at or above
+        // the FADE_FLOOR fraction of its base value.
+        use crate::age::FADE_FLOOR;
+        use colored::Color;
+        let cs = colorize_log_hash(
+            "abc1234",
+            Duration::from_secs(60 * 60 * 24 * 7),
+            true,
+        );
+        let Some(Color::TrueColor { r, g, b }) = cs.fgcolor else {
+            panic!("expected TrueColor under truecolor=true");
+        };
+        // LOG_HASH_BASE_RGB is (255, 215, 0). With FADE_FLOOR=0.30 the
+        // minimum red is ~76, green ~64, blue 0.
+        let min_red = (255.0 * FADE_FLOOR).round() as u8;
+        let min_green = (215.0 * FADE_FLOOR).round() as u8;
+        assert!(
+            r >= min_red.saturating_sub(1) && g >= min_green.saturating_sub(1) && b == 0,
+            "channels must not drop below the floor: ({r},{g},{b}) min=({min_red},{min_green},0)",
+        );
+    }
+
+    #[test]
+    fn log_subject_uses_truecolor_when_enabled() {
+        // Subjects need to fade too, otherwise the hash darkens while the
+        // text next to it stays bright — visually inconsistent.
+        use colored::Color;
+        let cs = colorize_log_subject("a commit subject", Duration::from_secs(0), true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor for subject when truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn log_subject_darkens_with_age_under_truecolor() {
+        use colored::Color;
+        let fresh = colorize_log_subject("subj", Duration::from_secs(0), true);
+        let hour = colorize_log_subject("subj", Duration::from_secs(60 * 60), true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: hr, .. })) =
+            (fresh.fgcolor, hour.fgcolor)
+        else {
+            panic!("both should be TrueColor under truecolor=true");
+        };
+        assert!(hr < fr, "hour-old subject should be darker than fresh: {fr} -> {hr}");
+    }
+
+    #[test]
+    fn log_age_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let cs = colorize_log_age("5m23s", Duration::from_secs(5 * 60 + 23), true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor for age when truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn log_age_darkens_with_age_under_truecolor() {
+        use colored::Color;
+        let fresh = colorize_log_age("0s", Duration::from_secs(0), true);
+        let hour = colorize_log_age("1h0m", Duration::from_secs(60 * 60), true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: hr, .. })) =
+            (fresh.fgcolor, hour.fgcolor)
+        else {
+            panic!("both should be TrueColor under truecolor=true");
+        };
+        assert!(hr < fr, "hour-old age column should be darker than fresh: {fr} -> {hr}");
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1336,7 +1336,17 @@ mod tests {
         };
         // LOG_HASH_BASE_RGB is (255, 215, 0). With FADE_FLOOR=0.30 the
         // minimum red is ~76, green ~64, blue 0.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "255 * 0.30 ≈ 76, well within u8 range"
+        )]
         let min_red = (255.0 * FADE_FLOOR).round() as u8;
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "215 * 0.30 ≈ 64, well within u8 range"
+        )]
         let min_green = (215.0 * FADE_FLOOR).round() as u8;
         assert!(
             r >= min_red.saturating_sub(1) && g >= min_green.saturating_sub(1) && b == 0,


### PR DESCRIPTION
## Summary

- Adds a 24-bit truecolor gradient to gsw's commit-log section so each row fades from a bright base color toward a dark floor (30% brightness) as the commit ages. Hashes start at golden yellow (255,215,0), subjects at near-white, the age column at neutral grey.
- Piecewise-linear across the existing Fresh/Recent/Aging/Stale boundaries (0s / 5min / 1h / 24h → factor 0.00 / 0.15 / 0.50 / 1.00) so per-minute steps are visible while you're working and the gradient reaches its floor by 24h.
- Auto-detects `COLORTERM=truecolor` / `24bit`. Falls back to the legacy 8-color path (yellow hash, dimmed subjects for old commits) when truecolor isn't advertised. `--truecolor` / `--no-truecolor` override the detection; `--no-color` / `$NO_COLOR` still kill everything.
- Drops `.italic()` from the fallback stale-subject styling — flagged as visually weird during review.

## Test plan

- [ ] `cargo test -p gsw` — 135 tests, all passing
- [ ] `cargo clippy -p gsw --all-targets -- -D warnings` — clean
- [ ] `COLORTERM=truecolor gsw --log-lines 6` in a repo with commits at varied ages → hashes/subjects/age cells visibly darken row-by-row
- [ ] `env -u COLORTERM gsw --log-lines 6` → legacy yellow hashes, subjects dim only for Aging/Stale, no italic
- [ ] `gsw --no-color` → no ANSI escapes
- [ ] `gsw --truecolor` with COLORTERM unset → gradient still applies
- [ ] `gsw --no-truecolor` with COLORTERM=truecolor → 8-color fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)