### PR TITLE
gsw: darken commit-log fade much sooner — pretty dark by 1h

### DIFF
--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -61,11 +61,13 @@ pub fn age_fade_factor(age: Duration) -> f32 {
     const FRESH_END: f32 = (60 * 5) as f32;
     const RECENT_END: f32 = (60 * 60) as f32;
     const AGING_END: f32 = (60 * 60 * 24) as f32;
-    // Factor checkpoints at each boundary. Front-loaded so Fresh and Recent
-    // get a perceptible per-minute step before the long Aging tail.
+    // Factor checkpoints at each boundary. Front-loaded so most of the
+    // gradient from base toward FADE_FLOOR is spent by the 1h Aging boundary
+    // — hour-old commits should already read as dim, and the 1h–24h tail is
+    // just the final sliver of darkening rather than the bulk of it.
     const F_FRESH: f32 = 0.00;
-    const F_RECENT: f32 = 0.15;
-    const F_AGING: f32 = 0.50;
+    const F_RECENT: f32 = 0.20;
+    const F_AGING: f32 = 0.85;
     const F_STALE: f32 = 1.00;
 
     let secs = age.as_secs_f32();

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -169,6 +169,21 @@ mod tests {
     }
 
     #[test]
+    fn fade_factor_is_pretty_dark_by_one_hour() {
+        // Commits past the 1h boundary should already look pretty dark — most
+        // of the gradient from base toward FADE_FLOOR is spent by then, so the
+        // long Aging tail is just the last bit of darkening rather than the
+        // bulk of it. Concretely: at 1h the factor should be >= 0.80, putting
+        // brightness at <= ~44% of base for the default 30% floor.
+        let one_hour = Duration::from_secs(60 * 60);
+        let factor = age_fade_factor(one_hour);
+        assert!(
+            factor >= 0.80,
+            "factor at 1h should be >= 0.80 so hour-old commits read as dim, was {factor}",
+        );
+    }
+
+    #[test]
     fn fade_factor_reaches_one_at_stale_boundary() {
         // At and beyond the 24h stale boundary the gradient should hit its
         // floor — i.e. factor = 1.0 — so further aging doesn't keep darkening.


### PR DESCRIPTION
## Summary
- Reshape the commit-age fade curve in `src/gsw/src/age.rs` so hour-old commits already read as dim: bump `F_RECENT` from 0.15 → 0.20 and `F_AGING` from 0.50 → 0.85.
- Bucket boundaries (5m / 1h / 24h) and `FADE_FLOOR` (0.30) are unchanged — only the per-checkpoint factor values move — so `age_dim_level`'s Fresh/Recent/Aging/Stale labels still bend at the same ages.
- Net effect at the 1h boundary: fade factor goes from 0.50 (≈65% of base brightness) to 0.85 (≈40.5%). The 1h–24h tail is now the final sliver of darkening rather than the bulk of it.
- Per-minute step + monotonicity guards (`fade_factor_increases_with_age`, `fade_factor_visible_step_per_minute_in_fresh_and_recent`) still pass under the new checkpoints (Fresh ≈ 0.04/min, Recent ≈ 0.0118/min).

## Test plan
- [x] `cargo test -p gsw` — all 119 unit tests + 17 integration tests green
- [x] New red test `fade_factor_is_pretty_dark_by_one_hour` was committed failing first (factor was 0.50) and passes after the constant change
- [ ] Eyeball `gsw` in a repo with commits of varying age — confirm 1h-old commits visibly dim, 24h+ commits sit at the floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)