### PR TITLE
fix(ic): parse Dolby Vision and side-data streams robustly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 I started this repo forever ago (2014!) to hold some tools I needed at the time. Now I'm converting the tools to ~~Golang~~ Rust
 for fun.
 
+> **In a hurry?** See [TLDR.md](./TLDR.md) for a one-line description of every tool.
+
 ## Shared Libraries
 
 ### repowalker

--- a/TLDR.md
+++ b/TLDR.md
@@ -1,0 +1,68 @@
+# TL;DR
+
+A one-line description of every program documented in the [README](./README.md), alphabetized. See the README for full options, examples, and install commands.
+
+| Tool | What it does |
+| --- | --- |
+| `aa` | Quickly prints your AWS caller identity as JSON, no pager. |
+| `aws2env` | Converts AWS credentials/config into env-var exports (use with `eval $(aws2env)`). |
+| `beta` | Records and replays terminal sessions; exports to HTML players or MP4/GIF. |
+| `bm` | Bulk Move — recursively find and move files matching a pattern to a destination. |
+| `cdknuke` | Removes `cdk.out` directories from AWS CDK projects throughout a repo. |
+| `cf` | Count Files — recursively counts files, with optional suffix/prefix/substring filters. |
+| `claude-usage` | Parses an Anthropic API usage CSV and computes per-model costs. |
+| `clipboard-random` | Generates random binary or Zalgo text data and copies it to the clipboard. |
+| `cwt` | Change Worktree — navigate, cycle, or jump between git worktrees. |
+| `dirc` | Copies the current directory to the clipboard, or emits a `cd` from a clipboard path. |
+| `dirhash` | SHA256 hash of a directory tree's contents to compare directories for equality. |
+| `diskhog` | Live terminal UI of per-process disk I/O on macOS (IOPS with sudo). |
+| `freeport` | Finds a free TCP port on localhost, cross-platform. |
+| `gitdiggin` | Recursively searches git repos for commits containing a string (messages and diffs). |
+| `gitrdun` | Shows your recent git commits across multiple repositories. |
+| `glo` | Finds and displays large objects in git repositories. |
+| `goup` | Updates Go dependencies across all `go.mod` files in a repo. |
+| `gr8` | Displays GitHub API rate limit info, color-coded, via the GitHub CLI. |
+| `gsw` | Git Status Watch — compact one-shot status dashboard meant to be wrapped by `viddy`/`watch`. |
+| `hexfind` | Searches for a hex string in a binary file and shows a hex dump with offsets. |
+| `htmlboard` | Pretty-prints HTML on the clipboard and puts it back. |
+| `ic` | Fast terminal image/video display utility (an `imgcat` alternative; video needs ffmpeg). |
+| `idear` | IDEA Reaper — cleans up orphaned `.idea` directories left by JetBrains IDEs. |
+| `inscribe` | Generates git commit messages from staged changes using Claude AI. |
+| `jsonboard` | Pretty-prints JSON on the clipboard and puts it back. |
+| `kitchen-sync` | Installs every Rust binary from a git repo with one command. |
+| `localnext` | Serves statically exported Next.js apps locally. |
+| `ng` | Navel-Gaze — watches JS/TS files and re-runs `pnpm lint` (or `--typecheck`) on change. |
+| `nodenuke` | Removes `node_modules` directories and lock files throughout a repo. |
+| `nodeup` | Updates npm/pnpm/yarn packages across all `package.json` directories. |
+| `nwt` | New Worktree — creates a git worktree with a random Docker-style name. |
+| `op-cache` | 1Password credential cache wrapping `op read` to avoid repeated prompts/Touch ID. |
+| `org-borg` | Bulk clone, update, and archive GitHub organization repositories via the GitHub CLI. |
+| `pk` | Process Killer — kills processes (incl. ones `ps`/`pkill` can't see) with dry-run, regex, and signal options. |
+| `polish` | Updates Rust dependencies across all `Cargo.toml` files in a repo. |
+| `portplz` | Generates a consistent unprivileged port number from directory name and git branch. |
+| `prcp` | Copies files with a Unicode progress bar; wildcards, multi-file, and verified move mode. |
+| `prgz` | Like `prcp` but gzip-compresses the file, showing progress in the console. |
+| `prhash` | Hashes files (MD5/SHA1/SHA256/SHA512/Blake3) with a progress bar, shasum-compatible output. |
+| `procinfo` | Detailed info about running processes matching a name (cwd, open files, connections). |
+| `r2-bucket-cleaner` | Lists and optionally clears all objects from a Cloudflare R2 bucket via wrangler. |
+| `rcc` | Rust Cross Compiler — simplifies cross-compilation (target detection, `Cross.toml`, build). |
+| `reposize` | Calculates the total size of a git repository, human-readable. |
+| `repotidy` | Runs `go mod tidy` in all `go.mod` directories within a git repo. |
+| `rr` | Rust Remover — runs `cargo clean` across all Rust projects to free disk space. |
+| `runat` | TUI to run a command at a specified time with a live countdown. |
+| `safeboard` | Monitors the clipboard for dangerous/invisible Unicode used in copy-paste attacks. |
+| `sf` | Size of Files — total size of files in directories, with optional suffix/prefix/substring filters. |
+| `spv` | Smart Process Viewer — find and view processes by PID/name/regex, with optional cwd and open files. |
+| `subito` | Subscribes to AWS IoT Core topics and prints received messages. |
+| `swt` | Subagent Worktree — isolated-worktree helper for parallel TDD (create/merge with green checks). |
+| `symfix` | Recursively finds and optionally fixes broken symlinks. |
+| `tc` | Token Count — counts estimated LLM tokens in files (multiple OpenAI tokenizers, stdin support). |
+| `tsm` | Terminal Session Manager — records every shell command to JSONL logs you can search and replay. |
+| `tubeboard` | Extracts the video ID from a YouTube URL on the clipboard. |
+| `unescapeboard` | Unescapes one level of `\"`-style escaping in clipboard text. |
+| `update-aws-credentials` | Writes AWS SSO clipboard credentials into your AWS config file. |
+| `vpn-tunnel` | Generates Docker-based gluetun + ProtonVPN + WireGuard tunnels with helper scripts. |
+| `wifiqr` | Generates WiFi QR codes (with optional logo) for automatic device connection. |
+| `wl` | Shows which process is listening on a given port. |
+| `wolly` | Wake-on-LAN tool that sends magic packets with auto subnet broadcast detection. |
+| `wu` | Cross-platform "who's using" a file/directory/device (process name, PID, user, mode). |

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1109,7 +1109,10 @@ fn get_video_dimensions(file_path: &Path) -> Result<(u32, u32)> {
             "-show_entries",
             "stream=width,height",
             "-of",
-            "csv=p=0",
+            // One value per line. Unlike `csv=p=0`, this writer does not append
+            // an empty trailing field for a stream's side-data section (e.g. a
+            // Dolby Vision configuration record), so the output stays clean.
+            "default=noprint_wrappers=1:nokey=1",
             file_path.to_str().unwrap(),
         ])
         .output()
@@ -1127,17 +1130,30 @@ fn get_video_dimensions(file_path: &Path) -> Result<(u32, u32)> {
 }
 
 /// Parse video width and height out of ffprobe's `stream=width,height` output.
+///
+/// ffprobe can emit more than the two values we ask for. When a stream carries
+/// side data — for example a Dolby Vision configuration record on a 4K HDR HEVC
+/// stream — its CSV writer appends an empty trailing field, yielding output like
+/// `"3840,2160,"`. Rather than assume an exact `W,H` layout, we take the first
+/// two integer tokens, tolerating commas, whitespace, and newlines so the parse
+/// stays correct across ffprobe output formats.
 fn parse_video_dimensions(output: &str) -> Result<(u32, u32)> {
-    let dimensions_str = output.trim();
+    let mut tokens = output
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|token| !token.is_empty());
 
-    // Parse "width,height" format using char-based splitting for UTF-8 safety
-    if let Some((width_str, height_str)) = dimensions_str.split_once(',') {
-        let width: u32 = width_str.parse().context("Failed to parse video width")?;
-        let height: u32 = height_str.parse().context("Failed to parse video height")?;
-        Ok((width, height))
-    } else {
-        anyhow::bail!("Invalid dimensions format from ffprobe: {}", dimensions_str);
-    }
+    let width: u32 = tokens
+        .next()
+        .context("ffprobe returned no video width")?
+        .parse()
+        .context("Failed to parse video width")?;
+    let height: u32 = tokens
+        .next()
+        .context("ffprobe returned no video height")?
+        .parse()
+        .context("Failed to parse video height")?;
+
+    Ok((width, height))
 }
 
 fn get_video_fps(file_path: &Path) -> Result<f64> {

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1165,7 +1165,12 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
         return Ok(DEFAULT_FPS);
     }
 
-    // Use ffprobe to get video frame rate
+    // Use ffprobe to get both frame-rate fields. avg_frame_rate is the true
+    // average rate (total frames / duration) and is what playback timing must
+    // use; r_frame_rate is only the timebase tick and, for variable-frame-rate
+    // recordings, can be a large multiple of the real rate. We keep the keys
+    // (no `nokey=1`) because ffprobe emits these fields in its own internal
+    // order regardless of the requested order, so position alone is ambiguous.
     let output = std::process::Command::new("ffprobe")
         .args([
             "-v",
@@ -1173,11 +1178,9 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
             "-select_streams",
             "v:0",
             "-show_entries",
-            "stream=r_frame_rate",
+            "stream=avg_frame_rate,r_frame_rate",
             "-of",
-            // Avoids the empty trailing field that `csv=p=0` appends for a
-            // stream's side-data section (e.g. a Dolby Vision config record).
-            "default=noprint_wrappers=1:nokey=1",
+            "default=noprint_wrappers=1",
             file_path.to_str().unwrap(),
         ])
         .output()
@@ -1191,33 +1194,57 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
     Ok(parse_video_fps(&fps_str))
 }
 
-/// Parse a frame rate from ffprobe's `stream=r_frame_rate` output.
+/// Choose a playback frame rate from ffprobe's `stream=avg_frame_rate,r_frame_rate`
+/// output (keyed `default` format, one `key=value` per line).
 ///
-/// ffprobe reports frame rates as a fraction such as `"24000/1001"`. As with the
-/// dimension probe, a stream's side data (e.g. a Dolby Vision configuration
-/// record) makes the CSV writer append an empty trailing field — `"24000/1001,"`
-/// — so we take the first whitespace/comma-delimited token before splitting the
-/// fraction. A `"0/0"` rate (unknown frame rate) or any unparseable value falls
-/// back to [`DEFAULT_FPS`] rather than producing NaN.
+/// `avg_frame_rate` (total frames ÷ duration) is the true playback rate and is
+/// preferred. For variable-frame-rate recordings — screen captures, for example —
+/// `r_frame_rate` is only the timebase tick and can be a large multiple of the
+/// real rate, which would make playback run too fast. We fall back to
+/// `r_frame_rate` only when `avg_frame_rate` is unknown (ffprobe reports `"0/0"`),
+/// and to [`DEFAULT_FPS`] when neither field is usable.
 fn parse_video_fps(output: &str) -> f64 {
-    let Some(token) = output
+    let mut avg = None;
+    let mut r = None;
+
+    for line in output.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "avg_frame_rate" => avg = parse_fps_fraction(value),
+            "r_frame_rate" => r = parse_fps_fraction(value),
+            _ => {}
+        }
+    }
+
+    avg.or(r).unwrap_or(DEFAULT_FPS)
+}
+
+/// Parse a single frame-rate field such as `"24000/1001"` into frames per second.
+///
+/// ffprobe reports rates as a `numerator/denominator` fraction. A stream's side
+/// data (e.g. a Dolby Vision configuration record) can make some output formats
+/// append an empty trailing field — `"24000/1001,"` — so we take the first
+/// whitespace/comma-delimited token before splitting the fraction. Returns
+/// [`None`] for an unknown rate (`"0/0"`), an empty field, or any value that does
+/// not parse to a finite, positive rate, so the caller can fall back rather than
+/// using NaN or a nonsensical rate.
+fn parse_fps_fraction(value: &str) -> Option<f64> {
+    let token = value
         .split(|c: char| c == ',' || c.is_whitespace())
-        .find(|token| !token.is_empty())
-    else {
-        return DEFAULT_FPS;
-    };
+        .find(|token| !token.is_empty())?;
 
     // Parse fraction like "24/1" or "30000/1001"; the token is ASCII in practice.
-    if let Some((num_str, denom_str)) = token.split_once('/') {
-        let numerator: f64 = num_str.parse().unwrap_or(DEFAULT_FPS);
-        let denominator: f64 = denom_str.parse().unwrap_or(1.0);
-        if denominator == 0.0 {
-            return DEFAULT_FPS;
-        }
+    let fps = if let Some((num_str, denom_str)) = token.split_once('/') {
+        let numerator: f64 = num_str.parse().ok()?;
+        let denominator: f64 = denom_str.parse().ok()?;
         numerator / denominator
     } else {
-        token.parse().unwrap_or(DEFAULT_FPS)
-    }
+        token.parse().ok()?
+    };
+
+    (fps.is_finite() && fps > 0.0).then_some(fps)
 }
 
 fn get_video_duration(file_path: &Path) -> Result<f64> {
@@ -2879,39 +2906,56 @@ not_a_number  1 /bin/bash
     }
 
     // =========================================================================
-    // Tests for parse_video_fps
+    // Tests for parse_fps_fraction (single frame-rate field)
     // =========================================================================
 
     #[test]
-    fn parse_fps_ntsc_fraction() {
-        assert!((parse_video_fps("30000/1001") - 29.970_029_97).abs() < 1e-6);
+    fn parse_fps_fraction_ntsc() {
+        assert!((parse_fps_fraction("30000/1001").unwrap() - 29.970_029_97).abs() < 1e-6);
     }
 
     #[test]
-    fn parse_fps_integer_fraction() {
-        assert_eq!(parse_video_fps("25/1\n"), 25.0);
+    fn parse_fps_fraction_integer() {
+        assert_eq!(parse_fps_fraction("25/1\n"), Some(25.0));
     }
 
     #[test]
-    fn parse_fps_handles_dolby_vision_trailing_comma() {
+    fn parse_fps_fraction_handles_dolby_vision_trailing_comma() {
         // Same DoVi side-data trailing comma as the dimension probe:
         // "24000/1001,". Splitting the fraction left the denominator as
         // "1001,", which silently fell back to 1.0 — yielding 24000 fps
         // instead of 23.976.
-        let fps = parse_video_fps("24000/1001,\n");
+        let fps = parse_fps_fraction("24000/1001,\n").unwrap();
         assert!((fps - 23.976_023_976).abs() < 1e-6, "got {fps}");
     }
 
     #[test]
-    fn parse_fps_handles_zero_denominator() {
+    fn parse_fps_fraction_zero_denominator_is_none() {
         // ffprobe reports "0/0" for streams with an unknown frame rate; a naive
-        // divide produces NaN, so we must fall back to the default instead.
-        assert_eq!(parse_video_fps("0/0"), DEFAULT_FPS);
+        // divide produces NaN, so this must be None and let the caller fall back.
+        assert_eq!(parse_fps_fraction("0/0"), None);
     }
+
+    #[test]
+    fn parse_fps_fraction_empty_is_none() {
+        assert_eq!(parse_fps_fraction(""), None);
+    }
+
+    // =========================================================================
+    // Tests for parse_video_fps (avg/r selection)
+    // =========================================================================
 
     #[test]
     fn parse_fps_empty_falls_back_to_default() {
         assert_eq!(parse_video_fps(""), DEFAULT_FPS);
+    }
+
+    #[test]
+    fn parse_fps_both_unknown_falls_back_to_default() {
+        assert_eq!(
+            parse_video_fps("r_frame_rate=0/0\navg_frame_rate=0/0\n"),
+            DEFAULT_FPS
+        );
     }
 
     #[test]

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1175,7 +1175,9 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
             "-show_entries",
             "stream=r_frame_rate",
             "-of",
-            "csv=p=0",
+            // Avoids the empty trailing field that `csv=p=0` appends for a
+            // stream's side-data section (e.g. a Dolby Vision config record).
+            "default=noprint_wrappers=1:nokey=1",
             file_path.to_str().unwrap(),
         ])
         .output()
@@ -1190,17 +1192,31 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
 }
 
 /// Parse a frame rate from ffprobe's `stream=r_frame_rate` output.
+///
+/// ffprobe reports frame rates as a fraction such as `"24000/1001"`. As with the
+/// dimension probe, a stream's side data (e.g. a Dolby Vision configuration
+/// record) makes the CSV writer append an empty trailing field — `"24000/1001,"`
+/// — so we take the first whitespace/comma-delimited token before splitting the
+/// fraction. A `"0/0"` rate (unknown frame rate) or any unparseable value falls
+/// back to [`DEFAULT_FPS`] rather than producing NaN.
 fn parse_video_fps(output: &str) -> f64 {
-    let fps_str = output.trim();
+    let Some(token) = output
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .find(|token| !token.is_empty())
+    else {
+        return DEFAULT_FPS;
+    };
 
-    // Parse fraction like "24/1" or "30000/1001" using char-based splitting
-    // for UTF-8 safety (in practice ffprobe output is ASCII).
-    if let Some((num_str, denom_str)) = fps_str.split_once('/') {
+    // Parse fraction like "24/1" or "30000/1001"; the token is ASCII in practice.
+    if let Some((num_str, denom_str)) = token.split_once('/') {
         let numerator: f64 = num_str.parse().unwrap_or(DEFAULT_FPS);
         let denominator: f64 = denom_str.parse().unwrap_or(1.0);
+        if denominator == 0.0 {
+            return DEFAULT_FPS;
+        }
         numerator / denominator
     } else {
-        fps_str.parse().unwrap_or(DEFAULT_FPS)
+        token.parse().unwrap_or(DEFAULT_FPS)
     }
 }
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1122,7 +1122,13 @@ fn get_video_dimensions(file_path: &Path) -> Result<(u32, u32)> {
         );
     }
 
-    let dimensions_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let dimensions_str = String::from_utf8_lossy(&output.stdout);
+    parse_video_dimensions(&dimensions_str)
+}
+
+/// Parse video width and height out of ffprobe's `stream=width,height` output.
+fn parse_video_dimensions(output: &str) -> Result<(u32, u32)> {
+    let dimensions_str = output.trim();
 
     // Parse "width,height" format using char-based splitting for UTF-8 safety
     if let Some((width_str, height_str)) = dimensions_str.split_once(',') {
@@ -2791,5 +2797,43 @@ not_a_number  1 /bin/bash
         assert!(matches!(result, Cow::Owned(_)));
         assert!(result.width() <= max_w);
         assert!(result.height() <= max_h);
+    }
+
+    // =========================================================================
+    // Tests for parse_video_dimensions
+    // =========================================================================
+
+    #[test]
+    fn parse_dimensions_plain_csv() {
+        assert_eq!(parse_video_dimensions("1920,1080").unwrap(), (1920, 1080));
+    }
+
+    #[test]
+    fn parse_dimensions_trailing_newline() {
+        assert_eq!(parse_video_dimensions("1920,1080\n").unwrap(), (1920, 1080));
+    }
+
+    #[test]
+    fn parse_dimensions_handles_dolby_vision_trailing_comma() {
+        // A Dolby Vision HEVC stream carries a DoVi configuration record as side
+        // data. ffprobe's CSV writer appends an empty trailing field for that
+        // nested section, yielding "3840,2160," — splitting only on the first
+        // comma used to leave the height as "2160,", which failed to parse.
+        assert_eq!(
+            parse_video_dimensions("3840,2160,\n").unwrap(),
+            (3840, 2160)
+        );
+    }
+
+    #[test]
+    fn parse_dimensions_handles_newline_separated() {
+        // ffprobe's `default=noprint_wrappers=1:nokey=1` writer emits one value
+        // per line; the parser must accept that layout too.
+        assert_eq!(parse_video_dimensions("3840\n2160\n").unwrap(), (3840, 2160));
+    }
+
+    #[test]
+    fn parse_dimensions_errors_when_height_missing() {
+        assert!(parse_video_dimensions("3840").is_err());
     }
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1156,10 +1156,13 @@ fn parse_video_dimensions(output: &str) -> Result<(u32, u32)> {
     Ok((width, height))
 }
 
+/// Frame rate used when ffprobe is unavailable or its output is unparseable.
+const DEFAULT_FPS: f64 = 24.0;
+
 fn get_video_fps(file_path: &Path) -> Result<f64> {
     if ensure_ffprobe_available().is_err() {
         eprintln!("Warning: ffprobe not found, using default 24 fps");
-        return Ok(24.0);
+        return Ok(DEFAULT_FPS);
     }
 
     // Use ffprobe to get video frame rate
@@ -1179,19 +1182,25 @@ fn get_video_fps(file_path: &Path) -> Result<f64> {
         .context("Failed to run ffprobe")?;
 
     if !output.status.success() {
-        return Ok(24.0); // Default to 24 fps
+        return Ok(DEFAULT_FPS); // Default to 24 fps
     }
 
-    let fps_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let fps_str = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_video_fps(&fps_str))
+}
+
+/// Parse a frame rate from ffprobe's `stream=r_frame_rate` output.
+fn parse_video_fps(output: &str) -> f64 {
+    let fps_str = output.trim();
 
     // Parse fraction like "24/1" or "30000/1001" using char-based splitting
     // for UTF-8 safety (in practice ffprobe output is ASCII).
     if let Some((num_str, denom_str)) = fps_str.split_once('/') {
-        let numerator: f64 = num_str.parse().unwrap_or(24.0);
+        let numerator: f64 = num_str.parse().unwrap_or(DEFAULT_FPS);
         let denominator: f64 = denom_str.parse().unwrap_or(1.0);
-        Ok(numerator / denominator)
+        numerator / denominator
     } else {
-        Ok(fps_str.parse().unwrap_or(24.0))
+        fps_str.parse().unwrap_or(DEFAULT_FPS)
     }
 }
 
@@ -2851,5 +2860,41 @@ not_a_number  1 /bin/bash
     #[test]
     fn parse_dimensions_errors_when_height_missing() {
         assert!(parse_video_dimensions("3840").is_err());
+    }
+
+    // =========================================================================
+    // Tests for parse_video_fps
+    // =========================================================================
+
+    #[test]
+    fn parse_fps_ntsc_fraction() {
+        assert!((parse_video_fps("30000/1001") - 29.970_029_97).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_fps_integer_fraction() {
+        assert_eq!(parse_video_fps("25/1\n"), 25.0);
+    }
+
+    #[test]
+    fn parse_fps_handles_dolby_vision_trailing_comma() {
+        // Same DoVi side-data trailing comma as the dimension probe:
+        // "24000/1001,". Splitting the fraction left the denominator as
+        // "1001,", which silently fell back to 1.0 — yielding 24000 fps
+        // instead of 23.976.
+        let fps = parse_video_fps("24000/1001,\n");
+        assert!((fps - 23.976_023_976).abs() < 1e-6, "got {fps}");
+    }
+
+    #[test]
+    fn parse_fps_handles_zero_denominator() {
+        // ffprobe reports "0/0" for streams with an unknown frame rate; a naive
+        // divide produces NaN, so we must fall back to the default instead.
+        assert_eq!(parse_video_fps("0/0"), DEFAULT_FPS);
+    }
+
+    #[test]
+    fn parse_fps_empty_falls_back_to_default() {
+        assert_eq!(parse_video_fps(""), DEFAULT_FPS);
     }
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2913,4 +2913,23 @@ not_a_number  1 /bin/bash
     fn parse_fps_empty_falls_back_to_default() {
         assert_eq!(parse_video_fps(""), DEFAULT_FPS);
     }
+
+    #[test]
+    fn parse_fps_prefers_avg_frame_rate_over_r_frame_rate() {
+        // A variable-frame-rate screen recording: r_frame_rate is the timebase
+        // tick (287/12 ≈ 23.92 fps) while avg_frame_rate is the true average
+        // (≈ 12.06 fps). Playback timing must use the average, or the video
+        // plays roughly 2× too fast.
+        let probe = "r_frame_rate=287/12\navg_frame_rate=60525000/5017157\n";
+        let fps = parse_video_fps(probe);
+        assert!((fps - 12.063).abs() < 0.01, "got {fps}");
+    }
+
+    #[test]
+    fn parse_fps_falls_back_to_r_frame_rate_when_avg_unknown() {
+        // Some containers report avg_frame_rate as "0/0" (unknown). Fall back to
+        // r_frame_rate rather than the hard-coded default.
+        let probe = "r_frame_rate=30/1\navg_frame_rate=0/0\n";
+        assert_eq!(parse_video_fps(probe), 30.0);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `ic` failing to parse video dimensions, frame rate, and FPS on streams with Dolby Vision side-data (trailing commas, `0/0` rates).
- Use `avg_frame_rate` for playback with fallback to `r_frame_rate`.
- Add red tests before each fix per TDD.

## Test plan
- [x] `cargo test -p ic` — all parsing tests pass (Dolby Vision side-data, 0/0 rates, avg/r_frame_rate fallback)
- [ ] Manually run `ic` against a Dolby Vision sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)