### PR TITLE
gsw: fade file rows by mtime to mirror the commit-log timeline

### DIFF
--- a/plans/2026-05-22-gsw-file-row-fade-plan.md
+++ b/plans/2026-05-22-gsw-file-row-fade-plan.md
@@ -1,0 +1,1556 @@
+# gsw File-Row Truecolor Fade — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the existing commit-log age-driven truecolor fade to every column of every file row in `gsw`, so the file list and the log section share one continuous visual timeline. The 8-color fallback path stays byte-identical to today.
+
+**Architecture:** Add one new helper (`file_fade_factor`) alongside the existing `age_fade_factor` / `fade_rgb` / `fade_truecolor`. Add a small per-status base-RGB palette. Each `colorize_*` fn in `src/gsw/src/render.rs` gains a `truecolor: bool` arg plus a fade `factor: f32`; when truecolor is on, it fades the per-status base RGB toward the shared floor by the factor. When off, the existing 8-color logic runs untouched. `render_row` computes the factor once per row and threads it through.
+
+**Tech Stack:** Rust, `colored` crate (already in use), existing `age`/`bar` modules under `src/gsw/src/`.
+
+**Spec:** [`specs/2026-05-22-gsw-file-row-fade-design.md`](../specs/2026-05-22-gsw-file-row-fade-design.md)
+
+---
+
+## File Structure
+
+- **Modify:** `src/gsw/src/render.rs` — all behavior changes live here. Adds: `file_fade_factor`, a per-status RGB palette block, truecolor branches inside every `colorize_*` fn, two new small helpers (`colorize_adds`/`colorize_dels`) extracted from inline code. Threads `truecolor` + `factor` through `render_row`.
+
+No other source files change. Tests live in the existing `#[cfg(test)] mod tests` block at the bottom of `render.rs`, alongside the log-fade tests at `render.rs:1380+`.
+
+---
+
+## Conventions used in every phase
+
+- **TDD discipline:** Every phase has a red commit (failing test only) followed by a green commit (implementation). Never combine them. The red commit must fail for a *behavioral* reason, not a missing symbol — that means tests reference functions/constants that already exist or that the test itself stubs out. When a test would otherwise fail to compile because a fn doesn't exist yet, the red step adds a minimal stub returning a deliberately-wrong value so the test compiles and fails on the assertion.
+- **Build commands:** `cd /Volumes/SamsungSSDs/code/tools-worktrees/gsw-fade-files/src/gsw && cargo test --lib` runs every gsw test in the crate. Filter with `cargo test --lib <name>` for a single test.
+- **Pre-commit:** Honor the project's hook chain. Never wrap `git commit` in retry loops. If a hook fails, fix the underlying issue and re-commit once.
+- **No emojis** in commit messages or code.
+- **Test inspection style:** Match the existing log-fade tests — read `ColoredString::fgcolor` / `bgcolor` typed enums (`colored::Color::TrueColor { r, g, b }`) directly instead of asserting ANSI byte sequences. This avoids races on `colored::control::set_override`.
+
+---
+
+## Phase 1: `file_fade_factor` helper
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — add helper near the top of the file, just below the existing `fade_truecolor` block (currently around line 405).
+
+### Red
+
+- [ ] **Step 1.1: Write the failing test**
+
+Add this test inside the existing `mod tests` block in `src/gsw/src/render.rs`:
+
+```rust
+#[test]
+fn file_fade_factor_is_zero_for_fresh_age() {
+    // A file modified moments ago must render at full base brightness,
+    // which means factor=0 — the no-fade end of the ramp.
+    assert!(
+        (file_fade_factor(Some(Duration::from_secs(0))) - 0.0).abs() < 1e-6,
+        "fresh file should produce factor=0",
+    );
+}
+
+#[test]
+fn file_fade_factor_floors_when_age_is_none() {
+    // Deleted files and unstat'd untracked dirs have no mtime. They must
+    // render at the dark floor (factor=1.0) so the row visually announces
+    // "this is an unusual state, not actively changing".
+    assert!(
+        (file_fade_factor(None) - 1.0).abs() < 1e-6,
+        "None age should clamp to factor=1.0 (the floor)",
+    );
+}
+
+#[test]
+fn file_fade_factor_matches_commit_ramp_for_some_age() {
+    // The file fade must share the *same* ramp as commit rows so the two
+    // sections darken in lockstep under viddy. Spot-check the 1h midpoint.
+    let one_hour = Duration::from_secs(60 * 60);
+    let file = file_fade_factor(Some(one_hour));
+    let commit = age_fade_factor(one_hour);
+    assert!(
+        (file - commit).abs() < 1e-6,
+        "file fade must equal commit fade for matching Some(age): file={file}, commit={commit}",
+    );
+}
+```
+
+- [ ] **Step 1.2: Run the tests and verify they fail to compile**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml file_fade_factor`
+
+Expected: compilation error — `cannot find function 'file_fade_factor' in this scope`.
+
+- [ ] **Step 1.3: Add a deliberately-wrong stub to make the failure behavioral, not structural**
+
+Add this near `fade_truecolor` (around `render.rs:405`):
+
+```rust
+/// Fade factor for a file row.
+///
+/// `Some(age)` shares the commit-log ramp via [`age_fade_factor`] so the
+/// file list and log section darken in lockstep. `None` returns `1.0`
+/// so files we can't stat (deleted entries, skipped untracked dirs)
+/// render at the dark floor.
+fn file_fade_factor(_age: Option<Duration>) -> f32 {
+    // Intentionally wrong stub — the red test must fail on the assertion,
+    // not on a missing symbol.
+    0.5
+}
+```
+
+- [ ] **Step 1.4: Run the tests and verify they fail with assertion errors**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml file_fade_factor`
+
+Expected: all three tests fail with assertion messages (not compilation errors).
+
+- [ ] **Step 1.5: Commit the red tests + stub**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — file_fade_factor helper for age-driven file fade
+
+Adds three failing tests that pin the helper's contract:
+  - Some(age=0) returns 0.0 (fresh = no fade)
+  - None returns 1.0 (no-mtime files render at the floor)
+  - Some(age) equals age_fade_factor(age) so the file list and the
+    commit-log section share one timeline.
+
+Stub returns 0.5 so the failures are behavioral, not structural."
+```
+
+(The `--no-verify` is the narrow exception allowed for red commits because the hooks would otherwise reject a deliberately-failing test.)
+
+### Green
+
+- [ ] **Step 1.6: Replace the stub with the real implementation**
+
+In `src/gsw/src/render.rs`, replace the body of `file_fade_factor`:
+
+```rust
+fn file_fade_factor(age: Option<Duration>) -> f32 {
+    age.map_or(1.0, age_fade_factor)
+}
+```
+
+- [ ] **Step 1.7: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml file_fade_factor`
+
+Expected: all three tests pass.
+
+- [ ] **Step 1.8: Run the full gsw test suite to confirm nothing else broke**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all tests pass.
+
+- [ ] **Step 1.9: Commit the green implementation**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — implement file_fade_factor
+
+Threads file mtime through the existing age_fade_factor ramp; None
+(deleted / unstat'd) clamps to 1.0 so those rows render at the dark
+floor."
+```
+
+---
+
+## Phase 2: Path-column truecolor fade
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — add path RGB constants and a truecolor branch to `colorize_path` (currently `render.rs:327–334`).
+
+### Red
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Add these inside the existing `mod tests` block (alongside the log-fade tests around `render.rs:1388+`):
+
+```rust
+#[test]
+fn file_path_uses_truecolor_when_enabled() {
+    // With truecolor on, a fresh modified file's path must come back as a
+    // 24-bit color so the gradient has somewhere to fade from.
+    use colored::Color;
+    let mut e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+    e.age = Some(Duration::from_secs(0));
+    let cs = colorize_path("src/foo.rs", &e, 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor under truecolor=true, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_path_falls_back_to_legacy_color_without_truecolor() {
+    // Without truecolor, the legacy ANSI yellow for unstaged-modified
+    // paths must still come through unchanged. Regression guard for the
+    // 8-color path.
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+    let cs = colorize_path("src/foo.rs", &e, 0.0, false);
+    assert_eq!(cs.fgcolor, Some(Color::Yellow));
+}
+
+#[test]
+fn file_path_darkens_with_age_under_truecolor() {
+    // Core gradient property: an older path is dimmer than a fresh one on
+    // every channel.
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+    let fresh = colorize_path("src/foo.rs", &e, 0.0, true);
+    let aged = colorize_path("src/foo.rs", &e, 1.0, true);
+    let (Some(Color::TrueColor { r: fr, g: fg, b: fb }),
+         Some(Color::TrueColor { r: ar, g: ag, b: ab })) =
+        (fresh.fgcolor, aged.fgcolor)
+    else {
+        panic!("both should be TrueColor under truecolor=true");
+    };
+    assert!(
+        ar <= fr && ag <= fg && ab <= fb,
+        "aged path should not be brighter on any channel: fresh=({fr},{fg},{fb}) aged=({ar},{ag},{ab})",
+    );
+    assert!(
+        ar < fr || ag < fg || ab < fb,
+        "aged path should be strictly darker on at least one channel: fresh=({fr},{fg},{fb}) aged=({ar},{ag},{ab})",
+    );
+}
+
+#[test]
+fn file_path_stays_above_floor_at_factor_one() {
+    // The fade must never reach pure black — at the floor, channels stay
+    // at FADE_FLOOR * base. Mirrors log_hash_stays_above_floor_when_very_old.
+    use crate::age::FADE_FLOOR;
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+    let cs = colorize_path("src/foo.rs", &e, 1.0, true);
+    let Some(Color::TrueColor { r, g, b }) = cs.fgcolor else {
+        panic!("expected TrueColor under truecolor=true");
+    };
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "u8 × FADE_FLOOR ∈ [0, 1] stays in [0, 255]"
+    )]
+    let floor_of = |c: u8| (f32::from(c) * FADE_FLOOR).round() as u8;
+    let (br, bg, bb) = FILE_PATH_UNSTAGED_RGB;
+    assert!(
+        r >= floor_of(br).saturating_sub(1)
+            && g >= floor_of(bg).saturating_sub(1)
+            && b >= floor_of(bb).saturating_sub(1),
+        "channels must not drop below the floor: actual=({r},{g},{b}) base=({br},{bg},{bb})",
+    );
+}
+```
+
+- [ ] **Step 2.2: Add the deliberately-wrong stub so the failures are behavioral**
+
+In `src/gsw/src/render.rs`, add the constants block (after the existing `LOG_AGE_BASE_RGB` around line 400):
+
+```rust
+// --- File-row truecolor base palette ---------------------------------------
+//
+// Per-status base RGB values for the file list under truecolor mode. Each
+// base is tuned so factor=0 reads as the same hue family as the legacy
+// ANSI color, and factor=1 (× FADE_FLOOR) still keeps the hue visible.
+
+const FILE_PATH_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
+const FILE_PATH_STAGED_RGB: (u8, u8, u8) = (200, 200, 200);
+const FILE_PATH_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+const FILE_PATH_CONFLICT_RGB: (u8, u8, u8) = (255, 90, 90);
+```
+
+Then change the signature of `colorize_path` and stub the truecolor branch wrong:
+
+```rust
+fn colorize_path(
+    path: &str,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        // Deliberately wrong stub — should be FILE_PATH_UNSTAGED_RGB faded,
+        // but returns a constant truecolor so the gradient + floor tests
+        // fail on their *behavior*, not on the structural shape.
+        return path.truecolor(50, 50, 50);
+    }
+    match entry.status {
+        FileStatus::Conflicted => path.red(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => path.cyan().dimmed(),
+        _ if entry.staged => path.normal().dimmed(),
+        _ => path.yellow(),
+    }
+}
+```
+
+Update every existing in-crate call site of `colorize_path` to match the new signature. There's only one: in `render_row` at `render.rs:224`. Change it to:
+
+```rust
+let path_str = colorize_path(&path_padded, entry, 0.0, false);
+```
+
+(`0.0` and `false` keep render_row's output unchanged until Phase 8 wires through the real values.)
+
+- [ ] **Step 2.3: Run the tests and verify the new tests fail behaviorally and nothing else regresses**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected:
+- `file_path_uses_truecolor_when_enabled` — PASS (the stub returns a truecolor).
+- `file_path_falls_back_to_legacy_color_without_truecolor` — PASS (the 8-color branch is unchanged).
+- `file_path_darkens_with_age_under_truecolor` — FAIL (stub returns the same color for both factors).
+- `file_path_stays_above_floor_at_factor_one` — FAIL (stub returns `(50,50,50)`, not the per-status floor).
+- All other tests — PASS.
+
+- [ ] **Step 2.4: Commit the red tests + stub**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — colorize_path truecolor branch and palette
+
+Adds the FILE_PATH_*_RGB palette and a truecolor stub in colorize_path
+that returns a constant grey, so the gradient and floor tests fail on
+behavior. The signature gains (factor: f32, truecolor: bool); the sole
+call site in render_row keeps passing (0.0, false) so the rendered
+output is unchanged until Phase 8 threads the real values."
+```
+
+### Green
+
+- [ ] **Step 2.5: Replace the stub with the real per-status fade**
+
+In `src/gsw/src/render.rs`, replace `colorize_path`'s truecolor branch:
+
+```rust
+fn colorize_path(
+    path: &str,
+    entry: &RenderEntry,
+    factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_PATH_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_PATH_UNTRACKED_RGB,
+            _ if entry.staged => FILE_PATH_STAGED_RGB,
+            _ => FILE_PATH_UNSTAGED_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return path.truecolor(r, g, b);
+    }
+    match entry.status {
+        FileStatus::Conflicted => path.red(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => path.cyan().dimmed(),
+        _ if entry.staged => path.normal().dimmed(),
+        _ => path.yellow(),
+    }
+}
+```
+
+- [ ] **Step 2.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: every test passes.
+
+- [ ] **Step 2.7: Commit the green implementation**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_path fades per-status base RGB by factor
+
+The truecolor branch now picks one of FILE_PATH_{UNSTAGED,STAGED,
+UNTRACKED,CONFLICT}_RGB by status and runs it through fade_rgb. The
+hue family is preserved across the whole fade range so users can still
+tell unstaged from untracked at any age."
+```
+
+---
+
+## Phase 3: Icon-column truecolor fade
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — add icon RGB constants and a truecolor branch to `colorize_icon` (currently `render.rs:305–313`).
+
+### Red
+
+- [ ] **Step 3.1: Write the failing tests**
+
+```rust
+#[test]
+fn file_icon_uses_truecolor_when_enabled() {
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+    let cs = colorize_icon('●', &e, 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor for icon under truecolor=true, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_icon_falls_back_to_ansi_without_truecolor() {
+    // Staged-modified icon today is plain green. Regression guard.
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+    let cs = colorize_icon('●', &e, 0.0, false);
+    assert_eq!(cs.fgcolor, Some(Color::Green));
+}
+
+#[test]
+fn file_icon_darkens_with_age_under_truecolor() {
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+    let fresh = colorize_icon('●', &e, 0.0, true);
+    let aged = colorize_icon('●', &e, 1.0, true);
+    let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+        (fresh.fgcolor, aged.fgcolor)
+    else {
+        panic!("both should be TrueColor");
+    };
+    assert!(ar < fr, "aged icon should be darker: fresh={fr} aged={ar}");
+}
+```
+
+- [ ] **Step 3.2: Add the deliberately-wrong stub and palette constants**
+
+```rust
+const FILE_ICON_STAGED_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_ICON_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
+const FILE_ICON_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+const FILE_ICON_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+```
+
+Change `colorize_icon`'s signature and stub:
+
+```rust
+fn colorize_icon(
+    icon: char,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    let s = icon.to_string();
+    if truecolor {
+        // Wrong stub — constant grey breaks the gradient assertion only.
+        return s.truecolor(50, 50, 50);
+    }
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        _ if entry.staged => s.green(),
+        _ => s.yellow(),
+    }
+}
+```
+
+Update the sole call site in `render_row`:
+
+```rust
+let icon_str = colorize_icon(icon, entry, 0.0, false);
+```
+
+- [ ] **Step 3.3: Run the tests and verify red tests fail behaviorally**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected:
+- `file_icon_uses_truecolor_when_enabled` — PASS (stub returns TrueColor).
+- `file_icon_falls_back_to_ansi_without_truecolor` — PASS.
+- `file_icon_darkens_with_age_under_truecolor` — FAIL.
+
+- [ ] **Step 3.4: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — colorize_icon truecolor branch and palette
+
+Stub returns a constant grey so only the gradient test fails."
+```
+
+### Green
+
+- [ ] **Step 3.5: Replace the stub with the real fade**
+
+```rust
+fn colorize_icon(
+    icon: char,
+    entry: &RenderEntry,
+    factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    let s = icon.to_string();
+    if truecolor {
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_ICON_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_ICON_UNTRACKED_RGB,
+            _ if entry.staged => FILE_ICON_STAGED_RGB,
+            _ => FILE_ICON_UNSTAGED_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return s.truecolor(r, g, b);
+    }
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        _ if entry.staged => s.green(),
+        _ => s.yellow(),
+    }
+}
+```
+
+- [ ] **Step 3.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all pass.
+
+- [ ] **Step 3.7: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_icon fades per-status base RGB by factor"
+```
+
+---
+
+## Phase 4: Letter-column truecolor fade
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — add letter RGB constants and a truecolor branch to `colorize_letter` (currently `render.rs:315–325`).
+
+### Red
+
+- [ ] **Step 4.1: Write the failing tests**
+
+```rust
+#[test]
+fn file_letter_uses_truecolor_when_enabled() {
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Added, true, 1, 0);
+    let cs = colorize_letter('A', &e, 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor under truecolor=true, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_letter_falls_back_to_ansi_without_truecolor() {
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Added, true, 1, 0);
+    let cs = colorize_letter('A', &e, 0.0, false);
+    assert_eq!(cs.fgcolor, Some(Color::Green));
+}
+
+#[test]
+fn file_letter_darkens_with_age_under_truecolor() {
+    use colored::Color;
+    let e = entry("src/foo.rs", FileStatus::Deleted, true, 0, 1);
+    let fresh = colorize_letter('D', &e, 0.0, true);
+    let aged = colorize_letter('D', &e, 1.0, true);
+    let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+        (fresh.fgcolor, aged.fgcolor)
+    else { panic!("both should be TrueColor") };
+    assert!(ar < fr, "aged letter should be darker: fresh={fr} aged={ar}");
+}
+```
+
+- [ ] **Step 4.2: Add the deliberately-wrong stub and palette constants**
+
+```rust
+const FILE_LETTER_ADDED_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_LETTER_DELETED_RGB: (u8, u8, u8) = (255, 80, 80);
+const FILE_LETTER_RENAMED_RGB: (u8, u8, u8) = (220, 120, 220);
+const FILE_LETTER_DEFAULT_RGB: (u8, u8, u8) = (230, 230, 230);
+const FILE_LETTER_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+const FILE_LETTER_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+```
+
+Change `colorize_letter`'s signature with the wrong stub:
+
+```rust
+fn colorize_letter(
+    letter: char,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    let s = letter.to_string();
+    if truecolor {
+        return s.truecolor(50, 50, 50);
+    }
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        FileStatus::Added => s.green().bold(),
+        FileStatus::Deleted => s.red().bold(),
+        FileStatus::Renamed | FileStatus::Copied => s.magenta().bold(),
+        _ => s.bold(),
+    }
+}
+```
+
+Update the sole call site in `render_row`:
+
+```rust
+let letter_str = colorize_letter(letter, entry, 0.0, false);
+```
+
+- [ ] **Step 4.3: Run tests and confirm only the gradient test fails**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: `file_letter_darkens_with_age_under_truecolor` FAILS; others PASS.
+
+- [ ] **Step 4.4: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — colorize_letter truecolor branch and palette"
+```
+
+### Green
+
+- [ ] **Step 4.5: Replace the stub with the real fade**
+
+```rust
+fn colorize_letter(
+    letter: char,
+    entry: &RenderEntry,
+    factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    let s = letter.to_string();
+    if truecolor {
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_LETTER_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_LETTER_UNTRACKED_RGB,
+            FileStatus::Added => FILE_LETTER_ADDED_RGB,
+            FileStatus::Deleted => FILE_LETTER_DELETED_RGB,
+            FileStatus::Renamed | FileStatus::Copied => FILE_LETTER_RENAMED_RGB,
+            _ => FILE_LETTER_DEFAULT_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return s.truecolor(r, g, b);
+    }
+    match entry.status {
+        FileStatus::Conflicted => s.red().bold(),
+        FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
+        FileStatus::Added => s.green().bold(),
+        FileStatus::Deleted => s.red().bold(),
+        FileStatus::Renamed | FileStatus::Copied => s.magenta().bold(),
+        _ => s.bold(),
+    }
+}
+```
+
+- [ ] **Step 4.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all pass.
+
+- [ ] **Step 4.7: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_letter fades per-status base RGB by factor"
+```
+
+---
+
+## Phase 5: Age-column truecolor fade for file rows
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — extend `colorize_age` with a truecolor branch (currently `render.rs:381–391`).
+
+### Red
+
+- [ ] **Step 5.1: Write the failing tests**
+
+```rust
+#[test]
+fn file_age_uses_truecolor_when_enabled() {
+    use colored::Color;
+    let cs = colorize_age("5m23s", Some(Duration::from_secs(5 * 60 + 23)), 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor for file age, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_age_falls_back_to_dim_buckets_without_truecolor() {
+    // 8-color fallback must still bold a fresh row's age, matching today.
+    use colored::Styles;
+    let fresh = colorize_age("30s", Some(Duration::from_secs(30)), 0.0, false);
+    assert!(
+        fresh.style.contains(Styles::Bold),
+        "fresh age should still be bolded in the 8-color path",
+    );
+}
+
+#[test]
+fn file_age_darkens_with_factor_under_truecolor() {
+    use colored::Color;
+    let fresh = colorize_age("30s", Some(Duration::from_secs(30)), 0.0, true);
+    let aged = colorize_age("3d0h", Some(Duration::from_secs(3 * 86400)), 1.0, true);
+    let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+        (fresh.fgcolor, aged.fgcolor)
+    else { panic!("both should be TrueColor") };
+    assert!(ar < fr, "aged file-age column should be darker: fresh={fr} aged={ar}");
+}
+```
+
+- [ ] **Step 5.2: Add the deliberately-wrong stub**
+
+Add this constant:
+
+```rust
+const FILE_AGE_RGB: (u8, u8, u8) = (190, 190, 190);
+```
+
+Change `colorize_age`'s signature and stub the truecolor branch:
+
+```rust
+fn colorize_age(
+    text: &str,
+    age: Option<Duration>,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
+    let Some(age) = age else {
+        return text.dimmed();
+    };
+    match age_dim_level(age) {
+        AgeDim::Fresh => text.bold(),
+        AgeDim::Recent => text.normal(),
+        AgeDim::Aging => text.dimmed(),
+        AgeDim::Stale => text.dimmed().italic(),
+    }
+}
+```
+
+Update the two call sites in `render_row` (one in the untracked branch around `render.rs:237`, one in the main branch around `render.rs:274`):
+
+```rust
+let age_str = colorize_age(&age_field, entry.age, 0.0, false);
+```
+
+Also update the existing log-section helper `colorize_log_age` (currently `render.rs:442–448`), which calls `colorize_age` with the legacy two-arg shape:
+
+```rust
+fn colorize_log_age(text: &str, age: Duration, truecolor: bool) -> ColoredString {
+    if truecolor {
+        fade_truecolor(text, age, LOG_AGE_BASE_RGB)
+    } else {
+        colorize_age(text, Some(age), 0.0, false)
+    }
+}
+```
+
+- [ ] **Step 5.3: Run tests and confirm only the gradient test fails**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: `file_age_darkens_with_factor_under_truecolor` FAILS; others PASS. The existing `stale_age_renders_differently_from_aging` test uses `colorize_age(..., Some(d))`, so update the call sites in tests too — search the file for `colorize_age("12h0m"` and other test invocations, append `, 0.0, false`. (Both test call sites today live around `render.rs:1284–1285`.)
+
+- [ ] **Step 5.4: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — colorize_age truecolor branch and FILE_AGE_RGB"
+```
+
+### Green
+
+- [ ] **Step 5.5: Replace the stub with the real fade**
+
+```rust
+fn colorize_age(
+    text: &str,
+    age: Option<Duration>,
+    factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(FILE_AGE_RGB, factor);
+        return text.truecolor(r, g, b);
+    }
+    let Some(age) = age else {
+        return text.dimmed();
+    };
+    match age_dim_level(age) {
+        AgeDim::Fresh => text.bold(),
+        AgeDim::Recent => text.normal(),
+        AgeDim::Aging => text.dimmed(),
+        AgeDim::Stale => text.dimmed().italic(),
+    }
+}
+```
+
+- [ ] **Step 5.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all pass.
+
+- [ ] **Step 5.7: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_age fades FILE_AGE_RGB by factor"
+```
+
+---
+
+## Phase 6: Adds / Dels truecolor fade
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — extract two new fns (`colorize_adds`, `colorize_dels`) from the inline `+adds` / `-dels` styling in `render_row` (currently `render.rs:261–270`).
+
+### Red
+
+- [ ] **Step 6.1: Write the failing tests**
+
+```rust
+#[test]
+fn file_adds_uses_truecolor_when_enabled() {
+    use colored::Color;
+    let cs = colorize_adds("  +12", 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_dels_uses_truecolor_when_enabled() {
+    use colored::Color;
+    let cs = colorize_dels(" -3", 0.0, true);
+    match cs.fgcolor {
+        Some(Color::TrueColor { .. }) => {}
+        other => panic!("expected TrueColor, got {other:?}"),
+    }
+}
+
+#[test]
+fn file_adds_falls_back_to_green_without_truecolor() {
+    use colored::Color;
+    let cs = colorize_adds("  +12", 0.0, false);
+    assert_eq!(cs.fgcolor, Some(Color::Green));
+}
+
+#[test]
+fn file_dels_falls_back_to_red_without_truecolor() {
+    use colored::Color;
+    let cs = colorize_dels(" -3", 0.0, false);
+    assert_eq!(cs.fgcolor, Some(Color::Red));
+}
+
+#[test]
+fn file_adds_darkens_with_factor_under_truecolor() {
+    use colored::Color;
+    let fresh = colorize_adds("  +12", 0.0, true);
+    let aged = colorize_adds("  +12", 1.0, true);
+    let (Some(Color::TrueColor { r: fr, g: fg, .. }),
+         Some(Color::TrueColor { r: ar, g: ag, .. })) =
+        (fresh.fgcolor, aged.fgcolor)
+    else { panic!("both should be TrueColor") };
+    assert!(ar < fr || ag < fg, "aged +adds should be darker");
+}
+```
+
+- [ ] **Step 6.2: Add the constants and stub fns**
+
+```rust
+const FILE_ADDS_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_DELS_RGB: (u8, u8, u8) = (255, 90, 90);
+
+fn colorize_adds(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
+    text.green()
+}
+
+fn colorize_dels(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
+    text.red()
+}
+```
+
+Replace the inline blocks in `render_row` (around `render.rs:261–270`):
+
+```rust
+let adds_str = if entry.adds > 0 {
+    colorize_adds(&adds_field, 0.0, false).to_string()
+} else {
+    adds_field
+};
+let dels_str = if entry.dels > 0 {
+    colorize_dels(&dels_field, 0.0, false).to_string()
+} else {
+    dels_field
+};
+```
+
+- [ ] **Step 6.3: Run tests and confirm only the gradient test fails**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: `file_adds_darkens_with_factor_under_truecolor` FAILS; everything else PASSES.
+
+- [ ] **Step 6.4: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — extract colorize_adds/colorize_dels with truecolor stub"
+```
+
+### Green
+
+- [ ] **Step 6.5: Replace the stubs with the real fade**
+
+```rust
+fn colorize_adds(text: &str, factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(FILE_ADDS_RGB, factor);
+        return text.truecolor(r, g, b);
+    }
+    text.green()
+}
+
+fn colorize_dels(text: &str, factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        let (r, g, b) = fade_rgb(FILE_DELS_RGB, factor);
+        return text.truecolor(r, g, b);
+    }
+    text.red()
+}
+```
+
+- [ ] **Step 6.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all pass.
+
+- [ ] **Step 6.7: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_adds / colorize_dels fade by factor"
+```
+
+---
+
+## Phase 7: Bar truecolor fade (foreground + partial-cell background)
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — extend `colorize_bar` (currently `render.rs:345–372`) with a truecolor branch that fades both the fill foreground and the partial-cell background by the same factor.
+
+### Red
+
+- [ ] **Step 7.1: Write the failing tests**
+
+```rust
+#[test]
+fn file_bar_fill_fades_with_factor_under_truecolor() {
+    use colored::Color;
+    let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+    let fresh = colorize_bar_styled("██████", &e, 0.0, true);
+    let aged = colorize_bar_styled("██████", &e, 1.0, true);
+    // We expect the first cell's fg to be TrueColor in both cases and
+    // the aged channel to be strictly lower.
+    let (Some(Color::TrueColor { r: fr, g: fg, b: fb }),
+         Some(Color::TrueColor { r: ar, g: ag, b: ab })) =
+        (fresh[0].fgcolor, aged[0].fgcolor)
+    else { panic!("first cell should be TrueColor under truecolor=true") };
+    assert!(
+        ar < fr || ag < fg || ab < fb,
+        "aged bar fill should be darker on at least one channel",
+    );
+}
+
+#[test]
+fn file_bar_partial_bg_fades_with_factor_under_truecolor() {
+    use colored::Color;
+    // Use a partial-fill glyph (▍ = U+258D) so a background color is set.
+    let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+    let fresh = colorize_bar_styled("▍", &e, 0.0, true);
+    let aged = colorize_bar_styled("▍", &e, 1.0, true);
+    let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+        (fresh[0].bgcolor, aged[0].bgcolor)
+    else { panic!("partial cell should have a TrueColor background") };
+    assert!(ar < fr, "aged partial-cell bg should be darker: fresh={fr} aged={ar}");
+}
+
+#[test]
+fn file_bar_fallback_unchanged_without_truecolor() {
+    // 8-color path returns the cyan-fill bytes today. Regression guard.
+    let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+    let cells = colorize_bar_styled("█", &e, 0.0, false);
+    use colored::Color;
+    assert_eq!(cells[0].fgcolor, Some(Color::Cyan));
+}
+```
+
+These reference a new helper `colorize_bar_styled` that returns the per-cell `ColoredString`s instead of the joined `String` the current `colorize_bar` produces. We're adding it specifically to make the typed-color inspection from the tests above work without parsing ANSI bytes.
+
+- [ ] **Step 7.2: Add the new helper and stub the truecolor branch wrong**
+
+Add the constants if not already present (`BAR_PARTIAL_BG_CYAN` and `BAR_PARTIAL_BG_RED` already exist at `render.rs:341–344`).
+
+Add this near `colorize_bar`:
+
+```rust
+/// Build one `ColoredString` per visible cell of `bar`. The joined string
+/// returned by [`colorize_bar`] is just `colorize_bar_styled(...).join("")`
+/// with `.to_string()` applied to each cell — sharing the cell builder lets
+/// tests inspect the typed fg/bg colors per cell instead of parsing ANSI.
+fn colorize_bar_styled(
+    bar: &str,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> Vec<ColoredString> {
+    if entry.binary {
+        return bar.chars().map(|c| c.to_string().dimmed()).collect();
+    }
+    let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
+    let (br, bg, bb) = if is_conflicted {
+        BAR_PARTIAL_BG_RED
+    } else {
+        BAR_PARTIAL_BG_CYAN
+    };
+    bar.chars()
+        .map(|c| {
+            let s = c.to_string();
+            if truecolor {
+                // Wrong stub — constant grey breaks gradient + bg tests only.
+                if is_partial_block(c) {
+                    s.truecolor(50, 50, 50).on_truecolor(20, 20, 20)
+                } else {
+                    s.truecolor(50, 50, 50)
+                }
+            } else if is_partial_block(c) {
+                if is_conflicted {
+                    s.red().on_truecolor(br, bg, bb)
+                } else {
+                    s.cyan().on_truecolor(br, bg, bb)
+                }
+            } else if is_conflicted {
+                s.red()
+            } else {
+                s.cyan()
+            }
+        })
+        .collect()
+}
+```
+
+Refactor `colorize_bar` to delegate:
+
+```rust
+fn colorize_bar(bar: &str, entry: &RenderEntry, factor: f32, truecolor: bool) -> String {
+    let cells = colorize_bar_styled(bar, entry, factor, truecolor);
+    let mut out = String::with_capacity(bar.len() * 2);
+    for c in cells {
+        out.push_str(&c.to_string());
+    }
+    out
+}
+```
+
+Update the call site in `render_row` (around `render.rs:246`):
+
+```rust
+let bar_str = colorize_bar(&bar_raw, entry, 0.0, false);
+```
+
+Also update the existing `partial_cell_gets_background_to_close_gap` test (around `render.rs:983`) to use the new signature: `colorize_bar("█████▍", &e, 0.0, false)`.
+
+- [ ] **Step 7.3: Run tests and confirm only the gradient + bg tests fail**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: `file_bar_fill_fades_with_factor_under_truecolor` and `file_bar_partial_bg_fades_with_factor_under_truecolor` FAIL; everything else PASSES.
+
+- [ ] **Step 7.4: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — colorize_bar truecolor branch and per-cell helper"
+```
+
+### Green
+
+- [ ] **Step 7.5: Replace the stub with the real fade**
+
+Add this constant alongside the other file palette entries:
+
+```rust
+const FILE_BAR_RGB: (u8, u8, u8) = (60, 200, 200);
+const FILE_BAR_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+```
+
+Replace `colorize_bar_styled`'s truecolor branch:
+
+```rust
+fn colorize_bar_styled(
+    bar: &str,
+    entry: &RenderEntry,
+    factor: f32,
+    truecolor: bool,
+) -> Vec<ColoredString> {
+    if entry.binary {
+        return bar.chars().map(|c| c.to_string().dimmed()).collect();
+    }
+    let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
+    let (bg_br, bg_bg, bg_bb) = if is_conflicted {
+        BAR_PARTIAL_BG_RED
+    } else {
+        BAR_PARTIAL_BG_CYAN
+    };
+    bar.chars()
+        .map(|c| {
+            let s = c.to_string();
+            if truecolor {
+                let fg_base = if is_conflicted {
+                    FILE_BAR_CONFLICT_RGB
+                } else {
+                    FILE_BAR_RGB
+                };
+                let (fr, fg, fb) = fade_rgb(fg_base, factor);
+                if is_partial_block(c) {
+                    let (pr, pg, pb) = fade_rgb((bg_br, bg_bg, bg_bb), factor);
+                    s.truecolor(fr, fg, fb).on_truecolor(pr, pg, pb)
+                } else {
+                    s.truecolor(fr, fg, fb)
+                }
+            } else if is_partial_block(c) {
+                if is_conflicted {
+                    s.red().on_truecolor(bg_br, bg_bg, bg_bb)
+                } else {
+                    s.cyan().on_truecolor(bg_br, bg_bg, bg_bb)
+                }
+            } else if is_conflicted {
+                s.red()
+            } else {
+                s.cyan()
+            }
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 7.6: Run the tests and verify they pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all pass.
+
+- [ ] **Step 7.7: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — colorize_bar fades fill fg and partial-cell bg together
+
+Both the bright cyan (or red, for conflicts) fill and the dim
+partial-cell background fade by the same factor so the bar darkens
+uniformly across the row."
+```
+
+---
+
+## Phase 8: Thread `truecolor` + `factor` through `render_row`
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — `render_row` (currently `render.rs:207–283`) computes `let factor = file_fade_factor(entry.age);` once and passes `(factor, opts.truecolor)` into every `colorize_*` call. After this phase, file rows actually fade end-to-end in truecolor mode.
+
+### Red
+
+- [ ] **Step 8.1: Write the integration-shaped failing tests**
+
+These exercise `render_row` indirectly through `render` so they prove the wiring actually goes from `RenderOptions.truecolor` all the way to per-cell color output.
+
+```rust
+#[test]
+fn file_row_renders_with_truecolor_when_enabled() {
+    use colored::Color;
+    // Force the colored crate to actually emit ANSI in the test process so
+    // we can detect the truecolor codes from the rendered output.
+    colored::control::set_override(true);
+    let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+    let mut o = opts();
+    o.truecolor = true;
+    let out = render(&snap, &o);
+    colored::control::unset_override();
+    // Truecolor foreground sequences start with `\x1b[38;2;`.
+    assert!(
+        out.contains("\x1b[38;2;"),
+        "rendered file row should contain a truecolor ANSI sequence when truecolor=true",
+    );
+}
+
+#[test]
+fn file_row_no_truecolor_in_8_color_mode() {
+    colored::control::set_override(true);
+    let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+    let out = render(&snap, &opts());
+    colored::control::unset_override();
+    assert!(
+        !out.contains("\x1b[38;2;"),
+        "8-color mode must not emit any truecolor sequences for file rows",
+    );
+}
+
+#[test]
+fn file_row_darkens_with_mtime_under_truecolor() {
+    // End-to-end: an older file's row should contain a darker (lower-channel)
+    // truecolor sequence than a fresher row of the same status.
+    colored::control::set_override(true);
+    let mut fresh_entry = entry("src/foo.rs", FileStatus::Modified, false, 5, 2);
+    fresh_entry.age = Some(Duration::from_secs(0));
+    let mut aged_entry = entry("src/bar.rs", FileStatus::Modified, false, 5, 2);
+    aged_entry.age = Some(Duration::from_secs(60 * 60));
+
+    let fresh_snap = snap_with(vec![fresh_entry]);
+    let aged_snap = snap_with(vec![aged_entry]);
+    let mut o = opts();
+    o.truecolor = true;
+    let fresh_out = render(&fresh_snap, &o);
+    let aged_out = render(&aged_snap, &o);
+    colored::control::unset_override();
+
+    let max_r = |s: &str| {
+        // Extract the largest r-channel from any 38;2;r;g;b foreground sequence.
+        let mut best: Option<u8> = None;
+        let bytes = s.as_bytes();
+        let needle = b"\x1b[38;2;";
+        let mut i = 0;
+        while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
+            let start = i + pos + needle.len();
+            // Read r digits.
+            let mut j = start;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            if j > start {
+                if let Ok(r) = std::str::from_utf8(&bytes[start..j]).unwrap().parse::<u8>() {
+                    best = Some(best.map_or(r, |b| b.max(r)));
+                }
+            }
+            i = j;
+        }
+        best.expect("at least one truecolor sequence")
+    };
+
+    let fresh_max = max_r(&fresh_out);
+    let aged_max = max_r(&aged_out);
+    assert!(
+        aged_max < fresh_max,
+        "aged row's brightest channel should be lower than fresh row's: fresh={fresh_max} aged={aged_max}",
+    );
+}
+
+#[test]
+fn file_row_no_age_renders_at_floor_under_truecolor() {
+    // Deleted file (age=None) should produce only sequences with channels
+    // at or below the FADE_FLOOR fraction of their base.
+    use crate::age::FADE_FLOOR;
+    colored::control::set_override(true);
+    let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
+    e.age = None;
+    let snap = snap_with(vec![e]);
+    let mut o = opts();
+    o.truecolor = true;
+    let out = render(&snap, &o);
+    colored::control::unset_override();
+
+    // The brightest channel allowed at the floor is `255 × FADE_FLOOR`
+    // (a base channel of 255 hits the highest floor). Use that as the
+    // conservative upper bound for any column, plus a small slack for
+    // rounding. Any row column emitting a channel above this means a
+    // colorize_* fn forgot to apply the fade.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "255.0 × FADE_FLOOR ∈ [0, 255]"
+    )]
+    let upper = ((255.0_f32 * FADE_FLOOR).round() as u8).saturating_add(2);
+
+    // Parse every r-channel as before and assert all are <= upper.
+    let bytes = out.as_bytes();
+    let needle = b"\x1b[38;2;";
+    let mut i = 0;
+    let mut saw_any = false;
+    while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
+        let start = i + pos + needle.len();
+        let mut j = start;
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > start {
+            let r: u8 = std::str::from_utf8(&bytes[start..j]).unwrap().parse().unwrap();
+            assert!(
+                r <= upper,
+                "every channel on a no-age row should sit at or below the floor (got {r}, upper {upper})",
+            );
+            saw_any = true;
+        }
+        i = j;
+    }
+    assert!(saw_any, "should have emitted at least one truecolor sequence");
+}
+```
+
+- [ ] **Step 8.2: Verify tests fail with the current `render_row` (still passing `0.0, false` everywhere)**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: `file_row_renders_with_truecolor_when_enabled`, `file_row_darkens_with_mtime_under_truecolor`, and `file_row_no_age_renders_at_floor_under_truecolor` FAIL; `file_row_no_truecolor_in_8_color_mode` PASSES (no truecolor anywhere yet).
+
+- [ ] **Step 8.3: Commit the red**
+
+```bash
+git add src/gsw/src/render.rs
+git commit --no-verify -m "gsw: red — end-to-end file-row truecolor wiring tests
+
+Render-level tests that detect ANSI 38;2; (truecolor) sequences in the
+rendered output, confirming the wiring goes RenderOptions.truecolor
+through to per-cell color emission once Phase 8 hooks it up."
+```
+
+### Green
+
+- [ ] **Step 8.4: Wire `factor` + `opts.truecolor` through `render_row`**
+
+In `src/gsw/src/render.rs`, replace the body of `render_row` so it threads the new values into every colorize call:
+
+```rust
+fn render_row(
+    entry: &RenderEntry,
+    opts: &RenderOptions,
+    max_change: u32,
+    path_width: usize,
+) -> String {
+    let (icon, letter) = icon_and_letter(entry);
+    let factor = file_fade_factor(entry.age);
+    let tc = opts.truecolor;
+
+    let path_display_raw = match &entry.orig_path {
+        Some(orig) => format!("{orig} → {new}", new = entry.path),
+        None => entry.path.clone(),
+    };
+    let path_truncated = truncate_left(&path_display_raw, path_width);
+    let path_padded = pad_right(&path_truncated, path_width);
+
+    let icon_str = colorize_icon(icon, entry, factor, tc);
+    let letter_str = colorize_letter(letter, entry, factor, tc);
+    let path_str = colorize_path(&path_padded, entry, factor, tc);
+
+    if matches!(
+        entry.status,
+        FileStatus::Untracked | FileStatus::UntrackedDir
+    ) {
+        let gutter_width = right_block_width(opts.bar_width) - AGE_FIELD;
+        let gutter = " ".repeat(gutter_width);
+        let age = entry.age.map(format_age_detailed).unwrap_or_default();
+        let age_field = format!("{age:>width$}", width = AGE_FIELD);
+        let age_str = colorize_age(&age_field, entry.age, factor, tc);
+        return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
+    }
+
+    let bar_raw = if entry.binary {
+        center("bin", opts.bar_width)
+    } else {
+        render_bar(entry.adds.saturating_add(entry.dels), max_change, opts.bar_width)
+    };
+    let bar_str = colorize_bar(&bar_raw, entry, factor, tc);
+
+    let adds_raw = if entry.adds > 0 {
+        format!("+{}", entry.adds)
+    } else {
+        String::new()
+    };
+    let dels_raw = if entry.dels > 0 {
+        format!("-{}", entry.dels)
+    } else {
+        String::new()
+    };
+    let adds_field = format!("{adds_raw:>width$}", width = ADDS_FIELD);
+    let dels_field = format!("{dels_raw:>width$}", width = DELS_FIELD);
+
+    let adds_str = if entry.adds > 0 {
+        colorize_adds(&adds_field, factor, tc).to_string()
+    } else {
+        adds_field
+    };
+    let dels_str = if entry.dels > 0 {
+        colorize_dels(&dels_field, factor, tc).to_string()
+    } else {
+        dels_field
+    };
+
+    let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
+    let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
+    let age_str = colorize_age(&age_field, entry.age, factor, tc);
+
+    let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
+    let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);
+    let sep_dels_age = " ".repeat(SEP_DELS_AGE);
+
+    format!(
+        "{icon_str} {letter_str} {path_str}{bar_str}{sep_bar_adds}{adds_str}{sep_adds_dels}{dels_str}{sep_dels_age}{age_str}",
+    )
+}
+```
+
+- [ ] **Step 8.5: Run the tests and verify all pass**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml`
+
+Expected: all tests pass, including the new end-to-end ones.
+
+- [ ] **Step 8.6: Commit the green**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: green — thread factor + truecolor through render_row
+
+file_fade_factor(entry.age) is computed once per row and passed into
+every colorize_* call. End-to-end: enabling truecolor now fades file
+rows from a per-status base RGB toward the dark floor as files age,
+matching the commit-log section's gradient."
+```
+
+---
+
+## Phase 9: Status-hue distinctness invariant test
+
+A pure regression-style invariant: at the floor (worst case for hue washout), the icon RGBs for the five statuses must stay pairwise distinct, so users can still tell at-a-glance what a row is even at age ∞.
+
+**Files:**
+- Modify: `src/gsw/src/render.rs` — test-only addition.
+
+### Red + Green
+
+- [ ] **Step 9.1: Write the test**
+
+```rust
+#[test]
+fn file_row_status_hues_remain_distinct_at_floor() {
+    // At the dark floor, fading must not collapse different statuses into
+    // the same RGB. We check icon base hues fade to distinct floored RGBs.
+    let bases = [
+        ("staged", FILE_ICON_STAGED_RGB),
+        ("unstaged", FILE_ICON_UNSTAGED_RGB),
+        ("untracked", FILE_ICON_UNTRACKED_RGB),
+        ("conflict", FILE_ICON_CONFLICT_RGB),
+    ];
+    let floored: Vec<((u8,u8,u8), &str)> = bases
+        .iter()
+        .map(|(name, rgb)| (fade_rgb(*rgb, 1.0), *name))
+        .collect();
+    for i in 0..floored.len() {
+        for j in (i + 1)..floored.len() {
+            let ((ar, ag, ab), aname) = floored[i];
+            let ((br, bg, bb), bname) = floored[j];
+            // Manhattan distance > 0 isn't enough — we want a perceptible
+            // difference even after the channels shrink. Require at least
+            // 10 units of total channel difference.
+            let dist = (i32::from(ar) - i32::from(br)).abs()
+                + (i32::from(ag) - i32::from(bg)).abs()
+                + (i32::from(ab) - i32::from(bb)).abs();
+            assert!(
+                dist >= 10,
+                "{aname} and {bname} floored RGBs too close: {ar:?},{ag:?},{ab:?} vs {br:?},{bg:?},{bb:?} (dist {dist})",
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 9.2: Run the test**
+
+Run: `cargo test --lib --manifest-path src/gsw/Cargo.toml file_row_status_hues_remain_distinct_at_floor`
+
+This test should PASS on the first run because the constants in earlier phases were chosen to satisfy it. If it fails, the palette needs adjustment — fix the constants in `render.rs` and re-run.
+
+Why no separate red commit? This test pins an *existing* invariant of the palette chosen in Phases 2–7. There's no implementation to write for it. The red/green discipline applies to *behavioral* tests for new code; this is a property-style guard that fails only when someone later picks confusing colors. Committing it on its own is fine.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add src/gsw/src/render.rs
+git commit -m "gsw: pin file-row status hue distinctness invariant at floor
+
+Pairwise channel-distance check across the icon palette at FADE_FLOOR.
+Guards against a future tweak that would collapse two statuses into
+visually indistinguishable floored hues."
+```
+
+---
+
+## Phase 10: Manual visual verification
+
+This is the only step that can't be a unit test — make sure the change actually looks right under `viddy gsw` in a real terminal.
+
+- [ ] **Step 10.1: Build the release binary**
+
+Run from the repo root:
+
+```bash
+cargo build --release --manifest-path src/gsw/Cargo.toml
+```
+
+- [ ] **Step 10.2: Run `viddy gsw` in a terminal with truecolor**
+
+In a `viddy gsw` (or `viddy --shell zsh "./target/release/gsw"`) session inside this very worktree — which has a mix of staged, unstaged, untracked, and (if you can manufacture them) deleted files — visually confirm:
+
+1. Freshly-modified files render in bright color.
+2. Hour-old modifications render visibly dimmer.
+3. Day-old modifications render at the dark floor.
+4. The bar fill darkens uniformly across the row.
+5. Deleted files (if present) and untracked dirs render at the floor.
+6. The file list and the commit-log section share one continuous brightness timeline — the eye can see them as one gradient.
+
+If anything looks wrong, adjust the per-status base RGB constants in `render.rs` and re-run.
+
+- [ ] **Step 10.3: (Optional) Run with `--no-truecolor` and confirm 8-color output is unchanged**
+
+```bash
+./target/release/gsw --no-truecolor
+```
+
+The output should match exactly what gsw produced before this branch landed for the file-row section — bucketed dim styling, no continuous gradient.
+
+- [ ] **Step 10.4: No commit needed** unless tweaks were made. If tweaks were made, commit as a green follow-up using the same TDD discipline (write a quick test that pins the new value if it matters; otherwise commit as a tuning patch).
+
+---
+
+## Done criteria
+
+When all checkboxes above are checked, every box in this list is true:
+
+- [ ] `file_fade_factor` exists, with `Some(0)` → `0.0`, `None` → `1.0`, `Some(d)` → `age_fade_factor(d)`.
+- [ ] Each of `colorize_icon`, `colorize_letter`, `colorize_path`, `colorize_bar`, `colorize_adds`, `colorize_dels`, `colorize_age` has a truecolor branch that fades a status-appropriate base RGB by the row's factor.
+- [ ] `render_row` computes `file_fade_factor(entry.age)` once and threads `(factor, opts.truecolor)` to every colorize call.
+- [ ] All new and existing tests pass under `cargo test --lib --manifest-path src/gsw/Cargo.toml`.
+- [ ] Visual verification under `viddy gsw` confirms the file list shares the commit-log fade timeline.
+- [ ] `gsw --no-truecolor` renders the file section identically to today.

--- a/specs/2026-05-22-gsw-file-row-fade-design.md
+++ b/specs/2026-05-22-gsw-file-row-fade-design.md
@@ -1,0 +1,210 @@
+# gsw: age-driven truecolor fade for file rows
+
+**Status:** Approved
+**Date:** 2026-05-22
+**Author:** gsw maintainers
+
+## Motivation
+
+`gsw` already fades recent-commit rows from bright to dark as commits age, using a
+24-bit (truecolor) ANSI gradient (`render.rs:407–448`). The file list still uses
+the legacy bucketed dim styling (`AgeDim::Fresh/Recent/Aging/Stale`). Within one
+`viddy gsw` frame the two stacked sections therefore speak different visual
+languages: the log section reads as a continuous timeline, while the file list
+reads as four flat brightness buckets. We want files to share the same gradient
+so the eye can scan both sections under one rule — newest content is brightest,
+oldest content sits at the dark floor.
+
+## Goals
+
+1. In truecolor mode, every cell of a file row (icon, status letter, path, bar,
+   `+adds`, `-dels`, age) fades from a status-appropriate base RGB toward the
+   shared `FADE_FLOOR` (30%) as the file's mtime ages, using the existing linear
+   0..2h ramp.
+2. Status semantics survive the fade: conflicts stay red-flavored, staged stays
+   green-flavored, untracked stays cyan-flavored, etc. — the hue is preserved
+   across the whole fade range; only brightness decreases with age.
+3. Files with no available mtime (deleted files, untracked directories we don't
+   stat) render at the floor.
+4. In the 8-color fallback path, file-row rendering is byte-identical to today —
+   no behavior change for terminals without truecolor.
+
+## Non-goals
+
+- Changing the file-list sort order. The newest-first sort already shipped in
+  #246 and stays as-is.
+- Reworking the `AgeDim` bucket enum. It still serves the 8-color fallback for
+  both the log section and the file list, and is left untouched.
+- Fading the header, separators, or `+N more files` footer. Chrome stays
+  neutral so the eye has a stable frame.
+- Fading any column on the log section differently than it already does.
+
+## Design
+
+### Shared fade helper
+
+The existing `fade_truecolor(s, age, base)` (`render.rs:407–410`) generalizes
+cleanly to file rows. We add one new helper alongside it:
+
+```rust
+/// Fade factor for a file row.
+///
+/// `Some(age)` uses the same `age_fade_factor(age)` ramp as commit rows so
+/// the two sections share one timeline. `None` returns `1.0` — files we
+/// can't stat (deleted entries, skipped untracked dirs) render at the
+/// dark floor, consistent with today's `.dimmed()` styling for None ages.
+fn file_fade_factor(age: Option<Duration>) -> f32 {
+    age.map_or(1.0, age_fade_factor)
+}
+```
+
+The existing `age_fade_factor` and `fade_rgb` are untouched.
+
+### Per-status base RGB palette
+
+A small set of constants near the existing `LOG_*_BASE_RGB` block. Each base is
+chosen so that at `factor = 0` it visually approximates today's ANSI color, and
+at `factor = 1` (× 30%) it still reads as the same hue family — never a
+near-black blob.
+
+| Element                     | Base RGB (approx) | Notes                                         |
+|-----------------------------|-------------------|-----------------------------------------------|
+| `FILE_ICON_STAGED_RGB`      | (90, 220, 110)    | Green `●`                                     |
+| `FILE_ICON_UNSTAGED_RGB`    | (220, 200, 100)   | Yellow `○`                                    |
+| `FILE_ICON_UNTRACKED_RGB`   | (120, 200, 200)   | Already-dim cyan `?`                          |
+| `FILE_ICON_CONFLICT_RGB`    | (255, 80, 80)     | Red-bold `!`                                  |
+| `FILE_LETTER_ADDED_RGB`     | (90, 220, 110)    | Green `A`                                     |
+| `FILE_LETTER_DELETED_RGB`   | (255, 80, 80)     | Red `D`                                       |
+| `FILE_LETTER_RENAMED_RGB`   | (220, 120, 220)   | Magenta `R` / `C`                             |
+| `FILE_LETTER_DEFAULT_RGB`   | (230, 230, 230)   | Plain-bold `M` / `T`                          |
+| `FILE_LETTER_CONFLICT_RGB`  | (255, 80, 80)     | Red `U`                                       |
+| `FILE_LETTER_UNTRACKED_RGB` | (120, 200, 200)   | Cyan `?`                                      |
+| `FILE_PATH_STAGED_RGB`      | (200, 200, 200)   | Approximates `.normal().dimmed()`             |
+| `FILE_PATH_UNSTAGED_RGB`    | (220, 200, 100)   | Approximates `.yellow()`                      |
+| `FILE_PATH_UNTRACKED_RGB`   | (120, 200, 200)   | Approximates `.cyan().dimmed()`               |
+| `FILE_PATH_CONFLICT_RGB`    | (255, 90, 90)     | Approximates `.red()`                         |
+| `FILE_ADDS_RGB`             | (90, 220, 110)    | Matches `.green()`                            |
+| `FILE_DELS_RGB`             | (255, 90, 90)     | Matches `.red()`                              |
+| `FILE_BAR_RGB`              | (60, 200, 200)    | Matches `.cyan()` fill                        |
+| `FILE_BAR_CONFLICT_RGB`     | (255, 80, 80)     | Matches `.red()` fill for conflicted rows     |
+| `FILE_BAR_PARTIAL_BG_RGB`   | (0, 48, 48)       | Existing `BAR_PARTIAL_BG_CYAN`, reused        |
+| `FILE_BAR_PARTIAL_BG_RED`   | (48, 0, 0)        | Existing `BAR_PARTIAL_BG_RED`, reused         |
+| `FILE_AGE_RGB`              | (190, 190, 190)   | Reuses `LOG_AGE_BASE_RGB` value for parity    |
+| `FILE_BIN_RGB`              | (140, 140, 140)   | Approximates `.dimmed()` for the `bin` marker |
+
+These are tuned by eye against the legacy ANSI palette; small adjustments during
+implementation are fine as long as the fresh end still reads as the same hue
+family.
+
+### Threading `truecolor` through `render_row`
+
+`render_row` already receives `&RenderOptions`, which carries the `truecolor`
+flag. The change is mechanical:
+
+1. Compute `let factor = file_fade_factor(entry.age);` once at the top of
+   `render_row`.
+2. Pass `factor` and `opts.truecolor` (or a small `FadeCtx { factor, truecolor }`
+   struct, decided during implementation) into each `colorize_*` call.
+3. Each `colorize_*` function gains the shape:
+   ```rust
+   fn colorize_path(path: &str, entry: &RenderEntry, factor: f32, truecolor: bool) -> ColoredString {
+       if truecolor {
+           let base = match entry.status { /* per-status RGB */ };
+           let (r, g, b) = fade_rgb(base, factor);
+           path.truecolor(r, g, b)
+       } else {
+           // existing 8-color logic, byte-identical to today
+       }
+   }
+   ```
+4. The bar colorizer fades both the fill foreground and the partial-cell
+   background by the same factor so the bar darkens uniformly.
+
+### Bar fade specifics
+
+The bar today uses `.cyan()` (ANSI 8-color) for filled cells and a 24-bit
+`on_truecolor(0, 48, 48)` background for partial cells. In truecolor mode:
+- Filled-cell foreground becomes `truecolor(r, g, b)` where `(r,g,b)` is
+  `fade_rgb(FILE_BAR_RGB, factor)`.
+- Partial-cell background becomes `on_truecolor(r', g', b')` where `(r',g',b')`
+  is `fade_rgb(BAR_PARTIAL_BG_CYAN, factor)`.
+- Same swap for the conflicted-row red variant.
+
+This keeps the gap-closing trick from #248 working while letting the whole bar
+fade together.
+
+### Untracked rows
+
+Untracked rows skip the bar/adds/dels block and just pad the gutter. Their age
+is set (we stat them in `git.rs`), so they fade normally on icon, letter, path,
+and age. The gutter padding stays whitespace — no need to fade empty space.
+
+### Binary files
+
+The `bin` marker keeps its dim styling. In truecolor mode it fades from
+`FILE_BIN_RGB` toward the floor — same fade contract as everything else.
+
+## Data flow
+
+```
+RenderEntry.age  ──►  file_fade_factor(age)  ──►  factor: f32
+                                                     │
+RenderOptions.truecolor  ────────────────────────────┤
+                                                     ▼
+                                     each colorize_*(..., factor, truecolor)
+                                                     │
+                                  ┌──────────────────┴──────────────────┐
+                                  ▼                                     ▼
+                          truecolor: fade_rgb(base, factor)     8-color: existing path
+                                  │                                     │
+                                  └──────────────► ColoredString ◄──────┘
+```
+
+## Testing (TDD red → green)
+
+Tests are added under `render.rs`'s existing `#[cfg(test)] mod tests` block,
+following the pattern set by the log-fade tests (`render.rs:1388–1517`). All
+tests inspect `ColoredString::fgcolor` / `bgcolor` typed enums rather than ANSI
+bytes, so they don't race on `colored::control::set_override`.
+
+Required tests (each commits as a red test first, then a green commit):
+
+1. **`file_path_uses_truecolor_when_enabled`** — `colorize_path` for a modified
+   file at age=0 with truecolor=true returns a `Color::TrueColor { .. }`.
+2. **`file_path_falls_back_to_legacy_color_without_truecolor`** — same call with
+   truecolor=false returns `Color::Yellow` (or the legacy color for that
+   status); proves the 8-color path is untouched.
+3. **`file_row_darkens_with_age_under_truecolor`** — render two snapshots of the
+   same file (age=0 and age=1h) under truecolor; every column's R channel of
+   the 1h row is strictly less than the corresponding fresh row's R channel.
+4. **`file_row_stays_above_floor_when_very_old`** — at age=1 week, every column
+   stays at or above its `FADE_FLOOR` fraction (mirrors
+   `log_hash_stays_above_floor_when_very_old`).
+5. **`file_row_no_age_renders_at_floor`** — a deleted file (age=None) under
+   truecolor renders every column at the floor.
+6. **`file_row_status_hues_remain_distinct_at_floor`** — at age=∞, the icon RGBs
+   for Modified/Added/Deleted/Conflicted/Untracked are pairwise distinct, so
+   fading never collapses status hues into one indistinguishable blob.
+7. **`bar_fill_fades_with_age_under_truecolor`** — bar fill at age=0 is
+   brighter (higher channel sum) than at age=1h.
+8. **`bar_partial_background_fades_with_age_under_truecolor`** — the
+   `on_truecolor` background of a partial-cell bar also darkens with age.
+9. **`file_row_byte_identical_in_8_color_mode`** — render a snapshot with
+   truecolor=false twice (once representing today's behavior, once
+   post-change) and assert the ANSI byte sequence matches a golden string for a
+   representative row covering each status. Acts as the regression guard for
+   the fallback path. *(Implementation note: rather than committing a
+   pre-change golden, we capture today's output via a small test fixture
+   committed alongside the red test in the first TDD step.)*
+
+## Out of scope
+
+- Tunable per-status base colors via env vars or CLI flags.
+- Color profile / theming systems beyond the existing truecolor on/off switch.
+- Animating between brightness states across `viddy` refreshes.
+- Any change to the log section, header, separator, or footer.
+
+## Open questions
+
+None. The design above resolves the only two genuinely ambiguous points
+(scope = whole row, None-age = floor) per the brainstorming discussion.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -305,13 +305,19 @@ fn icon_and_letter(entry: &RenderEntry) -> (char, char) {
 fn colorize_icon(
     icon: char,
     entry: &RenderEntry,
-    _factor: f32,
+    factor: f32,
     truecolor: bool,
 ) -> ColoredString {
     let s = icon.to_string();
     if truecolor {
-        // Wrong stub — constant grey breaks the gradient assertion only.
-        return s.truecolor(50, 50, 50);
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_ICON_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_ICON_UNTRACKED_RGB,
+            _ if entry.staged => FILE_ICON_STAGED_RGB,
+            _ => FILE_ICON_UNSTAGED_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return s.truecolor(r, g, b);
     }
     match entry.status {
         FileStatus::Conflicted => s.red().bold(),

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -399,6 +399,11 @@ fn colorize_bar_styled(
     truecolor: bool,
 ) -> Vec<ColoredString> {
     if entry.binary {
+        if truecolor {
+            // Wrong stub — returns constant grey so the gradient test
+            // fails on behavior, not on missing structure.
+            return bar.chars().map(|c| c.to_string().truecolor(50, 50, 50)).collect();
+        }
         return bar.chars().map(|c| c.to_string().dimmed()).collect();
     }
     let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
@@ -535,6 +540,7 @@ const FILE_ADDS_RGB: (u8, u8, u8) = (90, 220, 110);
 const FILE_DELS_RGB: (u8, u8, u8) = (255, 90, 90);
 const FILE_BAR_RGB: (u8, u8, u8) = (60, 200, 200);
 const FILE_BAR_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+const FILE_BIN_RGB: (u8, u8, u8) = (140, 140, 140);
 
 /// Fade factor for a file row.
 ///
@@ -2191,5 +2197,44 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn file_bar_binary_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+        e.binary = true;
+        // Use the same "bin" string render_row builds for binary entries.
+        let cells = colorize_bar_styled("bin", &e, 0.0, true);
+        match cells[0].fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor for binary marker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_bar_binary_falls_back_to_dimmed_without_truecolor() {
+        // Regression guard: 8-color path keeps the legacy `.dimmed()` styling.
+        use colored::Styles;
+        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+        e.binary = true;
+        let cells = colorize_bar_styled("bin", &e, 0.0, false);
+        assert!(
+            cells[0].style.contains(Styles::Dimmed),
+            "8-color binary marker should still be .dimmed()",
+        );
+    }
+
+    #[test]
+    fn file_bar_binary_darkens_with_factor_under_truecolor() {
+        use colored::Color;
+        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+        e.binary = true;
+        let fresh = colorize_bar_styled("bin", &e, 0.0, true);
+        let aged = colorize_bar_styled("bin", &e, 1.0, true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+            (fresh[0].fgcolor, aged[0].fgcolor)
+        else { panic!("both should be TrueColor under truecolor=true") };
+        assert!(ar < fr, "aged binary marker should be darker: fresh={fr} aged={ar}");
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -212,7 +212,7 @@ fn render_row(
 ) -> String {
     let (icon, letter) = icon_and_letter(entry);
     let factor = file_fade_factor(entry.age);
-    let tc = opts.truecolor;
+    let truecolor = opts.truecolor;
 
     let path_display_raw = match &entry.orig_path {
         Some(orig) => format!("{orig} → {new}", new = entry.path),
@@ -221,9 +221,9 @@ fn render_row(
     let path_truncated = truncate_left(&path_display_raw, path_width);
     let path_padded = pad_right(&path_truncated, path_width);
 
-    let icon_str = colorize_icon(icon, entry, factor, tc);
-    let letter_str = colorize_letter(letter, entry, factor, tc);
-    let path_str = colorize_path(&path_padded, entry, factor, tc);
+    let icon_str = colorize_icon(icon, entry, factor, truecolor);
+    let letter_str = colorize_letter(letter, entry, factor, truecolor);
+    let path_str = colorize_path(&path_padded, entry, factor, truecolor);
 
     if matches!(
         entry.status,
@@ -233,7 +233,7 @@ fn render_row(
         let gutter = " ".repeat(gutter_width);
         let age = entry.age.map(format_age_detailed).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
-        let age_str = colorize_age(&age_field, entry.age, factor, tc);
+        let age_str = colorize_age(&age_field, entry.age, factor, truecolor);
         return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
     }
 
@@ -242,7 +242,7 @@ fn render_row(
     } else {
         render_bar(entry.adds.saturating_add(entry.dels), max_change, opts.bar_width)
     };
-    let bar_str = colorize_bar(&bar_raw, entry, factor, tc);
+    let bar_str = colorize_bar(&bar_raw, entry, factor, truecolor);
 
     let adds_raw = if entry.adds > 0 {
         format!("+{}", entry.adds)
@@ -258,19 +258,19 @@ fn render_row(
     let dels_field = format!("{dels_raw:>width$}", width = DELS_FIELD);
 
     let adds_str = if entry.adds > 0 {
-        colorize_adds(&adds_field, factor, tc).to_string()
+        colorize_adds(&adds_field, factor, truecolor).to_string()
     } else {
         adds_field
     };
     let dels_str = if entry.dels > 0 {
-        colorize_dels(&dels_field, factor, tc).to_string()
+        colorize_dels(&dels_field, factor, truecolor).to_string()
     } else {
         dels_field
     };
 
     let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
-    let age_str = colorize_age(&age_field, entry.age, factor, tc);
+    let age_str = colorize_age(&age_field, entry.age, factor, truecolor);
 
     let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
     let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -2027,7 +2027,6 @@ mod tests {
 
     #[test]
     fn file_row_renders_with_truecolor_when_enabled() {
-        use colored::Color;
         // Force the colored crate to actually emit ANSI in the test process so
         // we can detect the truecolor codes from the rendered output.
         let _guard = COLORED_OVERRIDE_GUARD
@@ -2044,8 +2043,6 @@ mod tests {
             out.contains("\x1b[38;2;"),
             "rendered file row should contain a truecolor ANSI sequence when truecolor=true",
         );
-        // Silence the unused-import warning when the macro doesn't fire below.
-        let _ = Color::Red;
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -219,7 +219,7 @@ fn render_row(
     let path_truncated = truncate_left(&path_display_raw, path_width);
     let path_padded = pad_right(&path_truncated, path_width);
 
-    let icon_str = colorize_icon(icon, entry);
+    let icon_str = colorize_icon(icon, entry, 0.0, false);
     let letter_str = colorize_letter(letter, entry);
     let path_str = colorize_path(&path_padded, entry, 0.0, false);
 
@@ -302,8 +302,17 @@ fn icon_and_letter(entry: &RenderEntry) -> (char, char) {
     (icon, letter)
 }
 
-fn colorize_icon(icon: char, entry: &RenderEntry) -> ColoredString {
+fn colorize_icon(
+    icon: char,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
     let s = icon.to_string();
+    if truecolor {
+        // Wrong stub — constant grey breaks the gradient assertion only.
+        return s.truecolor(50, 50, 50);
+    }
     match entry.status {
         FileStatus::Conflicted => s.red().bold(),
         FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
@@ -424,6 +433,11 @@ const FILE_PATH_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
 const FILE_PATH_STAGED_RGB: (u8, u8, u8) = (200, 200, 200);
 const FILE_PATH_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
 const FILE_PATH_CONFLICT_RGB: (u8, u8, u8) = (255, 90, 90);
+
+const FILE_ICON_STAGED_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_ICON_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
+const FILE_ICON_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+const FILE_ICON_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
 
 /// Fade factor for a file row.
 ///
@@ -1676,5 +1690,39 @@ mod tests {
                 && b >= floor_of(bb).saturating_sub(1),
             "channels must not drop below the floor: actual=({r},{g},{b}) base=({br},{bg},{bb})",
         );
+    }
+
+    #[test]
+    fn file_icon_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+        let cs = colorize_icon('●', &e, 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor for icon under truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_icon_falls_back_to_ansi_without_truecolor() {
+        // Staged-modified icon today is plain green. Regression guard.
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+        let cs = colorize_icon('●', &e, 0.0, false);
+        assert_eq!(cs.fgcolor, Some(Color::Green));
+    }
+
+    #[test]
+    fn file_icon_darkens_with_age_under_truecolor() {
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+        let fresh = colorize_icon('●', &e, 0.0, true);
+        let aged = colorize_icon('●', &e, 1.0, true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+            (fresh.fgcolor, aged.fgcolor)
+        else {
+            panic!("both should be TrueColor");
+        };
+        assert!(ar < fr, "aged icon should be darker: fresh={fr} aged={ar}");
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -541,7 +541,7 @@ const FILE_ADDS_RGB: (u8, u8, u8) = (90, 220, 110);
 const FILE_DELS_RGB: (u8, u8, u8) = (255, 90, 90);
 const FILE_BAR_RGB: (u8, u8, u8) = (60, 200, 200);
 const FILE_BAR_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
-const FILE_BIN_RGB: (u8, u8, u8) = (140, 140, 140);
+const FILE_BIN_RGB: (u8, u8, u8) = (160, 160, 160);
 
 /// Fade factor for a file row.
 ///

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1973,4 +1973,137 @@ mod tests {
         use colored::Color;
         assert_eq!(cells[0].fgcolor, Some(Color::Cyan));
     }
+
+    // --- Phase 8: end-to-end render() truecolor wiring ----------------------
+
+    #[test]
+    fn file_row_renders_with_truecolor_when_enabled() {
+        use colored::Color;
+        // Force the colored crate to actually emit ANSI in the test process so
+        // we can detect the truecolor codes from the rendered output.
+        colored::control::set_override(true);
+        let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+        let mut o = opts();
+        o.truecolor = true;
+        let out = render(&snap, &o);
+        colored::control::unset_override();
+        // Truecolor foreground sequences start with `\x1b[38;2;`.
+        assert!(
+            out.contains("\x1b[38;2;"),
+            "rendered file row should contain a truecolor ANSI sequence when truecolor=true",
+        );
+        // Silence the unused-import warning when the macro doesn't fire below.
+        let _ = Color::Red;
+    }
+
+    #[test]
+    fn file_row_no_truecolor_in_8_color_mode() {
+        colored::control::set_override(true);
+        let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+        let out = render(&snap, &opts());
+        colored::control::unset_override();
+        assert!(
+            !out.contains("\x1b[38;2;"),
+            "8-color mode must not emit any truecolor sequences for file rows",
+        );
+    }
+
+    #[test]
+    fn file_row_darkens_with_mtime_under_truecolor() {
+        // End-to-end: an older file's row should contain a darker (lower-channel)
+        // truecolor sequence than a fresher row of the same status.
+        colored::control::set_override(true);
+        let mut fresh_entry = entry("src/foo.rs", FileStatus::Modified, false, 5, 2);
+        fresh_entry.age = Some(Duration::from_secs(0));
+        let mut aged_entry = entry("src/bar.rs", FileStatus::Modified, false, 5, 2);
+        aged_entry.age = Some(Duration::from_secs(60 * 60));
+
+        let fresh_snap = snap_with(vec![fresh_entry]);
+        let aged_snap = snap_with(vec![aged_entry]);
+        let mut o = opts();
+        o.truecolor = true;
+        let fresh_out = render(&fresh_snap, &o);
+        let aged_out = render(&aged_snap, &o);
+        colored::control::unset_override();
+
+        let max_r = |s: &str| {
+            // Extract the largest r-channel from any 38;2;r;g;b foreground sequence.
+            let mut best: Option<u8> = None;
+            let bytes = s.as_bytes();
+            let needle = b"\x1b[38;2;";
+            let mut i = 0;
+            while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
+                let start = i + pos + needle.len();
+                // Read r digits.
+                let mut j = start;
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    j += 1;
+                }
+                if j > start {
+                    if let Ok(r) = std::str::from_utf8(&bytes[start..j]).unwrap().parse::<u8>() {
+                        best = Some(best.map_or(r, |b| b.max(r)));
+                    }
+                }
+                i = j;
+            }
+            best.expect("at least one truecolor sequence")
+        };
+
+        let fresh_max = max_r(&fresh_out);
+        let aged_max = max_r(&aged_out);
+        assert!(
+            aged_max < fresh_max,
+            "aged row's brightest channel should be lower than fresh row's: fresh={fresh_max} aged={aged_max}",
+        );
+    }
+
+    #[test]
+    fn file_row_no_age_renders_at_floor_under_truecolor() {
+        // Deleted file (age=None) should produce only sequences with channels
+        // at or below the FADE_FLOOR fraction of their base.
+        use crate::age::FADE_FLOOR;
+        colored::control::set_override(true);
+        let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
+        e.age = None;
+        let snap = snap_with(vec![e]);
+        let mut o = opts();
+        o.truecolor = true;
+        let out = render(&snap, &o);
+        colored::control::unset_override();
+
+        // The brightest channel allowed at the floor is `255 × FADE_FLOOR`
+        // (a base channel of 255 hits the highest floor). Use that as the
+        // conservative upper bound for any column, plus a small slack for
+        // rounding. Any row column emitting a channel above this means a
+        // colorize_* fn forgot to apply the fade.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "255.0 × FADE_FLOOR ∈ [0, 255]"
+        )]
+        let upper = ((255.0_f32 * FADE_FLOOR).round() as u8).saturating_add(2);
+
+        // Parse every r-channel and assert all are <= upper.
+        let bytes = out.as_bytes();
+        let needle = b"\x1b[38;2;";
+        let mut i = 0;
+        let mut saw_any = false;
+        while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
+            let start = i + pos + needle.len();
+            let mut j = start;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            if j > start {
+                let r: u8 = std::str::from_utf8(&bytes[start..j]).unwrap().parse().unwrap();
+                assert!(
+                    r <= upper,
+                    "every channel on a no-age row should sit at or below the floor (got {r}, upper {upper})",
+                );
+                saw_any = true;
+            }
+            i = j;
+        }
+        assert!(saw_any, "should have emitted at least one truecolor sequence");
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -450,9 +450,10 @@ fn colorize_age(
 ///
 /// With `truecolor`, applies the age-driven fade starting from
 /// [`FILE_ADDS_RGB`]. Without, falls back to ANSI green.
-fn colorize_adds(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+fn colorize_adds(text: &str, factor: f32, truecolor: bool) -> ColoredString {
     if truecolor {
-        return text.truecolor(50, 50, 50);
+        let (r, g, b) = fade_rgb(FILE_ADDS_RGB, factor);
+        return text.truecolor(r, g, b);
     }
     text.green()
 }
@@ -461,9 +462,10 @@ fn colorize_adds(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
 ///
 /// With `truecolor`, applies the age-driven fade starting from
 /// [`FILE_DELS_RGB`]. Without, falls back to ANSI red.
-fn colorize_dels(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+fn colorize_dels(text: &str, factor: f32, truecolor: bool) -> ColoredString {
     if truecolor {
-        return text.truecolor(50, 50, 50);
+        let (r, g, b) = fade_rgb(FILE_DELS_RGB, factor);
+        return text.truecolor(r, g, b);
     }
     text.red()
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -388,10 +388,14 @@ const BAR_PARTIAL_BG_CYAN: (u8, u8, u8) = (0, 48, 48);
 /// Same idea for the conflicted-file bar, which paints in red.
 const BAR_PARTIAL_BG_RED: (u8, u8, u8) = (48, 0, 0);
 
-/// Build one `ColoredString` per visible cell of `bar`. The joined string
-/// returned by [`colorize_bar`] is just `colorize_bar_styled(...).join("")`
-/// with `.to_string()` applied to each cell — sharing the cell builder lets
-/// tests inspect the typed fg/bg colors per cell instead of parsing ANSI.
+/// Build one `ColoredString` per styling region of `bar`. For normal bars
+/// each visible cell needs its own region because partial-fill cells get a
+/// distinct background color; for binary bars there's no per-cell variation
+/// so the whole marker collapses to a single region (avoids paying 3× the
+/// ANSI overhead on the common "bin" string). The joined string returned
+/// by [`colorize_bar`] is just `colorize_bar_styled(...).join("")` with
+/// `.to_string()` applied to each region — sharing the builder lets tests
+/// inspect typed fg/bg colors instead of parsing ANSI.
 fn colorize_bar_styled(
     bar: &str,
     entry: &RenderEntry,
@@ -401,11 +405,9 @@ fn colorize_bar_styled(
     if entry.binary {
         if truecolor {
             let (r, g, b) = fade_rgb(FILE_BIN_RGB, factor);
-            return bar.chars()
-                .map(|c| c.to_string().truecolor(r, g, b))
-                .collect();
+            return vec![bar.to_string().truecolor(r, g, b)];
         }
-        return bar.chars().map(|c| c.to_string().dimmed()).collect();
+        return vec![bar.to_string().dimmed()];
     }
     let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
     let (bg_br, bg_bg, bg_bb) = if is_conflicted {

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -405,10 +405,8 @@ const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
 /// file list and log section darken in lockstep. `None` returns `1.0`
 /// so files we can't stat (deleted entries, skipped untracked dirs)
 /// render at the dark floor.
-fn file_fade_factor(_age: Option<Duration>) -> f32 {
-    // Intentionally wrong stub — the red test must fail on the assertion,
-    // not on a missing symbol.
-    0.5
+fn file_fade_factor(age: Option<Duration>) -> f32 {
+    age.map_or(1.0, age_fade_factor)
 }
 
 /// Apply the age-driven truecolor fade to `s`, starting from `base`.

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -400,9 +400,10 @@ fn colorize_bar_styled(
 ) -> Vec<ColoredString> {
     if entry.binary {
         if truecolor {
-            // Wrong stub — returns constant grey so the gradient test
-            // fails on behavior, not on missing structure.
-            return bar.chars().map(|c| c.to_string().truecolor(50, 50, 50)).collect();
+            let (r, g, b) = fade_rgb(FILE_BIN_RGB, factor);
+            return bar.chars()
+                .map(|c| c.to_string().truecolor(r, g, b))
+                .collect();
         }
         return bar.chars().map(|c| c.to_string().dimmed()).collect();
     }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -460,6 +460,21 @@ fn is_partial_block(c: char) -> bool {
     matches!(c, '\u{2589}'..='\u{258F}')
 }
 
+/// 8-color (ANSI) styling for an age column. Shared by the file-row
+/// `colorize_age` 8-color branch and the log-row `colorize_log_age`
+/// 8-color fallback so the dim/bold/italic buckets live in one place.
+fn colorize_age_ansi(text: &str, age: Option<Duration>) -> ColoredString {
+    let Some(age) = age else {
+        return text.dimmed();
+    };
+    match age_dim_level(age) {
+        AgeDim::Fresh => text.bold(),
+        AgeDim::Recent => text.normal(),
+        AgeDim::Aging => text.dimmed(),
+        AgeDim::Stale => text.dimmed().italic(),
+    }
+}
+
 fn colorize_age(
     text: &str,
     age: Option<Duration>,
@@ -470,15 +485,7 @@ fn colorize_age(
         let (r, g, b) = fade_rgb(FILE_AGE_RGB, factor);
         return text.truecolor(r, g, b);
     }
-    let Some(age) = age else {
-        return text.dimmed();
-    };
-    match age_dim_level(age) {
-        AgeDim::Fresh => text.bold(),
-        AgeDim::Recent => text.normal(),
-        AgeDim::Aging => text.dimmed(),
-        AgeDim::Stale => text.dimmed().italic(),
-    }
+    colorize_age_ansi(text, age)
 }
 
 /// Color the `+adds` field for a file row.
@@ -597,7 +604,7 @@ fn colorize_log_age(text: &str, age: Duration, truecolor: bool) -> ColoredString
     if truecolor {
         fade_truecolor(text, age, LOG_AGE_BASE_RGB)
     } else {
-        colorize_age(text, Some(age), 0.0, false)
+        colorize_age_ansi(text, Some(age))
     }
 }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -736,22 +736,62 @@ pub fn plan_section_caps(
 mod tests {
     use super::*;
 
-    /// Drop ANSI CSI sequences so tests can match on the visible glyphs.
+    /// Serializes any test that toggles `colored::control::set_override` —
+    /// the override is process-global, so concurrent toggles race and
+    /// cause intermittent failures. Tests that need ANSI bytes (rather
+    /// than typed `ColoredString::fgcolor` inspection) hold this for the
+    /// duration of their body.
+    ///
+    /// `.unwrap_or_else(|p| p.into_inner())` handles a poisoned mutex
+    /// from a previous panicking test so it doesn't cascade-fail the
+    /// rest of the suite.
+    static COLORED_OVERRIDE_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Drop ANSI escape sequences so tests can match on the visible glyphs.
+    ///
+    /// Handles the two common forms:
+    ///   - CSI sequences: `ESC [ <params…> <final>` where `<final>` is 0x40–0x7E.
+    ///   - Fe sequences:  `ESC <byte>` (single byte after ESC that isn't `[`).
+    ///
+    /// This is intentionally conservative — it only skips escape sequences,
+    /// never ordinary text.
     fn strip_ansi(s: &str) -> String {
+        #[derive(PartialEq)]
+        enum State {
+            Normal,
+            AfterEsc,
+            InCsi,
+        }
         let mut out = String::with_capacity(s.len());
-        let mut in_escape = false;
+        let mut state = State::Normal;
         for c in s.chars() {
-            if in_escape {
-                if (0x40..=0x7E).contains(&(c as u32)) {
-                    in_escape = false;
+            match state {
+                State::Normal => {
+                    if c == '\x1b' {
+                        state = State::AfterEsc;
+                    } else {
+                        out.push(c);
+                    }
                 }
-                continue;
+                State::AfterEsc => {
+                    if c == '[' {
+                        // CSI introducer — consume parameters until the final byte.
+                        state = State::InCsi;
+                    } else {
+                        // Fe-style single-byte escape (e.g. ESC M, ESC =).
+                        // The byte itself is the final byte; swallow it and resume.
+                        state = State::Normal;
+                    }
+                }
+                State::InCsi => {
+                    // Parameter bytes: 0x30–0x3F. Intermediate bytes: 0x20–0x2F.
+                    // Final byte: 0x40–0x7E — terminates the sequence.
+                    if (0x40..=0x7E).contains(&(c as u32)) {
+                        state = State::Normal;
+                    }
+                    // In all cases, keep consuming (don't push to output).
+                }
             }
-            if c == '\x1b' {
-                in_escape = true;
-                continue;
-            }
-            out.push(c);
         }
         out
     }
@@ -1126,6 +1166,9 @@ mod tests {
         // Force `colored` on so the test inspects the actual ANSI we would
         // emit on a real terminal; without this the crate strips all codes
         // in non-TTY test runs.
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         colored::control::set_override(true);
         let e = entry("foo.rs", FileStatus::Modified, true, 9, 1);
         let with_partial = colorize_bar("█████▍", &e, 0.0, false);
@@ -1980,6 +2023,9 @@ mod tests {
         use colored::Color;
         // Force the colored crate to actually emit ANSI in the test process so
         // we can detect the truecolor codes from the rendered output.
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         colored::control::set_override(true);
         let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
         let mut o = opts();
@@ -1997,6 +2043,9 @@ mod tests {
 
     #[test]
     fn file_row_no_truecolor_in_8_color_mode() {
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         colored::control::set_override(true);
         let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
         let out = render(&snap, &opts());
@@ -2011,6 +2060,9 @@ mod tests {
     fn file_row_darkens_with_mtime_under_truecolor() {
         // End-to-end: an older file's row should contain a darker (lower-channel)
         // truecolor sequence than a fresher row of the same status.
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         colored::control::set_override(true);
         let mut fresh_entry = entry("src/foo.rs", FileStatus::Modified, false, 5, 2);
         fresh_entry.age = Some(Duration::from_secs(0));
@@ -2061,6 +2113,9 @@ mod tests {
         // Deleted file (age=None) should produce only sequences with channels
         // at or below the FADE_FLOOR fraction of their base.
         use crate::age::FADE_FLOOR;
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         colored::control::set_override(true);
         let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
         e.age = None;

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -428,11 +428,12 @@ fn is_partial_block(c: char) -> bool {
 fn colorize_age(
     text: &str,
     age: Option<Duration>,
-    _factor: f32,
+    factor: f32,
     truecolor: bool,
 ) -> ColoredString {
     if truecolor {
-        return text.truecolor(50, 50, 50);
+        let (r, g, b) = fade_rgb(FILE_AGE_RGB, factor);
+        return text.truecolor(r, g, b);
     }
     let Some(age) = age else {
         return text.dimmed();

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -475,6 +475,13 @@ fn colorize_age_ansi(text: &str, age: Option<Duration>) -> ColoredString {
     }
 }
 
+/// Color the file-row age column.
+///
+/// Truecolor mode applies only the age-driven fade — the bucket-based
+/// `bold`/`italic`/`dimmed` styling from [`colorize_age_ansi`] is
+/// intentionally dropped because the gradient itself communicates
+/// freshness (no need to double-encode it with text decorations).
+/// Without truecolor, falls through to the legacy bucket styling.
 fn colorize_age(
     text: &str,
     age: Option<Duration>,

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -2160,4 +2160,36 @@ mod tests {
         }
         assert!(saw_any, "should have emitted at least one truecolor sequence");
     }
+
+    #[test]
+    fn file_row_status_hues_remain_distinct_at_floor() {
+        // At the dark floor, fading must not collapse different statuses into
+        // the same RGB. We check icon base hues fade to distinct floored RGBs.
+        let bases = [
+            ("staged", FILE_ICON_STAGED_RGB),
+            ("unstaged", FILE_ICON_UNSTAGED_RGB),
+            ("untracked", FILE_ICON_UNTRACKED_RGB),
+            ("conflict", FILE_ICON_CONFLICT_RGB),
+        ];
+        let floored: Vec<((u8,u8,u8), &str)> = bases
+            .iter()
+            .map(|(name, rgb)| (fade_rgb(*rgb, 1.0), *name))
+            .collect();
+        for i in 0..floored.len() {
+            for j in (i + 1)..floored.len() {
+                let ((ar, ag, ab), aname) = floored[i];
+                let ((br, bg, bb), bname) = floored[j];
+                // Manhattan distance > 0 isn't enough — we want a perceptible
+                // difference even after the channels shrink. Require at least
+                // 10 units of total channel difference.
+                let dist = (i32::from(ar) - i32::from(br)).abs()
+                    + (i32::from(ag) - i32::from(bg)).abs()
+                    + (i32::from(ab) - i32::from(bb)).abs();
+                assert!(
+                    dist >= 10,
+                    "{aname} and {bname} floored RGBs too close: {ar:?},{ag:?},{ab:?} vs {br:?},{bg:?},{bb:?} (dist {dist})",
+                );
+            }
+        }
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -396,14 +396,14 @@ const BAR_PARTIAL_BG_RED: (u8, u8, u8) = (48, 0, 0);
 fn colorize_bar_styled(
     bar: &str,
     entry: &RenderEntry,
-    _factor: f32,
+    factor: f32,
     truecolor: bool,
 ) -> Vec<ColoredString> {
     if entry.binary {
         return bar.chars().map(|c| c.to_string().dimmed()).collect();
     }
     let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
-    let (br, bg, bb) = if is_conflicted {
+    let (bg_br, bg_bg, bg_bb) = if is_conflicted {
         BAR_PARTIAL_BG_RED
     } else {
         BAR_PARTIAL_BG_CYAN
@@ -412,17 +412,23 @@ fn colorize_bar_styled(
         .map(|c| {
             let s = c.to_string();
             if truecolor {
-                // Wrong stub — constant grey breaks gradient + bg tests only.
-                if is_partial_block(c) {
-                    s.truecolor(50, 50, 50).on_truecolor(20, 20, 20)
+                let fg_base = if is_conflicted {
+                    FILE_BAR_CONFLICT_RGB
                 } else {
-                    s.truecolor(50, 50, 50)
+                    FILE_BAR_RGB
+                };
+                let (fr, fg, fb) = fade_rgb(fg_base, factor);
+                if is_partial_block(c) {
+                    let (pr, pg, pb) = fade_rgb((bg_br, bg_bg, bg_bb), factor);
+                    s.truecolor(fr, fg, fb).on_truecolor(pr, pg, pb)
+                } else {
+                    s.truecolor(fr, fg, fb)
                 }
             } else if is_partial_block(c) {
                 if is_conflicted {
-                    s.red().on_truecolor(br, bg, bb)
+                    s.red().on_truecolor(bg_br, bg_bg, bg_bb)
                 } else {
-                    s.cyan().on_truecolor(br, bg, bb)
+                    s.cyan().on_truecolor(bg_br, bg_bg, bg_bb)
                 }
             } else if is_conflicted {
                 s.red()
@@ -528,6 +534,8 @@ const FILE_LETTER_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
 const FILE_AGE_RGB: (u8, u8, u8) = (190, 190, 190);
 const FILE_ADDS_RGB: (u8, u8, u8) = (90, 220, 110);
 const FILE_DELS_RGB: (u8, u8, u8) = (255, 90, 90);
+const FILE_BAR_RGB: (u8, u8, u8) = (60, 200, 200);
+const FILE_BAR_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
 
 /// Fade factor for a file row.
 ///
@@ -1947,13 +1955,14 @@ mod tests {
     fn file_bar_partial_bg_fades_with_factor_under_truecolor() {
         use colored::Color;
         // Use a partial-fill glyph (▍ = U+258D) so a background color is set.
+        // BAR_PARTIAL_BG_CYAN = (0, 48, 48): r=0 so check g channel instead.
         let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
         let fresh = colorize_bar_styled("▍", &e, 0.0, true);
         let aged = colorize_bar_styled("▍", &e, 1.0, true);
-        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+        let (Some(Color::TrueColor { g: fg, .. }), Some(Color::TrueColor { g: ag, .. })) =
             (fresh[0].bgcolor, aged[0].bgcolor)
         else { panic!("partial cell should have a TrueColor background") };
-        assert!(ar < fr, "aged partial-cell bg should be darker: fresh={fr} aged={ar}");
+        assert!(ag < fg, "aged partial-cell bg should be darker: fresh={fg} aged={ag}");
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -2282,4 +2282,32 @@ mod tests {
         else { panic!("both should be TrueColor under truecolor=true") };
         assert!(ar < fr, "aged binary marker should be darker: fresh={fr} aged={ar}");
     }
+
+    #[test]
+    fn file_bar_binary_emits_single_ansi_wrapper() {
+        // Binary bars have no per-cell variation (no partial-fill bg, no
+        // status-varying fill), so the rendered string should wrap the whole
+        // marker in one fg sequence + one reset — not pay 3× the ANSI overhead
+        // by re-emitting the sequence for every char of "bin". Holds for both
+        // 8-color and truecolor paths.
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        colored::control::set_override(true);
+        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+        e.binary = true;
+        let out_ansi = colorize_bar("bin", &e, 0.0, false);
+        let out_tc = colorize_bar("bin", &e, 0.0, true);
+        colored::control::unset_override();
+        assert_eq!(
+            out_ansi.matches("\x1b[").count(),
+            2,
+            "8-color binary bar should emit exactly one ANSI fg + one reset: {out_ansi:?}",
+        );
+        assert_eq!(
+            out_tc.matches("\x1b[").count(),
+            2,
+            "truecolor binary bar should emit exactly one ANSI fg + one reset: {out_tc:?}",
+        );
+    }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -2179,36 +2179,69 @@ mod tests {
         assert!(saw_any, "should have emitted at least one truecolor sequence");
     }
 
-    #[test]
-    fn file_row_status_hues_remain_distinct_at_floor() {
-        // At the dark floor, fading must not collapse different statuses into
-        // the same RGB. We check icon base hues fade to distinct floored RGBs.
-        let bases = [
-            ("staged", FILE_ICON_STAGED_RGB),
-            ("unstaged", FILE_ICON_UNSTAGED_RGB),
-            ("untracked", FILE_ICON_UNTRACKED_RGB),
-            ("conflict", FILE_ICON_CONFLICT_RGB),
-        ];
-        let floored: Vec<((u8,u8,u8), &str)> = bases
-            .iter()
-            .map(|(name, rgb)| (fade_rgb(*rgb, 1.0), *name))
-            .collect();
-        for i in 0..floored.len() {
-            for j in (i + 1)..floored.len() {
-                let ((ar, ag, ab), aname) = floored[i];
-                let ((br, bg, bb), bname) = floored[j];
-                // Manhattan distance > 0 isn't enough — we want a perceptible
-                // difference even after the channels shrink. Require at least
-                // 10 units of total channel difference.
+    /// Shared invariant: every pair of *distinct* base RGBs in `palette`
+    /// must still differ by ≥ 10 units of Manhattan distance after fading
+    /// to the floor. Pairs that share the exact same base RGB (e.g. the
+    /// Deleted and Conflicted letters, both danger-red by design) are
+    /// skipped — fading can't separate what was equal to start with, and
+    /// merging those is the intent.
+    fn assert_palette_distinct_at_floor(palette_name: &str, palette: &[(&str, (u8, u8, u8))]) {
+        for i in 0..palette.len() {
+            for j in (i + 1)..palette.len() {
+                let (aname, abase) = palette[i];
+                let (bname, bbase) = palette[j];
+                if abase == bbase {
+                    continue;
+                }
+                let (ar, ag, ab) = fade_rgb(abase, 1.0);
+                let (br, bg, bb) = fade_rgb(bbase, 1.0);
                 let dist = (i32::from(ar) - i32::from(br)).abs()
                     + (i32::from(ag) - i32::from(bg)).abs()
                     + (i32::from(ab) - i32::from(bb)).abs();
                 assert!(
                     dist >= 10,
-                    "{aname} and {bname} floored RGBs too close: {ar:?},{ag:?},{ab:?} vs {br:?},{bg:?},{bb:?} (dist {dist})",
+                    "{palette_name}: {aname} and {bname} floored RGBs too close: \
+                     ({ar},{ag},{ab}) vs ({br},{bg},{bb}) (dist {dist})",
                 );
             }
         }
+    }
+
+    #[test]
+    fn file_row_status_hues_remain_distinct_at_floor() {
+        // At the dark floor, fading must not collapse different statuses
+        // into the same RGB. Guard each palette that varies by status so a
+        // future palette tweak can't silently merge two visually-distinct
+        // states (e.g. staged vs unstaged paths).
+        assert_palette_distinct_at_floor(
+            "icon",
+            &[
+                ("staged", FILE_ICON_STAGED_RGB),
+                ("unstaged", FILE_ICON_UNSTAGED_RGB),
+                ("untracked", FILE_ICON_UNTRACKED_RGB),
+                ("conflict", FILE_ICON_CONFLICT_RGB),
+            ],
+        );
+        assert_palette_distinct_at_floor(
+            "path",
+            &[
+                ("staged", FILE_PATH_STAGED_RGB),
+                ("unstaged", FILE_PATH_UNSTAGED_RGB),
+                ("untracked", FILE_PATH_UNTRACKED_RGB),
+                ("conflict", FILE_PATH_CONFLICT_RGB),
+            ],
+        );
+        assert_palette_distinct_at_floor(
+            "letter",
+            &[
+                ("added", FILE_LETTER_ADDED_RGB),
+                ("deleted", FILE_LETTER_DELETED_RGB),
+                ("renamed", FILE_LETTER_RENAMED_RGB),
+                ("default", FILE_LETTER_DEFAULT_RGB),
+                ("conflict", FILE_LETTER_CONFLICT_RGB),
+                ("untracked", FILE_LETTER_UNTRACKED_RGB),
+            ],
+        );
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -399,6 +399,18 @@ const LOG_SUBJECT_BASE_RGB: (u8, u8, u8) = (220, 220, 220);
 /// Base RGB for the commit-log age column.
 const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
 
+/// Fade factor for a file row.
+///
+/// `Some(age)` shares the commit-log ramp via [`age_fade_factor`] so the
+/// file list and log section darken in lockstep. `None` returns `1.0`
+/// so files we can't stat (deleted entries, skipped untracked dirs)
+/// render at the dark floor.
+fn file_fade_factor(_age: Option<Duration>) -> f32 {
+    // Intentionally wrong stub — the red test must fail on the assertion,
+    // not on a missing symbol.
+    0.5
+}
+
 /// Apply the age-driven truecolor fade to `s`, starting from `base`.
 ///
 /// Shared by every truecolor commit-log colorizer so the fade math lives
@@ -1530,6 +1542,40 @@ mod tests {
         assert!(
             !stale.style.contains(Styles::Italic),
             "stale subjects should be dimmed but not italicized in fallback mode",
+        );
+    }
+
+    #[test]
+    fn file_fade_factor_is_zero_for_fresh_age() {
+        // A file modified moments ago must render at full base brightness,
+        // which means factor=0 — the no-fade end of the ramp.
+        assert!(
+            (file_fade_factor(Some(Duration::from_secs(0))) - 0.0).abs() < 1e-6,
+            "fresh file should produce factor=0",
+        );
+    }
+
+    #[test]
+    fn file_fade_factor_floors_when_age_is_none() {
+        // Deleted files and unstat'd untracked dirs have no mtime. They must
+        // render at the dark floor (factor=1.0) so the row visually announces
+        // "this is an unusual state, not actively changing".
+        assert!(
+            (file_fade_factor(None) - 1.0).abs() < 1e-6,
+            "None age should clamp to factor=1.0 (the floor)",
+        );
+    }
+
+    #[test]
+    fn file_fade_factor_matches_commit_ramp_for_some_age() {
+        // The file fade must share the *same* ramp as commit rows so the two
+        // sections darken in lockstep under viddy. Spot-check the 1h midpoint.
+        let one_hour = Duration::from_secs(60 * 60);
+        let file = file_fade_factor(Some(one_hour));
+        let commit = age_fade_factor(one_hour);
+        assert!(
+            (file - commit).abs() < 1e-6,
+            "file fade must equal commit fade for matching Some(age): file={file}, commit={commit}",
         );
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -243,7 +243,7 @@ fn render_row(
     } else {
         render_bar(entry.adds.saturating_add(entry.dels), max_change, opts.bar_width)
     };
-    let bar_str = colorize_bar(&bar_raw, entry);
+    let bar_str = colorize_bar(&bar_raw, entry, 0.0, false);
 
     let adds_raw = if entry.adds > 0 {
         format!("+{}", entry.adds)
@@ -389,9 +389,18 @@ const BAR_PARTIAL_BG_CYAN: (u8, u8, u8) = (0, 48, 48);
 /// Same idea for the conflicted-file bar, which paints in red.
 const BAR_PARTIAL_BG_RED: (u8, u8, u8) = (48, 0, 0);
 
-fn colorize_bar(bar: &str, entry: &RenderEntry) -> String {
+/// Build one `ColoredString` per visible cell of `bar`. The joined string
+/// returned by [`colorize_bar`] is just `colorize_bar_styled(...).join("")`
+/// with `.to_string()` applied to each cell — sharing the cell builder lets
+/// tests inspect the typed fg/bg colors per cell instead of parsing ANSI.
+fn colorize_bar_styled(
+    bar: &str,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> Vec<ColoredString> {
     if entry.binary {
-        return bar.dimmed().to_string();
+        return bar.chars().map(|c| c.to_string().dimmed()).collect();
     }
     let is_conflicted = matches!(entry.status, FileStatus::Conflicted);
     let (br, bg, bb) = if is_conflicted {
@@ -399,21 +408,36 @@ fn colorize_bar(bar: &str, entry: &RenderEntry) -> String {
     } else {
         BAR_PARTIAL_BG_CYAN
     };
-    let mut out = String::with_capacity(bar.len() * 2);
-    for c in bar.chars() {
-        let s = c.to_string();
-        let colored = if is_partial_block(c) {
-            if is_conflicted {
-                s.red().on_truecolor(br, bg, bb)
+    bar.chars()
+        .map(|c| {
+            let s = c.to_string();
+            if truecolor {
+                // Wrong stub — constant grey breaks gradient + bg tests only.
+                if is_partial_block(c) {
+                    s.truecolor(50, 50, 50).on_truecolor(20, 20, 20)
+                } else {
+                    s.truecolor(50, 50, 50)
+                }
+            } else if is_partial_block(c) {
+                if is_conflicted {
+                    s.red().on_truecolor(br, bg, bb)
+                } else {
+                    s.cyan().on_truecolor(br, bg, bb)
+                }
+            } else if is_conflicted {
+                s.red()
             } else {
-                s.cyan().on_truecolor(br, bg, bb)
+                s.cyan()
             }
-        } else if is_conflicted {
-            s.red()
-        } else {
-            s.cyan()
-        };
-        out.push_str(&colored.to_string());
+        })
+        .collect()
+}
+
+fn colorize_bar(bar: &str, entry: &RenderEntry, factor: f32, truecolor: bool) -> String {
+    let cells = colorize_bar_styled(bar, entry, factor, truecolor);
+    let mut out = String::with_capacity(bar.len() * 2);
+    for c in cells {
+        out.push_str(&c.to_string());
     }
     out
 }
@@ -1097,9 +1121,9 @@ mod tests {
         // in non-TTY test runs.
         colored::control::set_override(true);
         let e = entry("foo.rs", FileStatus::Modified, true, 9, 1);
-        let with_partial = colorize_bar("█████▍", &e);
-        let all_full = colorize_bar("██████", &e);
-        let all_empty = colorize_bar("░░░░░░", &e);
+        let with_partial = colorize_bar("█████▍", &e, 0.0, false);
+        let all_full = colorize_bar("██████", &e, 0.0, false);
+        let all_empty = colorize_bar("░░░░░░", &e, 0.0, false);
         colored::control::unset_override();
 
         assert!(
@@ -1899,5 +1923,45 @@ mod tests {
             (fresh.fgcolor, aged.fgcolor)
         else { panic!("both should be TrueColor") };
         assert!(ar < fr || ag < fg, "aged +adds should be darker");
+    }
+
+    #[test]
+    fn file_bar_fill_fades_with_factor_under_truecolor() {
+        use colored::Color;
+        let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+        let fresh = colorize_bar_styled("██████", &e, 0.0, true);
+        let aged = colorize_bar_styled("██████", &e, 1.0, true);
+        // We expect the first cell's fg to be TrueColor in both cases and
+        // the aged channel to be strictly lower.
+        let (Some(Color::TrueColor { r: fr, g: fg, b: fb }),
+             Some(Color::TrueColor { r: ar, g: ag, b: ab })) =
+            (fresh[0].fgcolor, aged[0].fgcolor)
+        else { panic!("first cell should be TrueColor under truecolor=true") };
+        assert!(
+            ar < fr || ag < fg || ab < fb,
+            "aged bar fill should be darker on at least one channel",
+        );
+    }
+
+    #[test]
+    fn file_bar_partial_bg_fades_with_factor_under_truecolor() {
+        use colored::Color;
+        // Use a partial-fill glyph (▍ = U+258D) so a background color is set.
+        let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+        let fresh = colorize_bar_styled("▍", &e, 0.0, true);
+        let aged = colorize_bar_styled("▍", &e, 1.0, true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+            (fresh[0].bgcolor, aged[0].bgcolor)
+        else { panic!("partial cell should have a TrueColor background") };
+        assert!(ar < fr, "aged partial-cell bg should be darker: fresh={fr} aged={ar}");
+    }
+
+    #[test]
+    fn file_bar_fallback_unchanged_without_truecolor() {
+        // 8-color path returns the cyan-fill bytes today. Regression guard.
+        let e = entry("foo.rs", FileStatus::Modified, true, 6, 0);
+        let cells = colorize_bar_styled("█", &e, 0.0, false);
+        use colored::Color;
+        assert_eq!(cells[0].fgcolor, Some(Color::Cyan));
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -220,7 +220,7 @@ fn render_row(
     let path_padded = pad_right(&path_truncated, path_width);
 
     let icon_str = colorize_icon(icon, entry, 0.0, false);
-    let letter_str = colorize_letter(letter, entry);
+    let letter_str = colorize_letter(letter, entry, 0.0, false);
     let path_str = colorize_path(&path_padded, entry, 0.0, false);
 
     // Untracked files get a stripped-down row — no bar, no counts — but
@@ -327,8 +327,16 @@ fn colorize_icon(
     }
 }
 
-fn colorize_letter(letter: char, entry: &RenderEntry) -> ColoredString {
+fn colorize_letter(
+    letter: char,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
     let s = letter.to_string();
+    if truecolor {
+        return s.truecolor(50, 50, 50);
+    }
     match entry.status {
         FileStatus::Conflicted => s.red().bold(),
         FileStatus::Untracked | FileStatus::UntrackedDir => s.cyan().dimmed(),
@@ -444,6 +452,13 @@ const FILE_ICON_STAGED_RGB: (u8, u8, u8) = (90, 220, 110);
 const FILE_ICON_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
 const FILE_ICON_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
 const FILE_ICON_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+
+const FILE_LETTER_ADDED_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_LETTER_DELETED_RGB: (u8, u8, u8) = (255, 80, 80);
+const FILE_LETTER_RENAMED_RGB: (u8, u8, u8) = (220, 120, 220);
+const FILE_LETTER_DEFAULT_RGB: (u8, u8, u8) = (230, 230, 230);
+const FILE_LETTER_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
+const FILE_LETTER_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
 
 /// Fade factor for a file row.
 ///
@@ -1730,5 +1745,36 @@ mod tests {
             panic!("both should be TrueColor");
         };
         assert!(ar < fr, "aged icon should be darker: fresh={fr} aged={ar}");
+    }
+
+    #[test]
+    fn file_letter_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Added, true, 1, 0);
+        let cs = colorize_letter('A', &e, 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor under truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_letter_falls_back_to_ansi_without_truecolor() {
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Added, true, 1, 0);
+        let cs = colorize_letter('A', &e, 0.0, false);
+        assert_eq!(cs.fgcolor, Some(Color::Green));
+    }
+
+    #[test]
+    fn file_letter_darkens_with_age_under_truecolor() {
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Deleted, true, 0, 1);
+        let fresh = colorize_letter('D', &e, 0.0, true);
+        let aged = colorize_letter('D', &e, 1.0, true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+            (fresh.fgcolor, aged.fgcolor)
+        else { panic!("both should be TrueColor") };
+        assert!(ar < fr, "aged letter should be darker: fresh={fr} aged={ar}");
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -330,12 +330,21 @@ fn colorize_icon(
 fn colorize_letter(
     letter: char,
     entry: &RenderEntry,
-    _factor: f32,
+    factor: f32,
     truecolor: bool,
 ) -> ColoredString {
     let s = letter.to_string();
     if truecolor {
-        return s.truecolor(50, 50, 50);
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_LETTER_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_LETTER_UNTRACKED_RGB,
+            FileStatus::Added => FILE_LETTER_ADDED_RGB,
+            FileStatus::Deleted => FILE_LETTER_DELETED_RGB,
+            FileStatus::Renamed | FileStatus::Copied => FILE_LETTER_RENAMED_RGB,
+            _ => FILE_LETTER_DEFAULT_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return s.truecolor(r, g, b);
     }
     match entry.status {
         FileStatus::Conflicted => s.red().bold(),

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -234,7 +234,7 @@ fn render_row(
         let gutter = " ".repeat(gutter_width);
         let age = entry.age.map(format_age_detailed).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
-        let age_str = colorize_age(&age_field, entry.age);
+        let age_str = colorize_age(&age_field, entry.age, 0.0, false);
         return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
     }
 
@@ -271,7 +271,7 @@ fn render_row(
 
     let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
-    let age_str = colorize_age(&age_field, entry.age);
+    let age_str = colorize_age(&age_field, entry.age, 0.0, false);
 
     let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
     let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);
@@ -425,7 +425,15 @@ fn is_partial_block(c: char) -> bool {
     matches!(c, '\u{2589}'..='\u{258F}')
 }
 
-fn colorize_age(text: &str, age: Option<Duration>) -> ColoredString {
+fn colorize_age(
+    text: &str,
+    age: Option<Duration>,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
     let Some(age) = age else {
         return text.dimmed();
     };
@@ -468,6 +476,7 @@ const FILE_LETTER_RENAMED_RGB: (u8, u8, u8) = (220, 120, 220);
 const FILE_LETTER_DEFAULT_RGB: (u8, u8, u8) = (230, 230, 230);
 const FILE_LETTER_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
 const FILE_LETTER_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+const FILE_AGE_RGB: (u8, u8, u8) = (190, 190, 190);
 
 /// Fade factor for a file row.
 ///
@@ -523,7 +532,7 @@ fn colorize_log_age(text: &str, age: Duration, truecolor: bool) -> ColoredString
     if truecolor {
         fade_truecolor(text, age, LOG_AGE_BASE_RGB)
     } else {
-        colorize_age(text, Some(age))
+        colorize_age(text, Some(age), 0.0, false)
     }
 }
 
@@ -1361,8 +1370,8 @@ mod tests {
         // `colored::control::set_override`, which is process-global and would
         // race with other tests in parallel.
         use colored::Styles;
-        let aging = colorize_age("12h0m", Some(Duration::from_secs(2 * 3600)));
-        let stale = colorize_age("12h0m", Some(Duration::from_secs(2 * 86400)));
+        let aging = colorize_age("12h0m", Some(Duration::from_secs(2 * 3600)), 0.0, false);
+        let stale = colorize_age("12h0m", Some(Duration::from_secs(2 * 86400)), 0.0, false);
         assert!(
             stale.style.contains(Styles::Italic),
             "Stale should be italicized",
@@ -1594,6 +1603,38 @@ mod tests {
             panic!("both should be TrueColor under truecolor=true");
         };
         assert!(hr < fr, "hour-old age column should be darker than fresh: {fr} -> {hr}");
+    }
+
+    #[test]
+    fn file_age_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let cs = colorize_age("5m23s", Some(Duration::from_secs(5 * 60 + 23)), 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor for file age, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_age_falls_back_to_dim_buckets_without_truecolor() {
+        // 8-color fallback must still bold a fresh row's age, matching today.
+        use colored::Styles;
+        let fresh = colorize_age("30s", Some(Duration::from_secs(30)), 0.0, false);
+        assert!(
+            fresh.style.contains(Styles::Bold),
+            "fresh age should still be bolded in the 8-color path",
+        );
+    }
+
+    #[test]
+    fn file_age_darkens_with_factor_under_truecolor() {
+        use colored::Color;
+        let fresh = colorize_age("30s", Some(Duration::from_secs(30)), 0.0, true);
+        let aged = colorize_age("3d0h", Some(Duration::from_secs(3 * 86400)), 1.0, true);
+        let (Some(Color::TrueColor { r: fr, .. }), Some(Color::TrueColor { r: ar, .. })) =
+            (fresh.fgcolor, aged.fgcolor)
+        else { panic!("both should be TrueColor") };
+        assert!(ar < fr, "aged file-age column should be darker: fresh={fr} aged={ar}");
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -327,14 +327,18 @@ fn colorize_letter(letter: char, entry: &RenderEntry) -> ColoredString {
 fn colorize_path(
     path: &str,
     entry: &RenderEntry,
-    _factor: f32,
+    factor: f32,
     truecolor: bool,
 ) -> ColoredString {
     if truecolor {
-        // Deliberately wrong stub — should be FILE_PATH_UNSTAGED_RGB faded,
-        // but returns a constant truecolor so the gradient + floor tests
-        // fail on their *behavior*, not on the structural shape.
-        return path.truecolor(50, 50, 50);
+        let base = match entry.status {
+            FileStatus::Conflicted => FILE_PATH_CONFLICT_RGB,
+            FileStatus::Untracked | FileStatus::UntrackedDir => FILE_PATH_UNTRACKED_RGB,
+            _ if entry.staged => FILE_PATH_STAGED_RGB,
+            _ => FILE_PATH_UNSTAGED_RGB,
+        };
+        let (r, g, b) = fade_rgb(base, factor);
+        return path.truecolor(r, g, b);
     }
     match entry.status {
         FileStatus::Conflicted => path.red(),

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -211,6 +211,8 @@ fn render_row(
     path_width: usize,
 ) -> String {
     let (icon, letter) = icon_and_letter(entry);
+    let factor = file_fade_factor(entry.age);
+    let tc = opts.truecolor;
 
     let path_display_raw = match &entry.orig_path {
         Some(orig) => format!("{orig} → {new}", new = entry.path),
@@ -219,13 +221,10 @@ fn render_row(
     let path_truncated = truncate_left(&path_display_raw, path_width);
     let path_padded = pad_right(&path_truncated, path_width);
 
-    let icon_str = colorize_icon(icon, entry, 0.0, false);
-    let letter_str = colorize_letter(letter, entry, 0.0, false);
-    let path_str = colorize_path(&path_padded, entry, 0.0, false);
+    let icon_str = colorize_icon(icon, entry, factor, tc);
+    let letter_str = colorize_letter(letter, entry, factor, tc);
+    let path_str = colorize_path(&path_padded, entry, factor, tc);
 
-    // Untracked files get a stripped-down row — no bar, no counts — but
-    // pad the gutter where bar/adds/dels would be so the age column still
-    // lines up with normal rows above and below it.
     if matches!(
         entry.status,
         FileStatus::Untracked | FileStatus::UntrackedDir
@@ -234,7 +233,7 @@ fn render_row(
         let gutter = " ".repeat(gutter_width);
         let age = entry.age.map(format_age_detailed).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
-        let age_str = colorize_age(&age_field, entry.age, 0.0, false);
+        let age_str = colorize_age(&age_field, entry.age, factor, tc);
         return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
     }
 
@@ -243,7 +242,7 @@ fn render_row(
     } else {
         render_bar(entry.adds.saturating_add(entry.dels), max_change, opts.bar_width)
     };
-    let bar_str = colorize_bar(&bar_raw, entry, 0.0, false);
+    let bar_str = colorize_bar(&bar_raw, entry, factor, tc);
 
     let adds_raw = if entry.adds > 0 {
         format!("+{}", entry.adds)
@@ -259,19 +258,19 @@ fn render_row(
     let dels_field = format!("{dels_raw:>width$}", width = DELS_FIELD);
 
     let adds_str = if entry.adds > 0 {
-        colorize_adds(&adds_field, 0.0, false).to_string()
+        colorize_adds(&adds_field, factor, tc).to_string()
     } else {
         adds_field
     };
     let dels_str = if entry.dels > 0 {
-        colorize_dels(&dels_field, 0.0, false).to_string()
+        colorize_dels(&dels_field, factor, tc).to_string()
     } else {
         dels_field
     };
 
     let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
-    let age_str = colorize_age(&age_field, entry.age, 0.0, false);
+    let age_str = colorize_age(&age_field, entry.age, factor, tc);
 
     let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
     let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -259,12 +259,12 @@ fn render_row(
     let dels_field = format!("{dels_raw:>width$}", width = DELS_FIELD);
 
     let adds_str = if entry.adds > 0 {
-        adds_field.green().to_string()
+        colorize_adds(&adds_field, 0.0, false).to_string()
     } else {
         adds_field
     };
     let dels_str = if entry.dels > 0 {
-        dels_field.red().to_string()
+        colorize_dels(&dels_field, 0.0, false).to_string()
     } else {
         dels_field
     };
@@ -446,6 +446,28 @@ fn colorize_age(
     }
 }
 
+/// Color the `+adds` field for a file row.
+///
+/// With `truecolor`, applies the age-driven fade starting from
+/// [`FILE_ADDS_RGB`]. Without, falls back to ANSI green.
+fn colorize_adds(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
+    text.green()
+}
+
+/// Color the `-dels` field for a file row.
+///
+/// With `truecolor`, applies the age-driven fade starting from
+/// [`FILE_DELS_RGB`]. Without, falls back to ANSI red.
+fn colorize_dels(text: &str, _factor: f32, truecolor: bool) -> ColoredString {
+    if truecolor {
+        return text.truecolor(50, 50, 50);
+    }
+    text.red()
+}
+
 /// Base RGB for commit-log hashes when truecolor fading is on. Picked to
 /// match the perceptual feel of the legacy `yellow()` ANSI hash without
 /// depending on a specific terminal palette.
@@ -478,6 +500,8 @@ const FILE_LETTER_DEFAULT_RGB: (u8, u8, u8) = (230, 230, 230);
 const FILE_LETTER_CONFLICT_RGB: (u8, u8, u8) = (255, 80, 80);
 const FILE_LETTER_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
 const FILE_AGE_RGB: (u8, u8, u8) = (190, 190, 190);
+const FILE_ADDS_RGB: (u8, u8, u8) = (90, 220, 110);
+const FILE_DELS_RGB: (u8, u8, u8) = (255, 90, 90);
 
 /// Fade factor for a file row.
 ///
@@ -1827,5 +1851,51 @@ mod tests {
             (fresh.fgcolor, aged.fgcolor)
         else { panic!("both should be TrueColor") };
         assert!(ar < fr, "aged letter should be darker: fresh={fr} aged={ar}");
+    }
+
+    #[test]
+    fn file_adds_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let cs = colorize_adds("  +12", 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_dels_uses_truecolor_when_enabled() {
+        use colored::Color;
+        let cs = colorize_dels(" -3", 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_adds_falls_back_to_green_without_truecolor() {
+        use colored::Color;
+        let cs = colorize_adds("  +12", 0.0, false);
+        assert_eq!(cs.fgcolor, Some(Color::Green));
+    }
+
+    #[test]
+    fn file_dels_falls_back_to_red_without_truecolor() {
+        use colored::Color;
+        let cs = colorize_dels(" -3", 0.0, false);
+        assert_eq!(cs.fgcolor, Some(Color::Red));
+    }
+
+    #[test]
+    fn file_adds_darkens_with_factor_under_truecolor() {
+        use colored::Color;
+        let fresh = colorize_adds("  +12", 0.0, true);
+        let aged = colorize_adds("  +12", 1.0, true);
+        let (Some(Color::TrueColor { r: fr, g: fg, .. }),
+             Some(Color::TrueColor { r: ar, g: ag, .. })) =
+            (fresh.fgcolor, aged.fgcolor)
+        else { panic!("both should be TrueColor") };
+        assert!(ar < fr || ag < fg, "aged +adds should be darker");
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -221,7 +221,7 @@ fn render_row(
 
     let icon_str = colorize_icon(icon, entry);
     let letter_str = colorize_letter(letter, entry);
-    let path_str = colorize_path(&path_padded, entry);
+    let path_str = colorize_path(&path_padded, entry, 0.0, false);
 
     // Untracked files get a stripped-down row — no bar, no counts — but
     // pad the gutter where bar/adds/dels would be so the age column still
@@ -324,7 +324,18 @@ fn colorize_letter(letter: char, entry: &RenderEntry) -> ColoredString {
     }
 }
 
-fn colorize_path(path: &str, entry: &RenderEntry) -> ColoredString {
+fn colorize_path(
+    path: &str,
+    entry: &RenderEntry,
+    _factor: f32,
+    truecolor: bool,
+) -> ColoredString {
+    if truecolor {
+        // Deliberately wrong stub — should be FILE_PATH_UNSTAGED_RGB faded,
+        // but returns a constant truecolor so the gradient + floor tests
+        // fail on their *behavior*, not on the structural shape.
+        return path.truecolor(50, 50, 50);
+    }
     match entry.status {
         FileStatus::Conflicted => path.red(),
         FileStatus::Untracked | FileStatus::UntrackedDir => path.cyan().dimmed(),
@@ -398,6 +409,17 @@ const LOG_HASH_BASE_RGB: (u8, u8, u8) = (255, 215, 0);
 const LOG_SUBJECT_BASE_RGB: (u8, u8, u8) = (220, 220, 220);
 /// Base RGB for the commit-log age column.
 const LOG_AGE_BASE_RGB: (u8, u8, u8) = (190, 190, 190);
+
+// --- File-row truecolor base palette ---------------------------------------
+//
+// Per-status base RGB values for the file list under truecolor mode. Each
+// base is tuned so factor=0 reads as the same hue family as the legacy
+// ANSI color, and factor=1 (× FADE_FLOOR) still keeps the hue visible.
+
+const FILE_PATH_UNSTAGED_RGB: (u8, u8, u8) = (220, 200, 100);
+const FILE_PATH_STAGED_RGB: (u8, u8, u8) = (200, 200, 200);
+const FILE_PATH_UNTRACKED_RGB: (u8, u8, u8) = (120, 200, 200);
+const FILE_PATH_CONFLICT_RGB: (u8, u8, u8) = (255, 90, 90);
 
 /// Fade factor for a file row.
 ///
@@ -1574,6 +1596,81 @@ mod tests {
         assert!(
             (file - commit).abs() < 1e-6,
             "file fade must equal commit fade for matching Some(age): file={file}, commit={commit}",
+        );
+    }
+
+    #[test]
+    fn file_path_uses_truecolor_when_enabled() {
+        // With truecolor on, a fresh modified file's path must come back as a
+        // 24-bit color so the gradient has somewhere to fade from.
+        use colored::Color;
+        let mut e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+        e.age = Some(Duration::from_secs(0));
+        let cs = colorize_path("src/foo.rs", &e, 0.0, true);
+        match cs.fgcolor {
+            Some(Color::TrueColor { .. }) => {}
+            other => panic!("expected TrueColor under truecolor=true, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_path_falls_back_to_legacy_color_without_truecolor() {
+        // Without truecolor, the legacy ANSI yellow for unstaged-modified
+        // paths must still come through unchanged. Regression guard for the
+        // 8-color path.
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+        let cs = colorize_path("src/foo.rs", &e, 0.0, false);
+        assert_eq!(cs.fgcolor, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn file_path_darkens_with_age_under_truecolor() {
+        // Core gradient property: an older path is dimmer than a fresh one on
+        // every channel.
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+        let fresh = colorize_path("src/foo.rs", &e, 0.0, true);
+        let aged = colorize_path("src/foo.rs", &e, 1.0, true);
+        let (Some(Color::TrueColor { r: fr, g: fg, b: fb }),
+             Some(Color::TrueColor { r: ar, g: ag, b: ab })) =
+            (fresh.fgcolor, aged.fgcolor)
+        else {
+            panic!("both should be TrueColor under truecolor=true");
+        };
+        assert!(
+            ar <= fr && ag <= fg && ab <= fb,
+            "aged path should not be brighter on any channel: fresh=({fr},{fg},{fb}) aged=({ar},{ag},{ab})",
+        );
+        assert!(
+            ar < fr || ag < fg || ab < fb,
+            "aged path should be strictly darker on at least one channel: fresh=({fr},{fg},{fb}) aged=({ar},{ag},{ab})",
+        );
+    }
+
+    #[test]
+    fn file_path_stays_above_floor_at_factor_one() {
+        // The fade must never reach pure black — at the floor, channels stay
+        // at FADE_FLOOR * base. Mirrors log_hash_stays_above_floor_when_very_old.
+        use crate::age::FADE_FLOOR;
+        use colored::Color;
+        let e = entry("src/foo.rs", FileStatus::Modified, false, 1, 0);
+        let cs = colorize_path("src/foo.rs", &e, 1.0, true);
+        let Some(Color::TrueColor { r, g, b }) = cs.fgcolor else {
+            panic!("expected TrueColor under truecolor=true");
+        };
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "u8 × FADE_FLOOR ∈ [0, 1] stays in [0, 255]"
+        )]
+        let floor_of = |c: u8| (f32::from(c) * FADE_FLOOR).round() as u8;
+        let (br, bg, bb) = FILE_PATH_UNSTAGED_RGB;
+        assert!(
+            r >= floor_of(br).saturating_sub(1)
+                && g >= floor_of(bg).saturating_sub(1)
+                && b >= floor_of(bb).saturating_sub(1),
+            "channels must not drop below the floor: actual=({r},{g},{b}) base=({br},{bg},{bb})",
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds 24-bit truecolor age fade to every column of every file row (icon, status letter, path, bar, +adds, -dels, age, and the `bin` marker), sharing the existing commit-log gradient so both sections darken in lockstep under `viddy gsw`.
- Per-status base RGB palette preserves hue from full brightness down to `FADE_FLOOR` (30%); no-mtime files (deleted entries, unstat'd untracked dirs) render at the floor. 8-color fallback is byte-identical to today — `--no-truecolor` emits zero 24-bit sequences.
- Also fixes a real test flake: `colored::control::set_override` is process-global, so the new end-to-end tests plus the pre-existing `partial_cell_gets_background_to_close_gap` were racing under parallel `cargo test`. Serialized with a static `Mutex<()>` in `mod tests`. Caught a latent bug in `strip_ansi` (consumed `ESC + [` then bailed, leaving param bytes as literal output) while debugging the race.

## Test plan
- [ ] \`cargo test --manifest-path src/gsw/Cargo.toml --tests\` — 173 tests pass; verified clean across 10 consecutive runs after the race fix.
- [ ] \`viddy gsw --truecolor\` against a branch with mixed-age changes — fresh files bright, hour-old visibly dimmer, day-old at the floor; \`bin\` marker fades with the rest of the bar.
- [ ] \`viddy gsw --no-truecolor\` — file-section output byte-identical to pre-branch behavior.
- [ ] Phase 9 invariant test confirms icon palette stays pairwise distinguishable at the floor (Manhattan distance ≥ 10 across all pairs).

Spec: \`specs/2026-05-22-gsw-file-row-fade-design.md\`
Plan: \`plans/2026-05-22-gsw-file-row-fade-plan.md\`