### PR TITLE
gsw: render changed-files list at the bottom, fit to wrapper height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 .env.local
 .claude/
 .op-cache.json
+node_modules

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Reject commits that fail clippy. --all-targets covers tests/ and benches/,
+# where lints like unseparated_literal_suffix would otherwise slip through, and
+# -D warnings turns every workspace lint into a hard error.
+set -euo pipefail
+
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$'; then
+    echo "pre-commit: running cargo clippy --all-targets --workspace -- -D warnings"
+    cargo clippy --all-targets --workspace -- -D warnings
+fi

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "buffalo-tools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Tooling-only package: hosts the husky-managed git hooks for this Rust/Go monorepo.",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+
+packages:
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  husky@9.1.7: {}

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -281,9 +281,12 @@ fn main() -> Result<()> {
     //   post-header separator                                            1
     //   inter-section separator (only when both sections render)         0 or 1
     //   reserved row for a `+N more files` footer (only when files > 0)  0 or 1
-    // Whatever's left is split proportionally — so a short file list
-    // paired with a long log gets a fair share rather than being
-    // squeezed to one or two rows because `--log-lines` defaults to 20.
+    // Whatever's left goes to the file list first — it's the primary
+    // content and renders at the bottom, so it must stay fully on-screen
+    // rather than being squeezed by a long log (`--log-lines` defaults to
+    // 20). The log takes the remaining rows; only when the file list is
+    // itself truncated does a floor claw rows back to it. See
+    // `plan_section_caps`.
     let file_count = snapshot.files.len();
     let log_count = snapshot.log.len();
     let header_chrome: usize = 2;

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -103,6 +103,38 @@ fn effective_terminal_width(
         .max(1)
 }
 
+/// Rows a watch-like wrapper paints for its own chrome (title line, and on
+/// `watch(1)` a blank separator beneath it) before our output begins. We
+/// reserve these out of the wrapper-reported `LINES` so the bottom of our
+/// frame — the file list — isn't clipped below the fold. Reserving one row
+/// too many under wrappers with a single-line header (e.g. viddy) only leaves
+/// a harmless blank row; reserving too few clips real content, so we round up.
+const WRAPPER_TITLE_ROWS: usize = 2;
+
+/// Height assumed when no terminal-size signal is available at all (stdout is
+/// piped and the wrapper didn't export `LINES`). Matches the classic VT100
+/// default and the width fallback's spirit.
+const DEFAULT_TERMINAL_HEIGHT: usize = 24;
+
+/// Decide how many terminal rows gsw should fit its output within.
+///
+/// Mirrors [`effective_terminal_width`]: when stdout is captured by a
+/// watch-like wrapper (not a TTY) that exports `LINES`, trust that height —
+/// minus [`WRAPPER_TITLE_ROWS`] for the wrapper's own header — because
+/// `terminal_size()` can't see through the pipe. With a direct TTY, use the
+/// queried height. With no signal at all, fall back to
+/// [`DEFAULT_TERMINAL_HEIGHT`].
+fn effective_terminal_height(
+    tty_height: Option<usize>,
+    lines_env: Option<usize>,
+    stdout_is_tty: bool,
+) -> usize {
+    match (stdout_is_tty, lines_env) {
+        (false, Some(lines)) => lines.saturating_sub(WRAPPER_TITLE_ROWS).max(1),
+        _ => tty_height.unwrap_or(DEFAULT_TERMINAL_HEIGHT),
+    }
+}
+
 /// Should `colored::control::set_override(true)` be called?
 ///
 /// True only when output is captured by a watch-like wrapper (stdout is not
@@ -229,9 +261,11 @@ fn main() -> Result<()> {
 
     snapshot.upstream = detect_upstream();
 
-    let tty_size = terminal_size::terminal_size().map(|(w, h)| (usize::from(w.0), h.0));
+    let tty_size = terminal_size::terminal_size().map(|(w, h)| (usize::from(w.0), usize::from(h.0)));
     let tty_width = tty_size.map(|(w, _)| w);
-    let terminal_height = tty_size.map_or(24, |(_, h)| h);
+    let tty_height = tty_size.map(|(_, h)| h);
+    let lines_env: Option<usize> = std::env::var("LINES").ok().and_then(|s| s.parse().ok());
+    let terminal_height = effective_terminal_height(tty_height, lines_env, stdout_is_tty);
     let terminal_width =
         effective_terminal_width(tty_width, columns_env, stdout_is_tty, cli.width_offset);
 
@@ -247,11 +281,11 @@ fn main() -> Result<()> {
     // squeezed to one or two rows because `--log-lines` defaults to 20.
     let file_count = snapshot.files.len();
     let log_count = snapshot.log.len();
-    let header_chrome: u16 = 2;
-    let inter_chrome: u16 = if file_count > 0 && log_count > 0 { 1 } else { 0 };
-    let footer_chrome: u16 = if file_count > 0 { 1 } else { 0 };
+    let header_chrome: usize = 2;
+    let inter_chrome: usize = if file_count > 0 && log_count > 0 { 1 } else { 0 };
+    let footer_chrome: usize = if file_count > 0 { 1 } else { 0 };
     let chrome = header_chrome + inter_chrome + footer_chrome;
-    let available_rows = usize::from(terminal_height.saturating_sub(chrome)).max(1);
+    let available_rows = terminal_height.saturating_sub(chrome).max(1);
     let (planned_file_cap, planned_log_cap) =
         plan_section_caps(file_count, log_count, available_rows);
 
@@ -451,6 +485,41 @@ mod tests {
     fn width_uses_columns_minus_one_when_stdout_not_tty() {
         // viddy case: pipes captured, COLUMNS exported.
         assert_eq!(effective_terminal_width(None, Some(120), false, 0), 119);
+    }
+
+    #[test]
+    fn height_uses_lines_env_minus_wrapper_chrome_when_stdout_not_tty() {
+        // viddy/watch case: stdout piped, LINES exported. We budget to the
+        // wrapper's height minus its title chrome so the bottom file list
+        // isn't clipped below the wrapper's header.
+        assert_eq!(
+            effective_terminal_height(None, Some(40), false),
+            40 - WRAPPER_TITLE_ROWS,
+        );
+    }
+
+    #[test]
+    fn height_uses_tty_height_when_stdout_is_tty() {
+        // Interactive: trust the ioctl-reported height and ignore any stale
+        // inherited LINES value.
+        assert_eq!(effective_terminal_height(Some(50), Some(9999), true), 50);
+    }
+
+    #[test]
+    fn height_falls_back_to_default_when_no_signal() {
+        // Piped with no LINES exported: nothing to go on, so assume the
+        // classic 24-row terminal.
+        assert_eq!(
+            effective_terminal_height(None, None, false),
+            DEFAULT_TERMINAL_HEIGHT,
+        );
+    }
+
+    #[test]
+    fn height_never_collapses_to_zero_under_tiny_wrapper() {
+        // A pathologically short wrapper height must still leave at least one
+        // row rather than underflowing to zero.
+        assert_eq!(effective_terminal_height(None, Some(1), false), 1);
     }
 
     #[test]

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -103,13 +103,18 @@ fn effective_terminal_width(
         .max(1)
 }
 
-/// Rows a watch-like wrapper paints for its own chrome (title line, and on
-/// `watch(1)` a blank separator beneath it) before our output begins. We
-/// reserve these out of the wrapper-reported `LINES` so the bottom of our
-/// frame — the file list — isn't clipped below the fold. Reserving one row
-/// too many under wrappers with a single-line header (e.g. viddy) only leaves
-/// a harmless blank row; reserving too few clips real content, so we round up.
-const WRAPPER_TITLE_ROWS: usize = 2;
+/// Rows a watch-like wrapper paints for its own chrome (header, status/help
+/// bar, surrounding padding) before and after our output. The wrapper exports
+/// the *full* terminal height via `LINES` but only hands the command a smaller
+/// content area, so we reserve these rows or the bottom of our frame — the
+/// file list — gets clipped below the fold.
+///
+/// Measured empirically for viddy 1.3.0 (gsw's primary wrapper, per Cargo.toml):
+/// a 30-row terminal shows exactly 26 lines of command output, i.e. 4 rows of
+/// chrome, and this holds constant across terminal heights (20→16, 40→36).
+/// `watch(1)` uses fewer (~2); reserving the larger value only leaves a couple
+/// of harmless blank rows there, whereas reserving too few clips real content.
+const WRAPPER_CHROME_ROWS: usize = 4;
 
 /// Height assumed when no terminal-size signal is available at all (stdout is
 /// piped and the wrapper didn't export `LINES`). Matches the classic VT100
@@ -120,7 +125,7 @@ const DEFAULT_TERMINAL_HEIGHT: usize = 24;
 ///
 /// Mirrors [`effective_terminal_width`]: when stdout is captured by a
 /// watch-like wrapper (not a TTY) that exports `LINES`, trust that height —
-/// minus [`WRAPPER_TITLE_ROWS`] for the wrapper's own header — because
+/// minus [`WRAPPER_CHROME_ROWS`] for the wrapper's own header — because
 /// `terminal_size()` can't see through the pipe. With a direct TTY, use the
 /// queried height. With no signal at all, fall back to
 /// [`DEFAULT_TERMINAL_HEIGHT`].
@@ -130,7 +135,7 @@ fn effective_terminal_height(
     stdout_is_tty: bool,
 ) -> usize {
     match (stdout_is_tty, lines_env) {
-        (false, Some(lines)) => lines.saturating_sub(WRAPPER_TITLE_ROWS).max(1),
+        (false, Some(lines)) => lines.saturating_sub(WRAPPER_CHROME_ROWS).max(1),
         _ => tty_height.unwrap_or(DEFAULT_TERMINAL_HEIGHT),
     }
 }
@@ -494,7 +499,7 @@ mod tests {
         // isn't clipped below the wrapper's header.
         assert_eq!(
             effective_terminal_height(None, Some(40), false),
-            40 - WRAPPER_TITLE_ROWS,
+            40 - WRAPPER_CHROME_ROWS,
         );
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1571,6 +1571,33 @@ mod tests {
     }
 
     #[test]
+    fn log_section_renders_above_file_list() {
+        // Files render at the bottom so the recent-commit log stays anchored
+        // directly under the header. As files appear and disappear during
+        // work, the log keeps its position instead of being shoved around by
+        // a file list that grows and shrinks beneath it.
+        let file = entry("src/foo.rs", FileStatus::Modified, true, 1, 0);
+        let mut snap = snap_with(vec![file]);
+        snap.log = vec![log_entry("abc1234", "recent commit", 30)];
+        let mut o = opts();
+        o.log_lines = 5;
+        let out = strip_ansi(&render(&snap, &o));
+        let lines: Vec<&str> = out.lines().collect();
+        let log_idx = lines
+            .iter()
+            .position(|l| l.contains("abc1234"))
+            .expect("log row should appear");
+        let file_idx = lines
+            .iter()
+            .position(|l| l.contains("src/foo.rs"))
+            .expect("file row should appear");
+        assert!(
+            log_idx < file_idx,
+            "log section should render above the file list so files sit at the bottom:\n{out}",
+        );
+    }
+
+    #[test]
     fn log_section_has_separator_before_entries() {
         let mut snap = snap_with(vec![]);
         snap.log = vec![log_entry("abc1234", "first", 0)];

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -722,11 +722,17 @@ const LOG_FLOOR_ROWS: usize = 5;
 /// separator, and a reserved row for a possible `+N more files` footer).
 ///
 /// When everything fits, both sections are rendered in full. When the
-/// combined demand exceeds the available rows, rows are split
-/// proportionally to each section's demand — except the log section is
-/// floored at `min(LOG_FLOOR_ROWS, log_demand)` rows so recent commits
-/// stay readable even with a very long file list. Each non-empty
-/// section is guaranteed at least one row of its own.
+/// combined demand exceeds the available rows, the **file list wins**: it is
+/// the primary content (it shows what you're actively changing) and renders
+/// at the bottom, so it must stay fully on-screen rather than being clipped.
+/// Files get their full demand (leaving at least one row for a non-empty
+/// log), and the log takes whatever remains.
+///
+/// The one exception is a genuinely long file list that can't all fit: once
+/// the file section is itself being truncated (a `+N more files` footer would
+/// show), the log is floored at `min(LOG_FLOOR_ROWS, log_demand)` rows so
+/// recent-commit context doesn't collapse to a sliver. A short file list
+/// never gives up rows to that floor.
 ///
 /// Returns `(file_cap, log_cap)`. Each cap never exceeds the corresponding
 /// demand.
@@ -748,17 +754,25 @@ pub fn plan_section_caps(
         return (available_rows.min(file_demand), 0);
     }
 
-    // Both sections want rows and the total overflows. Compute the log
-    // section's proportional share, then lift it to the floor so a
-    // dominant file list can't squeeze the recent-commit context away.
-    // The cap on log_share preserves the existing invariant that the
-    // file section keeps at least one row when it has content.
-    let total_demand = file_demand + log_demand;
-    let raw_log = (log_demand * available_rows + total_demand / 2) / total_demand;
-    let log_ceiling = available_rows.saturating_sub(1).min(log_demand);
-    let log_floor = LOG_FLOOR_ROWS.min(log_demand).min(log_ceiling);
-    let log_share = raw_log.max(log_floor).min(log_ceiling);
-    let file_share = available_rows.saturating_sub(log_share).min(file_demand);
+    // Both sections want rows and the total overflows. Give the file list its
+    // full demand first, leaving at least one row for the log, then hand the
+    // log whatever remains. `.max(1)` keeps the file section visible even in a
+    // pathologically short budget.
+    let mut file_share = file_demand.min(available_rows.saturating_sub(1)).max(1);
+    let mut log_share = available_rows.saturating_sub(file_share);
+
+    // Only when the file list is itself truncated (a long list that can't all
+    // fit) do we floor the log, clawing rows back from the file section so
+    // recent-commit context survives a file-dominated frame.
+    if file_share < file_demand {
+        let log_floor = LOG_FLOOR_ROWS
+            .min(log_demand)
+            .min(available_rows.saturating_sub(1));
+        if log_share < log_floor {
+            log_share = log_floor;
+            file_share = available_rows.saturating_sub(log_share);
+        }
+    }
     (file_share, log_share)
 }
 
@@ -1268,12 +1282,12 @@ mod tests {
     }
 
     #[test]
-    fn plan_section_caps_splits_proportionally_when_overflowing() {
-        // 5 files vs 20 log rows competing for 10 rows: file share is
-        // round(5*10/25) = 2, log gets the remaining 8. This is the case
-        // that motivated the change — today the file list gets squeezed
-        // to 1 or 2 rows regardless of how few files the user actually has.
-        assert_eq!(plan_section_caps(5, 20, 10), (2, 8));
+    fn plan_section_caps_gives_files_full_demand_then_log_takes_rest() {
+        // 5 files vs a 20-commit log competing for 10 rows. Files are the
+        // primary content and fit entirely, so all 5 render; the log takes
+        // the remaining 5 rows. (The file list is never truncated here, so
+        // the log floor doesn't claw rows back from it.)
+        assert_eq!(plan_section_caps(5, 20, 10), (5, 5));
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -107,28 +107,35 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
         .max(1);
     let path_width = compute_path_width(opts);
 
-    for entry in snapshot.files.iter().take(display_count) {
-        lines.push(render_row(entry, opts, max_change, path_width));
-    }
-
-    let hidden = snapshot.files.len().saturating_sub(display_count);
-    if hidden > 0 {
-        lines.push(
-            format!("  +{hidden} more file{}", if hidden == 1 { "" } else { "s" })
-                .dimmed()
-                .to_string(),
-        );
-    }
-
-    if opts.log_lines > 0 && !snapshot.log.is_empty() {
-        // When there are no file rows above us, the post-header separator
-        // already sits directly above the log section; adding another would
-        // produce a double rule with nothing between them.
-        if !snapshot.files.is_empty() {
-            lines.push(render_separator(header_width));
-        }
+    // The recent-commit log renders first, directly under the header, so it
+    // stays anchored in place. The file list renders at the bottom: as files
+    // appear and disappear during work, they grow and shrink downward without
+    // shoving the log around.
+    let log_rendered = opts.log_lines > 0 && !snapshot.log.is_empty();
+    if log_rendered {
         for entry in snapshot.log.iter().take(opts.log_lines) {
             lines.push(render_log_row(entry, opts.terminal_width, opts.truecolor));
+        }
+    }
+
+    if !snapshot.files.is_empty() {
+        // Separate the file list from the log above it. When there's no log,
+        // the post-header separator already sits directly above the files, so
+        // adding another would produce a double rule with nothing between them.
+        if log_rendered {
+            lines.push(render_separator(header_width));
+        }
+        for entry in snapshot.files.iter().take(display_count) {
+            lines.push(render_row(entry, opts, max_change, path_width));
+        }
+
+        let hidden = snapshot.files.len().saturating_sub(display_count);
+        if hidden > 0 {
+            lines.push(
+                format!("  +{hidden} more file{}", if hidden == 1 { "" } else { "s" })
+                    .dimmed()
+                    .to_string(),
+            );
         }
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1239,6 +1239,29 @@ mod tests {
     }
 
     #[test]
+    fn plan_section_caps_shows_all_files_before_flooring_log() {
+        // The file list is the primary content and now renders at the bottom,
+        // so a short list must render in full rather than being squeezed to a
+        // single row by the log's floor. With 2 files competing against a
+        // 12-commit log for 6 rows, both files show and the log takes the
+        // remaining 4 rows — the user is never "limited to one file".
+        assert_eq!(plan_section_caps(2, 12, 6), (2, 4));
+    }
+
+    #[test]
+    fn plan_section_caps_does_not_squeeze_short_file_list_for_log_floor() {
+        // A 3-file list against a long log in a tight 8-row budget: all three
+        // files must show. The log yields rows to the file list because the
+        // files fit; the floor only protects the log when files genuinely
+        // can't all fit (see the "files dominate" case below).
+        let (f, _l) = plan_section_caps(3, 50, 8);
+        assert_eq!(
+            f, 3,
+            "all 3 files should render; the log floor must not steal rows from a short file list",
+        );
+    }
+
+    #[test]
     fn plan_section_caps_returns_full_demand_when_room_is_plenty() {
         // No contention: 5 files + 20 log rows easily fit in 100 rows.
         assert_eq!(plan_section_caps(5, 20, 100), (5, 20));

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -460,12 +460,14 @@ fn width_offset_flag_narrows_render() {
 }
 
 #[test]
-fn lines_env_under_watch_wrapper_keeps_output_within_terminal_height() {
+fn lines_env_under_watch_wrapper_keeps_output_within_content_area() {
     // viddy/watch capture stdout (no TTY) and export the terminal height via
-    // LINES. gsw must fit its whole frame within that height — otherwise the
-    // file list, which renders at the bottom, scrolls off the fold and the
-    // user can't see their own changes. Without honoring LINES, gsw falls
-    // back to a 24-row budget and overflows a short terminal.
+    // LINES. But the wrapper paints its own chrome and only hands the command
+    // a smaller content area: viddy 1.3.0 reserves 4 rows (measured — a
+    // 30-row terminal shows 26 lines of output). gsw must fit its whole frame
+    // within LINES minus that chrome, or the file list — which renders at the
+    // bottom — scrolls off the fold and the user can't see their own changes.
+    const VIDDY_CHROME_ROWS: usize = 4;
     let dir = setup_repo();
     // Many changed files so the frame *wants* far more than a short terminal.
     for i in 0..40 {
@@ -486,9 +488,10 @@ fn lines_env_under_watch_wrapper_keeps_output_within_terminal_height() {
     );
     let raw = String::from_utf8_lossy(&output.stdout);
     let count = raw.lines().count();
+    let budget = lines - VIDDY_CHROME_ROWS;
     assert!(
-        count <= lines,
-        "gsw emitted {count} lines but LINES={lines}; bottom rows (the file list) would be clipped:\n{raw}",
+        count <= budget,
+        "gsw emitted {count} lines but viddy's content area is only LINES-{VIDDY_CHROME_ROWS}={budget}; the bottom file list would be clipped:\n{raw}",
     );
 }
 

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -458,3 +458,36 @@ fn width_offset_flag_narrows_render() {
         "--width-offset 30 should narrow render enough to truncate path: {offset_str}",
     );
 }
+
+#[test]
+fn lines_env_under_watch_wrapper_keeps_output_within_terminal_height() {
+    // viddy/watch capture stdout (no TTY) and export the terminal height via
+    // LINES. gsw must fit its whole frame within that height — otherwise the
+    // file list, which renders at the bottom, scrolls off the fold and the
+    // user can't see their own changes. Without honoring LINES, gsw falls
+    // back to a 24-row budget and overflows a short terminal.
+    let dir = setup_repo();
+    // Many changed files so the frame *wants* far more than a short terminal.
+    for i in 0..40 {
+        fs::write(dir.path().join(format!("file_{i:02}.txt")), "x\n").unwrap();
+    }
+    let lines = 15usize;
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .env("COLUMNS", "80")
+        .env("LINES", lines.to_string())
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(
+        output.status.success(),
+        "gsw exited non-zero: stderr = {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let count = raw.lines().count();
+    assert!(
+        count <= lines,
+        "gsw emitted {count} lines but LINES={lines}; bottom rows (the file list) would be clipped:\n{raw}",
+    );
+}

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -471,7 +471,7 @@ fn lines_env_under_watch_wrapper_keeps_output_within_terminal_height() {
     for i in 0..40 {
         fs::write(dir.path().join(format!("file_{i:02}.txt")), "x\n").unwrap();
     }
-    let lines = 15usize;
+    let lines = 15_usize;
     let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
         .arg("--no-color")
         .env("COLUMNS", "80")
@@ -489,5 +489,43 @@ fn lines_env_under_watch_wrapper_keeps_output_within_terminal_height() {
     assert!(
         count <= lines,
         "gsw emitted {count} lines but LINES={lines}; bottom rows (the file list) would be clipped:\n{raw}",
+    );
+}
+
+#[test]
+fn short_file_list_renders_in_full_in_a_short_terminal() {
+    // The user's report: with a couple of changed files and a long commit
+    // log in a short terminal, the file list at the bottom was squeezed to a
+    // single row with a "+N more file" footer (and clipped off-screen). Files
+    // are the primary content, so a short list must render in full and the
+    // log must yield rows — no truncation footer, every file visible.
+    let dir = setup_repo();
+    // Build a long log so it competes hard for rows.
+    for i in 0..12 {
+        fs::write(dir.path().join("a.txt"), format!("rev {i}\n")).unwrap();
+        run_git(dir.path(), &["add", "a.txt"]);
+        run_git(dir.path(), &["commit", "-q", "-m", &format!("log-subject-{i}")]);
+    }
+    // Exactly two changed files.
+    fs::write(dir.path().join("f1.txt"), "one\n").unwrap();
+    fs::write(dir.path().join("f2.txt"), "two\n").unwrap();
+    run_git(dir.path(), &["add", "f1.txt", "f2.txt"]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_gsw"))
+        .arg("--no-color")
+        .env("COLUMNS", "80")
+        .env("LINES", "12")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let raw = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        raw.contains("f1.txt") && raw.contains("f2.txt"),
+        "both files should be visible, not squeezed behind a '+N more' footer:\n{raw}",
+    );
+    assert!(
+        !raw.contains("more file"),
+        "a 2-file list must not show a truncation footer in a 12-row terminal:\n{raw}",
     );
 }


### PR DESCRIPTION
## Summary
- Render gsw's changed-files list at the bottom, directly below the recent-commit log, so the log stays anchored under the header while files grow/shrink downward during work.
- Make the file list the primary content in row budgeting: it gets its full demand first and the log takes the remainder, so a short file list is never squeezed to a single `+N more` row by a long log. A log floor only claws rows back when the file list itself is truncated.
- Fit output to the terminal height under watch-style wrappers (viddy/watch) by reading `LINES` and reserving the wrapper's chrome rows, so the bottom file list isn't clipped below the fold.
- Add husky pre-commit hooks and ignore `node_modules`.

## Test plan
- [ ] `cargo test -p gsw` (164 unit + 19 integration tests pass)
- [ ] `cargo clippy -p gsw --all-targets` clean
- [ ] Run `gsw` under viddy/watch in a short terminal with several changed files and confirm the file list is fully visible at the bottom
- [ ] Run `gsw` directly in a TTY and confirm normal rendering is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)