### PR TITLE
crap: resume a Claude Code session from its original directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crap"
+version = "0.1.0"
+dependencies = [
+ "buildinfo",
+ "clap",
+ "colored",
+ "dirs",
+ "serde_json",
+ "shellsetup",
+ "tempfile",
+]
+
+[[package]]
 name = "crc-fast"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -312,6 +312,13 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
     `-p` (previous). Can also jump directly to a worktree by directory name or branch name.
     Use `--shell-setup` to automatically add shell integration to your config.
   - To install: `cargo install --git https://github.com/timmattison/tools cwt`
+- crap (Claude, Resume Anywhere Please)
+  - Resume a Claude Code session from wherever you are. Given a session id, `crap` looks the
+    session up under `~/.claude/projects`, recovers the directory it originally ran in, `cd`s
+    there, and re-launches Claude with `--resume <id>` — preferring your `clauded` alias if you
+    have one, otherwise plain `claude`. If the original directory no longer exists it tells you
+    and stops. Run `crap --shell-setup` once to install the shell function.
+  - To install: `cargo install --git https://github.com/timmattison/tools crap`
 - ng (navel-gaze)
   - Watches JS/TS source files in the current directory and re-runs `pnpm lint` on change. Pass
     `-t` / `--typecheck` to run `pnpm typecheck` instead. Events are debounced (300ms), and common
@@ -1207,6 +1214,71 @@ wtm               # Quick alias for main worktree
 - `3`: Worktree not found
 - `4`: Could not determine current worktree (for -f/-p)
 - `5`: Shell setup failed
+
+## crap (Claude, Resume Anywhere Please)
+
+Resume a Claude Code session from any directory. You give `crap` a session id; it finds that session under `~/.claude/projects`, recovers the directory the session originally ran in, changes into it, and re-launches Claude with `--resume <id>` from there.
+
+### Basic Usage
+
+```bash
+crap 57570685-2d64-4431-8ab6-c021a12fa1af   # cd into that session's dir and resume it
+```
+
+The session id is the name of the `.jsonl` file under `~/.claude/projects/<project>/`. `crap` reads the directory from the session log itself (the sanitized project folder name is lossy), so it always lands in the real original path.
+
+If you have a `clauded` alias or command (e.g. `claude --dangerously-skip-permissions`), `crap` uses it; otherwise it falls back to plain `claude`. If the session's original directory no longer exists, `crap` prints an error and stops without launching anything.
+
+### Options
+
+- `[SESSION_ID]`: The Claude session id to resume
+- `--shell-setup`: Add the `crap` shell function to your ~/.zshrc or ~/.bashrc
+
+### Shell Integration
+
+Because a program can't change its parent shell's working directory — and can't see shell aliases such as `clauded` — `crap` ships as a shell function. Install it once:
+
+```bash
+crap --shell-setup
+```
+
+Then run `source ~/.zshrc` (or `~/.bashrc`), or open a new terminal. After that, `crap <session-id>` will `cd` into the session's directory and resume it.
+
+> **Note:** `--shell-setup` supports bash and zsh. The bare `crap` binary still works without the function — it just prints the session's directory to stdout instead of changing into it.
+
+#### Manual Setup
+
+If you prefer to add it manually, add this to your `~/.bashrc` or `~/.zshrc`:
+
+```bash
+function crap() {
+    if [ "$#" -eq 0 ]; then
+        command crap
+        return $?
+    fi
+    local __crap_session="$1"
+    local __crap_dir
+    __crap_dir=$(command crap "$__crap_session") || return $?
+    cd "$__crap_dir" || return 1
+    if command -v clauded >/dev/null 2>&1; then
+        eval 'clauded --resume "$__crap_session"'
+    else
+        claude --resume "$__crap_session"
+    fi
+}
+```
+
+The `eval` is intentional: shell aliases aren't expanded inside function bodies, so it ensures a `clauded` alias is honored at call time. The `command crap` calls reach the binary past the function of the same name.
+
+### Exit Codes
+
+- `0`: Success
+- `1`: No session found with that id
+- `2`: Session has no recorded working directory
+- `3`: The session's original directory no longer exists
+- `4`: Invalid session id
+- `5`: Shell setup failed
+- `6`: Could not determine your home directory
 
 ## bm (bulk move)
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
     session up under `~/.claude/projects`, recovers the directory it originally ran in, `cd`s
     there, and re-launches Claude with `--resume <id>` — preferring your `clauded` alias if you
     have one, otherwise plain `claude`. If the original directory no longer exists it tells you
-    and stops. Run `crap --shell-setup` once to install the shell function.
+    and stops, and it refuses to resume a session that's already open in another running process
+    (pass `--force` to override) so two processes can't corrupt the same session log. Run
+    `crap --shell-setup` once to install the shell function.
   - To install: `cargo install --git https://github.com/timmattison/tools crap`
 - ng (navel-gaze)
   - Watches JS/TS source files in the current directory and re-runs `pnpm lint` on change. Pass
@@ -1229,9 +1231,23 @@ The session id is the name of the `.jsonl` file under `~/.claude/projects/<proje
 
 If you have a `clauded` alias or command (e.g. `claude --dangerously-skip-permissions`), `crap` uses it; otherwise it falls back to plain `claude`. If the session's original directory no longer exists, `crap` prints an error and stops without launching anything.
 
+### Don't attach twice
+
+Claude Code records every live CLI session under `~/.claude/sessions/<pid>.json` and removes it on clean exit. Before resuming, `crap` checks that registry: if the session you asked for is already open in another running `claude` process, it refuses and tells you where:
+
+```text
+Error: session '4d1637ec-…' is already running (pid 62043, idle)
+       in /Volumes/code/muxiavelli
+       resuming it again can corrupt the session log.
+       re-run with --force to resume anyway.
+```
+
+This prevents two processes from appending to the same session log at once. The check verifies the recorded pid is still a live `claude` process (so a stale file left by a crash — or a pid since reused by something else — won't trigger a false alarm). Pass `--force` to resume anyway.
+
 ### Options
 
 - `[SESSION_ID]`: The Claude session id to resume
+- `-f, --force`: Resume even if the session appears to be running in another process
 - `--shell-setup`: Add the `crap` shell function to your ~/.zshrc or ~/.bashrc
 
 ### Shell Integration
@@ -1252,13 +1268,15 @@ If you prefer to add it manually, add this to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 function crap() {
-    if [ "$#" -eq 0 ]; then
-        command crap
-        return $?
-    fi
-    local __crap_session="$1"
-    local __crap_dir
-    __crap_dir=$(command crap "$__crap_session") || return $?
+    local __crap_out
+    __crap_out=$(command crap "$@") || return $?
+    local __crap_dir __crap_session
+    {
+        IFS= read -r __crap_dir
+        IFS= read -r __crap_session
+    } <<EOF
+$__crap_out
+EOF
     cd "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
@@ -1268,7 +1286,7 @@ function crap() {
 }
 ```
 
-The `eval` is intentional: shell aliases aren't expanded inside function bodies, so it ensures a `clauded` alias is honored at call time. The `command crap` calls reach the binary past the function of the same name.
+The binary prints two lines on success — the directory to enter and the session id to resume — which the function reads back; forwarding `"$@"` lets flags like `--force` reach the binary. The `eval` is intentional: shell aliases aren't expanded inside function bodies, so it ensures a `clauded` alias is honored at call time. The `command crap` calls reach the binary past the function of the same name.
 
 ### Exit Codes
 
@@ -1279,6 +1297,7 @@ The `eval` is intentional: shell aliases aren't expanded inside function bodies,
 - `4`: Invalid session id
 - `5`: Shell setup failed
 - `6`: Could not determine your home directory
+- `7`: The session is already running in another process (use `--force` to override)
 
 ## bm (bulk move)
 

--- a/README.md
+++ b/README.md
@@ -1270,13 +1270,9 @@ If you prefer to add it manually, add this to your `~/.bashrc` or `~/.zshrc`:
 function crap() {
     local __crap_out
     __crap_out=$(command crap "$@") || return $?
-    local __crap_dir __crap_session
-    {
-        IFS= read -r __crap_dir
-        IFS= read -r __crap_session
-    } <<EOF
-$__crap_out
-EOF
+    local __crap_session __crap_dir
+    __crap_session=${__crap_out%%$'\n'*}
+    __crap_dir=${__crap_out#*$'\n'}
     cd -- "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
@@ -1286,7 +1282,7 @@ EOF
 }
 ```
 
-The binary prints two lines on success — the directory to enter and the session id to resume — which the function reads back; forwarding `"$@"` lets flags like `--force` reach the binary. The `eval` is intentional: shell aliases aren't expanded inside function bodies, so it ensures a `clauded` alias is honored at call time. The `command crap` calls reach the binary past the function of the same name.
+The binary prints the session id on the first line and the directory on the rest; the function takes the first line as the session id and everything after it as the directory, so a path containing a newline stays intact. Forwarding `"$@"` lets flags like `--force` reach the binary. The `eval` is intentional: shell aliases aren't expanded inside function bodies, so it ensures a `clauded` alias is honored at call time. The `command crap` calls reach the binary past the function of the same name.
 
 ### Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -1277,7 +1277,7 @@ function crap() {
     } <<EOF
 $__crap_out
 EOF
-    cd "$__crap_dir" || return 1
+    cd -- "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
     else

--- a/TLDR.md
+++ b/TLDR.md
@@ -12,6 +12,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `cf` | Count Files — recursively counts files, with optional suffix/prefix/substring filters. |
 | `claude-usage` | Parses an Anthropic API usage CSV and computes per-model costs. |
 | `clipboard-random` | Generates random binary or Zalgo text data and copies it to the clipboard. |
+| `crap` | Claude, Resume Anywhere Please — resume a Claude Code session from its original directory (refuses if it's already running). |
 | `cwt` | Change Worktree — navigate, cycle, or jump between git worktrees. |
 | `dirc` | Copies the current directory to the clipboard, or emits a `cd` from a clipboard path. |
 | `dirhash` | SHA256 hash of a directory tree's contents to compare directories for equality. |

--- a/src/crap/Cargo.toml
+++ b/src/crap/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "crap"
+version = "0.1.0"
+edition.workspace = true
+
+[[bin]]
+name = "crap"
+path = "src/main.rs"
+
+[dependencies]
+buildinfo.workspace = true
+clap.workspace = true
+colored.workspace = true
+dirs.workspace = true
+serde_json.workspace = true
+shellsetup.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -50,17 +50,28 @@ enum ResolveError {
     DirectoryMissing(PathBuf),
 }
 
-/// Returns `true` if `id` is safe to use as a `.jsonl` filename component.
+/// Returns `true` if `id` is a canonical UUID (`8-4-4-4-12` hex digits).
 ///
-/// Rejects empty strings, anything containing a path separator (`/` or `\`),
-/// and any traversal sequence (`..`) so a crafted id cannot escape the
-/// projects directory.
+/// Claude session ids are always UUIDs and the id only ever names a `.jsonl`
+/// file under `~/.claude/projects`. Requiring this exact shape rejects typo'd
+/// ids up front and, as a side effect, guarantees no path separator, traversal
+/// sequence, or shell metacharacter can ride through to the filesystem lookup
+/// or the shell function. Hex is matched case-insensitively.
 fn is_valid_session_id(id: &str) -> bool {
-    !id.is_empty()
-        && id != ".."
-        && !id.contains('/')
-        && !id.contains('\\')
-        && !id.contains("..")
+    /// Hyphen positions in a canonical UUID, and its total length.
+    const HYPHEN_POSITIONS: [usize; 4] = [8, 13, 18, 23];
+    const UUID_LEN: usize = 36;
+
+    if id.len() != UUID_LEN {
+        return false;
+    }
+    id.bytes().enumerate().all(|(i, b)| {
+        if HYPHEN_POSITIONS.contains(&i) {
+            b == b'-'
+        } else {
+            b.is_ascii_hexdigit()
+        }
+    })
 }
 
 /// Extracts the first non-empty `cwd` value from Claude session JSONL contents.

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -236,19 +236,23 @@ fn pid_is_alive(pid: u32) -> bool {
 
 /// Formats the binary's success output for the shell function to read back.
 ///
-/// Emits two parts separated by a newline. The shell function `cd`s into the
-/// directory and resumes the session id.
+/// The session id (a validated UUID) is emitted first, on its own line; the
+/// directory comes last. Putting the variable-content directory last means a
+/// path that itself contains a newline can't be mistaken for the end of the
+/// session-id field — the shell function takes the first line as the session id
+/// and everything after it as the directory.
 fn format_output(dir: &Path, session_id: &str) -> String {
-    format!("{}\n{}\n", dir.display(), session_id)
+    format!("{session_id}\n{}\n", dir.display())
 }
 
 /// The shell function installed by `crap --shell-setup`.
 ///
 /// `crap` shadows the binary, so the function reaches the binary explicitly via
 /// `command crap`, forwarding all arguments (so flags like `--force` work). The
-/// binary prints two lines on success — the resolved directory and the session
-/// id — which the function reads back; it then `cd`s there and re-launches
-/// Claude. `clauded` is resolved through `eval` so that an alias of that name is
+/// binary prints the session id on the first line and the resolved directory on
+/// the rest; the function splits on the first newline (so a directory
+/// containing newlines survives intact), `cd`s there, and re-launches Claude.
+/// `clauded` is resolved through `eval` so that an alias of that name is
 /// expanded at call time (shell aliases are otherwise not expanded inside
 /// function bodies); if no `clauded` exists, plain `claude` is used. If the
 /// binary exits non-zero (session not found, already running, …) its message is
@@ -257,13 +261,9 @@ const SHELL_CODE: &str = r#"
 function crap() {
     local __crap_out
     __crap_out=$(command crap "$@") || return $?
-    local __crap_dir __crap_session
-    {
-        IFS= read -r __crap_dir
-        IFS= read -r __crap_session
-    } <<EOF
-$__crap_out
-EOF
+    local __crap_session __crap_dir
+    __crap_session=${__crap_out%%$'\n'*}
+    __crap_dir=${__crap_out#*$'\n'}
     cd -- "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
@@ -643,11 +643,12 @@ mod tests {
     #[test]
     fn shell_code_defines_function_and_dispatches_to_claude() {
         assert!(SHELL_CODE.contains("function crap()"));
-        // Forwards all args (so --force reaches the binary) and reads back the
-        // two-line output (directory, then session id).
+        // Forwards all args so --force reaches the binary.
         assert!(SHELL_CODE.contains("command crap \"$@\""));
-        assert!(SHELL_CODE.contains("read -r __crap_dir"));
-        assert!(SHELL_CODE.contains("read -r __crap_session"));
+        // Splits the output on the first newline: session id leads, directory
+        // is the remainder (so a path with embedded newlines stays whole).
+        assert!(SHELL_CODE.contains("__crap_session=${__crap_out%%$'\\n'*}"));
+        assert!(SHELL_CODE.contains("__crap_dir=${__crap_out#*$'\\n'}"));
         assert!(SHELL_CODE.contains("clauded --resume"));
         assert!(SHELL_CODE.contains("claude --resume"));
     }

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -234,6 +234,14 @@ fn pid_is_alive(pid: u32) -> bool {
         .contains("claude")
 }
 
+/// Formats the binary's success output for the shell function to read back.
+///
+/// Emits two parts separated by a newline. The shell function `cd`s into the
+/// directory and resumes the session id.
+fn format_output(dir: &Path, session_id: &str) -> String {
+    format!("{}\n{}\n", dir.display(), session_id)
+}
+
 /// The shell function installed by `crap --shell-setup`.
 ///
 /// `crap` shadows the binary, so the function reaches the binary explicitly via
@@ -350,10 +358,7 @@ fn main() {
                     exit(exit_codes::SESSION_ALREADY_RUNNING);
                 }
             }
-            // Two machine-readable lines for the shell function: the directory
-            // to cd into, then the session id to pass to `--resume`.
-            println!("{}", dir.display());
-            println!("{session_id}");
+            print!("{}", format_output(&dir, &session_id));
         }
         Err(ResolveError::InvalidSessionId) => {
             eprintln!(

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -585,6 +585,13 @@ mod tests {
     }
 
     #[test]
+    fn shell_code_guards_cd_against_dash_prefixed_dirs() {
+        // `cd -- "$dir"` stops option parsing, so a directory whose name begins
+        // with '-' is treated as a path rather than a flag.
+        assert!(SHELL_CODE.contains("cd -- \"$__crap_dir\""));
+    }
+
+    #[test]
     fn shell_code_defines_function_and_dispatches_to_claude() {
         assert!(SHELL_CODE.contains("function crap()"));
         // Forwards all args (so --force reaches the binary) and reads back the

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -33,6 +33,8 @@ mod exit_codes {
     pub const SHELL_SETUP_ERROR: i32 = 5;
     /// The user's home directory could not be determined.
     pub const NO_HOME_DIR: i32 = 6;
+    /// The session is already running in another process.
+    pub const SESSION_ALREADY_RUNNING: i32 = 7;
 }
 
 /// Why a session id could not be resolved to an existing directory.
@@ -152,8 +154,25 @@ struct SessionRecord {
 ///
 /// Returns `None` if the JSON is malformed or is missing the `pid`/`sessionId`
 /// fields that uniquely identify a running session.
-fn parse_session_record(_json: &str) -> Option<SessionRecord> {
-    todo!("implemented in the green commit")
+fn parse_session_record(json: &str) -> Option<SessionRecord> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    let pid = u32::try_from(value.get("pid")?.as_u64()?).ok()?;
+    let session_id = value.get("sessionId")?.as_str()?.to_string();
+    let cwd = value
+        .get("cwd")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let status = value
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    Some(SessionRecord {
+        pid,
+        session_id,
+        cwd,
+        status,
+    })
 }
 
 /// Finds a currently-running session attached to `session_id`.
@@ -162,15 +181,26 @@ fn parse_session_record(_json: &str) -> Option<SessionRecord> {
 /// whose `session_id` matches and whose pid `is_alive` reports as still
 /// running. The `is_alive` predicate is injected so this logic is testable
 /// without spawning real processes.
-fn find_live_session<F>(
-    _sessions_dir: &Path,
-    _session_id: &str,
-    _is_alive: F,
-) -> Option<SessionRecord>
+fn find_live_session<F>(sessions_dir: &Path, session_id: &str, is_alive: F) -> Option<SessionRecord>
 where
     F: Fn(u32) -> bool,
 {
-    todo!("implemented in the green commit")
+    for entry in std::fs::read_dir(sessions_dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(record) = parse_session_record(&contents) else {
+            continue;
+        };
+        if record.session_id == session_id && is_alive(record.pid) {
+            return Some(record);
+        }
+    }
+    None
 }
 
 /// Reports whether `pid` is a currently-running Claude CLI process.
@@ -178,26 +208,43 @@ where
 /// Uses `ps -p <pid> -o command=`: a non-empty, successful result means the pid
 /// exists, and requiring `claude` in the command line guards against a stale
 /// session file whose pid has since been reused by an unrelated process.
-fn pid_is_alive(_pid: u32) -> bool {
-    todo!("implemented in the green commit")
+fn pid_is_alive(pid: u32) -> bool {
+    let Ok(output) = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .to_lowercase()
+        .contains("claude")
 }
 
 /// The shell function installed by `crap --shell-setup`.
 ///
 /// `crap` shadows the binary, so the function reaches the binary explicitly via
-/// `command crap` to resolve the session's directory. It then `cd`s there and
-/// re-launches Claude. `clauded` is resolved through `eval` so that an alias of
-/// that name is expanded at call time (shell aliases are otherwise not expanded
-/// inside function bodies); if no `clauded` exists, plain `claude` is used.
+/// `command crap`, forwarding all arguments (so flags like `--force` work). The
+/// binary prints two lines on success — the resolved directory and the session
+/// id — which the function reads back; it then `cd`s there and re-launches
+/// Claude. `clauded` is resolved through `eval` so that an alias of that name is
+/// expanded at call time (shell aliases are otherwise not expanded inside
+/// function bodies); if no `clauded` exists, plain `claude` is used. If the
+/// binary exits non-zero (session not found, already running, …) its message is
+/// shown and the function stops without changing directory.
 const SHELL_CODE: &str = r#"
 function crap() {
-    if [ "$#" -eq 0 ]; then
-        command crap
-        return $?
-    fi
-    local __crap_session="$1"
-    local __crap_dir
-    __crap_dir=$(command crap "$__crap_session") || return $?
+    local __crap_out
+    __crap_out=$(command crap "$@") || return $?
+    local __crap_dir __crap_session
+    {
+        IFS= read -r __crap_dir
+        IFS= read -r __crap_session
+    } <<EOF
+$__crap_out
+EOF
     cd "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
@@ -230,6 +277,14 @@ struct Cli {
     /// `~/.claude/projects`).
     #[arg(value_name = "SESSION_ID", required_unless_present = "shell_setup")]
     session_id: Option<String>,
+
+    /// Resume even if the session appears to be running in another process.
+    ///
+    /// By default `crap` refuses to resume a session that is already open
+    /// elsewhere, because two processes writing the same session log can
+    /// corrupt it.
+    #[arg(short, long)]
+    force: bool,
 
     /// Install the `crap` shell function into your shell config, then exit.
     ///
@@ -264,7 +319,31 @@ fn main() {
     };
 
     match resolve_session_dir(&projects_dir, &session_id) {
-        Ok(dir) => println!("{}", dir.display()),
+        Ok(dir) => {
+            if !cli.force {
+                if let Some(live) = claude_sessions_dir()
+                    .and_then(|s| find_live_session(&s, &session_id, pid_is_alive))
+                {
+                    let status = live.status.as_deref().unwrap_or("running");
+                    eprintln!(
+                        "{} session '{session_id}' is already running (pid {}, {status})",
+                        "Error:".red().bold(),
+                        live.pid
+                    );
+                    eprintln!("       in {}", live.cwd);
+                    eprintln!("       resuming it again can corrupt the session log.");
+                    eprintln!(
+                        "       re-run with {} to resume anyway.",
+                        "--force".yellow()
+                    );
+                    exit(exit_codes::SESSION_ALREADY_RUNNING);
+                }
+            }
+            // Two machine-readable lines for the shell function: the directory
+            // to cd into, then the session id to pass to `--resume`.
+            println!("{}", dir.display());
+            println!("{session_id}");
+        }
         Err(ResolveError::InvalidSessionId) => {
             eprintln!(
                 "{} '{session_id}' is not a valid session id",
@@ -508,7 +587,11 @@ mod tests {
     #[test]
     fn shell_code_defines_function_and_dispatches_to_claude() {
         assert!(SHELL_CODE.contains("function crap()"));
-        assert!(SHELL_CODE.contains("command crap"));
+        // Forwards all args (so --force reaches the binary) and reads back the
+        // two-line output (directory, then session id).
+        assert!(SHELL_CODE.contains("command crap \"$@\""));
+        assert!(SHELL_CODE.contains("read -r __crap_dir"));
+        assert!(SHELL_CODE.contains("read -r __crap_session"));
         assert!(SHELL_CODE.contains("clauded --resume"));
         assert!(SHELL_CODE.contains("claude --resume"));
     }

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -1,0 +1,364 @@
+//! crap — "Claude, Resume Anywhere Please".
+//!
+//! Resume a Claude Code session from whatever directory it was originally
+//! started in, no matter where you are now. Given a session id, `crap` looks
+//! up that session under `~/.claude/projects`, recovers the directory it ran
+//! in, changes into it, and re-launches Claude with `--resume <id>`.
+//!
+//! Because a binary cannot change its parent shell's working directory (nor see
+//! shell aliases such as `clauded`), the user-facing `crap` command is a shell
+//! function installed via `crap --shell-setup`. This binary's job is to resolve
+//! a session id to its original directory and print that path to stdout; the
+//! shell function performs the `cd` and runs `clauded`/`claude` from there.
+
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+use buildinfo::version_string;
+use clap::Parser;
+use colored::Colorize;
+use shellsetup::ShellIntegration;
+
+/// Exit codes for the different failure conditions.
+mod exit_codes {
+    /// No session file matched the given id.
+    pub const SESSION_NOT_FOUND: i32 = 1;
+    /// The session file had no recorded working directory.
+    pub const NO_CWD_IN_SESSION: i32 = 2;
+    /// The recorded working directory no longer exists.
+    pub const DIRECTORY_MISSING: i32 = 3;
+    /// The session id was not a valid filename component.
+    pub const INVALID_SESSION_ID: i32 = 4;
+    /// Shell setup failed.
+    pub const SHELL_SETUP_ERROR: i32 = 5;
+    /// The user's home directory could not be determined.
+    pub const NO_HOME_DIR: i32 = 6;
+}
+
+/// Why a session id could not be resolved to an existing directory.
+#[derive(Debug)]
+enum ResolveError {
+    /// The session id contained path separators or traversal sequences.
+    InvalidSessionId,
+    /// No `<session_id>.jsonl` file was found under any project directory.
+    SessionNotFound,
+    /// The session file exists but records no working directory.
+    NoCwdInSession,
+    /// The recorded working directory no longer exists on disk.
+    DirectoryMissing(PathBuf),
+}
+
+/// Returns `true` if `id` is safe to use as a `.jsonl` filename component.
+///
+/// Rejects empty strings, anything containing a path separator (`/` or `\`),
+/// and any traversal sequence (`..`) so a crafted id cannot escape the
+/// projects directory.
+fn is_valid_session_id(_id: &str) -> bool {
+    todo!("implemented in the green commit")
+}
+
+/// Extracts the first non-empty `cwd` value from Claude session JSONL contents.
+///
+/// Each line is an independent JSON object; the early bookkeeping lines often
+/// carry `"cwd": null`, so the first line with a non-empty string `cwd` wins.
+/// Non-JSON lines are skipped. Returns `None` if no usable `cwd` is present.
+fn extract_cwd(_contents: &str) -> Option<String> {
+    todo!("implemented in the green commit")
+}
+
+/// Locates `<session_id>.jsonl` inside any immediate subdirectory of
+/// `projects_dir`, returning its full path if found.
+fn find_session_file(_projects_dir: &Path, _session_id: &str) -> Option<PathBuf> {
+    todo!("implemented in the green commit")
+}
+
+/// Resolves a session id to the existing directory the session ran in.
+///
+/// # Errors
+///
+/// Returns a [`ResolveError`] when the id is invalid, no session file matches,
+/// the session records no working directory, or that directory no longer
+/// exists.
+fn resolve_session_dir(
+    _projects_dir: &Path,
+    _session_id: &str,
+) -> Result<PathBuf, ResolveError> {
+    todo!("implemented in the green commit")
+}
+
+/// Returns the `~/.claude/projects` directory, or `None` if the home directory
+/// cannot be determined.
+fn claude_projects_dir() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".claude").join("projects"))
+}
+
+/// The shell function installed by `crap --shell-setup`.
+///
+/// `crap` shadows the binary, so the function reaches the binary explicitly via
+/// `command crap` to resolve the session's directory. It then `cd`s there and
+/// re-launches Claude. `clauded` is resolved through `eval` so that an alias of
+/// that name is expanded at call time (shell aliases are otherwise not expanded
+/// inside function bodies); if no `clauded` exists, plain `claude` is used.
+const SHELL_CODE: &str = r#"
+function crap() {
+    if [ "$#" -eq 0 ]; then
+        command crap
+        return $?
+    fi
+    local __crap_session="$1"
+    local __crap_dir
+    __crap_dir=$(command crap "$__crap_session") || return $?
+    cd "$__crap_dir" || return 1
+    if command -v clauded >/dev/null 2>&1; then
+        eval 'clauded --resume "$__crap_session"'
+    else
+        claude --resume "$__crap_session"
+    fi
+}
+"#;
+
+/// Installs the `crap` shell function into the user's shell config.
+fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
+    let integration = ShellIntegration::new(
+        "crap",
+        "Claude, Resume Anywhere Please",
+        SHELL_CODE,
+    )
+    .with_command("crap", "Resume a Claude session from its original directory");
+    integration.setup()
+}
+
+/// Command-line interface for `crap`.
+#[derive(Parser)]
+#[command(name = "crap")]
+#[command(
+    about = "Claude, Resume Anywhere Please — resume a Claude session from its original directory"
+)]
+#[command(version = version_string!())]
+struct Cli {
+    /// The Claude session id to resume (the `.jsonl` filename under
+    /// `~/.claude/projects`).
+    #[arg(value_name = "SESSION_ID", required_unless_present = "shell_setup")]
+    session_id: Option<String>,
+
+    /// Install the `crap` shell function into your shell config, then exit.
+    ///
+    /// Run this once: `crap --shell-setup`. After re-sourcing your shell,
+    /// `crap <session-id>` will cd into the session's directory and resume it.
+    #[arg(long)]
+    shell_setup: bool,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    if cli.shell_setup {
+        match setup_shell_integration() {
+            Ok(()) => exit(0),
+            Err(e) => {
+                eprintln!("{} {e}", "Error:".red().bold());
+                exit(exit_codes::SHELL_SETUP_ERROR);
+            }
+        }
+    }
+
+    // `required_unless_present = "shell_setup"` guarantees this is present here.
+    let session_id = cli.session_id.expect("session id is required without --shell-setup");
+
+    let Some(projects_dir) = claude_projects_dir() else {
+        eprintln!(
+            "{} could not determine your home directory",
+            "Error:".red().bold()
+        );
+        exit(exit_codes::NO_HOME_DIR);
+    };
+
+    match resolve_session_dir(&projects_dir, &session_id) {
+        Ok(dir) => println!("{}", dir.display()),
+        Err(ResolveError::InvalidSessionId) => {
+            eprintln!(
+                "{} '{session_id}' is not a valid session id",
+                "Error:".red().bold()
+            );
+            exit(exit_codes::INVALID_SESSION_ID);
+        }
+        Err(ResolveError::SessionNotFound) => {
+            eprintln!(
+                "{} no Claude session found with id '{session_id}'",
+                "Error:".red().bold()
+            );
+            eprintln!("       looked under {}", projects_dir.display());
+            exit(exit_codes::SESSION_NOT_FOUND);
+        }
+        Err(ResolveError::NoCwdInSession) => {
+            eprintln!(
+                "{} session '{session_id}' has no recorded working directory",
+                "Error:".red().bold()
+            );
+            exit(exit_codes::NO_CWD_IN_SESSION);
+        }
+        Err(ResolveError::DirectoryMissing(path)) => {
+            eprintln!(
+                "{} the directory for session '{session_id}' no longer exists:",
+                "Error:".red().bold()
+            );
+            eprintln!("       {}", path.display());
+            exit(exit_codes::DIRECTORY_MISSING);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// A representative session id used across tests.
+    const SAMPLE_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+    /// Builds a single JSONL line recording `cwd`.
+    fn cwd_line(cwd: &str) -> String {
+        format!("{}\n", serde_json::json!({ "cwd": cwd }))
+    }
+
+    #[test]
+    fn extract_cwd_returns_first_non_null_cwd() {
+        let contents = format!(
+            "{}{}{}{}",
+            "{\"type\":\"summary\"}\n",
+            "{\"cwd\":null}\n",
+            cwd_line("/Users/tim/code/foo"),
+            cwd_line("/Users/tim/code/bar"),
+        );
+        assert_eq!(
+            extract_cwd(&contents).as_deref(),
+            Some("/Users/tim/code/foo")
+        );
+    }
+
+    #[test]
+    fn extract_cwd_skips_non_json_and_missing_or_empty() {
+        let contents = "not json at all\n{\"foo\":1}\n{\"cwd\":\"\"}\n";
+        assert_eq!(extract_cwd(contents), None);
+    }
+
+    #[test]
+    fn extract_cwd_empty_input_is_none() {
+        assert_eq!(extract_cwd(""), None);
+    }
+
+    #[test]
+    fn extract_cwd_handles_multibyte_paths() {
+        let contents = cwd_line("/Users/tim/コード/café");
+        assert_eq!(
+            extract_cwd(&contents).as_deref(),
+            Some("/Users/tim/コード/café")
+        );
+    }
+
+    #[test]
+    fn valid_session_id_accepts_uuid() {
+        assert!(is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e1901"));
+    }
+
+    #[test]
+    fn valid_session_id_rejects_traversal_and_separators() {
+        assert!(!is_valid_session_id(""));
+        assert!(!is_valid_session_id(".."));
+        assert!(!is_valid_session_id("../etc/passwd"));
+        assert!(!is_valid_session_id("a/b"));
+        assert!(!is_valid_session_id("a\\b"));
+    }
+
+    #[test]
+    fn find_session_file_locates_jsonl_in_project_subdir() {
+        let dir = tempdir().unwrap();
+        let projects = dir.path();
+        let proj = projects.join("-Users-tim-code-foo");
+        fs::create_dir_all(&proj).unwrap();
+        let file = proj.join(format!("{SAMPLE_ID}.jsonl"));
+        fs::write(&file, "{}\n").unwrap();
+
+        assert_eq!(find_session_file(projects, SAMPLE_ID), Some(file));
+    }
+
+    #[test]
+    fn find_session_file_returns_none_when_absent() {
+        let dir = tempdir().unwrap();
+        assert_eq!(find_session_file(dir.path(), SAMPLE_ID), None);
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_id() {
+        let dir = tempdir().unwrap();
+        assert!(matches!(
+            resolve_session_dir(dir.path(), "../escape"),
+            Err(ResolveError::InvalidSessionId)
+        ));
+    }
+
+    #[test]
+    fn resolve_errors_when_session_missing() {
+        let dir = tempdir().unwrap();
+        assert!(matches!(
+            resolve_session_dir(dir.path(), SAMPLE_ID),
+            Err(ResolveError::SessionNotFound)
+        ));
+    }
+
+    #[test]
+    fn resolve_errors_when_no_cwd_in_session() {
+        let dir = tempdir().unwrap();
+        let proj = dir.path().join("proj");
+        fs::create_dir_all(&proj).unwrap();
+        fs::write(proj.join(format!("{SAMPLE_ID}.jsonl")), "{\"cwd\":null}\n").unwrap();
+
+        assert!(matches!(
+            resolve_session_dir(dir.path(), SAMPLE_ID),
+            Err(ResolveError::NoCwdInSession)
+        ));
+    }
+
+    #[test]
+    fn resolve_errors_when_directory_missing() {
+        let dir = tempdir().unwrap();
+        let proj = dir.path().join("proj");
+        fs::create_dir_all(&proj).unwrap();
+        let missing = dir.path().join("gone");
+        fs::write(
+            proj.join(format!("{SAMPLE_ID}.jsonl")),
+            cwd_line(missing.to_str().unwrap()),
+        )
+        .unwrap();
+
+        match resolve_session_dir(dir.path(), SAMPLE_ID) {
+            Err(ResolveError::DirectoryMissing(path)) => assert_eq!(path, missing),
+            other => panic!("expected DirectoryMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_returns_existing_directory() {
+        let dir = tempdir().unwrap();
+        let proj = dir.path().join("proj");
+        fs::create_dir_all(&proj).unwrap();
+        let cwd = dir.path().join("real-cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(
+            proj.join(format!("{SAMPLE_ID}.jsonl")),
+            cwd_line(cwd.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(resolve_session_dir(dir.path(), SAMPLE_ID).unwrap(), cwd);
+    }
+
+    #[test]
+    fn shell_code_defines_function_and_dispatches_to_claude() {
+        assert!(SHELL_CODE.contains("function crap()"));
+        assert!(SHELL_CODE.contains("command crap"));
+        assert!(SHELL_CODE.contains("clauded --resume"));
+        assert!(SHELL_CODE.contains("claude --resume"));
+    }
+}

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -441,6 +441,25 @@ mod tests {
     }
 
     #[test]
+    fn valid_session_id_requires_uuid_shape() {
+        // Anything that isn't a canonical 8-4-4-4-12 UUID is rejected, so a
+        // typo'd id fails fast and shell metacharacters never reach the binary.
+        assert!(!is_valid_session_id("not-a-uuid"));
+        assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e190")); // too short
+        assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e19011")); // too long
+        assert!(!is_valid_session_id("4733ee2a1ad64619a01a11840b8e1901")); // no hyphens
+        assert!(!is_valid_session_id("4733ee2g-1ad6-4619-a01a-11840b8e1901")); // 'g' not hex
+        assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e1901 ; rm -rf ~"));
+        assert!(!is_valid_session_id("4733ee2a 1ad6 4619 a01a 11840b8e1901")); // spaces
+    }
+
+    #[test]
+    fn valid_session_id_accepts_uppercase_hex() {
+        // Hex is case-insensitive even though Claude writes lowercase ids.
+        assert!(is_valid_session_id("4733EE2A-1AD6-4619-A01A-11840B8E1901"));
+    }
+
+    #[test]
     fn find_session_file_locates_jsonl_in_project_subdir() {
         let dir = tempdir().unwrap();
         let projects = dir.path();

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -245,7 +245,7 @@ function crap() {
     } <<EOF
 $__crap_out
 EOF
-    cd "$__crap_dir" || return 1
+    cd -- "$__crap_dir" || return 1
     if command -v clauded >/dev/null 2>&1; then
         eval 'clauded --resume "$__crap_session"'
     else

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -126,6 +126,62 @@ fn claude_projects_dir() -> Option<PathBuf> {
     Some(dirs::home_dir()?.join(".claude").join("projects"))
 }
 
+/// Returns the `~/.claude/sessions` directory, or `None` if the home directory
+/// cannot be determined.
+///
+/// Claude Code writes one `<pid>.json` file here per live CLI session and
+/// removes it on clean exit, so it serves as a registry of running sessions.
+fn claude_sessions_dir() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".claude").join("sessions"))
+}
+
+/// A running Claude CLI session, as recorded under `~/.claude/sessions`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionRecord {
+    /// The process id of the running `claude` process.
+    pid: u32,
+    /// The session id this process is attached to.
+    session_id: String,
+    /// The directory the session is running in.
+    cwd: String,
+    /// The reported activity status (e.g. `"busy"` or `"idle"`), if present.
+    status: Option<String>,
+}
+
+/// Parses a `~/.claude/sessions/<pid>.json` record.
+///
+/// Returns `None` if the JSON is malformed or is missing the `pid`/`sessionId`
+/// fields that uniquely identify a running session.
+fn parse_session_record(_json: &str) -> Option<SessionRecord> {
+    todo!("implemented in the green commit")
+}
+
+/// Finds a currently-running session attached to `session_id`.
+///
+/// Scans every `<pid>.json` under `sessions_dir` and returns the first record
+/// whose `session_id` matches and whose pid `is_alive` reports as still
+/// running. The `is_alive` predicate is injected so this logic is testable
+/// without spawning real processes.
+fn find_live_session<F>(
+    _sessions_dir: &Path,
+    _session_id: &str,
+    _is_alive: F,
+) -> Option<SessionRecord>
+where
+    F: Fn(u32) -> bool,
+{
+    todo!("implemented in the green commit")
+}
+
+/// Reports whether `pid` is a currently-running Claude CLI process.
+///
+/// Uses `ps -p <pid> -o command=`: a non-empty, successful result means the pid
+/// exists, and requiring `claude` in the command line guards against a stale
+/// session file whose pid has since been reused by an unrelated process.
+fn pid_is_alive(_pid: u32) -> bool {
+    todo!("implemented in the green commit")
+}
+
 /// The shell function installed by `crap --shell-setup`.
 ///
 /// `crap` shadows the binary, so the function reaches the binary explicitly via
@@ -386,6 +442,67 @@ mod tests {
         .unwrap();
 
         assert_eq!(resolve_session_dir(dir.path(), SAMPLE_ID).unwrap(), cwd);
+    }
+
+    /// A real session record as written by Claude Code.
+    const SESSION_JSON: &str = r#"{"pid":17041,"sessionId":"3eafa9f8-9d1f-43cf-b417-eb9efcb8ed4d","cwd":"/Volumes/code/crap","startedAt":1779730239473,"version":"2.1.150","kind":"interactive","entrypoint":"cli","status":"busy","updatedAt":1779730460209}"#;
+
+    #[test]
+    fn parse_session_record_extracts_fields() {
+        let rec = parse_session_record(SESSION_JSON).expect("should parse");
+        assert_eq!(rec.pid, 17041);
+        assert_eq!(rec.session_id, "3eafa9f8-9d1f-43cf-b417-eb9efcb8ed4d");
+        assert_eq!(rec.cwd, "/Volumes/code/crap");
+        assert_eq!(rec.status.as_deref(), Some("busy"));
+    }
+
+    #[test]
+    fn parse_session_record_rejects_malformed_or_incomplete() {
+        assert_eq!(parse_session_record("not json"), None);
+        assert_eq!(parse_session_record("{\"pid\":1}"), None); // no sessionId
+        assert_eq!(parse_session_record("{\"sessionId\":\"x\"}"), None); // no pid
+    }
+
+    #[test]
+    fn find_live_session_matches_only_alive_pid_for_id() {
+        let dir = tempdir().unwrap();
+        let target = "3eafa9f8-9d1f-43cf-b417-eb9efcb8ed4d";
+
+        // A different session, alive — must be ignored.
+        fs::write(
+            dir.path().join("100.json"),
+            serde_json::json!({"pid":100,"sessionId":"other","cwd":"/x"}).to_string(),
+        )
+        .unwrap();
+        // The target session — written with pid 17041.
+        fs::write(dir.path().join("17041.json"), SESSION_JSON).unwrap();
+
+        // Nothing alive -> no live session.
+        assert_eq!(find_live_session(dir.path(), target, |_| false), None);
+
+        // Only the target pid alive -> found.
+        let found = find_live_session(dir.path(), target, |pid| pid == 17041)
+            .expect("target session should be found");
+        assert_eq!(found.pid, 17041);
+        assert_eq!(found.cwd, "/Volumes/code/crap");
+    }
+
+    #[test]
+    fn find_live_session_ignores_stale_record_for_target() {
+        let dir = tempdir().unwrap();
+        let target = "3eafa9f8-9d1f-43cf-b417-eb9efcb8ed4d";
+        fs::write(dir.path().join("17041.json"), SESSION_JSON).unwrap();
+
+        // The matching record exists but its pid is dead (process exited
+        // uncleanly leaving the file behind) -> not a live session.
+        assert_eq!(find_live_session(dir.path(), target, |_| false), None);
+    }
+
+    #[test]
+    fn find_live_session_missing_dir_is_none() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("no-sessions-here");
+        assert_eq!(find_live_session(&missing, "anything", |_| true), None);
     }
 
     #[test]

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -620,6 +620,20 @@ mod tests {
     }
 
     #[test]
+    fn output_emits_session_id_before_directory() {
+        // The session id (a validated UUID) goes on the first line; the
+        // directory comes last so any newline inside a path can't be mistaken
+        // for the end of the session-id field.
+        let weird_dir = Path::new("/Users/tim/od\nd\u{2009}dir");
+        let out = format_output(weird_dir, SAMPLE_ID);
+
+        assert_eq!(out.lines().next(), Some(SAMPLE_ID));
+        // Everything after the first newline is the directory, intact.
+        let rest = out.split_once('\n').map(|(_, rest)| rest).unwrap();
+        assert_eq!(rest.trim_end_matches('\n'), weird_dir.to_str().unwrap());
+    }
+
+    #[test]
     fn shell_code_guards_cd_against_dash_prefixed_dirs() {
         // `cd -- "$dir"` stops option parsing, so a directory whose name begins
         // with '-' is treated as a path rather than a flag.

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -53,8 +53,12 @@ enum ResolveError {
 /// Rejects empty strings, anything containing a path separator (`/` or `\`),
 /// and any traversal sequence (`..`) so a crafted id cannot escape the
 /// projects directory.
-fn is_valid_session_id(_id: &str) -> bool {
-    todo!("implemented in the green commit")
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id != ".."
+        && !id.contains('/')
+        && !id.contains('\\')
+        && !id.contains("..")
 }
 
 /// Extracts the first non-empty `cwd` value from Claude session JSONL contents.
@@ -62,14 +66,37 @@ fn is_valid_session_id(_id: &str) -> bool {
 /// Each line is an independent JSON object; the early bookkeeping lines often
 /// carry `"cwd": null`, so the first line with a non-empty string `cwd` wins.
 /// Non-JSON lines are skipped. Returns `None` if no usable `cwd` is present.
-fn extract_cwd(_contents: &str) -> Option<String> {
-    todo!("implemented in the green commit")
+fn extract_cwd(contents: &str) -> Option<String> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if let Some(cwd) = value.get("cwd").and_then(serde_json::Value::as_str) {
+            if !cwd.is_empty() {
+                return Some(cwd.to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Locates `<session_id>.jsonl` inside any immediate subdirectory of
 /// `projects_dir`, returning its full path if found.
-fn find_session_file(_projects_dir: &Path, _session_id: &str) -> Option<PathBuf> {
-    todo!("implemented in the green commit")
+fn find_session_file(projects_dir: &Path, session_id: &str) -> Option<PathBuf> {
+    let file_name = format!("{session_id}.jsonl");
+    for entry in std::fs::read_dir(projects_dir).ok()?.flatten() {
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
+            let candidate = entry.path().join(&file_name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 /// Resolves a session id to the existing directory the session ran in.
@@ -79,11 +106,18 @@ fn find_session_file(_projects_dir: &Path, _session_id: &str) -> Option<PathBuf>
 /// Returns a [`ResolveError`] when the id is invalid, no session file matches,
 /// the session records no working directory, or that directory no longer
 /// exists.
-fn resolve_session_dir(
-    _projects_dir: &Path,
-    _session_id: &str,
-) -> Result<PathBuf, ResolveError> {
-    todo!("implemented in the green commit")
+fn resolve_session_dir(projects_dir: &Path, session_id: &str) -> Result<PathBuf, ResolveError> {
+    if !is_valid_session_id(session_id) {
+        return Err(ResolveError::InvalidSessionId);
+    }
+    let file = find_session_file(projects_dir, session_id).ok_or(ResolveError::SessionNotFound)?;
+    let contents = std::fs::read_to_string(&file).map_err(|_| ResolveError::SessionNotFound)?;
+    let cwd = extract_cwd(&contents).ok_or(ResolveError::NoCwdInSession)?;
+    let path = PathBuf::from(cwd);
+    if !path.is_dir() {
+        return Err(ResolveError::DirectoryMissing(path));
+    }
+    Ok(path)
 }
 
 /// Returns the `~/.claude/projects` directory, or `None` if the home directory


### PR DESCRIPTION
## Summary

Adds **crap** ("Claude, Resume Anywhere Please") — a tool that resumes a Claude Code session from wherever you are. Given a session id, `crap` looks the session up under `~/.claude/projects`, recovers the directory it originally ran in, `cd`s there, and re-launches Claude with `--resume <id>` (preferring a `clauded` alias if present, otherwise plain `claude`).

Because a binary can neither change its parent shell's working directory nor see shell aliases, `crap` ships as a shell function (installed via `crap --shell-setup`, using the repo's `shellsetup` lib) wrapping a binary that resolves the session — mirroring the existing `cwt`/`wt` split.

## Key behaviors

- **Authoritative directory resolution** — reads the original `cwd` from the session's `.jsonl` rather than decoding the sanitized project-folder name (which is lossy), so it always lands in the real path.
- **Refuses to attach twice** — Claude maintains `~/.claude/sessions/<pid>.json` for each live CLI session (removed on clean exit). Before resuming, `crap` checks that registry and refuses if the session is already open in a still-running `claude` process, reporting its pid, status, and directory. This prevents two processes from corrupting the same session log. The check verifies the pid is a live `claude` process, guarding against stale files and pid reuse. `--force` overrides.
- **Clear failures** — distinct exit codes and messages for: session not found, no recorded cwd, original directory missing, invalid session id, and already-running.
- **Shell-agnostic dispatch** — the `clauded` alias is expanded at call time via `eval` (aliases aren't expanded inside function bodies), verified in both bash and zsh.

## Tests

19 unit tests (session-id validation, cwd extraction incl. multibyte paths, session-file location, end-to-end resolution, session-record parsing, and live-session detection via an injected liveness predicate). Built TDD red→green. Verified end-to-end against real `~/.claude` data, and the shell function verified in bash and zsh.

## Docs

README updated with usage, the don't-attach-twice behavior, manual shell setup, and exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)