### PR TITLE
fix(crap): pass --help/--version/--shell-setup through the shell function instead of mangling them

### DIFF
--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -1846,6 +1846,95 @@ mod tests {
         assert!(SHELL_CODE.contains(r#"*" --status "*) command crap "$@"; return $?"#));
     }
 
+    /// Sources `SHELL_CODE` in a real `bash`, with a fake `crap` binary (and
+    /// fake `claude`/`clauded`) ahead of it on `PATH`, then runs `crap <args>`.
+    ///
+    /// The fake binary mimics clap: informational flags print a recognizable
+    /// marker to stdout and exit 0; anything else emits a `<session>\n<dir>`
+    /// resume target. Returns the captured stdout plus whether the `claude`
+    /// stub was invoked (it drops a marker file when called).
+    ///
+    /// All paths are keyed on the pid + a nanosecond timestamp so concurrent
+    /// runs of this test never share a temp dir.
+    #[cfg(unix)]
+    fn run_shell_function(args: &str) -> (String, bool) {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("crap-shell-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+
+        let claude_marker = dir.join("claude_called");
+
+        // Fake `crap`: informational flags print a marker and exit 0, exactly
+        // as clap does; the default path prints a resume target.
+        let fake_crap = "#!/bin/sh\n\
+            case \" $* \" in\n\
+            \x20 *\" --help \"*|*\" -h \"*) printf 'CRAP_HELP_MARKER\\nUsage: crap\\nmore\\n'; exit 0 ;;\n\
+            \x20 *\" --version \"*|*\" -V \"*) printf 'CRAP_VERSION_MARKER 0.1.0\\n'; exit 0 ;;\n\
+            esac\n\
+            printf 'session-xyz\\n/tmp/crap-resume-dir\\n'\n";
+
+        // Fake `claude`/`clauded`: record that a resume was attempted.
+        let fake_claude = format!("#!/bin/sh\n: > {:?}\n", claude_marker);
+
+        for (name, body) in [
+            ("crap", fake_crap.to_string()),
+            ("claude", fake_claude.clone()),
+            ("clauded", fake_claude.clone()),
+        ] {
+            let path = dir.join(name);
+            fs::write(&path, body).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let base_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{base_path}", dir.display());
+        let script = format!("{SHELL_CODE}\ncrap {args}\n");
+
+        let output = Command::new("bash")
+            .env("PATH", new_path)
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("bash should be available");
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let claude_called = claude_marker.exists();
+        let _ = fs::remove_dir_all(&dir);
+        (stdout, claude_called)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_function_passes_help_and_version_through() {
+        // These flags make the binary print to stdout and exit 0. Without a
+        // pass-through, the function captures that text and tries to `cd` into
+        // it as a resume directory. Each must reach the terminal verbatim and
+        // never trigger a resume.
+        for (args, marker) in [
+            ("--help", "CRAP_HELP_MARKER"),
+            ("-h", "CRAP_HELP_MARKER"),
+            ("--version", "CRAP_VERSION_MARKER"),
+            ("-V", "CRAP_VERSION_MARKER"),
+        ] {
+            let (stdout, claude_called) = run_shell_function(args);
+            assert!(
+                stdout.contains(marker),
+                "`crap {args}` should print the binary's output verbatim, got: {stdout:?}"
+            );
+            assert!(
+                !claude_called,
+                "`crap {args}` must not attempt a resume"
+            );
+        }
+    }
+
     // Two distinct session ids for the per-directory listing tests.
     const ID_A: &str = "aaaaaaaa-1111-2222-3333-444444444444";
     const ID_B: &str = "bbbbbbbb-1111-2222-3333-444444444444";

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -1883,6 +1883,7 @@ mod tests {
             case \" $* \" in\n\
             \x20 *\" --help \"*|*\" -h \"*) printf 'CRAP_HELP_MARKER\\nUsage: crap\\nmore\\n'; exit 0 ;;\n\
             \x20 *\" --version \"*|*\" -V \"*) printf 'CRAP_VERSION_MARKER 0.1.0\\n'; exit 0 ;;\n\
+            \x20 *\" --shell-setup \"*) printf 'CRAP_SETUP_MARKER\\nTo activate, run:\\n  source ~/.zshrc\\n'; exit 0 ;;\n\
             esac\n\
             printf 'session-xyz\\n/tmp/crap-resume-dir\\n'\n";
 
@@ -1918,16 +1919,19 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn shell_function_passes_help_and_version_through() {
-        // These flags make the binary print to stdout and exit 0. Without a
-        // pass-through, the function captures that text and tries to `cd` into
-        // it as a resume directory. Each must reach the terminal verbatim and
-        // never trigger a resume.
+    fn shell_function_passes_informational_flags_through() {
+        // These flags make the binary print to stdout and exit 0 without
+        // mutating the parent shell. Without a pass-through, the function
+        // captures that text and tries to `cd` into it as a resume directory.
+        // Each must reach the terminal verbatim and never trigger a resume.
+        // `--shell-setup` is included because, on an upgrade, the already-loaded
+        // function would otherwise swallow its activation instructions.
         for (args, marker) in [
             ("--help", "CRAP_HELP_MARKER"),
             ("-h", "CRAP_HELP_MARKER"),
             ("--version", "CRAP_VERSION_MARKER"),
             ("-V", "CRAP_VERSION_MARKER"),
+            ("--shell-setup", "CRAP_SETUP_MARKER"),
         ] {
             let (stdout, claude_called) = run_shell_function(args);
             assert!(

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -767,13 +767,16 @@ fn format_here_output(session_id: &str, link_to_cleanup: Option<&Path>) -> Strin
 ///   was created because this already is the session's own directory.
 const SHELL_CODE: &str = r#"
 function crap() {
-    # These flags make the binary print to stdout and exit 0 without changing
-    # the parent shell: --status only queries, and --help/-h/--version/-V emit
-    # informational text. Run them straight through so their output reaches the
-    # terminal instead of being parsed as a "<session-id>\n<dir>" resume target
-    # (which would otherwise `cd` into the help/listing text and mangle it).
+    # These flags make the binary print to stdout and exit 0 without mutating
+    # the parent shell: --status queries, --help/-h/--version/-V emit
+    # informational text, and --shell-setup writes the rc file (not the live
+    # shell) and prints activation instructions. Run them straight through so
+    # their output reaches the terminal instead of being parsed as a
+    # "<session-id>\n<dir>" resume target (which would otherwise `cd` into that
+    # text and mangle it). --shell-setup matters on upgrades, when this very
+    # function is already loaded and would otherwise swallow its instructions.
     case " $* " in
-        *" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*)
+        *" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*|*" --shell-setup "*)
             command crap "$@"; return $? ;;
     esac
     local __crap_out
@@ -1843,11 +1846,12 @@ mod tests {
 
     #[test]
     fn shell_code_passes_informational_flags_through_untouched() {
-        // `--status` queries, and --help/-h/--version/-V print informational
-        // text; none change the parent shell, and each must reach the terminal
-        // rather than being parsed as a "<session-id>\n<dir>" resume target.
+        // `--status` queries, --help/-h/--version/-V print informational text,
+        // and --shell-setup writes the rc file (not the live shell); none mutate
+        // the parent shell, and each must reach the terminal rather than being
+        // parsed as a "<session-id>\n<dir>" resume target.
         assert!(SHELL_CODE.contains(
-            r#"*" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*)"#
+            r#"*" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*|*" --shell-setup "*)"#
         ));
         assert!(SHELL_CODE.contains(r#"command crap "$@"; return $?"#));
     }

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -767,11 +767,14 @@ fn format_here_output(session_id: &str, link_to_cleanup: Option<&Path>) -> Strin
 ///   was created because this already is the session's own directory.
 const SHELL_CODE: &str = r#"
 function crap() {
-    # --status only queries; it never changes the parent shell. Run it straight
-    # through so its output (a token, or a multi-line listing) reaches the
-    # terminal instead of being parsed as a "<session-id>\n<dir>" resume target.
+    # These flags make the binary print to stdout and exit 0 without changing
+    # the parent shell: --status only queries, and --help/-h/--version/-V emit
+    # informational text. Run them straight through so their output reaches the
+    # terminal instead of being parsed as a "<session-id>\n<dir>" resume target
+    # (which would otherwise `cd` into the help/listing text and mangle it).
     case " $* " in
-        *" --status "*) command crap "$@"; return $? ;;
+        *" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*)
+            command crap "$@"; return $? ;;
     esac
     local __crap_out
     __crap_out=$(command crap "$@") || return $?
@@ -1839,11 +1842,14 @@ mod tests {
     }
 
     #[test]
-    fn shell_code_passes_status_through_untouched() {
-        // `--status` only queries; it never changes the parent shell, and its
-        // output (a token or a multi-line listing) must reach the terminal
+    fn shell_code_passes_informational_flags_through_untouched() {
+        // `--status` queries, and --help/-h/--version/-V print informational
+        // text; none change the parent shell, and each must reach the terminal
         // rather than being parsed as a "<session-id>\n<dir>" resume target.
-        assert!(SHELL_CODE.contains(r#"*" --status "*) command crap "$@"; return $?"#));
+        assert!(SHELL_CODE.contains(
+            r#"*" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*)"#
+        ));
+        assert!(SHELL_CODE.contains(r#"command crap "$@"; return $?"#));
     }
 
     /// Sources `SHELL_CODE` in a real `bash`, with a fake `crap` binary (and
@@ -1886,7 +1892,7 @@ mod tests {
         for (name, body) in [
             ("crap", fake_crap.to_string()),
             ("claude", fake_claude.clone()),
-            ("clauded", fake_claude.clone()),
+            ("clauded", fake_claude),
         ] {
             let path = dir.join(name);
             fs::write(&path, body).unwrap();


### PR DESCRIPTION
## Problem

The `crap` shell function (installed by `crap --shell-setup`) wraps the binary and parses its stdout as a `<session-id>\n<dir>` resume target. Flags that make the *binary* print to stdout and exit `0` — `--help`, `-h`, `--version`, `-V`, and `--shell-setup` — were captured and misinterpreted: the function tried to `cd` into the help/version/setup text, producing mangled output. Only `--status` was being passed through.

## Fix

Extend the existing `--status` pass-through `case` to also match the informational flags. They print and exit 0 without mutating the parent shell, so they must reach the terminal verbatim:

```sh
case " $* " in
    *" --status "*|*" --help "*|*" -h "*|*" --version "*|*" -V "*|*" --shell-setup "*)
        command crap "$@"; return $? ;;
esac
```

`--shell-setup` matters specifically on **upgrades**: the already-loaded function would otherwise swallow the "re-source your shell / `yadm alt`" instructions — i.e. the command used to deliver the fix was itself broken by the old function.

Load-bearing flags (`--here`, plain resume, `--force`) still take the resume path; verified there's no `-h`/`--here` glob collision.

## Tests

Added a behavioral test that sources `SHELL_CODE` in real `bash` with a fake `crap` binary on `PATH` and asserts each informational flag's output reaches the terminal verbatim and never triggers a resume (parallel-safe via pid+nanos temp dir). Done test-first as two red→green pairs. All 82 crap tests pass; clippy and check clean.

## Note for users

After merging, re-run `crap --shell-setup` and re-source your shell to pick up the updated function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)