### PR TITLE
fix(buildinfo): watch the branch ref so the embedded git hash can't go stale

### DIFF
--- a/src/buildinfo/build.rs
+++ b/src/buildinfo/build.rs
@@ -10,16 +10,24 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+// Share the rerun-path selection logic with the library's test suite so it can
+// be unit tested (a build script cannot be tested directly).
+#[path = "src/rerun.rs"]
+mod rerun;
+
 fn main() {
     // Dynamically find the git directory (works in worktrees too)
     if let Some(git_dir) = get_git_dir() {
-        let git_head = git_dir.join("HEAD");
-        let git_index = git_dir.join("index");
+        // Branch refs live in the common dir, which differs from `git_dir` in a
+        // linked worktree; fall back to `git_dir` when they coincide.
+        let git_common_dir = get_git_common_dir().unwrap_or_else(|| git_dir.clone());
+        let head_contents = std::fs::read_to_string(git_dir.join("HEAD")).unwrap_or_default();
 
-        // Tell Cargo to rerun this if HEAD or index changes
-        // This ensures rebuilds when commits change or files are staged
-        println!("cargo:rerun-if-changed={}", git_head.display());
-        println!("cargo:rerun-if-changed={}", git_index.display());
+        // Tell Cargo which git files to watch so a new commit (including a moved
+        // branch) forces this script to rerun and recapture the hash.
+        for path in rerun::rerun_if_changed_paths(&git_dir, &git_common_dir, &head_contents) {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
     }
 
     let git_hash = get_git_hash().unwrap_or_else(|| "unknown".to_string());
@@ -67,10 +75,15 @@ fn get_git_dirty() -> Option<String> {
 }
 
 fn get_git_dir() -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output()
-        .ok()?;
+    git_rev_parse(&["rev-parse", "--git-dir"])
+}
+
+fn get_git_common_dir() -> Option<PathBuf> {
+    git_rev_parse(&["rev-parse", "--git-common-dir"])
+}
+
+fn git_rev_parse(args: &[&str]) -> Option<PathBuf> {
+    let output = Command::new("git").args(args).output().ok()?;
 
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src/buildinfo/src/lib.rs
+++ b/src/buildinfo/src/lib.rs
@@ -17,6 +17,8 @@
 
 pub use const_format::formatcp;
 
+pub mod rerun;
+
 /// Git commit hash captured at build time (7 characters).
 pub const GIT_HASH: &str = env!("BUILD_GIT_HASH");
 

--- a/src/buildinfo/src/rerun.rs
+++ b/src/buildinfo/src/rerun.rs
@@ -27,10 +27,21 @@ pub fn rerun_if_changed_paths(
     git_common_dir: &Path,
     head_contents: &str,
 ) -> Vec<PathBuf> {
-    // NOTE: this only watches HEAD and index. A symbolic-ref HEAD never changes
-    // when the branch moves, so this fails to rebuild on new commits. Fixed in
-    // the follow-up commit.
-    vec![git_dir.join("HEAD"), git_dir.join("index")]
+    let mut paths = vec![git_dir.join("HEAD"), git_dir.join("index")];
+
+    // When HEAD is a symbolic ref, the commit it points at changes via the
+    // branch ref (loose under refs/, or rolled into packed-refs), never via
+    // HEAD itself. Watch both so a moved branch forces a rebuild. These live in
+    // the shared common dir, which differs from `git_dir` inside a worktree.
+    if let Some(reference) = head_contents.strip_prefix("ref:") {
+        let reference = reference.trim();
+        if !reference.is_empty() {
+            paths.push(git_common_dir.join(reference));
+            paths.push(git_common_dir.join("packed-refs"));
+        }
+    }
+
+    paths
 }
 
 #[cfg(test)]

--- a/src/buildinfo/src/rerun.rs
+++ b/src/buildinfo/src/rerun.rs
@@ -1,0 +1,84 @@
+//! Selects which git files Cargo must watch (via `cargo:rerun-if-changed`) so
+//! the commit hash captured at build time stays in sync with the checked-out
+//! commit.
+//!
+//! This logic lives in its own module so it can be unit tested and shared
+//! between the build script (`build.rs`) and the library's test suite.
+
+use std::path::{Path, PathBuf};
+
+/// Returns the set of paths that, when changed, should trigger a rebuild so the
+/// embedded git hash matches the current commit.
+///
+/// - `git_dir` is the resolved git directory (`.git` in a normal repository, or
+///   the per-worktree git dir in a linked worktree).
+/// - `git_common_dir` is the shared git directory where branch refs live; it
+///   equals `git_dir` outside of worktrees.
+/// - `head_contents` is the raw text of `<git_dir>/HEAD`.
+///
+/// `HEAD` and `index` are always watched. When `HEAD` is a symbolic ref
+/// (e.g. `ref: refs/heads/main`), the referenced branch ref and `packed-refs`
+/// are also watched — because those, not `HEAD` (whose contents stay
+/// `ref: refs/heads/main`), are what change when the branch advances to a new
+/// commit. Omitting them lets `cargo install` / `cargo install-update` reuse a
+/// cached build-script result and bake a stale commit hash into the binary.
+pub fn rerun_if_changed_paths(
+    git_dir: &Path,
+    git_common_dir: &Path,
+    head_contents: &str,
+) -> Vec<PathBuf> {
+    // NOTE: this only watches HEAD and index. A symbolic-ref HEAD never changes
+    // when the branch moves, so this fails to rebuild on new commits. Fixed in
+    // the follow-up commit.
+    vec![git_dir.join("HEAD"), git_dir.join("index")]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbolic_ref_head_watches_branch_ref_and_packed_refs() {
+        let git_dir = Path::new("/repo/.git");
+        let paths = rerun_if_changed_paths(git_dir, git_dir, "ref: refs/heads/main\n");
+
+        assert!(paths.contains(&git_dir.join("HEAD")));
+        assert!(paths.contains(&git_dir.join("index")));
+        assert!(
+            paths.contains(&git_dir.join("refs/heads/main")),
+            "the branch ref must be watched so a moved branch triggers a rebuild; got {paths:?}"
+        );
+        assert!(
+            paths.contains(&git_dir.join("packed-refs")),
+            "packed-refs must be watched in case the branch ref is packed; got {paths:?}"
+        );
+    }
+
+    #[test]
+    fn detached_head_watches_only_head_and_index() {
+        let git_dir = Path::new("/repo/.git");
+        let paths = rerun_if_changed_paths(
+            git_dir,
+            git_dir,
+            "0064899bc1ae2c411701ed7f35ce8f8d00d21d31\n",
+        );
+
+        // A detached HEAD holds the commit directly, so its own contents change
+        // per commit and there is no branch ref to watch.
+        assert_eq!(paths, vec![git_dir.join("HEAD"), git_dir.join("index")]);
+    }
+
+    #[test]
+    fn worktree_resolves_branch_ref_against_common_dir() {
+        let git_dir = Path::new("/repo/.git/worktrees/feature");
+        let common_dir = Path::new("/repo/.git");
+        let paths = rerun_if_changed_paths(git_dir, common_dir, "ref: refs/heads/feature\n");
+
+        // HEAD and index are per-worktree...
+        assert!(paths.contains(&git_dir.join("HEAD")));
+        // ...but the branch ref lives in the shared common dir, not the
+        // worktree git dir.
+        assert!(paths.contains(&common_dir.join("refs/heads/feature")));
+        assert!(!paths.contains(&git_dir.join("refs/heads/feature")));
+    }
+}


### PR DESCRIPTION
## Problem

`crap --version` (and every other tool in the repo) reported a commit hash **33 commits behind** the code actually installed, even right after `update.sh` ran `cargo install-update`.

Root cause: `buildinfo/build.rs` captures the commit hash at build time and registered `cargo:rerun-if-changed` only for `.git/HEAD` and `.git/index`. When `HEAD` is a symbolic ref (`ref: refs/heads/main`) its contents never change as the branch advances — so `cargo install` / `cargo install-update` reused a cached build-script result and baked a stale hash. The file that actually changes (`refs/heads/<branch>`, or `packed-refs`) was never watched.

## Fix

Resolve `HEAD` to its branch ref and additionally watch that ref plus `packed-refs`, resolved against the git **common dir** (`git rev-parse --git-common-dir`) so it's correct inside linked worktrees too. The path-selection logic is extracted into a pure, unit-tested `rerun_if_changed_paths` shared between the build script and the lib test suite (a build script can't be tested directly).

This affects **every tool** in the workspace, since they all source their version string from `buildinfo::version_string!()`.

## Verification

Real build-script output now emits:
```
cargo:rerun-if-changed=…/refs/heads/<branch>   ← NEW (common dir)
cargo:rerun-if-changed=…/packed-refs           ← NEW
```
plus the per-worktree `HEAD`/`index`. 6/6 `buildinfo` tests pass; `cargo clippy --all-targets --workspace -- -D warnings` clean.

Built test-first (red → green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)