### PR TITLE
fix(gsw): size separators to the terminal width

### DIFF
--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -882,18 +882,20 @@ mod tests {
     }
 
     #[test]
-    fn separator_matches_header_visible_width() {
-        // If the separator is wider than the header line, resizing the
-        // terminal smaller wraps it onto the next line. Size it to match.
+    fn separator_spans_terminal_width() {
+        // The separator should fill exactly the terminal width — not the
+        // width of the header above it. A long header used to size the rule
+        // to match, which wrapped it onto a second line on narrower
+        // terminals. Sizing to the terminal keeps it to a single line.
+        let opts = opts();
         let snap = snap_with(vec![]);
-        let out = strip_ansi(&render(&snap, &opts()));
-        let mut lines = out.lines();
-        let header = lines.next().expect("header line");
-        let sep = lines.next().expect("separator line");
+        let out = strip_ansi(&render(&snap, &opts));
+        let sep = out.lines().nth(1).expect("separator line");
         assert_eq!(
-            UnicodeWidthStr::width(header),
             UnicodeWidthStr::width(sep),
-            "separator width should match header width\n  header: {header:?}\n  sep:    {sep:?}",
+            opts.terminal_width,
+            "separator width should match terminal width ({})\n  sep: {sep:?}",
+            opts.terminal_width,
         );
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -90,9 +90,8 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     let mut lines = Vec::new();
 
     let header_plain = header_text(snapshot);
-    let header_width = UnicodeWidthStr::width(header_plain.as_str());
     lines.push(header_plain.bold().to_string());
-    lines.push(render_separator(header_width));
+    lines.push(render_separator(opts.terminal_width));
 
     let display_count = match opts.max_files {
         Some(0) | None => snapshot.files.len(),
@@ -123,7 +122,7 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
         // the post-header separator already sits directly above the files, so
         // adding another would produce a double rule with nothing between them.
         if log_rendered {
-            lines.push(render_separator(header_width));
+            lines.push(render_separator(opts.terminal_width));
         }
         for entry in snapshot.files.iter().take(display_count) {
             lines.push(render_row(entry, opts, max_change, path_width));


### PR DESCRIPTION
## Summary

The `gsw` separator rule was sized to the visible width of the header text above it. With a long header, the rule extended past the terminal edge and wrapped onto a second line.

This sizes both the post-header rule and the pre-file-list rule to the full terminal width instead, so the separator always occupies exactly one line regardless of header length.

## Testing

- Rewrote `separator_spans_terminal_width` (red → green) asserting the rule fills `terminal_width` rather than header width.
- Full `gsw` suite passes (172 unit + 20 integration tests); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)