### PR TITLE
Add uuidplz: random v4 + repeatable name-based v5 UUIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6666,6 +6666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7667,7 +7673,19 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuidplz"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buildinfo",
+ "clap",
+ "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ icy_sixel = "0.5"
 # Random
 rand = "0.9"
 names = { version = "0.14", default-features = false }
+uuid = { version = "1", features = ["v4", "v5"] }
 
 # System info
 sysinfo = "0.36"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
       for a service that needs to live behind a reverse proxy that also needs to be consistent across deployments and
       separate instances/VMs.
     - To install: `cargo install --git https://github.com/timmattison/tools portplz`
+- uuidplz
+    - Generates UUIDs. With no input it prints a random v4 UUID. Given a string or a file it seeds a name-based
+      v5 (SHA-1) UUID, so the same input always produces the same UUID — handy for stable, reproducible IDs. The
+      argument is auto-detected as a file when it names one (override with `--string`/`--file`), and piped stdin
+      is hashed too (empty stdin falls back to random). The namespace defaults to the RFC 4122 URL namespace and
+      can be overridden with `--namespace <uuid>`. The bare UUID goes to stdout (pipe-friendly); `-v/--verbose`
+      explains the derivation on stderr. Examples: `uuidplz`, `uuidplz "my-key"`, `uuidplz config.json`,
+      `cat data.bin | uuidplz`, `uuidplz --namespace 6ba7b810-9dad-11d1-80b4-00c04fd430c8 example.com`.
+    - To install: `cargo install --git https://github.com/timmattison/tools uuidplz`
 - tubeboard
     - Waits for text that looks like a YouTube video URL to be put on the clipboard and then extracts the video ID from
       it.

--- a/TLDR.md
+++ b/TLDR.md
@@ -62,6 +62,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `tubeboard` | Extracts the video ID from a YouTube URL on the clipboard. |
 | `unescapeboard` | Unescapes one level of `\"`-style escaping in clipboard text. |
 | `update-aws-credentials` | Writes AWS SSO clipboard credentials into your AWS config file. |
+| `uuidplz` | Prints a random v4 UUID, or a repeatable v5 UUID seeded from a string, a file's contents, or stdin. |
 | `vpn-tunnel` | Generates Docker-based gluetun + ProtonVPN + WireGuard tunnels with helper scripts. |
 | `wifiqr` | Generates WiFi QR codes (with optional logo) for automatic device connection. |
 | `wl` | Shows which process is listening on a given port. |

--- a/src/uuidplz/Cargo.toml
+++ b/src/uuidplz/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uuidplz"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+buildinfo.workspace = true
+clap.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/src/uuidplz/src/main.rs
+++ b/src/uuidplz/src/main.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 /// Default RFC 4122 namespace used for v5 generation when `--namespace` is not
 /// given. The URL namespace is a well-known constant, so output is reproducible
 /// and interoperable with other UUIDv5 implementations.
-const DEFAULT_NAMESPACE: Uuid = Uuid::nil();
+const DEFAULT_NAMESPACE: Uuid = Uuid::NAMESPACE_URL;
 
 #[derive(Parser)]
 #[command(name = "uuidplz")]
@@ -23,11 +23,11 @@ struct Cli {
     input: Option<String>,
 
     /// Treat INPUT as a literal string, even if a file by that name exists.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "file")]
     string: bool,
 
     /// Treat INPUT as a file path and hash its contents.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "string")]
     file: bool,
 
     /// Namespace UUID for v5 generation (defaults to the RFC 4122 URL namespace).
@@ -76,8 +76,19 @@ fn resolve(
     file_exists: bool,
     stdin_is_tty: bool,
 ) -> Result<Resolution, ResolveError> {
-    let _ = (input, force_string, force_file, file_exists, stdin_is_tty);
-    todo!()
+    match input {
+        Some(value) => {
+            let from_file = force_file || (!force_string && file_exists);
+            if from_file {
+                Ok(Resolution::FromFile(value.to_string()))
+            } else {
+                Ok(Resolution::FromString(value.to_string()))
+            }
+        }
+        None if force_string || force_file => Err(ResolveError::FlagWithoutInput),
+        None if stdin_is_tty => Ok(Resolution::Random),
+        None => Ok(Resolution::FromStdin),
+    }
 }
 
 /// Parse the optional `--namespace` value, falling back to [`DEFAULT_NAMESPACE`].
@@ -86,19 +97,20 @@ fn resolve(
 ///
 /// Returns an error if `arg` is `Some` but not a valid UUID.
 fn parse_namespace(arg: Option<&str>) -> Result<Uuid, uuid::Error> {
-    let _ = arg;
-    todo!()
+    match arg {
+        Some(s) => Uuid::parse_str(s),
+        None => Ok(DEFAULT_NAMESPACE),
+    }
 }
 
 /// Generate a random version-4 UUID.
 fn generate_v4() -> Uuid {
-    todo!()
+    Uuid::new_v4()
 }
 
 /// Generate a name-based version-5 (SHA-1) UUID from a namespace and name bytes.
 fn generate_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
-    let _ = (namespace, name);
-    todo!()
+    Uuid::new_v5(namespace, name)
 }
 
 /// Read a file's raw bytes for hashing.
@@ -107,14 +119,19 @@ fn generate_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
 ///
 /// Returns an error (with the path attached) if the file cannot be read.
 fn read_file_bytes(path: &str) -> anyhow::Result<Vec<u8>> {
-    let _ = path;
-    todo!()
+    std::fs::read(path).with_context(|| format!("failed to read file '{path}'"))
 }
 
 /// Render a human-readable description of how the UUID was derived, for `--verbose`.
 fn describe(resolution: &Resolution, namespace: &Uuid) -> String {
-    let _ = (resolution, namespace);
-    todo!()
+    match resolution {
+        Resolution::Random => "generated a random v4 UUID".to_string(),
+        Resolution::FromString(_) => format!("v5 UUID from string (namespace {namespace})"),
+        Resolution::FromFile(path) => {
+            format!("v5 UUID from file '{path}' (namespace {namespace})")
+        }
+        Resolution::FromStdin => format!("v5 UUID from stdin (namespace {namespace})"),
+    }
 }
 
 fn main() -> anyhow::Result<()> {

--- a/src/uuidplz/src/main.rs
+++ b/src/uuidplz/src/main.rs
@@ -121,8 +121,11 @@ fn generate_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
 /// v5 name. To deliberately get the v5 of an empty value, pass an explicit empty
 /// argument (`uuidplz ""`) instead.
 fn uuid_for_stdin(namespace: &Uuid, stdin_bytes: &[u8]) -> Uuid {
-    let _ = (namespace, stdin_bytes);
-    todo!()
+    if stdin_bytes.is_empty() {
+        generate_v4()
+    } else {
+        generate_v5(namespace, stdin_bytes)
+    }
 }
 
 /// Read a file's raw bytes for hashing.

--- a/src/uuidplz/src/main.rs
+++ b/src/uuidplz/src/main.rs
@@ -113,6 +113,18 @@ fn generate_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
     Uuid::new_v5(namespace, name)
 }
 
+/// Produce a UUID from bytes read on stdin.
+///
+/// Empty input means nothing was actually piped (e.g. running non-interactively
+/// with no redirect), so fall back to a random v4 UUID rather than hashing the
+/// empty string into a surprising constant. Any non-empty input is hashed as a
+/// v5 name. To deliberately get the v5 of an empty value, pass an explicit empty
+/// argument (`uuidplz ""`) instead.
+fn uuid_for_stdin(namespace: &Uuid, stdin_bytes: &[u8]) -> Uuid {
+    let _ = (namespace, stdin_bytes);
+    todo!()
+}
+
 /// Read a file's raw bytes for hashing.
 ///
 /// # Errors
@@ -159,7 +171,11 @@ fn main() -> anyhow::Result<()> {
         }
     })?;
 
-    let uuid = match &resolution {
+    // Some resolutions are refined after I/O (empty stdin falls back to random),
+    // so track the effective resolution for the --verbose description.
+    let mut effective = resolution;
+    let mut stdin_was_empty = false;
+    let uuid = match &effective {
         Resolution::Random => generate_v4(),
         Resolution::FromString(s) => generate_v5(&namespace, s.as_bytes()),
         Resolution::FromFile(path) => generate_v5(&namespace, &read_file_bytes(path)?),
@@ -169,12 +185,16 @@ fn main() -> anyhow::Result<()> {
                 .lock()
                 .read_to_end(&mut buf)
                 .context("failed to read stdin")?;
-            generate_v5(&namespace, &buf)
+            stdin_was_empty = buf.is_empty();
+            uuid_for_stdin(&namespace, &buf)
         }
     };
+    if stdin_was_empty {
+        effective = Resolution::Random;
+    }
 
     if cli.verbose {
-        eprintln!("uuidplz: {}", describe(&resolution, &namespace));
+        eprintln!("uuidplz: {}", describe(&effective, &namespace));
     }
     println!("{uuid}");
 
@@ -239,6 +259,27 @@ mod tests {
             assert_eq!(a, b);
             assert_eq!(a.get_version(), Some(Version::Sha1));
         }
+    }
+
+    // --- stdin handling ---
+
+    #[test]
+    fn stdin_empty_yields_random_v4() {
+        // Empty stdin means nothing was piped, so we must NOT hash the empty
+        // string into a constant — fall back to random, and two calls differ.
+        let a = uuid_for_stdin(&DEFAULT_NAMESPACE, b"");
+        let b = uuid_for_stdin(&DEFAULT_NAMESPACE, b"");
+        assert_eq!(a.get_version(), Some(Version::Random));
+        assert_eq!(b.get_version(), Some(Version::Random));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn stdin_nonempty_yields_matching_v5() {
+        let bytes = b"piped data";
+        let u = uuid_for_stdin(&DEFAULT_NAMESPACE, bytes);
+        assert_eq!(u, generate_v5(&DEFAULT_NAMESPACE, bytes));
+        assert_eq!(u.get_version(), Some(Version::Sha1));
     }
 
     // --- v4 generation ---

--- a/src/uuidplz/src/main.rs
+++ b/src/uuidplz/src/main.rs
@@ -1,0 +1,365 @@
+use anyhow::Context;
+use buildinfo::version_string;
+use clap::Parser;
+use std::io::{self, IsTerminal, Read};
+use uuid::Uuid;
+
+/// Default RFC 4122 namespace used for v5 generation when `--namespace` is not
+/// given. The URL namespace is a well-known constant, so output is reproducible
+/// and interoperable with other UUIDv5 implementations.
+const DEFAULT_NAMESPACE: Uuid = Uuid::nil();
+
+#[derive(Parser)]
+#[command(name = "uuidplz")]
+#[command(version = version_string!())]
+#[command(
+    about = "Generate a random UUID, or a repeatable name-based UUIDv5 from a string or file",
+    long_about = None
+)]
+struct Cli {
+    /// Input to derive a v5 UUID from. If it names an existing file, the file's
+    /// contents are hashed; otherwise the text itself is hashed. Omit entirely
+    /// to generate a random v4 UUID (or pipe data on stdin for v5).
+    input: Option<String>,
+
+    /// Treat INPUT as a literal string, even if a file by that name exists.
+    #[arg(long)]
+    string: bool,
+
+    /// Treat INPUT as a file path and hash its contents.
+    #[arg(long)]
+    file: bool,
+
+    /// Namespace UUID for v5 generation (defaults to the RFC 4122 URL namespace).
+    #[arg(long, value_name = "UUID")]
+    namespace: Option<String>,
+
+    /// Print how the UUID was derived to stderr (stdout stays just the UUID).
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+/// How the program will produce a UUID, after resolving arguments and environment.
+#[derive(Debug, PartialEq, Eq)]
+enum Resolution {
+    /// No input: emit a random v4 UUID.
+    Random,
+    /// Hash the given string's UTF-8 bytes as a v5 name.
+    FromString(String),
+    /// Read the file at this path and hash its bytes as a v5 name.
+    FromFile(String),
+    /// Read all of stdin and hash its bytes as a v5 name.
+    FromStdin,
+}
+
+/// Why argument resolution failed.
+#[derive(Debug, PartialEq, Eq)]
+enum ResolveError {
+    /// `--string`/`--file` were given without any INPUT argument.
+    FlagWithoutInput,
+}
+
+/// Decide what to generate from parsed arguments and environment.
+///
+/// `file_exists` reports whether `input` (when present) names an existing file;
+/// it is injected so the decision stays pure and unit-testable. `stdin_is_tty`
+/// distinguishes an interactive terminal (random) from piped data (hash stdin).
+///
+/// # Errors
+///
+/// Returns [`ResolveError::FlagWithoutInput`] if `--string`/`--file` are set but
+/// no `input` was provided.
+fn resolve(
+    input: Option<&str>,
+    force_string: bool,
+    force_file: bool,
+    file_exists: bool,
+    stdin_is_tty: bool,
+) -> Result<Resolution, ResolveError> {
+    let _ = (input, force_string, force_file, file_exists, stdin_is_tty);
+    todo!()
+}
+
+/// Parse the optional `--namespace` value, falling back to [`DEFAULT_NAMESPACE`].
+///
+/// # Errors
+///
+/// Returns an error if `arg` is `Some` but not a valid UUID.
+fn parse_namespace(arg: Option<&str>) -> Result<Uuid, uuid::Error> {
+    let _ = arg;
+    todo!()
+}
+
+/// Generate a random version-4 UUID.
+fn generate_v4() -> Uuid {
+    todo!()
+}
+
+/// Generate a name-based version-5 (SHA-1) UUID from a namespace and name bytes.
+fn generate_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
+    let _ = (namespace, name);
+    todo!()
+}
+
+/// Read a file's raw bytes for hashing.
+///
+/// # Errors
+///
+/// Returns an error (with the path attached) if the file cannot be read.
+fn read_file_bytes(path: &str) -> anyhow::Result<Vec<u8>> {
+    let _ = path;
+    todo!()
+}
+
+/// Render a human-readable description of how the UUID was derived, for `--verbose`.
+fn describe(resolution: &Resolution, namespace: &Uuid) -> String {
+    let _ = (resolution, namespace);
+    todo!()
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let namespace = parse_namespace(cli.namespace.as_deref())
+        .map_err(|e| anyhow::anyhow!("invalid --namespace value: {e}"))?;
+
+    let stdin = io::stdin();
+    let input_ref = cli.input.as_deref();
+    let file_exists = input_ref
+        .map(|p| std::path::Path::new(p).is_file())
+        .unwrap_or(false);
+
+    let resolution = resolve(
+        input_ref,
+        cli.string,
+        cli.file,
+        file_exists,
+        stdin.is_terminal(),
+    )
+    .map_err(|e| match e {
+        ResolveError::FlagWithoutInput => {
+            anyhow::anyhow!("--string/--file require an INPUT argument")
+        }
+    })?;
+
+    let uuid = match &resolution {
+        Resolution::Random => generate_v4(),
+        Resolution::FromString(s) => generate_v5(&namespace, s.as_bytes()),
+        Resolution::FromFile(path) => generate_v5(&namespace, &read_file_bytes(path)?),
+        Resolution::FromStdin => {
+            let mut buf = Vec::new();
+            stdin
+                .lock()
+                .read_to_end(&mut buf)
+                .context("failed to read stdin")?;
+            generate_v5(&namespace, &buf)
+        }
+    };
+
+    if cli.verbose {
+        eprintln!("uuidplz: {}", describe(&resolution, &namespace));
+    }
+    println!("{uuid}");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Version;
+
+    // --- v5 generation ---
+
+    #[test]
+    fn v5_matches_known_vector() {
+        // Canonical example from Python's uuid docs:
+        // uuid5(NAMESPACE_DNS, 'python.org') == 886313e1-3b8a-5372-9b90-0c9aee199e5d
+        let expected = Uuid::parse_str("886313e1-3b8a-5372-9b90-0c9aee199e5d").unwrap();
+        assert_eq!(generate_v5(&Uuid::NAMESPACE_DNS, b"python.org"), expected);
+    }
+
+    #[test]
+    fn v5_is_deterministic() {
+        let a = generate_v5(&DEFAULT_NAMESPACE, b"hello");
+        let b = generate_v5(&DEFAULT_NAMESPACE, b"hello");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn v5_differs_for_different_input() {
+        let a = generate_v5(&DEFAULT_NAMESPACE, b"alpha");
+        let b = generate_v5(&DEFAULT_NAMESPACE, b"beta");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn v5_reports_version_5() {
+        let u = generate_v5(&DEFAULT_NAMESPACE, b"hello");
+        assert_eq!(u.get_version(), Some(Version::Sha1));
+    }
+
+    #[test]
+    fn default_namespace_is_rfc_url() {
+        assert_eq!(DEFAULT_NAMESPACE, Uuid::NAMESPACE_URL);
+    }
+
+    #[test]
+    fn string_and_file_bytes_produce_same_uuid() {
+        // Identical bytes via the string path or the file path must yield the
+        // same UUID, since v5 hashes raw bytes.
+        let via_string = generate_v5(&DEFAULT_NAMESPACE, "config.json".as_bytes());
+        let via_file = generate_v5(&DEFAULT_NAMESPACE, b"config.json");
+        assert_eq!(via_string, via_file);
+    }
+
+    #[test]
+    fn v5_handles_multibyte_utf8() {
+        // Must not panic on multi-byte input and must stay deterministic.
+        for s in ["日本語", "café", "🎉🎊"] {
+            let a = generate_v5(&DEFAULT_NAMESPACE, s.as_bytes());
+            let b = generate_v5(&DEFAULT_NAMESPACE, s.as_bytes());
+            assert_eq!(a, b);
+            assert_eq!(a.get_version(), Some(Version::Sha1));
+        }
+    }
+
+    // --- v4 generation ---
+
+    #[test]
+    fn v4_reports_version_4() {
+        assert_eq!(generate_v4().get_version(), Some(Version::Random));
+    }
+
+    #[test]
+    fn v4_is_random_across_calls() {
+        assert_ne!(generate_v4(), generate_v4());
+    }
+
+    // --- namespace parsing ---
+
+    #[test]
+    fn parse_namespace_defaults_to_url() {
+        assert_eq!(parse_namespace(None).unwrap(), Uuid::NAMESPACE_URL);
+    }
+
+    #[test]
+    fn parse_namespace_accepts_valid_uuid() {
+        // NAMESPACE_DNS, supplied as a string.
+        let ns = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+        assert_eq!(parse_namespace(Some(ns)).unwrap(), Uuid::NAMESPACE_DNS);
+    }
+
+    #[test]
+    fn parse_namespace_rejects_invalid_uuid() {
+        assert!(parse_namespace(Some("not-a-uuid")).is_err());
+    }
+
+    // --- resolution matrix ---
+
+    #[test]
+    fn resolve_no_input_tty_is_random() {
+        assert_eq!(
+            resolve(None, false, false, false, true).unwrap(),
+            Resolution::Random
+        );
+    }
+
+    #[test]
+    fn resolve_no_input_piped_is_stdin() {
+        assert_eq!(
+            resolve(None, false, false, false, false).unwrap(),
+            Resolution::FromStdin
+        );
+    }
+
+    #[test]
+    fn resolve_autodetects_existing_file() {
+        assert_eq!(
+            resolve(Some("config.json"), false, false, true, true).unwrap(),
+            Resolution::FromFile("config.json".into())
+        );
+    }
+
+    #[test]
+    fn resolve_autodetects_missing_file_as_string() {
+        assert_eq!(
+            resolve(Some("config.json"), false, false, false, true).unwrap(),
+            Resolution::FromString("config.json".into())
+        );
+    }
+
+    #[test]
+    fn resolve_force_string_overrides_existing_file() {
+        assert_eq!(
+            resolve(Some("config.json"), true, false, true, true).unwrap(),
+            Resolution::FromString("config.json".into())
+        );
+    }
+
+    #[test]
+    fn resolve_force_file_even_when_not_detected() {
+        assert_eq!(
+            resolve(Some("data"), false, true, false, true).unwrap(),
+            Resolution::FromFile("data".into())
+        );
+    }
+
+    #[test]
+    fn resolve_flags_without_input_error() {
+        assert_eq!(
+            resolve(None, true, false, false, true),
+            Err(ResolveError::FlagWithoutInput)
+        );
+        assert_eq!(
+            resolve(None, false, true, false, true),
+            Err(ResolveError::FlagWithoutInput)
+        );
+    }
+
+    // --- file reading ---
+
+    #[test]
+    fn read_file_bytes_returns_contents() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"hello bytes").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        assert_eq!(read_file_bytes(&path).unwrap(), b"hello bytes");
+    }
+
+    #[test]
+    fn read_file_bytes_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.bin");
+        assert!(read_file_bytes(missing.to_str().unwrap()).is_err());
+    }
+
+    // --- verbose description ---
+
+    #[test]
+    fn describe_random_mentions_v4() {
+        assert_eq!(
+            describe(&Resolution::Random, &DEFAULT_NAMESPACE),
+            "generated a random v4 UUID"
+        );
+    }
+
+    #[test]
+    fn describe_file_includes_path_and_namespace() {
+        let ns = Uuid::NAMESPACE_DNS;
+        let d = describe(&Resolution::FromFile("x.txt".into()), &ns);
+        assert!(d.contains("x.txt"), "should mention the file path: {d}");
+        assert!(
+            d.contains(&ns.to_string()),
+            "should mention the namespace: {d}"
+        );
+    }
+
+    // --- CLI wiring ---
+
+    #[test]
+    fn cli_rejects_string_and_file_together() {
+        assert!(Cli::try_parse_from(["uuidplz", "--string", "--file", "x"]).is_err());
+    }
+}


### PR DESCRIPTION
## What

A new tool, `uuidplz`, that generates UUIDs:

| Invocation | Output |
|---|---|
| `uuidplz` | Random **v4** UUID |
| `uuidplz "my-key"` | Repeatable **v5** UUID from the string |
| `uuidplz config.json` | v5 from the file's **contents** (auto-detected when the arg names a file) |
| `uuidplz --string config.json` | v5 from the literal text (force string) |
| `uuidplz --file data` | v5 from file contents; errors if the path is missing |
| `cat data.bin \| uuidplz` | v5 from piped stdin bytes |
| `--namespace <uuid>` | Override the default RFC 4122 URL namespace |
| `-v/--verbose` | Print the derivation to **stderr** (stdout stays a bare UUID) |

The "repeatable" path is a standard RFC 4122 name-based UUIDv5 (SHA-1 of namespace + name): same namespace + same bytes always yields the same UUID, on any machine. No input → random v4.

## Design notes

- **Input auto-detection with overrides:** a positional arg that names an existing file is hashed by contents; otherwise the literal text is hashed. `--string`/`--file` force interpretation and are mutually exclusive (clap-enforced).
- **Namespace:** defaults to the RFC 4122 URL namespace (`Uuid::NAMESPACE_URL`) for reproducible, interoperable output; overridable via `--namespace <uuid>`.
- **Empty stdin falls back to random v4.** In non-interactive contexts (scripts, CI, command substitution) stdin is not a TTY but carries no data; hashing the empty string would produce a constant, breaking "no input → random". Non-empty stdin is still hashed. To deliberately hash an empty value, pass `uuidplz ""`.
- **No `--shell-setup`** — nothing mutates the parent shell, so per the repo's shell-integration guidance it's deliberately omitted.
- Pipe-friendly: only the UUID goes to stdout; verbose info goes to stderr.

## Conventions

- Built test-first (red → commit → green → commit); **26 tests** cover v5 determinism + the canonical `NAMESPACE_DNS`/`python.org` vector, v4 randomness/version, the input-resolution matrix, namespace parsing, file reads, UTF-8 safety (日本語/café/🎉), empty-stdin fallback, and the `--string`/`--file` conflict.
- Uses `buildinfo::version_string!()` for `--version`.
- Auto-included via the workspace `members = ["src/*"]`; adds a `uuid` workspace dependency.
- Documented in `README.md` and `TLDR.md`.
- `cargo clippy --all-targets --workspace -- -D warnings` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)