### PR TITLE
Pin rustfmt, reformat workspace, and gate formatting in the pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# Reject commits that fail clippy. --all-targets covers tests/ and benches/,
-# where lints like unseparated_literal_suffix would otherwise slip through, and
-# -D warnings turns every workspace lint into a hard error.
+# Reject commits that fail formatting or clippy. cargo fmt --check runs first
+# because it is fast and catches drift before the slower clippy pass.
+# --all-targets covers tests/ and benches/, where lints like
+# unseparated_literal_suffix would otherwise slip through, and -D warnings
+# turns every workspace lint into a hard error.
 set -euo pipefail
 
 if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$'; then
+    echo "pre-commit: running cargo fmt --all -- --check"
+    cargo fmt --all -- --check
     echo "pre-commit: running cargo clippy --all-targets --workspace -- -D warnings"
     cargo clippy --all-targets --workspace -- -D warnings
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,6 +8,12 @@
 # The trigger regex also matches rustfmt.toml and rust-toolchain.toml at the
 # repo root: a commit that bumps the toolchain or style config is the scenario
 # most likely to introduce drift, so the gate must run on those changes too.
+#
+# Both checks read the WORKING TREE, not the staged index, so a partially
+# staged file (or one staged then edited) is checked in its on-disk state, not
+# the version being committed. This is a deliberate trade-off: index-only
+# checking (stash --keep-index dances) is fragile, and the workspace-wide cargo
+# commands cannot operate on a virtual index anyway.
 set -euo pipefail
 
 if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$|^(rustfmt|rust-toolchain)\.toml$'; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,9 +4,13 @@
 # --all-targets covers tests/ and benches/, where lints like
 # unseparated_literal_suffix would otherwise slip through, and -D warnings
 # turns every workspace lint into a hard error.
+#
+# The trigger regex also matches rustfmt.toml and rust-toolchain.toml at the
+# repo root: a commit that bumps the toolchain or style config is the scenario
+# most likely to introduce drift, so the gate must run on those changes too.
 set -euo pipefail
 
-if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$'; then
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo\.(toml|lock)$|^(rustfmt|rust-toolchain)\.toml$'; then
     echo "pre-commit: running cargo fmt --all -- --check"
     cargo fmt --all -- --check
     echo "pre-commit: running cargo clippy --all-targets --workspace -- -D warnings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6216,6 +6216,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "repo-guards"
+version = "0.1.0"
+
+[[package]]
 name = "reposize"
 version = "0.1.0"
 dependencies = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the toolchain so the formatting contract (and clippy gate) is
+# machine-independent: every contributor and CI run resolves the exact same
+# rustfmt/clippy behavior instead of whatever stable happens to be installed.
+# See issue #273. Bump deliberately; after bumping, re-run `cargo fmt --all`
+# in a dedicated style-only commit if the check no longer passes.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# Make the style contract explicit instead of inferred from the crate edition,
+# so formatting stays stable across future rust-toolchain.toml bumps (rustfmt
+# only changes formatting defaults between style editions). See issue #273.
+style_edition = "2021"

--- a/src/cdknuke/src/main.rs
+++ b/src/cdknuke/src/main.rs
@@ -60,13 +60,14 @@ fn main() {
 
         // Check for target directories
         if entry.file_type().is_some_and(|ft| ft.is_dir())
-            && target_dirs.contains(&entry_name.as_ref()) {
-                found_any = true;
-                println!("Removing directory: {}", entry.path().display());
-                if let Err(e) = fs::remove_dir_all(entry.path()) {
-                    eprintln!("Error removing {}: {}", entry.path().display(), e);
-                }
+            && target_dirs.contains(&entry_name.as_ref())
+        {
+            found_any = true;
+            println!("Removing directory: {}", entry.path().display());
+            if let Err(e) = fs::remove_dir_all(entry.path()) {
+                eprintln!("Error removing {}: {}", entry.path().display(), e);
             }
+        }
     }
 
     // Also check for cdk.out at the top level even without --hidden

--- a/src/cf/src/main.rs
+++ b/src/cf/src/main.rs
@@ -43,7 +43,9 @@ fn main() -> Result<()> {
         Some(FilterType::Suffix(suffix))
     } else if let Some(prefix) = cli.prefix {
         Some(FilterType::Prefix(prefix))
-    } else { cli.substring.map(FilterType::Substring) };
+    } else {
+        cli.substring.map(FilterType::Substring)
+    };
 
     let walker = FileWalker::new(cli.paths).with_filter(filter);
 

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -31,7 +31,7 @@ use std::process::exit;
 use buildinfo::version_string;
 use clap::Parser;
 use colored::Colorize;
-use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL};
+use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
 use serde::Serialize;
 use shellsetup::ShellIntegration;
 
@@ -225,7 +225,10 @@ fn classify_session_state(contents: &str) -> SessionState {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
         };
-        if value.get("isSidechain").and_then(serde_json::Value::as_bool) == Some(true)
+        if value
+            .get("isSidechain")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
             || value.get("isMeta").and_then(serde_json::Value::as_bool) == Some(true)
         {
             continue;
@@ -370,8 +373,8 @@ fn resolve_here_link(
     if !is_valid_session_id(session_id) {
         return Err(HereResolveError::InvalidSessionId);
     }
-    let original = find_session_file(projects_dir, session_id)
-        .ok_or(HereResolveError::SessionNotFound)?;
+    let original =
+        find_session_file(projects_dir, session_id).ok_or(HereResolveError::SessionNotFound)?;
     prepare_here_link(projects_dir, &original, pwd, session_id).map_err(HereResolveError::Io)
 }
 
@@ -832,12 +835,11 @@ function crap() {
 
 /// Installs the `crap` shell function into the user's shell config.
 fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
-    let integration = ShellIntegration::new(
-        "crap",
-        "Claude, Resume Anywhere Please",
-        SHELL_CODE,
-    )
-    .with_command("crap", "Resume a Claude session from its original directory");
+    let integration = ShellIntegration::new("crap", "Claude, Resume Anywhere Please", SHELL_CODE)
+        .with_command(
+            "crap",
+            "Resume a Claude session from its original directory",
+        );
     integration.setup()
 }
 
@@ -1384,10 +1386,14 @@ mod tests {
         // typo'd id fails fast and shell metacharacters never reach the binary.
         assert!(!is_valid_session_id("not-a-uuid"));
         assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e190")); // too short
-        assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e19011")); // too long
+        assert!(!is_valid_session_id(
+            "4733ee2a-1ad6-4619-a01a-11840b8e19011"
+        )); // too long
         assert!(!is_valid_session_id("4733ee2a1ad64619a01a11840b8e1901")); // no hyphens
         assert!(!is_valid_session_id("4733ee2g-1ad6-4619-a01a-11840b8e1901")); // 'g' not hex
-        assert!(!is_valid_session_id("4733ee2a-1ad6-4619-a01a-11840b8e1901 ; rm -rf ~"));
+        assert!(!is_valid_session_id(
+            "4733ee2a-1ad6-4619-a01a-11840b8e1901 ; rm -rf ~"
+        ));
         assert!(!is_valid_session_id("4733ee2a 1ad6 4619 a01a 11840b8e1901")); // spaces
     }
 
@@ -1441,7 +1447,10 @@ mod tests {
                 .join("-Volumes-x-here-cwd")
                 .join(format!("{SAMPLE_ID}.jsonl"))
         );
-        assert!(fs::symlink_metadata(&link).unwrap().file_type().is_symlink());
+        assert!(fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert_eq!(fs::read_link(&link).unwrap(), original);
     }
 
@@ -1684,9 +1693,10 @@ mod tests {
         // ...but the session is live, so the live status wins for `state`.
         fs::write(sessions.path().join("17041.json"), SESSION_JSON).unwrap();
 
-        let report =
-            resolve_status_report(projects.path(), sessions.path(), LIVE_ID, |pid| pid == 17041)
-                .unwrap();
+        let report = resolve_status_report(projects.path(), sessions.path(), LIVE_ID, |pid| {
+            pid == 17041
+        })
+        .unwrap();
         assert_eq!(report.state, "busy (live, pid 17041)");
     }
 
@@ -1942,10 +1952,7 @@ mod tests {
                 stdout.contains(marker),
                 "`crap {args}` should print the binary's output verbatim, got: {stdout:?}"
             );
-            assert!(
-                !claude_called,
-                "`crap {args}` must not attempt a resume"
-            );
+            assert!(!claude_called, "`crap {args}` must not attempt a resume");
         }
     }
 
@@ -2023,12 +2030,18 @@ mod tests {
 
     #[test]
     fn format_timestamp_prettifies_iso8601() {
-        assert_eq!(format_timestamp("2026-05-25T18:43:05.109Z"), "2026-05-25 18:43:05");
+        assert_eq!(
+            format_timestamp("2026-05-25T18:43:05.109Z"),
+            "2026-05-25 18:43:05"
+        );
     }
 
     #[test]
     fn format_timestamp_handles_missing_subseconds() {
-        assert_eq!(format_timestamp("2026-05-25T18:43:05Z"), "2026-05-25 18:43:05");
+        assert_eq!(
+            format_timestamp("2026-05-25T18:43:05Z"),
+            "2026-05-25 18:43:05"
+        );
     }
 
     #[test]
@@ -2067,7 +2080,10 @@ mod tests {
         assert_eq!(reports[0].session_id, ID_A);
         assert_eq!(reports[1].session_id, ID_B);
         assert!(reports.iter().all(|r| r.state == "waiting-for-user"));
-        assert_eq!(reports[1].started.as_deref(), Some("2026-05-25T11:00:00.000Z"));
+        assert_eq!(
+            reports[1].started.as_deref(),
+            Some("2026-05-25T11:00:00.000Z")
+        );
         assert_eq!(reports[1].last.as_deref(), Some("2026-05-25T11:00:00.000Z"));
     }
 
@@ -2090,10 +2106,12 @@ mod tests {
     fn resolve_dir_statuses_empty_when_folder_absent() {
         let projects = tempdir().unwrap();
         let sessions = tempdir().unwrap();
-        let reports =
-            resolve_dir_statuses(projects.path(), sessions.path(), Path::new("/no/such/dir"), |_| {
-                false
-            });
+        let reports = resolve_dir_statuses(
+            projects.path(),
+            sessions.path(),
+            Path::new("/no/such/dir"),
+            |_| false,
+        );
         assert!(reports.is_empty());
     }
 
@@ -2108,7 +2126,8 @@ mod tests {
         write_session_in(&folder, LIVE_ID, "2026-05-25T10:00:00.000Z");
         fs::write(sessions.path().join("17041.json"), SESSION_JSON).unwrap();
 
-        let reports = resolve_dir_statuses(projects.path(), sessions.path(), pwd, |pid| pid == 17041);
+        let reports =
+            resolve_dir_statuses(projects.path(), sessions.path(), pwd, |pid| pid == 17041);
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].state, "busy (live, pid 17041)");
     }
@@ -2237,9 +2256,10 @@ mod tests {
         let sessions = tempdir().unwrap();
         fs::write(sessions.path().join("17041.json"), SESSION_JSON).unwrap();
 
-        let report =
-            resolve_status_report(projects.path(), sessions.path(), LIVE_ID, |pid| pid == 17041)
-                .unwrap();
+        let report = resolve_status_report(projects.path(), sessions.path(), LIVE_ID, |pid| {
+            pid == 17041
+        })
+        .unwrap();
         assert_eq!(report.state, "busy (live, pid 17041)");
     }
 

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -230,10 +230,9 @@ fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
 fn find_current_worktree(worktrees: &[Worktree], repo_root: &Path) -> Option<usize> {
     let canonical = std::fs::canonicalize(repo_root).ok()?;
 
-    worktrees.iter().position(|wt| {
-        std::fs::canonicalize(&wt.path)
-            .is_ok_and(|p| paths_equal(&p, &canonical))
-    })
+    worktrees
+        .iter()
+        .position(|wt| std::fs::canonicalize(&wt.path).is_ok_and(|p| paths_equal(&p, &canonical)))
 }
 
 /// Compares two paths, handling case-insensitivity on macOS.

--- a/src/goup/src/main.rs
+++ b/src/goup/src/main.rs
@@ -17,9 +17,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::other(
-            "Command failed",
-        ));
+        return Err(std::io::Error::other("Command failed"));
     }
 
     println!("Ran {} in {}", command.join(" "), dir.display());

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -246,19 +246,16 @@ fn ensure_file_exists(file_path: &Path) -> Result<()> {
     match fs::metadata(file_path) {
         Ok(metadata) => {
             if metadata.is_dir() {
-                anyhow::bail!(
-                    "{} is a directory, not a file",
-                    file_path.display()
-                );
+                anyhow::bail!("{} is a directory, not a file", file_path.display());
             }
             Ok(())
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             anyhow::bail!("File not found: {}", file_path.display());
         }
-        Err(error) => Err(error).with_context(|| {
-            format!("Failed to access file: {}", file_path.display())
-        }),
+        Err(error) => {
+            Err(error).with_context(|| format!("Failed to access file: {}", file_path.display()))
+        }
     }
 }
 
@@ -2932,7 +2929,10 @@ not_a_number  1 /bin/bash
     fn parse_dimensions_handles_newline_separated() {
         // ffprobe's `default=noprint_wrappers=1:nokey=1` writer emits one value
         // per line; the parser must accept that layout too.
-        assert_eq!(parse_video_dimensions("3840\n2160\n").unwrap(), (3840, 2160));
+        assert_eq!(
+            parse_video_dimensions("3840\n2160\n").unwrap(),
+            (3840, 2160)
+        );
     }
 
     #[test]

--- a/src/idear/src/main.rs
+++ b/src/idear/src/main.rs
@@ -50,16 +50,15 @@ fn main() -> Result<()> {
     for entry in walker {
         let entry = entry?;
 
-        if entry.file_type().is_dir()
-            && is_idea_only_directory(entry.path())? {
-                if cli.delete || cli.dry_run {
-                    let size = calculate_dir_size(entry.path())?;
-                    total_size += size;
-                    found_dirs.push((entry.path().to_path_buf(), size));
-                } else {
-                    println!("{}", entry.path().display());
-                }
+        if entry.file_type().is_dir() && is_idea_only_directory(entry.path())? {
+            if cli.delete || cli.dry_run {
+                let size = calculate_dir_size(entry.path())?;
+                total_size += size;
+                found_dirs.push((entry.path().to_path_buf(), size));
+            } else {
+                println!("{}", entry.path().display());
             }
+        }
     }
 
     if cli.delete || cli.dry_run {

--- a/src/ng/src/main.rs
+++ b/src/ng/src/main.rs
@@ -65,7 +65,11 @@ const CLEAR_SCREEN: &str = "\x1B[2J\x1B[1;1H";
 /// terminal. When piped or redirected, returns an empty string so the output
 /// stays clean.
 fn screen_clear_sequence(is_tty: bool) -> &'static str {
-    if is_tty { CLEAR_SCREEN } else { "" }
+    if is_tty {
+        CLEAR_SCREEN
+    } else {
+        ""
+    }
 }
 
 fn run_pnpm_script(script: &str) {
@@ -85,7 +89,10 @@ fn run_pnpm_script(script: &str) {
             println!("{}", format!("pnpm {script} passed.").green());
         }
         Ok(s) => {
-            let code = s.code().map(|c| c.to_string()).unwrap_or_else(|| "?".into());
+            let code = s
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "?".into());
             println!("{}", format!("pnpm {script} failed (exit {code}).").red());
         }
         Err(e) => {
@@ -132,9 +139,7 @@ fn collect_watch_dirs(root: &Path) -> Vec<PathBuf> {
 fn is_relevant_event(kind: &notify::EventKind) -> bool {
     matches!(
         kind,
-        notify::EventKind::Create(_)
-            | notify::EventKind::Modify(_)
-            | notify::EventKind::Remove(_)
+        notify::EventKind::Create(_) | notify::EventKind::Modify(_) | notify::EventKind::Remove(_)
     )
 }
 

--- a/src/nodenuke/src/main.rs
+++ b/src/nodenuke/src/main.rs
@@ -69,12 +69,13 @@ fn main() {
 
         // Check for target directories
         if entry.file_type().is_some_and(|ft| ft.is_dir())
-            && target_dirs.contains(&entry_name.as_ref()) {
-                println!("Removing directory: {}", entry.path().display());
-                if let Err(e) = fs::remove_dir_all(entry.path()) {
-                    eprintln!("Error removing {}: {}", entry.path().display(), e);
-                }
+            && target_dirs.contains(&entry_name.as_ref())
+        {
+            println!("Removing directory: {}", entry.path().display());
+            if let Err(e) = fs::remove_dir_all(entry.path()) {
+                eprintln!("Error removing {}: {}", entry.path().display(), e);
             }
+        }
     }
 
     // Second pass: Find and remove target files
@@ -90,12 +91,13 @@ fn main() {
 
         // Check for target files
         if entry.file_type().is_some_and(|ft| ft.is_file())
-            && target_files.contains(&entry_name.as_ref()) {
-                println!("Removing file: {}", entry.path().display());
-                if let Err(e) = fs::remove_file(entry.path()) {
-                    eprintln!("Error removing {}: {}", entry.path().display(), e);
-                }
+            && target_files.contains(&entry_name.as_ref())
+        {
+            println!("Removing file: {}", entry.path().display());
+            if let Err(e) = fs::remove_file(entry.path()) {
+                eprintln!("Error removing {}: {}", entry.path().display(), e);
             }
+        }
     }
 
     println!("Cleanup complete!");

--- a/src/nwt/src/main.rs
+++ b/src/nwt/src/main.rs
@@ -702,9 +702,7 @@ fn sanitize_for_filesystem(name: &str) -> Option<String> {
     // Reject names that start with a dot followed by only dots and underscores
     // (could be attempts to create hidden or traversal paths). Use chars().skip(1)
     // instead of byte indexing so the check is safe on any UTF-8 input.
-    if sanitized.starts_with('.')
-        && sanitized.chars().skip(1).all(|c| c == '.' || c == '_')
-    {
+    if sanitized.starts_with('.') && sanitized.chars().skip(1).all(|c| c == '.' || c == '_') {
         return None;
     }
 

--- a/src/op-cache/src/lib.rs
+++ b/src/op-cache/src/lib.rs
@@ -373,10 +373,13 @@ fn fetch_binary_from_1password(op_path: &OpPath, output_path: &Path) -> Result<(
             ])
             .output()
         {
-            Ok(output) if output.status.success()
-                && output_path.exists() && output_path.metadata().is_ok_and(|m| m.len() > 0) => {
-                    return Ok(());
-                }
+            Ok(output)
+                if output.status.success()
+                    && output_path.exists()
+                    && output_path.metadata().is_ok_and(|m| m.len() > 0) =>
+            {
+                return Ok(());
+            }
             _ => {}
         }
 

--- a/src/org-borg/src/github.rs
+++ b/src/org-borg/src/github.rs
@@ -5,14 +5,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 pub struct GitHubClient {
     client: reqwest::Client,
-    #[allow(dead_code, reason = "retained for future API calls that need the raw token")]
+    #[allow(
+        dead_code,
+        reason = "retained for future API calls that need the raw token"
+    )]
     token: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct User {
     pub login: String,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub id: i64,
     pub name: Option<String>,
     pub email: Option<String>,
@@ -25,7 +31,10 @@ pub struct User {
 #[derive(Debug, Deserialize)]
 pub struct Organization {
     pub login: String,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub id: i64,
     pub description: Option<String>,
     pub public_repos: Option<i32>,
@@ -33,24 +42,45 @@ pub struct Organization {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Repository {
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub id: i64,
     pub name: String,
     pub full_name: String,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub html_url: String,
     pub ssh_url: String,
     pub clone_url: String,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub description: Option<String>,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub fork: bool,
     pub archived: bool,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub disabled: bool,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub private: bool,
-    #[allow(dead_code, reason = "deserialized from GitHub API but not yet surfaced")]
+    #[allow(
+        dead_code,
+        reason = "deserialized from GitHub API but not yet surfaced"
+    )]
     pub default_branch: Option<String>,
 }
 

--- a/src/polish/src/main.rs
+++ b/src/polish/src/main.rs
@@ -17,9 +17,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::other(
-            "Command failed",
-        ));
+        return Err(std::io::Error::other("Command failed"));
     }
 
     println!("Ran {} in {}", command.join(" "), dir.display());

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -122,8 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         match gix::discover(path) {
             Ok(repo) => {
-                let repo_name =
-                    get_repo_root_name(&repo).unwrap_or_else(|| basename.to_string());
+                let repo_name = get_repo_root_name(&repo).unwrap_or_else(|| basename.to_string());
                 match get_git_branch(&repo) {
                     Some(branch) => PortSource::GitRepo { repo_name, branch },
                     None => PortSource::DetachedHead { repo_name },
@@ -193,7 +192,10 @@ mod tests {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let repo = gix::discover(path).expect("Should find git repo");
         let name = get_repo_root_name(&repo);
-        assert!(name.is_some(), "Should find repo root name for a valid repo");
+        assert!(
+            name.is_some(),
+            "Should find repo root name for a valid repo"
+        );
         let name = name.unwrap();
         assert!(!name.is_empty(), "Repo root name should not be empty");
         assert!(!name.contains('/'), "Should be a basename, not a path");
@@ -205,15 +207,13 @@ mod tests {
         // Discover repo from the current path (may be a worktree)
         let worktree_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
         let worktree_repo = gix::discover(worktree_path).expect("Should find repo");
-        let worktree_name =
-            get_repo_root_name(&worktree_repo).expect("Should get repo root name");
+        let worktree_name = get_repo_root_name(&worktree_repo).expect("Should get repo root name");
 
         // Discover repo from the main repo root (parent of common_dir)
         let common = std::fs::canonicalize(worktree_repo.common_dir()).unwrap();
         let main_repo_root = common.parent().unwrap();
         let main_repo = gix::discover(main_repo_root).expect("Should find main repo");
-        let main_name =
-            get_repo_root_name(&main_repo).expect("Should get main repo root name");
+        let main_name = get_repo_root_name(&main_repo).expect("Should get main repo root name");
 
         assert_eq!(
             worktree_name, main_name,

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -1503,14 +1503,13 @@ fn read_yes_no_with_ctrlc() -> bool {
                         let _ = io::stderr().flush();
                         let _ = crossterm::terminal::enable_raw_mode();
                     }
-                    KeyCode::Backspace
-                        if input.pop().is_some() => {
-                            // Erase character from display
-                            let _ = crossterm::terminal::disable_raw_mode();
-                            eprint!("\x08 \x08"); // backspace, space, backspace
-                            let _ = io::stderr().flush();
-                            let _ = crossterm::terminal::enable_raw_mode();
-                        }
+                    KeyCode::Backspace if input.pop().is_some() => {
+                        // Erase character from display
+                        let _ = crossterm::terminal::disable_raw_mode();
+                        eprint!("\x08 \x08"); // backspace, space, backspace
+                        let _ = io::stderr().flush();
+                        let _ = crossterm::terminal::enable_raw_mode();
+                    }
                     _ => {}
                 }
             }

--- a/src/repo-guards/Cargo.toml
+++ b/src/repo-guards/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "repo-guards"
+version = "0.1.0"
+edition.workspace = true
+
+[lints]
+workspace = true

--- a/src/repo-guards/src/lib.rs
+++ b/src/repo-guards/src/lib.rs
@@ -1,0 +1,9 @@
+//! Host crate for repository-level guard tests.
+//!
+//! This crate exists solely to carry automated tests that prove the repo's
+//! own guardrails actually fire — for example, that the `.husky/pre-commit`
+//! hook rejects misformatted Rust. It is not a tool: it ships no binary and
+//! deliberately omits the `--version`/git-hash handling the repo otherwise
+//! mandates for tools, because there is nothing for a user to run.
+//!
+//! All meaningful behavior lives in `tests/`; this library is empty by design.

--- a/src/repo-guards/tests/pre_commit_hook.rs
+++ b/src/repo-guards/tests/pre_commit_hook.rs
@@ -1,0 +1,162 @@
+//! Integration tests that run the repo's real `.husky/pre-commit` hook against
+//! throwaway fixtures and assert on its exit status.
+//!
+//! These cover *existing* correct behavior of the hook, so a TDD red phase is
+//! impossible — they pass immediately against the current hook. The mutation
+//! check that substitutes for red (neuter the hook, watch
+//! `staged_misformatted_rust_file_fails_the_gate` fail, restore, watch it pass)
+//! is documented in the commit body, not committed as code.
+//!
+//! Parallel safety: a `bacon` loop runs `cargo test` concurrently with the
+//! pre-commit hook's own `cargo test`, so two copies of each test can execute
+//! at once. Every fixture directory is keyed on the process id plus a
+//! nanosecond timestamp so concurrent runs never share a path.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A deliberately misformatted Rust source file. `cargo fmt --check` rejects it
+/// because of the run-together braces, doubled spaces, and stray whitespace.
+const MISFORMATTED_MAIN_RS: &str = "fn main()    {println!(\"hi\" ) ;}\n";
+
+/// Absolute, canonical path to the real hook under test.
+fn hook_path() -> PathBuf {
+    let hook = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.husky/pre-commit");
+    fs::canonicalize(&hook)
+        .unwrap_or_else(|e| panic!("cannot canonicalize hook path {}: {e}", hook.display()))
+}
+
+/// Path to the repo's pinned toolchain file, copied into each fixture so
+/// `cargo fmt` resolves the same rustfmt as the rest of the workspace.
+fn rust_toolchain_path() -> PathBuf {
+    let toolchain = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../rust-toolchain.toml");
+    fs::canonicalize(&toolchain).unwrap_or_else(|e| {
+        panic!(
+            "cannot canonicalize rust-toolchain path {}: {e}",
+            toolchain.display()
+        )
+    })
+}
+
+/// Create a process-unique fixture directory.
+fn unique_fixture_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before UNIX_EPOCH")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("repo-guards-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create fixture dir");
+    dir
+}
+
+/// Build a minimal cargo package inside `dir` whose `src/main.rs` is
+/// misformatted. The empty `[workspace]` table stops cargo from walking up into
+/// any parent manifest, and the copied `rust-toolchain.toml` pins rustfmt.
+fn write_fixture_package(dir: &Path) {
+    fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[workspace]\n",
+    )
+    .expect("write fixture Cargo.toml");
+
+    fs::create_dir_all(dir.join("src")).expect("create fixture src dir");
+    fs::write(dir.join("src/main.rs"), MISFORMATTED_MAIN_RS).expect("write misformatted main.rs");
+
+    fs::copy(rust_toolchain_path(), dir.join("rust-toolchain.toml"))
+        .expect("copy rust-toolchain.toml into fixture");
+}
+
+/// `git init` the fixture and stage `paths`. No commit (hence no identity
+/// config) is needed: `git diff --cached` compares the index to the empty tree.
+fn git_init_and_stage(dir: &Path, paths: &[&str]) {
+    run_git(dir, &["init", "-q"]);
+    let mut add = vec!["add"];
+    add.extend_from_slice(paths);
+    run_git(dir, &add);
+}
+
+/// Run `git -C <dir> <args>` and assert it succeeded.
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        // Scrub inherited git env so the fixture repo is the one git operates
+        // on, even when invoked from inside this repo's own git hooks/tests.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Run the real hook with `dir` as CWD, scrubbing inherited git env vars so the
+/// hook operates on the fixture repo rather than this test's repo. Returns true
+/// if the hook exited zero.
+fn run_hook(dir: &Path) -> bool {
+    Command::new("bash")
+        .arg(hook_path())
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .status()
+        .expect("failed to spawn pre-commit hook")
+        .success()
+}
+
+/// Best-effort cleanup; the per-process+nanos path is the real isolation, so a
+/// failed removal cannot collide with another run.
+fn cleanup(dir: &Path) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+/// Mutation test for the gate: a staged, misformatted `.rs` file must make the
+/// hook exit non-zero. If this ever passes with a broken hook, the guard is
+/// dead — that is exactly what we are protecting against.
+#[test]
+fn staged_misformatted_rust_file_fails_the_gate() {
+    let dir = unique_fixture_dir();
+    write_fixture_package(&dir);
+    git_init_and_stage(&dir, &["src/main.rs", "Cargo.toml", "rust-toolchain.toml"]);
+
+    let passed = run_hook(&dir);
+    cleanup(&dir);
+
+    assert!(
+        !passed,
+        "hook should reject a staged misformatted .rs file, but it exited zero"
+    );
+}
+
+/// When only a non-Rust file is staged, the trigger condition is false and the
+/// gate is skipped — so the hook exits zero even though a misformatted
+/// `src/main.rs` sits on disk (unstaged). This proves the trigger, not the
+/// formatter, is what runs: if the gate fired anyway it would catch the file
+/// and fail.
+#[test]
+fn staged_non_rust_file_skips_the_gate() {
+    let dir = unique_fixture_dir();
+    write_fixture_package(&dir);
+    fs::write(dir.join("README.md"), "# fixture\n").expect("write README.md");
+
+    // Only the README is staged; the misformatted main.rs stays unstaged.
+    git_init_and_stage(&dir, &["README.md"]);
+
+    let passed = run_hook(&dir);
+    cleanup(&dir);
+
+    assert!(
+        passed,
+        "hook should skip the gate when no Rust/Cargo files are staged, but it exited non-zero"
+    );
+}

--- a/src/repo-guards/tests/pre_commit_hook.rs
+++ b/src/repo-guards/tests/pre_commit_hook.rs
@@ -138,6 +138,39 @@ fn staged_misformatted_rust_file_fails_the_gate() {
     );
 }
 
+/// A minimal `rustfmt.toml` whose only job is to be a staged file that matches
+/// the gate's trigger regex. The pinned style edition mirrors the workspace.
+const RUSTFMT_TOML: &str = "style_edition = \"2021\"\n";
+
+/// Staging only a toolchain/style config file (and nothing else) must still
+/// trigger the gate, because such a commit is the exact scenario most likely to
+/// introduce formatting/lint drift. We prove the gate fires by leaving a
+/// misformatted `src/main.rs` unstaged on disk: if the gate runs, `cargo fmt
+/// --check` sees the dirty tree and the hook exits non-zero; if the gate is
+/// skipped, the hook exits zero and this test fails.
+#[test]
+fn staged_toolchain_config_alone_triggers_the_gate() {
+    // `rust-toolchain.toml` is already written by `write_fixture_package`, so it
+    // only needs staging; `rustfmt.toml` is written here first.
+    for config_file in ["rustfmt.toml", "rust-toolchain.toml"] {
+        let dir = unique_fixture_dir();
+        write_fixture_package(&dir);
+        fs::write(dir.join("rustfmt.toml"), RUSTFMT_TOML).expect("write rustfmt.toml");
+
+        // Stage ONLY the config file. The misformatted main.rs stays unstaged,
+        // so the gate must fire on the config file alone to catch it.
+        git_init_and_stage(&dir, &[config_file]);
+
+        let passed = run_hook(&dir);
+        cleanup(&dir);
+
+        assert!(
+            !passed,
+            "hook should run the gate when {config_file} is staged, but it exited zero (gate skipped)"
+        );
+    }
+}
+
 /// When only a non-Rust file is staged, the trigger condition is false and the
 /// gate is skipped — so the hook exits zero even though a misformatted
 /// `src/main.rs` sits on disk (unstaged). This proves the trigger, not the

--- a/src/repotidy/src/main.rs
+++ b/src/repotidy/src/main.rs
@@ -16,9 +16,7 @@ fn run_command_in_directory(dir: &Path, command: &[&str]) -> Result<(), std::io:
             dir.display(),
             String::from_utf8_lossy(&output.stderr)
         );
-        return Err(std::io::Error::other(
-            "Command failed",
-        ));
+        return Err(std::io::Error::other("Command failed"));
     }
 
     println!("Ran {} in {}", command.join(" "), dir.display());

--- a/src/rr/src/main.rs
+++ b/src/rr/src/main.rs
@@ -47,9 +47,7 @@ fn run_cargo_clean(dir: &Path, dry_run: bool) -> Result<(), std::io::Error> {
             dir.display(),
             String::from_utf8_lossy(&output.stderr).trim()
         );
-        return Err(std::io::Error::other(
-            "cargo clean failed",
-        ));
+        return Err(std::io::Error::other("cargo clean failed"));
     }
 
     println!("Cleaned: {}", dir.display());

--- a/src/runat/src/main.rs
+++ b/src/runat/src/main.rs
@@ -142,10 +142,10 @@ fn run_app(
                     KeyCode::Char('q') | KeyCode::Char('c')
                         if key
                             .modifiers
-                            .contains(crossterm::event::KeyModifiers::CONTROL)
-                        => {
-                            app.should_quit = true;
-                        }
+                            .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                    {
+                        app.should_quit = true;
+                    }
                     _ => {}
                 }
             }

--- a/src/sf/src/main.rs
+++ b/src/sf/src/main.rs
@@ -43,7 +43,9 @@ fn main() -> Result<()> {
         Some(FilterType::Suffix(suffix))
     } else if let Some(prefix) = cli.prefix {
         Some(FilterType::Prefix(prefix))
-    } else { cli.substring.map(FilterType::Substring) };
+    } else {
+        cli.substring.map(FilterType::Substring)
+    };
 
     let walker = FileWalker::new(cli.paths).with_filter(filter);
 

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -542,8 +542,7 @@ enum ConfigTarget {
 fn resolve_config_target(rendered_path: &Path) -> ConfigTarget {
     let direct = || ConfigTarget::Direct(rendered_path.to_path_buf());
 
-    let (Some(parent), Some(file_name)) =
-        (rendered_path.parent(), rendered_path.file_name())
+    let (Some(parent), Some(file_name)) = (rendered_path.parent(), rendered_path.file_name())
     else {
         return direct();
     };
@@ -558,7 +557,10 @@ fn resolve_config_target(rendered_path: &Path) -> ConfigTarget {
     };
     for entry in entries.flatten() {
         let entry_name = entry.file_name();
-        let Some(suffix) = entry_name.to_string_lossy().strip_prefix(&prefix).map(str::to_owned)
+        let Some(suffix) = entry_name
+            .to_string_lossy()
+            .strip_prefix(&prefix)
+            .map(str::to_owned)
         else {
             continue;
         };
@@ -1304,10 +1306,8 @@ function prmv() { OLD_PRCP; }
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_nanos();
-        let dir = std::env::temp_dir().join(format!(
-            "shellsetup-{tag}-{}-{nanos}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("shellsetup-{tag}-{}-{nanos}", std::process::id()));
         fs::create_dir_all(&dir).expect("create unique temp dir");
         dir
     }
@@ -1318,10 +1318,7 @@ function prmv() { OLD_PRCP; }
         let rc = dir.join(".zshrc");
         fs::write(&rc, "# config\n").unwrap();
 
-        assert_eq!(
-            resolve_config_target(&rc),
-            ConfigTarget::Direct(rc.clone())
-        );
+        assert_eq!(resolve_config_target(&rc), ConfigTarget::Direct(rc.clone()));
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/src/tsm-jsonl/src/lib.rs
+++ b/src/tsm-jsonl/src/lib.rs
@@ -201,11 +201,10 @@ pub fn read_all(path: &Path) -> Result<SessionLog, JsonlError> {
             });
         }
     };
-    let header: Header = serde_json::from_str(&first_line).map_err(|_| {
-        JsonlError::MalformedFirstLine {
+    let header: Header =
+        serde_json::from_str(&first_line).map_err(|_| JsonlError::MalformedFirstLine {
             line: first_line.clone(),
-        }
-    })?;
+        })?;
 
     // Lines 2..N: each must parse as a PrecmdRecord. Track the 1-indexed line number for
     // error reporting (line 1 = header, so the first record is line 2).
@@ -214,12 +213,11 @@ pub fn read_all(path: &Path) -> Result<SessionLog, JsonlError> {
     for line_result in lines {
         line_number = line_number.saturating_add(1);
         let line = line_result?;
-        let record: PrecmdRecord = serde_json::from_str(&line).map_err(|_| {
-            JsonlError::MalformedRecordLine {
+        let record: PrecmdRecord =
+            serde_json::from_str(&line).map_err(|_| JsonlError::MalformedRecordLine {
                 line_number,
                 line: line.clone(),
-            }
-        })?;
+            })?;
         records.push(record);
     }
 
@@ -315,8 +313,7 @@ mod tests {
             "expected MissingHeader, got: {err:?}"
         );
         // File must remain empty or nonexistent.
-        let exists_and_empty = !path.exists()
-            || fs::metadata(&path).expect("metadata").len() == 0;
+        let exists_and_empty = !path.exists() || fs::metadata(&path).expect("metadata").len() == 0;
         assert!(exists_and_empty, "file must remain empty or absent");
     }
 

--- a/src/tsm/src/main.rs
+++ b/src/tsm/src/main.rs
@@ -21,8 +21,8 @@ use chrono::Utc;
 use clap::{Parser, Subcommand};
 use tsm_id::SessionId;
 use tsm_jsonl::{
-    Header, HeaderKind, JsonlError, PrecmdKind, PrecmdRecord, TupleStub, append_header,
-    append_record,
+    append_header, append_record, Header, HeaderKind, JsonlError, PrecmdKind, PrecmdRecord,
+    TupleStub,
 };
 use wait_timeout::ChildExt;
 
@@ -113,9 +113,7 @@ fn is_redacted(name: &str) -> bool {
 /// Split `env` into (kept, redacted-keys-sorted). Values for keys that match
 /// the redaction list are dropped entirely from the kept map; their names are
 /// pushed onto `redacted_keys` and the result is sorted alphabetically.
-fn redact_env(
-    env: BTreeMap<String, String>,
-) -> (BTreeMap<String, String>, Vec<String>) {
+fn redact_env(env: BTreeMap<String, String>) -> (BTreeMap<String, String>, Vec<String>) {
     let mut kept = BTreeMap::new();
     let mut redacted = Vec::new();
     for (k, v) in env {
@@ -292,7 +290,11 @@ fn parent_pid() -> u32 {
     #[cfg(unix)]
     {
         let p = std::os::unix::process::parent_id();
-        if p == 0 { std::process::id() } else { p }
+        if p == 0 {
+            std::process::id()
+        } else {
+            p
+        }
     }
     #[cfg(not(unix))]
     {
@@ -324,7 +326,9 @@ fn rotate_error_log_if_needed(path: &Path) {
         buf.drain(..=nl);
     }
     let tmp = path.with_extension(format!("log.tmp.{}", std::process::id()));
-    let Ok(mut out) = File::create(&tmp) else { return };
+    let Ok(mut out) = File::create(&tmp) else {
+        return;
+    };
     if out.write_all(&buf).is_err() {
         let _ = fs::remove_file(&tmp);
         return;
@@ -358,7 +362,9 @@ fn write_fail_counter(path: &Path, value: u32) {
 
 /// Read the current fail counter (0 if absent or unparseable).
 fn read_fail_counter(path: &Path) -> u32 {
-    let Ok(s) = fs::read_to_string(path) else { return 0 };
+    let Ok(s) = fs::read_to_string(path) else {
+        return 0;
+    };
     s.trim().parse::<u32>().unwrap_or(0)
 }
 
@@ -414,8 +420,7 @@ fn build_header() -> Header {
         |_| "unknown".to_string(),
         |h| h.to_string_lossy().into_owned(),
     );
-    let terminal_program =
-        std::env::var("TERM_PROGRAM").unwrap_or_else(|_| "unknown".to_string());
+    let terminal_program = std::env::var("TERM_PROGRAM").unwrap_or_else(|_| "unknown".to_string());
     Header {
         kind: HeaderKind::Header,
         schema_version: 1,
@@ -469,15 +474,11 @@ fn append_record_with_header(path: &Path, record: &PrecmdRecord) -> Result<(), J
 
 /// The core of the recorder. Returns `Ok(())` on success, `Err(String)` on
 /// any internal failure (the caller logs the message and bumps the counter).
-fn do_record(
-    state_dir: &Path,
-    exit_code: i32,
-    last_command: String,
-) -> Result<(), String> {
+fn do_record(state_dir: &Path, exit_code: i32, last_command: String) -> Result<(), String> {
     let raw_id = std::env::var("TSM_SESSION_ID")
         .map_err(|_| "record: TSM_SESSION_ID is not set".to_string())?;
-    let session_id = SessionId::from_hex(&raw_id)
-        .map_err(|e| format!("record: invalid TSM_SESSION_ID: {e}"))?;
+    let session_id =
+        SessionId::from_hex(&raw_id).map_err(|e| format!("record: invalid TSM_SESSION_ID: {e}"))?;
 
     let _ = state_dir; // path resolution for the session log uses XDG_DATA_HOME.
     let log_path = session_log_path(&session_id)
@@ -504,11 +505,7 @@ fn do_record(
     Ok(())
 }
 
-fn handle_record(
-    exit_code: i32,
-    last_command: String,
-    probe_subprocess: Option<String>,
-) {
+fn handle_record(exit_code: i32, last_command: String, probe_subprocess: Option<String>) {
     let state_dir = xdg_state_home();
     let err_log = state_dir.as_deref().map(error_log_path_in);
 
@@ -530,7 +527,11 @@ fn handle_record(
         return;
     }
 
-    match do_record(state_dir.as_deref().unwrap_or(Path::new(".")), exit_code, last_command) {
+    match do_record(
+        state_dir.as_deref().unwrap_or(Path::new(".")),
+        exit_code,
+        last_command,
+    ) {
         Ok(()) => {
             if let Some(dir) = state_dir.as_deref() {
                 reset_fail_counter(dir);
@@ -552,9 +553,7 @@ fn main() {
     match cli.command {
         Commands::ShellInit { shell } => {
             if shell != "zsh" {
-                eprintln!(
-                    "tsm: shell-init: only \"zsh\" is supported in v1, got: {shell}"
-                );
+                eprintln!("tsm: shell-init: only \"zsh\" is supported in v1, got: {shell}");
                 std::process::exit(EXIT_UNSUPPORTED_SHELL);
             }
             let session_id = SessionId::random();
@@ -579,8 +578,7 @@ mod tests {
 
     /// Build a fixed session ID for deterministic snippet inspection.
     fn fixed_session_id() -> SessionId {
-        SessionId::from_hex("0123456789abcdef0123456789abcdef")
-            .expect("fixed hex is valid")
+        SessionId::from_hex("0123456789abcdef0123456789abcdef").expect("fixed hex is valid")
     }
 
     #[test]
@@ -608,10 +606,7 @@ mod tests {
     fn zsh_snippet_uses_random_id_when_called_via_main() {
         let a = generate_zsh_snippet(&SessionId::random());
         let b = generate_zsh_snippet(&SessionId::random());
-        assert_ne!(
-            a, b,
-            "two snippets generated with random ids should differ"
-        );
+        assert_ne!(a, b, "two snippets generated with random ids should differ");
     }
 
     #[test]

--- a/src/tsm/tests/record.rs
+++ b/src/tsm/tests/record.rs
@@ -63,15 +63,20 @@ fn record_first_call_writes_header() {
         .success();
 
     let log_path = session_log_path(&data, TEST_SESSION_ID);
-    assert!(log_path.exists(), "session log file must exist at {log_path:?}");
+    assert!(
+        log_path.exists(),
+        "session log file must exist at {log_path:?}"
+    );
 
     let contents = fs::read_to_string(&log_path).expect("read log");
     let first_line = contents.lines().next().expect("at least one line");
-    let header: Header =
-        serde_json::from_str(first_line).expect("line 1 must parse as Header");
+    let header: Header = serde_json::from_str(first_line).expect("line 1 must parse as Header");
     assert!(matches!(header.kind, HeaderKind::Header));
     assert_eq!(header.schema_version, 1);
-    assert!(!header.tsm_version.is_empty(), "tsm_version should be populated");
+    assert!(
+        !header.tsm_version.is_empty(),
+        "tsm_version should be populated"
+    );
 }
 
 #[test]
@@ -93,10 +98,13 @@ fn record_second_call_appends_record_after_header() {
     let log_path = session_log_path(&data, TEST_SESSION_ID);
     let contents = fs::read_to_string(&log_path).expect("read log");
     let lines: Vec<&str> = contents.lines().collect();
-    assert_eq!(lines.len(), 2, "expected exactly 2 lines, got: {contents:?}");
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected exactly 2 lines, got: {contents:?}"
+    );
 
-    let header: Header =
-        serde_json::from_str(lines[0]).expect("line 1 must parse as Header");
+    let header: Header = serde_json::from_str(lines[0]).expect("line 1 must parse as Header");
     assert!(matches!(header.kind, HeaderKind::Header));
 
     let record: PrecmdRecord =
@@ -162,7 +170,10 @@ fn record_failure_increments_fail_counter() {
         .success();
 
     let counter = fail_count_path(&state);
-    assert!(counter.exists(), "fail-count file must exist at {counter:?}");
+    assert!(
+        counter.exists(),
+        "fail-count file must exist at {counter:?}"
+    );
     let v = fs::read_to_string(&counter).expect("read counter");
     assert_eq!(v.trim(), "1");
 
@@ -226,8 +237,7 @@ fn record_redacts_aws_session_token() {
     let contents = fs::read_to_string(&log_path).expect("read log");
     let lines: Vec<&str> = contents.lines().collect();
     assert!(lines.len() >= 2, "expected header + record");
-    let record: PrecmdRecord =
-        serde_json::from_str(lines[1]).expect("line 2 is PrecmdRecord");
+    let record: PrecmdRecord = serde_json::from_str(lines[1]).expect("line 2 is PrecmdRecord");
     assert!(
         !record.env.contains_key("AWS_SESSION_TOKEN"),
         "AWS_SESSION_TOKEN must be redacted out of env"
@@ -237,7 +247,9 @@ fn record_redacts_aws_session_token() {
         "MY_API_KEY must be redacted out of env"
     );
     assert!(
-        record.redacted_keys.contains(&"AWS_SESSION_TOKEN".to_string()),
+        record
+            .redacted_keys
+            .contains(&"AWS_SESSION_TOKEN".to_string()),
         "AWS_SESSION_TOKEN must be in redacted_keys"
     );
     assert!(


### PR DESCRIPTION
Closes #273.

## Why

`cargo fmt --all -- --check` failed on a clean checkout of `main` with 70 diff hunks across 22 crates. "Formatted" was defined by whatever rustfmt happened to be installed (no toolchain pin, no style pin), and the pre-commit hook only gated clippy, so drift accumulated silently.

## What

Four commits, in dependency order (gate only enabled once the repo is clean; "clean" only well-defined once the formatter is pinned):

1. **`rust-toolchain.toml` + `rustfmt.toml`** — pin the toolchain to 1.96.0 (rustfmt 1.9.0) with rustfmt/clippy components, and state `style_edition = "2021"` explicitly so the style contract survives future pin bumps. The toolchain pin is load-bearing: rustfmt changes formatting across versions *within* a style edition, so `rustfmt.toml` alone can't make the contract machine-independent.
2. **Style-only reformat** — `cargo fmt --all` under the pinned toolchain; 23 files, all `.rs`, no manual edits. Semantically inert: workspace check, clippy `-D warnings`, and the full test suite (1009 passed / 0 failed / 8 ignored) pass unchanged. Release build clean.
3. **`Cargo.lock` prune** — drift the reformat surfaced (stale entries from the removed `claude-usage` crate, regenerated by any cargo invocation); split into its own commit so the reformat stays literally style-only.
4. **Pre-commit fmt gate** — `cargo fmt --all -- --check` runs before the clippy pass whenever Rust sources or Cargo manifests are staged. Mutation-tested: a staged formatting violation passed the old hook (exit 0 — gate proven missing) and is rejected by the new one (real `git commit` probe failed); clean staging passes. Hook passes shellcheck.

## Verification

- `cargo fmt --all -- --check` exits 0 — and does so under both rustfmt 1.9.0 (pinned) and 1.8.0, so the committed formatting is a fixed point across formatter generations
- `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (1009 passed), `cargo build --release`: all green
- Mutation test of the gate documented in the final commit

## Follow-up

While mutation-testing the gate, found that **no git hooks fire in fresh worktrees at all** (`core.hooksPath` → `.husky/_`, which only exists after `pnpm install`) — plausibly the real mechanism behind the drift. Filed as #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)