### PR TITLE
feat(crap): let --here pin the forked session to a chosen UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,16 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1658,27 +1648,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,16 @@ A couple of things to know:
 - The replayed history still references the *original* directory's paths. Claude works in your current directory from here on, but the conversation it inherits talks about the old one.
 - It still won't resume a session that's open elsewhere unless you pass `--force` (forking reads the live transcript, which can be mid-write).
 
+#### Choosing the forked session's id
+
+By default the fork gets a random new id, which you only learn after Claude starts. Pass a second argument to choose it yourself:
+
+```bash
+crap --here 57570685-2d64-4431-8ab6-c021a12fa1af 9f8e7d6c-5b4a-3210-fedc-ba9876543210
+```
+
+The new id must be a valid UUID, and `crap` refuses it if it already names a session (so the fork can never overwrite an unrelated transcript). This is handy when a script needs to know the resumed session's id in advance — generate a UUID, hand it to `crap --here`, and you already know where the new transcript will live. Omit it to keep the random-id behavior.
+
 ### Don't attach twice
 
 Claude Code records every live CLI session under `~/.claude/sessions/<pid>.json` and removes it on clean exit. Before resuming, `crap` checks that registry: if the session you asked for is already open in another running `claude` process, it refuses and tells you where:

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -9,7 +9,9 @@
 //! `--resume <id>` only against the project folder matching the current working
 //! directory, so `crap --here` symlinks the session's transcript into that
 //! folder and resumes it as a `--fork-session` (a fresh id), leaving the
-//! original transcript untouched. The symlink is removed once the session ends.
+//! original transcript untouched. Because the fork only reads that transcript,
+//! `--here` works even while the original session is still live in another
+//! process. The symlink is removed once the session ends.
 //!
 //! With `--status`, it resumes nothing: it classifies where the session left
 //! off — `waiting-for-user`, `busy`, `awaiting-assistant`, or `empty`, inferred
@@ -867,6 +869,10 @@ struct Cli {
     /// By default `crap` refuses to resume a session that is already open
     /// elsewhere, because two processes writing the same session log can
     /// corrupt it.
+    ///
+    /// This guard applies only to the default resume mode. `--here` forks a
+    /// fresh session (it only reads the original transcript), so it is never
+    /// blocked by a live original and ignores `--force`.
     #[arg(short, long)]
     force: bool,
 
@@ -874,7 +880,8 @@ struct Cli {
     ///
     /// `crap` symlinks the session into the current directory's project folder
     /// so `claude --resume` can find it here, then resumes it as a forked
-    /// (new-id) session — the original transcript is left untouched. Use this to
+    /// (new-id) session — the original transcript is only read, never written,
+    /// so this works even if the original session is still live. Use this to
     /// carry a conversation's context into a different working directory.
     #[arg(long)]
     here: bool,
@@ -915,11 +922,12 @@ struct Cli {
 ///
 /// The default resume mode reuses the session id, so a second process would
 /// append to the same transcript as the live one — that can corrupt it, so a
-/// live session blocks the resume unless `--force` overrides it. The `here`
-/// flag is threaded through for the `--here` fork path (see Phase 3) but is not
-/// yet consulted.
-fn should_block_for_live(_here: bool, force: bool) -> bool {
-    !force
+/// live session blocks the resume unless `--force` overrides it. `--here`
+/// resumes with `--fork-session`, which only *reads* the original transcript
+/// and writes a fresh file, so a live original can never be corrupted by it —
+/// `--here` therefore never blocks (and `--force` is irrelevant to it).
+fn should_block_for_live(here: bool, force: bool) -> bool {
+    !here && !force
 }
 
 /// Aborts with a clear message if `session_id` is already open in another live

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -741,11 +741,20 @@ fn format_dir_statuses(pwd: &Path, reports: &[SessionStatusReport]) -> String {
 
 /// Builds the session-status table — one row per report, timestamps prettified
 /// into the cells — ready for rendering.
+///
+/// Rendered with [`ContentArrangement::Disabled`] so each column is sized to its
+/// own content and the table is laid out at its natural width, **never wrapping
+/// a cell to fit the terminal**. Wrapping would chop a session UUID or timestamp
+/// across lines (unreadable), and — because the dynamic arrangement reads the
+/// ambient terminal width — would make the output depend on a shared,
+/// uncontrolled resource, so the rendering (and any test asserting on it) would
+/// silently change with the window size. Long rows simply overflow and let the
+/// terminal soft-wrap.
 fn dir_statuses_table(reports: &[SessionStatusReport]) -> Table {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_content_arrangement(ContentArrangement::Disabled)
         .set_header(vec!["SESSION", "STATE", "STARTED", "LAST"]);
     for report in reports {
         let started = report

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -2108,6 +2108,129 @@ mod tests {
         }
     }
 
+    /// Sources `SHELL_CODE` in a real `bash` with a fake `crap` that emits
+    /// here-mode output carrying `new_id_field` as its third field (and
+    /// `__CRAP_NO_LINK__`, so the symlink watcher is skipped), plus fake
+    /// `claude`/`clauded` that record the exact arguments they were resumed
+    /// with. Returns those recorded arguments, one per line.
+    ///
+    /// When `provide_clauded` is true the preferred `clauded` is on `PATH` and
+    /// records; otherwise only plain `claude` is available. All paths are keyed
+    /// on pid + a nanosecond timestamp so concurrent runs never share a temp
+    /// dir.
+    #[cfg(unix)]
+    fn run_here_shell_function(new_id_field: &str, provide_clauded: bool) -> String {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        // The session id the fake binary reports as the resumed original.
+        const HERE_SESSION: &str = "33333333-4444-5555-6666-777777777777";
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("crap-here-shell-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+
+        let args_file = dir.join("claude_args");
+
+        // Fake `crap`: emit a here-output whose third field is `new_id_field`.
+        let fake_crap = format!(
+            "#!/bin/sh\nprintf '{HERE_SENTINEL}\\n%s\\n%s\\n%s\\n' '{HERE_SESSION}' '{new_id_field}' '{NO_LINK_SENTINEL}'\n"
+        );
+
+        // Fake `claude`/`clauded`: record the exact argument list, one per line.
+        let fake_claude = format!("#!/bin/sh\nprintf '%s\\n' \"$@\" > {:?}\n", args_file);
+
+        let mut tools = vec![("crap", fake_crap), ("claude", fake_claude.clone())];
+        if provide_clauded {
+            tools.push(("clauded", fake_claude));
+        }
+        for (name, body) in tools {
+            let path = dir.join(name);
+            fs::write(&path, body).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let base_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{base_path}", dir.display());
+        let script = format!("{SHELL_CODE}\ncrap --here {HERE_SESSION}\n");
+
+        let output = Command::new("bash")
+            .env("PATH", new_path)
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("bash should be available");
+        assert!(
+            output.status.success(),
+            "here-mode shell function failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let recorded = fs::read_to_string(&args_file).unwrap_or_default();
+        let _ = fs::remove_dir_all(&dir);
+        recorded
+    }
+
+    /// A well-formed forked-session id for the here-mode dispatch tests.
+    const FORCED_NEW_ID: &str = "99999999-8888-7777-6666-555555555555";
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_function_pins_forced_new_id_via_session_id() {
+        // When the binary supplies a forced id, the resume must fork *and* pin
+        // the fork to that id with `--session-id`, on both the `clauded` and the
+        // plain `claude` dispatch paths.
+        for provide_clauded in [true, false] {
+            let recorded = run_here_shell_function(FORCED_NEW_ID, provide_clauded);
+            let args: Vec<&str> = recorded.lines().collect();
+            assert!(
+                args.contains(&"--fork-session"),
+                "must still fork (clauded={provide_clauded}); got {args:?}"
+            );
+            let pos = args
+                .iter()
+                .position(|a| *a == "--session-id")
+                .unwrap_or_else(|| {
+                    panic!("--session-id missing (clauded={provide_clauded}): {args:?}")
+                });
+            assert_eq!(
+                args.get(pos + 1).copied(),
+                Some(FORCED_NEW_ID),
+                "the forced id must follow --session-id (clauded={provide_clauded})"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_function_omits_session_id_without_a_forced_new_id() {
+        // The sentinel third field means "let Claude mint a random id": the
+        // resume forks but must not pass --session-id.
+        let recorded = run_here_shell_function(NO_NEW_ID_SENTINEL, true);
+        let args: Vec<&str> = recorded.lines().collect();
+        assert!(
+            args.contains(&"--fork-session"),
+            "must still fork: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--session-id"),
+            "no forced id => no --session-id: {args:?}"
+        );
+    }
+
+    #[test]
+    fn shell_code_parses_new_id_field_and_pins_session_id() {
+        // here-mode reads the third field and, unless it is the sentinel, pins
+        // the fork's id via `claude --session-id`.
+        assert!(SHELL_CODE.contains(NO_NEW_ID_SENTINEL));
+        assert!(SHELL_CODE.contains("--session-id"));
+    }
+
     // Two distinct session ids for the per-directory listing tests.
     const ID_A: &str = "aaaaaaaa-1111-2222-3333-444444444444";
     const ID_B: &str = "bbbbbbbb-1111-2222-3333-444444444444";

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -735,13 +735,26 @@ const HERE_SENTINEL: &str = "__CRAP_HERE__";
 /// function can tell "nothing to clean up" apart from a real path.
 const NO_LINK_SENTINEL: &str = "__CRAP_NO_LINK__";
 
+/// Placeholder used in the forced-new-id field when `--here` was given no
+/// explicit new session id, so the shell function knows to let Claude mint a
+/// fresh random id (`--fork-session`) instead of pinning one (`--session-id`).
+const NO_NEW_ID_SENTINEL: &str = "__CRAP_NO_NEW_ID__";
+
 /// Formats `--here` output for the shell function: the [`HERE_SENTINEL`], then
-/// the session id, then the symlink to remove once the session ends (or
-/// [`NO_LINK_SENTINEL`] when none was created).
+/// the session id, then the caller-supplied forked-session id (or
+/// [`NO_NEW_ID_SENTINEL`] when none was given), then the symlink to remove once
+/// the session ends (or [`NO_LINK_SENTINEL`] when none was created).
 ///
 /// The cleanup path is emitted last so that — like [`format_output`] — a path
-/// containing a newline survives intact as "everything after the second line".
-fn format_here_output(session_id: &str, link_to_cleanup: Option<&Path>) -> String {
+/// containing a newline survives intact as "everything after the final field
+/// separator". The forced-new-id is a validated UUID (or the sentinel), so it
+/// never contains a newline and is safe in the middle.
+fn format_here_output(
+    session_id: &str,
+    new_session_id: Option<&str>,
+    link_to_cleanup: Option<&Path>,
+) -> String {
+    let _new_id = new_session_id.unwrap_or(NO_NEW_ID_SENTINEL);
     let link = match link_to_cleanup {
         Some(path) => path.display().to_string(),
         None => NO_LINK_SENTINEL.to_string(),
@@ -971,7 +984,7 @@ fn run_here(projects_dir: &Path, session_id: &str, force: bool) -> ! {
 
     match resolve_here_link(projects_dir, &pwd, session_id) {
         Ok(link) => {
-            print!("{}", format_here_output(session_id, link.as_deref()));
+            print!("{}", format_here_output(session_id, None, link.as_deref()));
             exit(0);
         }
         Err(HereResolveError::InvalidSessionId) => {
@@ -1839,23 +1852,49 @@ mod tests {
     #[test]
     fn here_output_carries_sentinel_session_and_link() {
         let link = Path::new("/Users/tim/.claude/projects/-x/abc.jsonl");
-        let out = format_here_output(SAMPLE_ID, Some(link));
+        let out = format_here_output(SAMPLE_ID, None, Some(link));
 
         let mut lines = out.lines();
         assert_eq!(lines.next(), Some(HERE_SENTINEL));
         assert_eq!(lines.next(), Some(SAMPLE_ID));
-        // Everything after the second newline is the link path, intact.
-        let rest = out.splitn(3, '\n').nth(2).unwrap();
+        // No forced id was given, so the third field is the sentinel.
+        assert_eq!(lines.next(), Some(NO_NEW_ID_SENTINEL));
+        // Everything after the third newline is the link path, intact.
+        let rest = out.splitn(4, '\n').nth(3).unwrap();
         assert_eq!(rest.trim_end_matches('\n'), link.to_str().unwrap());
     }
 
     #[test]
     fn here_output_uses_no_link_sentinel_when_nothing_to_clean() {
-        let out = format_here_output(SAMPLE_ID, None);
+        let out = format_here_output(SAMPLE_ID, None, None);
 
         assert_eq!(out.lines().next(), Some(HERE_SENTINEL));
-        let link_field = out.splitn(3, '\n').nth(2).unwrap();
+        let link_field = out.splitn(4, '\n').nth(3).unwrap();
         assert_eq!(link_field.trim_end_matches('\n'), NO_LINK_SENTINEL);
+    }
+
+    #[test]
+    fn here_output_carries_forced_new_session_id() {
+        // When the caller supplies a forked-session id, it rides as the third
+        // field so the shell function can pass it to `claude --session-id`.
+        let link = Path::new("/Users/tim/.claude/projects/-x/abc.jsonl");
+        let out = format_here_output(SAMPLE_ID, Some(ID_B), Some(link));
+
+        let mut lines = out.lines();
+        assert_eq!(lines.next(), Some(HERE_SENTINEL));
+        assert_eq!(lines.next(), Some(SAMPLE_ID));
+        assert_eq!(lines.next(), Some(ID_B));
+        // The link still lives last, after the forced-id field.
+        let rest = out.splitn(4, '\n').nth(3).unwrap();
+        assert_eq!(rest.trim_end_matches('\n'), link.to_str().unwrap());
+    }
+
+    #[test]
+    fn here_output_uses_no_new_id_sentinel_when_absent() {
+        // Without a caller-supplied id, the third field is the sentinel so the
+        // shell function lets Claude mint a fresh random id.
+        let out = format_here_output(SAMPLE_ID, None, None);
+        assert_eq!(out.lines().nth(2), Some(NO_NEW_ID_SENTINEL));
     }
 
     #[test]
@@ -1863,9 +1902,9 @@ mod tests {
         // The link lives last in the output, so a newline inside the path can't
         // be mistaken for a field boundary.
         let link = Path::new("/Users/tim/od\ndd/abc.jsonl");
-        let out = format_here_output(SAMPLE_ID, Some(link));
+        let out = format_here_output(SAMPLE_ID, None, Some(link));
 
-        let rest = out.splitn(3, '\n').nth(2).unwrap();
+        let rest = out.splitn(4, '\n').nth(3).unwrap();
         assert_eq!(rest.trim_end_matches('\n'), link.to_str().unwrap());
     }
 

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -11,7 +11,10 @@
 //! folder and resumes it as a `--fork-session` (a fresh id), leaving the
 //! original transcript untouched. Because the fork only reads that transcript,
 //! `--here` works even while the original session is still live in another
-//! process. The symlink is removed once the session ends.
+//! process. The symlink is removed once the session ends. A second argument
+//! (`crap --here <id> <new-id>`) pins the fork to a chosen UUID via
+//! `claude --session-id` instead of a random one, provided it does not already
+//! name an existing session.
 //!
 //! With `--status`, it resumes nothing: it classifies where the session left
 //! off — `waiting-for-user`, `busy`, `awaiting-assistant`, or `empty`, inferred
@@ -1286,6 +1289,20 @@ mod tests {
             resolve_new_session_id(Some("not-a-uuid")),
             Err(InvalidNewSessionId)
         );
+    }
+
+    #[test]
+    fn here_accepts_session_and_new_id_positionals() {
+        let cli = Cli::try_parse_from(["crap", "--here", ID_A, ID_B]).expect("should parse");
+        assert!(cli.here);
+        assert_eq!(cli.session_id.as_deref(), Some(ID_A));
+        assert_eq!(cli.new_session_id.as_deref(), Some(ID_B));
+    }
+
+    #[test]
+    fn new_session_id_positional_requires_here() {
+        // A forked id is meaningless without --here, so clap must reject it.
+        assert!(Cli::try_parse_from(["crap", ID_A, ID_B]).is_err());
     }
 
     #[test]

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -802,12 +802,14 @@ fn format_here_output(
 /// * **default** — `<session-id>\n<dir>`: the function `cd`s into the original
 ///   directory (splitting on the first newline so a path containing newlines
 ///   survives intact) and resumes.
-/// * **`--here`** — `__CRAP_HERE__\n<session-id>\n<link-or-sentinel>`: the binary
-///   has already symlinked the session into the *current* directory's project
-///   folder, so the function stays put, resumes with `--fork-session` (a fresh
-///   session id, leaving the original transcript untouched), and finally removes
-///   that symlink — unless the link field is `__CRAP_NO_LINK__`, meaning none
-///   was created because this already is the session's own directory.
+/// * **`--here`** — `__CRAP_HERE__\n<session-id>\n<new-id-or-sentinel>\n<link-or-sentinel>`:
+///   the binary has already symlinked the session into the *current* directory's
+///   project folder, so the function stays put, resumes with `--fork-session` (a
+///   fresh session id, leaving the original transcript untouched), and finally
+///   removes that symlink — unless the link field is `__CRAP_NO_LINK__`, meaning
+///   none was created because this already is the session's own directory. When
+///   the new-id field is not `__CRAP_NO_NEW_ID__`, the fork is pinned to that id
+///   via `--session-id` instead of a random one.
 const SHELL_CODE: &str = r#"
 function crap() {
     # These flags make the binary print to stdout and exit 0 without mutating
@@ -825,9 +827,11 @@ function crap() {
     local __crap_out
     __crap_out=$(command crap "$@") || return $?
     if [ "${__crap_out%%$'\n'*}" = "__CRAP_HERE__" ]; then
-        local __crap_rest __crap_session __crap_link __crap_folder __crap_n0 __crap_watcher
+        local __crap_rest __crap_session __crap_newid __crap_link __crap_folder __crap_n0 __crap_watcher
         __crap_rest=${__crap_out#*$'\n'}
         __crap_session=${__crap_rest%%$'\n'*}
+        __crap_rest=${__crap_rest#*$'\n'}
+        __crap_newid=${__crap_rest%%$'\n'*}
         __crap_link=${__crap_rest#*$'\n'}
         if [ "$__crap_link" != "__CRAP_NO_LINK__" ]; then
             # Claude only needs the symlink while it reads the transcript at
@@ -850,10 +854,20 @@ function crap() {
             __crap_watcher=$!
             disown 2>/dev/null
         fi
+        # Build the resume argv: always --fork-session, so the original
+        # transcript is left untouched. When the binary supplied a forced id
+        # (third field is not the sentinel), pin the fork to it with
+        # --session-id instead of letting Claude mint a random one. The earlier
+        # "command crap" call has already consumed the function's own arguments,
+        # so reusing the positional parameters here is safe.
+        set -- --resume "$__crap_session" --fork-session
+        if [ "$__crap_newid" != "__CRAP_NO_NEW_ID__" ]; then
+            set -- "$@" --session-id "$__crap_newid"
+        fi
         if command -v clauded >/dev/null 2>&1; then
-            eval 'clauded --resume "$__crap_session" --fork-session'
+            eval 'clauded "$@"'
         else
-            claude --resume "$__crap_session" --fork-session
+            claude "$@"
         fi
         if [ "$__crap_link" != "__CRAP_NO_LINK__" ]; then
             kill "$__crap_watcher" 2>/dev/null

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -910,14 +910,22 @@ struct Cli {
     shell_setup: bool,
 }
 
-/// Aborts with a clear message if `session_id` is already open in another live
-/// process, unless `force` overrides the check.
+/// Whether a session that is already live in another process should block a
+/// resume of it.
 ///
-/// Both resume modes call this: two processes writing one session log can
-/// corrupt it, and even `--here`'s fork reads the live transcript while it is
-/// being written. `--force` bypasses the guard.
-fn abort_if_session_live(session_id: &str, force: bool) {
-    if force {
+/// The default resume mode reuses the session id, so a second process would
+/// append to the same transcript as the live one — that can corrupt it, so a
+/// live session blocks the resume unless `--force` overrides it. The `here`
+/// flag is threaded through for the `--here` fork path (see Phase 3) but is not
+/// yet consulted.
+fn should_block_for_live(_here: bool, force: bool) -> bool {
+    !force
+}
+
+/// Aborts with a clear message if `session_id` is already open in another live
+/// process and [`should_block_for_live`] says that should block this resume.
+fn abort_if_session_live(session_id: &str, here: bool, force: bool) {
+    if !should_block_for_live(here, force) {
         return;
     }
     if let Some(live) =
@@ -951,7 +959,7 @@ fn run_here(projects_dir: &Path, session_id: &str, force: bool) -> ! {
     };
 
     // Guard before creating anything, so an aborted resume leaves no stray link.
-    abort_if_session_live(session_id, force);
+    abort_if_session_live(session_id, true, force);
 
     match resolve_here_link(projects_dir, &pwd, session_id) {
         Ok(link) => {
@@ -1078,7 +1086,7 @@ fn main() {
 
     match resolve_session_dir(&projects_dir, &session_id) {
         Ok(dir) => {
-            abort_if_session_live(&session_id, cli.force);
+            abort_if_session_live(&session_id, false, cli.force);
             print!("{}", format_output(&dir, &session_id));
         }
         Err(ResolveError::InvalidSessionId) => {
@@ -1126,6 +1134,17 @@ mod tests {
     /// Builds a single JSONL line recording `cwd`.
     fn cwd_line(cwd: &str) -> String {
         format!("{}\n", serde_json::json!({ "cwd": cwd }))
+    }
+
+    #[test]
+    fn default_mode_blocks_a_live_session_unless_forced() {
+        // Default resume reuses the session id, so a live original must block.
+        assert!(should_block_for_live(false, false));
+    }
+
+    #[test]
+    fn force_overrides_the_live_block_in_default_mode() {
+        assert!(!should_block_for_live(false, true));
     }
 
     #[test]

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -754,12 +754,12 @@ fn format_here_output(
     new_session_id: Option<&str>,
     link_to_cleanup: Option<&Path>,
 ) -> String {
-    let _new_id = new_session_id.unwrap_or(NO_NEW_ID_SENTINEL);
+    let new_id = new_session_id.unwrap_or(NO_NEW_ID_SENTINEL);
     let link = match link_to_cleanup {
         Some(path) => path.display().to_string(),
         None => NO_LINK_SENTINEL.to_string(),
     };
-    format!("{HERE_SENTINEL}\n{session_id}\n{link}\n")
+    format!("{HERE_SENTINEL}\n{session_id}\n{new_id}\n{link}\n")
 }
 
 /// The shell function installed by `crap --shell-setup`.

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -396,9 +396,13 @@ struct InvalidNewSessionId;
 ///
 /// Returns [`InvalidNewSessionId`] if `new_session_id` is `Some` but not a UUID.
 fn resolve_new_session_id(
-    _new_session_id: Option<&str>,
+    new_session_id: Option<&str>,
 ) -> Result<Option<&str>, InvalidNewSessionId> {
-    Err(InvalidNewSessionId)
+    match new_session_id {
+        None => Ok(None),
+        Some(id) if is_valid_session_id(id) => Ok(Some(id)),
+        Some(_) => Err(InvalidNewSessionId),
+    }
 }
 
 /// Returns the `~/.claude/sessions` directory, or `None` if the home directory

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -2524,6 +2524,32 @@ mod tests {
     }
 
     #[test]
+    fn dir_statuses_table_never_wraps_cells_to_fit_a_narrow_terminal() {
+        // The status table must render at its natural content width regardless of
+        // the terminal: a session UUID or timestamp chopped across lines is
+        // unreadable, and tying the layout to the ambient terminal width makes the
+        // output (and every test that asserts on it) depend on a shared,
+        // uncontrolled resource — a flaky-test trap. Force an absurdly narrow
+        // width and demand every cell still appears whole on one line.
+        let reports = vec![SessionStatusReport {
+            session_id: ID_A.to_string(),
+            state: "waiting-for-user".to_string(),
+            started: Some("2026-05-25T10:00:00.000Z".to_string()),
+            last: Some("2026-05-25T12:30:45.000Z".to_string()),
+        }];
+        let mut table = dir_statuses_table(&reports);
+        table.set_width(20);
+        let rendered = table.to_string();
+        assert!(
+            rendered.contains(ID_A),
+            "UUID must stay intact at narrow width, got:\n{rendered}"
+        );
+        assert!(rendered.contains("waiting-for-user"));
+        assert!(rendered.contains("2026-05-25 10:00:00"));
+        assert!(rendered.contains("2026-05-25 12:30:45"));
+    }
+
+    #[test]
     fn format_dir_statuses_uses_plural_and_dash_for_missing_times() {
         let reports = vec![
             SessionStatusReport {

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -414,8 +414,11 @@ fn resolve_new_session_id(
 /// already names a session would let the fork overwrite an unrelated
 /// conversation — the opposite of `--here`'s "leave the original untouched"
 /// guarantee. `None` (no forced id, Claude mints a random one) never collides.
-fn new_session_id_collides(_projects_dir: &Path, _new_session_id: Option<&str>) -> bool {
-    false
+fn new_session_id_collides(projects_dir: &Path, new_session_id: Option<&str>) -> bool {
+    match new_session_id {
+        Some(id) => find_session_file(projects_dir, id).is_some(),
+        None => false,
+    }
 }
 
 /// Returns the `~/.claude/sessions` directory, or `None` if the home directory

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -380,6 +380,27 @@ fn resolve_here_link(
     prepare_here_link(projects_dir, &original, pwd, session_id).map_err(HereResolveError::Io)
 }
 
+/// A caller-supplied `--here` new-session id that is not a valid UUID.
+#[derive(Debug, PartialEq, Eq)]
+struct InvalidNewSessionId;
+
+/// Validates the optional forked-session id a caller passed as the second
+/// `--here` argument.
+///
+/// Returns `Ok(None)` when none was supplied (so Claude mints a fresh random
+/// id), `Ok(Some(id))` when it is a valid UUID, and `Err(InvalidNewSessionId)`
+/// when one was supplied but is malformed. Validating up front keeps a bad id
+/// from ever reaching the shell function's `claude --session-id`.
+///
+/// # Errors
+///
+/// Returns [`InvalidNewSessionId`] if `new_session_id` is `Some` but not a UUID.
+fn resolve_new_session_id(
+    _new_session_id: Option<&str>,
+) -> Result<Option<&str>, InvalidNewSessionId> {
+    Err(InvalidNewSessionId)
+}
+
 /// Returns the `~/.claude/sessions` directory, or `None` if the home directory
 /// cannot be determined.
 ///
@@ -877,6 +898,15 @@ struct Cli {
     )]
     session_id: Option<String>,
 
+    /// Id to assign the forked session created by `--here` (must be a UUID).
+    ///
+    /// Only valid with `--here`. When given, the resumed fork is created with
+    /// this exact id (`claude --fork-session --session-id <id>`) instead of a
+    /// random one — useful when a caller needs to know the new id in advance.
+    /// Without it, Claude mints a fresh random id as before.
+    #[arg(value_name = "NEW_SESSION_ID", requires = "here")]
+    new_session_id: Option<String>,
+
     /// Resume even if the session appears to be running in another process.
     ///
     /// By default `crap` refuses to resume a session that is already open
@@ -968,9 +998,10 @@ fn abort_if_session_live(session_id: &str, here: bool, force: bool) {
     }
 }
 
-/// Handles `crap --here <id>`: symlink the session into the current directory's
-/// project folder and emit the here-mode output the shell function consumes.
-fn run_here(projects_dir: &Path, session_id: &str, force: bool) -> ! {
+/// Handles `crap --here <id> [<new-id>]`: symlink the session into the current
+/// directory's project folder and emit the here-mode output the shell function
+/// consumes, optionally pinning the forked session's id to `new_session_id`.
+fn run_here(projects_dir: &Path, session_id: &str, new_session_id: Option<&str>, force: bool) -> ! {
     let Ok(pwd) = std::env::current_dir() else {
         eprintln!(
             "{} could not determine the current directory",
@@ -979,12 +1010,29 @@ fn run_here(projects_dir: &Path, session_id: &str, force: bool) -> ! {
         exit(exit_codes::HERE_PWD_UNAVAILABLE);
     };
 
+    // Validate the optional forced id before creating anything, so a bad id
+    // aborts without leaving a stray symlink behind.
+    let new_id = match resolve_new_session_id(new_session_id) {
+        Ok(id) => id,
+        Err(InvalidNewSessionId) => {
+            eprintln!(
+                "{} '{}' is not a valid session id",
+                "Error:".red().bold(),
+                new_session_id.unwrap_or_default()
+            );
+            exit(exit_codes::INVALID_SESSION_ID);
+        }
+    };
+
     // Guard before creating anything, so an aborted resume leaves no stray link.
     abort_if_session_live(session_id, true, force);
 
     match resolve_here_link(projects_dir, &pwd, session_id) {
         Ok(link) => {
-            print!("{}", format_here_output(session_id, None, link.as_deref()));
+            print!(
+                "{}",
+                format_here_output(session_id, new_id, link.as_deref())
+            );
             exit(0);
         }
         Err(HereResolveError::InvalidSessionId) => {
@@ -1102,7 +1150,12 @@ fn main() {
         .expect("session id is required without --shell-setup or --status");
 
     if cli.here {
-        run_here(&projects_dir, &session_id, cli.force);
+        run_here(
+            &projects_dir,
+            &session_id,
+            cli.new_session_id.as_deref(),
+            cli.force,
+        );
     }
 
     match resolve_session_dir(&projects_dir, &session_id) {
@@ -1166,6 +1219,27 @@ mod tests {
     #[test]
     fn force_overrides_the_live_block_in_default_mode() {
         assert!(!should_block_for_live(false, true));
+    }
+
+    #[test]
+    fn resolve_new_session_id_accepts_a_valid_uuid() {
+        // A well-formed UUID is passed through so `--here` can pin the fork.
+        assert_eq!(resolve_new_session_id(Some(ID_B)), Ok(Some(ID_B)));
+    }
+
+    #[test]
+    fn resolve_new_session_id_absent_is_none() {
+        // No second argument means Claude mints a fresh random id, as before.
+        assert_eq!(resolve_new_session_id(None), Ok(None));
+    }
+
+    #[test]
+    fn resolve_new_session_id_rejects_a_non_uuid() {
+        // A malformed id must be caught before it reaches `claude --session-id`.
+        assert_eq!(
+            resolve_new_session_id(Some("not-a-uuid")),
+            Err(InvalidNewSessionId)
+        );
     }
 
     #[test]

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -1148,6 +1148,14 @@ mod tests {
     }
 
     #[test]
+    fn here_mode_never_blocks_a_live_session() {
+        // `--here` resumes with `--fork-session`: it only reads the original
+        // transcript and writes a fresh file, so a live original can never be
+        // corrupted by it. A live session must therefore not block `--here`.
+        assert!(!should_block_for_live(true, false));
+    }
+
+    #[test]
     fn extract_cwd_returns_first_non_null_cwd() {
         let contents = format!(
             "{}{}{}{}",

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -735,6 +735,13 @@ fn format_dir_statuses(pwd: &Path, reports: &[SessionStatusReport]) -> String {
     }
     let count = reports.len();
     let noun = if count == 1 { "session" } else { "sessions" };
+    let table = dir_statuses_table(reports);
+    format!("{count} {noun} for {}\n\n{table}\n", pwd.display())
+}
+
+/// Builds the session-status table — one row per report, timestamps prettified
+/// into the cells — ready for rendering.
+fn dir_statuses_table(reports: &[SessionStatusReport]) -> Table {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -756,7 +763,7 @@ fn format_dir_statuses(pwd: &Path, reports: &[SessionStatusReport]) -> String {
             last,
         ]);
     }
-    format!("{count} {noun} for {}\n\n{table}\n", pwd.display())
+    table
 }
 
 /// Formats the binary's success output for the shell function to read back.

--- a/src/crap/src/main.rs
+++ b/src/crap/src/main.rs
@@ -57,6 +57,8 @@ mod exit_codes {
     pub const HERE_LINK_ERROR: i32 = 8;
     /// `--here`: the current working directory could not be determined.
     pub const HERE_PWD_UNAVAILABLE: i32 = 9;
+    /// `--here`: the requested new session id already names a transcript.
+    pub const NEW_SESSION_ID_EXISTS: i32 = 10;
 }
 
 /// Why a session id could not be resolved to an existing directory.
@@ -403,6 +405,17 @@ fn resolve_new_session_id(
         Some(id) if is_valid_session_id(id) => Ok(Some(id)),
         Some(_) => Err(InvalidNewSessionId),
     }
+}
+
+/// Whether pinning a `--here` fork to `new_session_id` would collide with an
+/// existing transcript.
+///
+/// `claude --session-id <id>` writes to `<id>.jsonl`, so reusing an id that
+/// already names a session would let the fork overwrite an unrelated
+/// conversation — the opposite of `--here`'s "leave the original untouched"
+/// guarantee. `None` (no forced id, Claude mints a random one) never collides.
+fn new_session_id_collides(_projects_dir: &Path, _new_session_id: Option<&str>) -> bool {
+    false
 }
 
 /// Returns the `~/.claude/sessions` directory, or `None` if the home directory
@@ -1042,6 +1055,18 @@ fn run_here(projects_dir: &Path, session_id: &str, new_session_id: Option<&str>,
         }
     };
 
+    // Refuse to pin the fork to an id that already names a transcript: that
+    // would let `claude --session-id` overwrite an unrelated session.
+    if new_session_id_collides(projects_dir, new_id) {
+        eprintln!(
+            "{} a session with id '{}' already exists",
+            "Error:".red().bold(),
+            new_id.unwrap_or_default()
+        );
+        eprintln!("       choose a fresh id so the fork does not overwrite it");
+        exit(exit_codes::NEW_SESSION_ID_EXISTS);
+    }
+
     // Guard before creating anything, so an aborted resume leaves no stray link.
     abort_if_session_live(session_id, true, force);
 
@@ -1258,6 +1283,26 @@ mod tests {
             resolve_new_session_id(Some("not-a-uuid")),
             Err(InvalidNewSessionId)
         );
+    }
+
+    #[test]
+    fn new_session_id_collides_when_the_id_already_exists() {
+        // Pinning a fork to an id that already names a transcript would let it
+        // overwrite that conversation, so it must be reported as a collision.
+        let projects = tempdir().unwrap();
+        let folder = projects.path().join("some-project");
+        fs::create_dir_all(&folder).unwrap();
+        fs::write(folder.join(format!("{ID_B}.jsonl")), "{}\n").unwrap();
+        assert!(new_session_id_collides(projects.path(), Some(ID_B)));
+    }
+
+    #[test]
+    fn new_session_id_does_not_collide_when_unused_or_absent() {
+        let projects = tempdir().unwrap();
+        fs::create_dir_all(projects.path().join("some-project")).unwrap();
+        // An id no transcript uses is free, and "no forced id" never collides.
+        assert!(!new_session_id_collides(projects.path(), Some(ID_B)));
+        assert!(!new_session_id_collides(projects.path(), None));
     }
 
     #[test]

--- a/src/crap/tests/here_new_id.rs
+++ b/src/crap/tests/here_new_id.rs
@@ -1,0 +1,113 @@
+//! End-to-end tests for `crap --here <session> [<new-id>]` driving the real
+//! binary, verifying the optional forced new session id rides through to the
+//! here-mode protocol the shell function consumes.
+//!
+//! These run the compiled `crap` against a throwaway `HOME`, so they exercise
+//! CLI parsing, validation, and output formatting together — the glue that the
+//! in-crate unit tests cannot reach because `run_here` calls `exit`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A resolvable original session id, created in every throwaway `HOME`.
+const ORIG: &str = "11111111-2222-3333-4444-555555555555";
+/// A well-formed UUID used as the caller-supplied forked-session id.
+const NEW: &str = "99999999-8888-7777-6666-555555555555";
+
+// These mirror the binary's `--here` wire protocol (see `format_here_output`
+// in `main.rs`); an integration test deliberately re-states the contract it is
+// pinning rather than reaching into private constants.
+const HERE_SENTINEL: &str = "__CRAP_HERE__";
+const NO_NEW_ID_SENTINEL: &str = "__CRAP_NO_NEW_ID__";
+
+/// A process-unique temp directory, keyed on pid + nanoseconds so concurrent
+/// runs of this test never share state.
+fn unique_root(tag: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("crap-it-{tag}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Sets up a throwaway `HOME` containing the resolvable session [`ORIG`], then
+/// runs the real `crap --here ORIG <extra_args>` binary from a fresh working
+/// directory. Returns the captured process output.
+fn run_here(tag: &str, extra_args: &[&str]) -> Output {
+    let root = unique_root(tag);
+    let home = root.join("home");
+    let session_folder = home.join(".claude").join("projects").join("orig-project");
+    fs::create_dir_all(&session_folder).unwrap();
+    fs::write(
+        session_folder.join(format!("{ORIG}.jsonl")),
+        "{\"cwd\":\"/x\"}\n",
+    )
+    .unwrap();
+
+    let work = root.join("work");
+    fs::create_dir_all(&work).unwrap();
+
+    let mut args = vec!["--here", ORIG];
+    args.extend_from_slice(extra_args);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_crap"))
+        .env("HOME", &home)
+        .current_dir(&work)
+        .args(&args)
+        .output()
+        .expect("crap binary should run");
+
+    let _ = fs::remove_dir_all(&root);
+    output
+}
+
+#[test]
+fn here_pins_supplied_new_session_id() {
+    let out = run_here("pins", &[NEW]);
+    assert!(
+        out.status.success(),
+        "exit status was {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.first().copied(), Some(HERE_SENTINEL));
+    assert_eq!(lines.get(1).copied(), Some(ORIG));
+    // The forced id rides as the third field for the shell's `--session-id`.
+    assert_eq!(lines.get(2).copied(), Some(NEW));
+}
+
+#[test]
+fn here_without_new_id_uses_sentinel() {
+    let out = run_here("plain", &[]);
+    assert!(
+        out.status.success(),
+        "exit status was {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    // Without a forced id the third field is the sentinel, so the shell lets
+    // Claude mint a fresh random id.
+    assert_eq!(lines.get(2).copied(), Some(NO_NEW_ID_SENTINEL));
+}
+
+#[test]
+fn here_rejects_invalid_new_id() {
+    let out = run_here("bad", &["not-a-uuid"]);
+    assert!(
+        !out.status.success(),
+        "a malformed new id must abort the resume"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not a valid session id"),
+        "stderr: {stderr}"
+    );
+}

--- a/src/crap/tests/here_new_id.rs
+++ b/src/crap/tests/here_new_id.rs
@@ -38,15 +38,29 @@ fn unique_root(tag: &str) -> PathBuf {
 /// runs the real `crap --here ORIG <extra_args>` binary from a fresh working
 /// directory. Returns the captured process output.
 fn run_here(tag: &str, extra_args: &[&str]) -> Output {
+    run_here_planting(tag, extra_args, &[])
+}
+
+/// Like [`run_here`], but also plants a transcript for each id in `also_plant`,
+/// so collisions with an existing session can be exercised.
+fn run_here_planting(tag: &str, extra_args: &[&str], also_plant: &[&str]) -> Output {
     let root = unique_root(tag);
     let home = root.join("home");
-    let session_folder = home.join(".claude").join("projects").join("orig-project");
+    let projects = home.join(".claude").join("projects");
+
+    let session_folder = projects.join("orig-project");
     fs::create_dir_all(&session_folder).unwrap();
     fs::write(
         session_folder.join(format!("{ORIG}.jsonl")),
         "{\"cwd\":\"/x\"}\n",
     )
     .unwrap();
+
+    let extra_folder = projects.join("other-project");
+    fs::create_dir_all(&extra_folder).unwrap();
+    for id in also_plant {
+        fs::write(extra_folder.join(format!("{id}.jsonl")), "{}\n").unwrap();
+    }
 
     let work = root.join("work");
     fs::create_dir_all(&work).unwrap();
@@ -96,6 +110,19 @@ fn here_without_new_id_uses_sentinel() {
     // Without a forced id the third field is the sentinel, so the shell lets
     // Claude mint a fresh random id.
     assert_eq!(lines.get(2).copied(), Some(NO_NEW_ID_SENTINEL));
+}
+
+#[test]
+fn here_rejects_a_new_id_that_already_exists() {
+    // Pinning the fork to an id that already names a transcript would overwrite
+    // it, so `--here` must refuse before launching Claude.
+    let out = run_here_planting("collide", &[NEW], &[NEW]);
+    assert!(
+        !out.status.success(),
+        "a colliding new id must abort the resume"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("already exists"), "stderr: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds an optional second positional to `crap --here`:

```bash
crap --here <SESSION_ID> <NEW_SESSION_ID>   # NEW_SESSION_ID is optional
```

When given, the forked session created by `--here` is pinned to that exact UUID via `claude --fork-session --session-id <id>` instead of getting a random one. Omit it to keep the existing random-id behavior. This lets a caller know the resumed session's id in advance (e.g. generate a UUID, hand it to `crap --here`, and you already know where the new transcript will live).

## Why it touches the shell integration

The binary never launches `claude` — the installed shell function does. So the new id has to travel **binary → stdout protocol → shell function → `claude --session-id`**. The `--here` wire protocol gained a fourth field (the forced id, or `__CRAP_NO_NEW_ID__`), inserted *before* the newline-prone cleanup link so the link stays last. `SHELL_CODE` now parses that field and appends `--session-id "$__crap_newid"` to the resume on both the `clauded` and plain `claude` paths.

## Safety

- The new id must be a valid UUID (rejected up front, before any symlink is created).
- `crap` refuses an id that already names an existing session, so a fork can never overwrite an unrelated transcript — preserving `--here`'s "the original is only read, never written" guarantee. New exit code `NEW_SESSION_ID_EXISTS` (10).
- `NEW_SESSION_ID` requires `--here` (clap rejects it otherwise).

## Tests (all green — 97 unit + 4 integration)

Built test-first, red→commit→green→commit per increment:

- `format_here_output` 4-field layout incl. newline-safety of the link field
- `resolve_new_session_id` accept/reject/absent
- `new_session_id_collides` against a real temp project tree
- **Real-binary** integration tests (`tests/here_new_id.rs`): pins the id, uses the sentinel when absent, rejects invalid, rejects collisions
- **Real-bash** e2e harness: asserts `claude` is resumed with `--session-id <new>` (and omitted otherwise), on both dispatch paths
- `requires = "here"` contract — **mutation-verified** (removing `requires` fails the test)
- Portability: emitted function passes `bash -n` + `zsh -n`, and the live zsh runtime was confirmed to pass `--session-id` correctly

## Note for the reviewer

The shell passes `--fork-session --session-id <new>` together. Both flags exist (`claude --help`), but I didn't run live interactive `claude` to confirm they compose. `--fork-session` is kept always-on so that if `claude` ever ignored the pair it degrades to a random id (no data loss) rather than appending to the original. If `claude` instead *errors* on the combo, the fix is one line — drop `--fork-session` when `__crap_newid` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
