### PR TITLE
feat(hooks): gate pre-commit on cargo test + Go (gofmt, vet, test)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
-# Reject commits that fail formatting or clippy. cargo fmt --check runs first
-# because it is fast and catches drift before the slower clippy pass.
-# --all-targets covers tests/ and benches/, where lints like
-# unseparated_literal_suffix would otherwise slip through, and -D warnings
-# turns every workspace lint into a hard error.
+# Reject commits that fail formatting, clippy, or the test suite. The three
+# Rust gates run cheapest-first so a commit fails fast on the quickest check:
+#
+#   1. cargo fmt --check  - formatting drift; no compile, so it is fastest.
+#   2. cargo clippy       - lints as hard errors. --all-targets covers tests/
+#                           and benches/, where lints like
+#                           unseparated_literal_suffix would otherwise slip
+#                           through, and -D warnings turns every workspace lint
+#                           into a hard error.
+#   3. cargo test         - the workspace test suite. Slowest, so it runs last;
+#                           clippy's --all-targets has already compiled the test
+#                           targets, so this pass is mostly incremental + run.
 #
 # The trigger regex also matches rustfmt.toml and rust-toolchain.toml at the
 # repo root: a commit that bumps the toolchain or style config is the scenario
 # most likely to introduce drift, so the gate must run on those changes too.
 #
-# Both checks read the WORKING TREE, not the staged index, so a partially
+# All three checks read the WORKING TREE, not the staged index, so a partially
 # staged file (or one staged then edited) is checked in its on-disk state, not
 # the version being committed. This is a deliberate trade-off: index-only
 # checking (stash --keep-index dances) is fragile, and the workspace-wide cargo
@@ -21,4 +28,6 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo
     cargo fmt --all -- --check
     echo "pre-commit: running cargo clippy --all-targets --workspace -- -D warnings"
     cargo clippy --all-targets --workspace -- -D warnings
+    echo "pre-commit: running cargo test --workspace"
+    cargo test --workspace
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Reject commits that fail formatting, clippy, or the test suite. The three
-# Rust gates run cheapest-first so a commit fails fast on the quickest check:
+# Reject commits that fail formatting, linting, or the test suite, for both
+# languages in this repo: Rust first, then Go. Each language's gates only run
+# when a staged change touches that language's files (see the trigger regexes
+# below), so a Go-only commit never pays for the Rust toolchain and vice versa.
+#
+# The three Rust gates run cheapest-first so a commit fails fast on the
+# quickest check:
 #
 #   1. cargo fmt --check  - formatting drift; no compile, so it is fastest.
 #   2. cargo clippy       - lints as hard errors. --all-targets covers tests/
@@ -30,4 +35,29 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo
     cargo clippy --all-targets --workspace -- -D warnings
     echo "pre-commit: running cargo test --workspace"
     cargo test --workspace
+fi
+
+# The Go module gets the same treatment, again cheapest-first:
+#   1. gofmt -l   - format check; no compile, so it is fastest. gofmt -l lists
+#                   any file whose formatting differs; a non-empty list fails.
+#   2. go vet     - compiles + runs the static analysers (printf mismatches,
+#                   unreachable code, etc.).
+#   3. go test    - compiles + runs the suite. Slowest, so it runs last.
+#
+# These run in Go's default readonly module mode. That mode does not modify
+# go.sum, so a fresh worktree with a COLD module cache may report
+# "missing go.sum entry" on the first Go commit. The module cache lives at
+# $GOPATH/pkg/mod and is shared across every worktree, so warming it once with
+# `go mod download all` fixes this for all of them.
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.go$|(^|/)go\.(mod|sum)$'; then
+    echo "pre-commit: running gofmt -l (format check)"
+    gofmt_unformatted=$(gofmt -l .)
+    if [ -n "$gofmt_unformatted" ]; then
+        printf 'gofmt: these files are not formatted (run: gofmt -w .):\n%s\n' "$gofmt_unformatted" >&2
+        exit 1
+    fi
+    echo "pre-commit: running go vet ./..."
+    go vet ./...
+    echo "pre-commit: running go test ./..."
+    go test ./...
 fi


### PR DESCRIPTION
## What

Extends the husky pre-commit hook to run the test suites (and Go checks), not just Rust fmt + clippy.

- **Rust**: adds `cargo test --workspace` after `cargo fmt --check` and `cargo clippy` — cheapest-first (fmt → clippy → test) so a commit still fails fast on the quickest check.
- **Go**: new block running `gofmt -l` (format check) → `go vet ./...` → `go test ./...`, triggered when a staged change touches `.go`/`go.mod`/`go.sum`.

The two language blocks have independent triggers, so a commit only pays for the toolchain it actually touches.

## Why

The gate compiled test code (via clippy `--all-targets`) but never *ran* it, so a test that compiled cleanly yet failed at runtime (e.g. the `crap` `format_dir_statuses` regression) sailed straight through commit. Go was not gated at all.

## Verification

- **Rust gate** mutation-tested in an isolated temp crate: failing test → rejected (exit 101) *after* fmt+clippy pass; passing test → allowed.
- **Go gate** mutation-tested in an isolated stdlib-only module: unformatted → rejected at `gofmt`; `printf` mismatch → rejected at `go vet`; failing test → rejected at `go test`; clean → allowed.
- **End-to-end smoke**: a real `git commit` of a misformatted `.go` file was rejected by husky → the hook → the gofmt gate (HEAD unchanged), proving the hook fires on real commits.
- **Baseline green**: full `cargo test --workspace` (86 suites, 0 failures) and readonly `go vet`/`go test` pass.
- **Shellcheck-clean.**

Note: `go.sum` needed no change (`go mod tidy` is a no-op); the earlier "missing go.sum entry" errors were a cold module cache in a fresh worktree — documented in the hook with the one-time `go mod download all` warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)