### PR TITLE
feat(portplz): derive per-user ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,16 +1221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "claude-usage"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "csv",
- "serde",
-]
-
-[[package]]
 name = "clipboard-random"
 version = "0.1.0"
 dependencies = [
@@ -1670,27 +1660,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -5680,6 +5649,7 @@ name = "portplz-core"
 version = "0.1.0"
 dependencies = [
  "gix",
+ "libc",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",

--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
 - Used as the foundation for clipboard transformation tools like `htmlboard`, `jsonboard`, and `unescapeboard`
 
 ### portplz-core
-A shared Rust library that derives a deterministic, unprivileged TCP port from a git repository's root name and
-current branch (or, with no git, a directory name). It hides SHA-256 hashing and `gix` repository discovery behind
-a single `derive()` entry point. Used by `portplz` (which prints the port) and `sirn` (which serves on it), so both
-agree on the same port for a given project without `portplz` needing to be installed.
+A shared Rust library that derives a deterministic, unprivileged TCP port from a git repository's root name,
+current branch, and the current user (or, with no git, a directory name plus the user). Mixing in the user means
+two people on the same machine get different ports for the same repo and branch, so they can run the same project
+side by side without colliding. It hides SHA-256 hashing, `gix` repository discovery, and user detection behind a
+single `derive()` entry point. Used by `portplz` (which prints the port) and `sirn` (which serves on it), so both
+agree on the same port for a given project and user without `portplz` needing to be installed. Set `PORTPLZ_UID`
+to a fixed integer to override the detected user (handy for reproducing a teammate's port or pinning one in
+containers/CI).
 
 ## The tools
 
@@ -104,16 +108,18 @@ agree on the same port for a given project without `portplz` needing to be insta
       I thought that was cooler. Just run `subito topic1 topic2 topic3 ...` and you'll see the messages.
     - To install: `go install github.com/timmattison/tools/cmd/subito@latest`
 - portplz
-    - Generates an unprivileged port number based on the name of the current directory and git branch. Nice for picking a port number
-      for a service that needs to live behind a reverse proxy that also needs to be consistent across deployments and
-      separate instances/VMs.
+    - Generates an unprivileged port number based on the name of the current directory, the git branch, and the current
+      user. Mixing in the user lets two people run the same branch of the same repo at the same time without colliding.
+      Nice for picking a port number for a service that needs to live behind a reverse proxy that also needs to be
+      consistent across deployments and separate instances/VMs. Set `PORTPLZ_UID` to a fixed integer to override the
+      detected user.
     - To install: `cargo install --git https://github.com/timmattison/tools portplz`
 - sirn
     - Serve It Right Now — a tiny, zero-config HTTP file server. Run `sirn <file>...` to serve each file at
       `/<basename>`, or `sirn` with no arguments to serve the current directory as a browsable tree. The listening
-      port is derived automatically from the git repo root and branch (the same algorithm as `portplz`), so a given
-      project always serves on a stable port; override it with `-p/--port`. Binds `127.0.0.1` by default — use
-      `--bind 0.0.0.0` to expose it on the LAN.
+      port is derived automatically from the git repo root, branch, and current user (the same algorithm as `portplz`),
+      so a given project always serves on a stable port and two users on one machine don't collide; override it with
+      `-p/--port`. Binds `127.0.0.1` by default — use `--bind 0.0.0.0` to expose it on the LAN.
     - To install: `cargo install --git https://github.com/timmattison/tools sirn`
 - uuidplz
     - Generates UUIDs. With no input it prints a random v4 UUID. Given a string or a file it seeds a name-based

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ containers/CI).
 - portplz
     - Generates an unprivileged port number based on the name of the current directory, the git branch, and the current
       user. Mixing in the user lets two people run the same branch of the same repo at the same time without colliding.
-      Nice for picking a port number for a service that needs to live behind a reverse proxy that also needs to be
-      consistent across deployments and separate instances/VMs. Set `PORTPLZ_UID` to a fixed integer to override the
-      detected user.
+      Because the user is mixed in, the derived port is *not* the same across machines by default — different
+      deployments, instances, or VMs run the service under different uids and so land on different ports. To get a port
+      that stays consistent across deployments and separate instances/VMs — say, for a service living behind a reverse
+      proxy — set `PORTPLZ_UID` to the same fixed integer on each, which overrides the detected user and pins the port.
     - To install: `cargo install --git https://github.com/timmattison/tools portplz`
 - sirn
     - Serve It Right Now — a tiny, zero-config HTTP file server. Run `sirn <file>...` to serve each file at

--- a/src/portplz-core/Cargo.toml
+++ b/src/portplz-core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 sha2.workspace = true
 gix.workspace = true
 thiserror.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -73,8 +73,20 @@ pub enum UserSaltError {
 /// - any other non-empty value → `Err(UserSaltError::InvalidUidOverride)`,
 ///   carrying the original untrimmed raw string
 fn parse_uid_override(raw: Option<&str>) -> Result<Option<UserSalt>, UserSaltError> {
-    // RED stub: silently drops malformed input (old behavior) so the new tests fail.
-    Ok(raw.and_then(|r| r.trim().parse::<u32>().ok()).map(UserSalt::Uid))
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        // An empty or whitespace-only value clears the override (use live detection).
+        return Ok(None);
+    }
+    match trimmed.parse::<u32>() {
+        Ok(uid) => Ok(Some(UserSalt::Uid(uid))),
+        // Carry the original untrimmed raw string so the error reflects exactly
+        // what the user set.
+        Err(_) => Err(UserSaltError::InvalidUidOverride(raw.to_string())),
+    }
 }
 
 /// Identifies the current user so two people on the same machine derive

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -289,6 +289,29 @@ mod tests {
     }
 
     #[test]
+    fn test_name_hash_component_strips_newlines() {
+        // A name containing newlines must not leak them into the hash component,
+        // or the `\n` boundary between the user and location components becomes
+        // ambiguous and two distinct (user, location) pairs could collide.
+        let component = UserSalt::Name("a\nb\rc".into()).hash_component();
+        assert!(
+            !component.contains('\n'),
+            "Name hash component must not contain a newline, got: {component:?}"
+        );
+        assert!(
+            !component.contains('\r'),
+            "Name hash component must not contain a carriage return, got: {component:?}"
+        );
+
+        // A newline-free name must pass through unchanged (no over-stripping).
+        assert_eq!(
+            UserSalt::Name("alice".into()).hash_component(),
+            "alice",
+            "a name without newlines must be unchanged"
+        );
+    }
+
+    #[test]
     fn test_describe_includes_name_label() {
         let path = std::path::Path::new("/example/myrepo");
         let d = derive(path, true, &UserSalt::Name("alice".into())).expect("derive");

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -45,6 +45,71 @@ pub fn unprivileged_port_from_string(input: &str) -> DerivedPort {
     DerivedPort(port)
 }
 
+/// Environment variable that overrides the detected user.
+///
+/// When set to a non-negative integer it replaces the live user id in the port
+/// derivation. This lets you reproduce another user's port, or pin a stable
+/// port in containers/CI where the uid differs from your workstation.
+pub const PORTPLZ_UID_ENV: &str = "PORTPLZ_UID";
+
+/// Identifies the current user so two people on the same machine derive
+/// different ports for the same repo and branch.
+///
+/// On Unix the identity is the numeric POSIX user id; on platforms without one
+/// (e.g. Windows) it falls back to the login name. Use [`UserSalt::current`] for
+/// the live value, or construct a fixed [`UserSalt::Uid`]/[`UserSalt::Name`] in
+/// tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UserSalt {
+    /// A numeric POSIX user id (the common case on Unix).
+    Uid(u32),
+    /// A login name, used where no numeric uid exists (e.g. Windows).
+    Name(String),
+}
+
+impl UserSalt {
+    /// Resolves the current user.
+    ///
+    /// Honors the [`PORTPLZ_UID_ENV`] override first; otherwise uses the live
+    /// POSIX uid on Unix, or the login name on platforms without one.
+    #[must_use]
+    pub fn current() -> Self {
+        if let Some(uid) = std::env::var(PORTPLZ_UID_ENV)
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u32>().ok())
+        {
+            return Self::Uid(uid);
+        }
+
+        #[cfg(unix)]
+        {
+            // SAFETY: `getuid` is a POSIX call that always succeeds, has no
+            // preconditions, and can neither fail nor invoke undefined behavior.
+            Self::Uid(unsafe { libc::getuid() })
+        }
+        #[cfg(not(unix))]
+        {
+            Self::Name(
+                std::env::var("USERNAME")
+                    .or_else(|_| std::env::var("USER"))
+                    .unwrap_or_else(|_| "unknown".to_string()),
+            )
+        }
+    }
+
+    /// The component mixed into the port hash to distinguish users.
+    fn hash_component(&self) -> String {
+        // RED stub: ignores the variant so every user hashes identically.
+        String::new()
+    }
+
+    /// Human-readable label appended to `--verbose` output, e.g. `uid 501`.
+    fn label(&self) -> String {
+        // RED stub: empty so the description omits the user.
+        String::new()
+    }
+}
+
 /// Describes how the port's hash input was determined.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PortSource {
@@ -104,11 +169,22 @@ fn get_git_branch(repo: &gix::Repository) -> Option<String> {
     }
 }
 
-/// The result of deriving a port: the port and how it was derived.
+/// The result of deriving a port: the port, how it was derived, and for whom.
 #[derive(Debug, Clone)]
 pub struct Derivation {
     pub port: DerivedPort,
     pub source: PortSource,
+    pub user: UserSalt,
+}
+
+impl Derivation {
+    /// One-line human-readable description including the user, e.g.
+    /// `Port 51877 for repo 'foo' on branch 'main' (uid 501)`.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        // RED stub: omits the user label.
+        self.source.describe(self.port)
+    }
 }
 
 /// Errors that can occur while deriving a port.
@@ -122,11 +198,12 @@ pub enum DeriveError {
 ///
 /// When `no_git` is true, or `path` is not inside a git repo, the directory
 /// basename is used; otherwise the repo-root name plus the current branch
-/// (detached HEAD falls back to just the repo-root name).
+/// (detached HEAD falls back to just the repo-root name). `user` is mixed into
+/// the hash so different users derive different ports for the same location.
 ///
 /// # Errors
 /// Returns [`DeriveError::NoBasename`] if `path` has no final path component.
-pub fn derive(path: &Path, no_git: bool) -> Result<Derivation, DeriveError> {
+pub fn derive(path: &Path, no_git: bool, user: &UserSalt) -> Result<Derivation, DeriveError> {
     let basename = path
         .file_name()
         .ok_or(DeriveError::NoBasename)?
@@ -148,8 +225,13 @@ pub fn derive(path: &Path, no_git: bool) -> Result<Derivation, DeriveError> {
         }
     };
 
-    let port = unprivileged_port_from_string(&source.hash_input());
-    Ok(Derivation { port, source })
+    let hash_input = format!("{}\n{}", user.hash_component(), source.hash_input());
+    let port = unprivileged_port_from_string(&hash_input);
+    Ok(Derivation {
+        port,
+        source,
+        user: user.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -168,6 +250,40 @@ mod tests {
         assert_eq!(
             unprivileged_port_from_string("example").get(),
             unprivileged_port_from_string("example").get()
+        );
+    }
+
+    #[test]
+    fn test_different_users_get_different_ports() {
+        let path = std::path::Path::new("/example/myrepo");
+        let a = derive(path, true, &UserSalt::Uid(501)).expect("derive");
+        let b = derive(path, true, &UserSalt::Uid(502)).expect("derive");
+        assert_ne!(
+            a.port.get(),
+            b.port.get(),
+            "different users must derive different ports for the same location"
+        );
+    }
+
+    #[test]
+    fn test_describe_includes_uid_label() {
+        let path = std::path::Path::new("/example/myrepo");
+        let d = derive(path, true, &UserSalt::Uid(501)).expect("derive");
+        assert!(
+            d.describe().contains("(uid 501)"),
+            "verbose description must include the uid, got: {}",
+            d.describe()
+        );
+    }
+
+    #[test]
+    fn test_describe_includes_name_label() {
+        let path = std::path::Path::new("/example/myrepo");
+        let d = derive(path, true, &UserSalt::Name("alice".into())).expect("derive");
+        assert!(
+            d.describe().contains("(user 'alice')"),
+            "verbose description must include the login name, got: {}",
+            d.describe()
         );
     }
 
@@ -338,8 +454,8 @@ mod tests {
             ],
         );
 
-        let d1 = derive(dir, false).expect("derive should succeed");
-        let d2 = derive(dir, false).expect("derive should succeed");
+        let d1 = derive(dir, false, &UserSalt::Uid(501)).expect("derive should succeed");
+        let d2 = derive(dir, false, &UserSalt::Uid(501)).expect("derive should succeed");
         assert_eq!(
             d1.port.get(),
             d2.port.get(),

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -98,15 +98,24 @@ impl UserSalt {
     }
 
     /// The component mixed into the port hash to distinguish users.
+    ///
+    /// A uid renders as its decimal digits (no separators), which contain no
+    /// newline, so prefixing it to the location's hash input keeps the
+    /// user/location boundary unambiguous.
     fn hash_component(&self) -> String {
-        // RED stub: ignores the variant so every user hashes identically.
-        String::new()
+        match self {
+            Self::Uid(uid) => uid.to_string(),
+            Self::Name(name) => name.clone(),
+        }
     }
 
-    /// Human-readable label appended to `--verbose` output, e.g. `uid 501`.
+    /// Human-readable label appended to `--verbose` output, e.g. `uid 501`
+    /// or `user 'alice'`.
     fn label(&self) -> String {
-        // RED stub: empty so the description omits the user.
-        String::new()
+        match self {
+            Self::Uid(uid) => format!("uid {uid}"),
+            Self::Name(name) => format!("user '{name}'"),
+        }
     }
 }
 
@@ -182,8 +191,11 @@ impl Derivation {
     /// `Port 51877 for repo 'foo' on branch 'main' (uid 501)`.
     #[must_use]
     pub fn describe(&self) -> String {
-        // RED stub: omits the user label.
-        self.source.describe(self.port)
+        format!(
+            "{} ({})",
+            self.source.describe(self.port),
+            self.user.label()
+        )
     }
 }
 

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -101,11 +101,16 @@ impl UserSalt {
     ///
     /// A uid renders as its decimal digits (no separators), which contain no
     /// newline, so prefixing it to the location's hash input keeps the
-    /// user/location boundary unambiguous.
+    /// user/location boundary unambiguous. For the `Name` variant, newline
+    /// characters (`\n` and `\r`) are stripped from the login name for the same
+    /// reason: the derived-port hash input uses `\n` as the boundary between the
+    /// user and location components, so a newline inside the name would make
+    /// that boundary ambiguous and let two distinct (user, location) pairs
+    /// collide onto the same port.
     fn hash_component(&self) -> String {
         match self {
             Self::Uid(uid) => uid.to_string(),
-            Self::Name(name) => name.clone(),
+            Self::Name(name) => name.chars().filter(|c| *c != '\n' && *c != '\r').collect(),
         }
     }
 

--- a/src/portplz-core/src/lib.rs
+++ b/src/portplz-core/src/lib.rs
@@ -50,7 +50,32 @@ pub fn unprivileged_port_from_string(input: &str) -> DerivedPort {
 /// When set to a non-negative integer it replaces the live user id in the port
 /// derivation. This lets you reproduce another user's port, or pin a stable
 /// port in containers/CI where the uid differs from your workstation.
+///
+/// An empty or whitespace-only value is treated as unset (live detection is
+/// used). A non-empty value that is not a non-negative integer is a hard error
+/// ([`UserSaltError::InvalidUidOverride`]) — it is no longer silently ignored,
+/// which would otherwise hand back a surprising, silently-different port.
 pub const PORTPLZ_UID_ENV: &str = "PORTPLZ_UID";
+
+/// Error resolving the current user from the environment.
+#[derive(Debug, thiserror::Error)]
+pub enum UserSaltError {
+    /// `PORTPLZ_UID` was set to a non-empty value that is not a non-negative integer.
+    #[error("PORTPLZ_UID must be a non-negative integer, but was set to '{0}'")]
+    InvalidUidOverride(String),
+}
+
+/// Parses the `PORTPLZ_UID` override value.
+///
+/// - `None`, or an empty/whitespace-only string → `Ok(None)` (no override; use
+///   live detection)
+/// - a non-negative integer (after trimming) → `Ok(Some(UserSalt::Uid(n)))`
+/// - any other non-empty value → `Err(UserSaltError::InvalidUidOverride)`,
+///   carrying the original untrimmed raw string
+fn parse_uid_override(raw: Option<&str>) -> Result<Option<UserSalt>, UserSaltError> {
+    // RED stub: silently drops malformed input (old behavior) so the new tests fail.
+    Ok(raw.and_then(|r| r.trim().parse::<u32>().ok()).map(UserSalt::Uid))
+}
 
 /// Identifies the current user so two people on the same machine derive
 /// different ports for the same repo and branch.
@@ -72,28 +97,30 @@ impl UserSalt {
     ///
     /// Honors the [`PORTPLZ_UID_ENV`] override first; otherwise uses the live
     /// POSIX uid on Unix, or the login name on platforms without one.
-    #[must_use]
-    pub fn current() -> Self {
-        if let Some(uid) = std::env::var(PORTPLZ_UID_ENV)
-            .ok()
-            .and_then(|raw| raw.trim().parse::<u32>().ok())
-        {
-            return Self::Uid(uid);
+    ///
+    /// # Errors
+    /// Returns [`UserSaltError::InvalidUidOverride`] when `PORTPLZ_UID` is set to
+    /// a non-empty value that is not a non-negative integer (e.g. `abc` or `-1`).
+    /// An empty or whitespace-only value is treated as unset and falls through to
+    /// live detection without erroring.
+    pub fn current() -> Result<Self, UserSaltError> {
+        if let Some(user) = parse_uid_override(std::env::var(PORTPLZ_UID_ENV).ok().as_deref())? {
+            return Ok(user);
         }
 
         #[cfg(unix)]
         {
             // SAFETY: `getuid` is a POSIX call that always succeeds, has no
             // preconditions, and can neither fail nor invoke undefined behavior.
-            Self::Uid(unsafe { libc::getuid() })
+            Ok(Self::Uid(unsafe { libc::getuid() }))
         }
         #[cfg(not(unix))]
         {
-            Self::Name(
+            Ok(Self::Name(
                 std::env::var("USERNAME")
                     .or_else(|_| std::env::var("USER"))
                     .unwrap_or_else(|_| "unknown".to_string()),
-            )
+            ))
         }
     }
 
@@ -254,6 +281,61 @@ pub fn derive(path: &Path, no_git: bool, user: &UserSalt) -> Result<Derivation, 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_uid_override_rejects_non_numeric() {
+        assert!(
+            parse_uid_override(Some("abc")).is_err(),
+            "a non-numeric PORTPLZ_UID must be a hard error"
+        );
+    }
+
+    #[test]
+    fn parse_uid_override_rejects_negative() {
+        assert!(
+            parse_uid_override(Some("-1")).is_err(),
+            "a negative PORTPLZ_UID must be a hard error"
+        );
+    }
+
+    #[test]
+    fn parse_uid_override_accepts_integer() {
+        assert_eq!(
+            parse_uid_override(Some("5")).expect("valid uid"),
+            Some(UserSalt::Uid(5))
+        );
+    }
+
+    #[test]
+    fn parse_uid_override_trims_surrounding_whitespace() {
+        assert_eq!(
+            parse_uid_override(Some("  7 ")).expect("valid uid"),
+            Some(UserSalt::Uid(7))
+        );
+    }
+
+    #[test]
+    fn parse_uid_override_treats_blank_as_unset() {
+        assert_eq!(
+            parse_uid_override(Some("")).expect("empty is unset"),
+            None,
+            "an empty PORTPLZ_UID must clear the override without erroring"
+        );
+        assert_eq!(
+            parse_uid_override(Some("   ")).expect("whitespace is unset"),
+            None,
+            "a whitespace-only PORTPLZ_UID must clear the override without erroring"
+        );
+    }
+
+    #[test]
+    fn parse_uid_override_treats_missing_as_unset() {
+        assert_eq!(
+            parse_uid_override(None).expect("missing is unset"),
+            None,
+            "an unset PORTPLZ_UID must use live detection without erroring"
+        );
+    }
 
     #[test]
     fn test_port_generation() {

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => env::current_dir()?,
     };
 
-    let user = portplz_core::UserSalt::current();
+    let user = portplz_core::UserSalt::current()?;
     let derivation = portplz_core::derive(&path, cli.no_git, &user)?;
 
     if cli.verbose {

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(name = "portplz")]
 #[command(version = version_string!())]
-#[command(about = "Generate a port number from the git repo root and branch name", long_about = None)]
+#[command(about = "Generate a port number from the git repo root, branch, and current user", long_about = None)]
 struct Cli {
     #[arg(help = "Directory path (defaults to current directory)")]
     path: Option<String>,

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -30,10 +30,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => env::current_dir()?,
     };
 
-    let derivation = portplz_core::derive(&path, cli.no_git)?;
+    let user = portplz_core::UserSalt::current();
+    let derivation = portplz_core::derive(&path, cli.no_git, &user)?;
 
     if cli.verbose {
-        println!("{}", derivation.source.describe(derivation.port));
+        println!("{}", derivation.describe());
     } else {
         println!("{}", derivation.port.get());
     }

--- a/src/portplz/src/main.rs
+++ b/src/portplz/src/main.rs
@@ -22,7 +22,18 @@ struct Cli {
     no_git: bool,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
+    // Render any error via Display (not the default `Termination` Debug form) so
+    // the user sees the helpful message — e.g. a malformed `PORTPLZ_UID` reports
+    // "PORTPLZ_UID must be a non-negative integer, ..." instead of an opaque
+    // `InvalidUidOverride("abc")` — then exit non-zero.
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     let path: PathBuf = match cli.path {

--- a/src/portplz/tests/cli.rs
+++ b/src/portplz/tests/cli.rs
@@ -3,17 +3,22 @@
 //! These lock in the externally-observable output of the thin-shell CLI so the
 //! refactor onto `portplz_core::derive` cannot silently change a derived port or
 //! the `--verbose` wording. The `--no-git` directory case is fully deterministic
-//! (the port arithmetic is frozen and no filesystem access occurs for `--no-git`),
-//! so the expected values are stable constants and the test is parallel-safe.
+//! once the user is pinned: each test sets `PORTPLZ_UID` on the child process
+//! (child-env only, so concurrent runs stay isolated and the result is
+//! machine-independent), and `/tmp` (basename `tmp`) does no filesystem work, so
+//! the expected values are stable constants.
 
 use std::process::Command;
 
-/// `portplz <path> --no-git` derives the port from the path's basename only,
-/// so `/tmp` (basename `tmp`) always yields this port.
-const TMP_PORT: &str = "53008";
+/// `portplz /tmp --no-git` with `PORTPLZ_UID=0` derives the port from
+/// `"0\ntmp"`, which always yields this port.
+const TMP_PORT_UID0: &str = "19642";
 
-fn run(args: &[&str]) -> String {
+/// Runs the binary with `PORTPLZ_UID` pinned so the derived port does not depend
+/// on whoever runs the test suite.
+fn run_with_uid(uid: &str, args: &[&str]) -> String {
     let output = Command::new(env!("CARGO_BIN_EXE_portplz"))
+        .env("PORTPLZ_UID", uid)
         .args(args)
         .output()
         .expect("run portplz binary");
@@ -30,13 +35,25 @@ fn run(args: &[&str]) -> String {
 
 #[test]
 fn no_git_prints_just_the_port() {
-    assert_eq!(run(&["/tmp", "--no-git"]), TMP_PORT);
+    assert_eq!(run_with_uid("0", &["/tmp", "--no-git"]), TMP_PORT_UID0);
 }
 
 #[test]
-fn no_git_verbose_prints_the_directory_description() {
+fn no_git_verbose_prints_the_directory_description_with_user() {
     assert_eq!(
-        run(&["/tmp", "--no-git", "--verbose"]),
-        format!("Port {TMP_PORT} for directory 'tmp' (no git repo)")
+        run_with_uid("0", &["/tmp", "--no-git", "--verbose"]),
+        format!("Port {TMP_PORT_UID0} for directory 'tmp' (no git repo) (uid 0)")
+    );
+}
+
+#[test]
+fn portplz_uid_override_changes_the_port() {
+    // Two different users derive different ports for the same location, so the
+    // suite stays correct even when the real runner happens to be uid 0.
+    let port_a = run_with_uid("0", &["/tmp", "--no-git"]);
+    let port_b = run_with_uid("1", &["/tmp", "--no-git"]);
+    assert_ne!(
+        port_a, port_b,
+        "PORTPLZ_UID must change the derived port for the same directory"
     );
 }

--- a/src/portplz/tests/cli.rs
+++ b/src/portplz/tests/cli.rs
@@ -47,6 +47,26 @@ fn no_git_verbose_prints_the_directory_description_with_user() {
 }
 
 #[test]
+fn portplz_rejects_malformed_uid() {
+    // A malformed PORTPLZ_UID must be a hard error, not silently ignored. Set the
+    // env var on the child only so concurrent test runs stay isolated.
+    let output = Command::new(env!("CARGO_BIN_EXE_portplz"))
+        .env("PORTPLZ_UID", "abc")
+        .args(["/tmp", "--no-git"])
+        .output()
+        .expect("run portplz binary");
+    assert!(
+        !output.status.success(),
+        "portplz must exit non-zero on a malformed PORTPLZ_UID"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("portplz stderr is valid UTF-8");
+    assert!(
+        stderr.contains("PORTPLZ_UID"),
+        "stderr must mention PORTPLZ_UID, got: {stderr:?}"
+    );
+}
+
+#[test]
 fn portplz_uid_override_changes_the_port() {
     // Two different users derive different ports for the same location, so the
     // suite stays correct even when the real runner happens to be uid 0.

--- a/src/sirn/src/main.rs
+++ b/src/sirn/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Some(p) => p.to_path_buf(),
                 None => std::env::current_dir()?,
             };
-            let user = portplz_core::UserSalt::current()?;
+            let user = portplz_core::UserSalt::current().map_err(|e| e.to_string())?;
             let d = portplz_core::derive(&derive_path, cli.no_git, &user)?;
             let src = if cli.verbose {
                 Some(d.describe())

--- a/src/sirn/src/main.rs
+++ b/src/sirn/src/main.rs
@@ -68,9 +68,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Some(p) => p.to_path_buf(),
                 None => std::env::current_dir()?,
             };
-            let d = portplz_core::derive(&derive_path, cli.no_git)?;
+            let user = portplz_core::UserSalt::current();
+            let d = portplz_core::derive(&derive_path, cli.no_git, &user)?;
             let src = if cli.verbose {
-                Some(d.source.describe(d.port))
+                Some(d.describe())
             } else {
                 None
             };

--- a/src/sirn/src/main.rs
+++ b/src/sirn/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Some(p) => p.to_path_buf(),
                 None => std::env::current_dir()?,
             };
-            let user = portplz_core::UserSalt::current();
+            let user = portplz_core::UserSalt::current()?;
             let d = portplz_core::derive(&derive_path, cli.no_git, &user)?;
             let src = if cli.verbose {
                 Some(d.describe())

--- a/src/sirn/tests/cli.rs
+++ b/src/sirn/tests/cli.rs
@@ -121,3 +121,31 @@ fn directory_mixed_with_files_aborts_startup() {
         "stderr should explain the directory cannot be mixed with files, got: {stderr}"
     );
 }
+
+/// A malformed PORTPLZ_UID must surface the helpful Display message on stderr,
+/// not the opaque Debug form of the error. portplz already renders this via its
+/// main()/run() split; sirn must match (it renders every other startup error via
+/// Display too). Set the env var on the child only so concurrent runs stay isolated.
+#[test]
+fn malformed_uid_reports_helpful_message() {
+    // A single (non-existent) file forces Files mode; build_routes inspects only
+    // basenames, so the path need not exist. Port derivation then calls
+    // UserSalt::current(), which errors on the malformed PORTPLZ_UID before any bind.
+    let output = Command::new(env!("CARGO_BIN_EXE_sirn"))
+        .env("PORTPLZ_UID", "abc")
+        .arg("/some/dir/file.txt")
+        .output()
+        .expect("spawning sirn with a malformed PORTPLZ_UID should succeed");
+
+    assert!(
+        !output.status.success(),
+        "a malformed PORTPLZ_UID should make sirn exit non-zero, got {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("PORTPLZ_UID must be a non-negative integer"),
+        "stderr should surface the helpful Display message, not the Debug form, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

`portplz` and `sirn` now derive the unprivileged TCP port from the current **user** in addition to the git repo root and branch (or directory name with `--no-git`). On Unix the user is the POSIX uid; on platforms without one (e.g. Windows) it's the login name. Two people on the same machine now get **different** ports for the same repo and branch, so they can run the same project side by side without colliding.

## PORTPLZ_UID override

Set `PORTPLZ_UID` to a fixed integer to override the detected user — handy for reproducing a teammate's port, pinning a stable port across deployments/instances/VMs (where uids differ), or in containers/CI. A malformed `PORTPLZ_UID` is a **hard error** rather than being silently ignored.

## Details

- New `UserSalt` (`Uid` / `Name`) resolved via `UserSalt::current()`, mixed into the SHA-256 hash input ahead of the location with a `\n` boundary. Newlines are stripped from login names so that boundary stays unambiguous.
- `derive()` gains a `user: &UserSalt` parameter; `Derivation` carries the user and `describe()` appends it to `--verbose` output (e.g. `… (uid 501)`).
- README + `--help` updated. The cross-deployment/VM consistency note now explains that pinning `PORTPLZ_UID` is required for a stable port across machines (since the uid is mixed in by default).

## Testing

Built test-first (red → green) throughout: per-user port divergence, verbose labelling, `PORTPLZ_UID` parsing/override, malformed-value rejection, and newline sanitization. `cargo test` and `cargo clippy --all-targets -- -D warnings` are green for `portplz-core`, `portplz`, and `sirn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)