### PR TITLE
fix(bm): address Rust port review findings (cross-volume robustness, mtime, partial summary)

### DIFF
--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -354,10 +354,19 @@ fn move_file_with(
         Ok(()) => Ok(MoveOutcome::Renamed),
         Err(err) if is_cross_device_error(&err) => {
             // Different filesystems: copy the bytes over, then remove the
-            // original only once the copy has fully succeeded.
-            copy_across_volumes(source, destination)?;
-            std::fs::remove_file(source)?;
-            Ok(MoveOutcome::Copied)
+            // original only once the copy has fully succeeded. If the copy
+            // fails partway, delete the truncated destination so a failed move
+            // never leaves a corrupt file behind; the source is left intact.
+            match copy_across_volumes(source, destination) {
+                Ok(_) => {
+                    std::fs::remove_file(source)?;
+                    Ok(MoveOutcome::Copied)
+                }
+                Err(copy_err) => {
+                    let _ = std::fs::remove_file(destination);
+                    Err(copy_err)
+                }
+            }
         }
         Err(err) => Err(err),
     }
@@ -856,7 +865,7 @@ mod tests {
             |_s, d| {
                 // A copy that writes a truncated file, then fails partway.
                 std::fs::write(d, b"par").unwrap();
-                Err(std::io::Error::new(std::io::ErrorKind::Other, "disk full"))
+                Err(std::io::Error::other("disk full"))
             },
         )
         .unwrap_err();

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -493,6 +493,24 @@ pub fn copy_file(
     Ok(total)
 }
 
+/// Returned by [`execute_plan`] when a move fails partway through a batch.
+///
+/// Carries the [`Summary`] of everything successfully moved *before* the
+/// failure, so callers can report partial progress instead of discarding it.
+#[derive(Debug, thiserror::Error)]
+#[error("moving {} to {}", .source_path.display(), .destination.display())]
+pub struct ExecuteError {
+    /// Files moved (and skipped) before the failure.
+    pub summary: Summary,
+    /// The source file whose move failed.
+    pub source_path: PathBuf,
+    /// The destination the failed move targeted.
+    pub destination: PathBuf,
+    /// The underlying I/O error.
+    #[source]
+    pub source: std::io::Error,
+}
+
 /// Execute every move in `plan`, using `copy_across_volumes` for any move that
 /// crosses a filesystem boundary.
 ///
@@ -502,29 +520,26 @@ pub fn copy_file(
 pub fn execute_plan(
     plan: &MovePlan,
     mut copy_across_volumes: impl FnMut(&Path, &Path) -> std::io::Result<u64>,
-) -> anyhow::Result<Summary> {
-    use anyhow::Context;
-
+) -> Result<Summary, ExecuteError> {
     let mut summary = Summary {
         skipped: plan.skipped.len(),
         ..Summary::default()
     };
 
     for planned in &plan.moves {
-        let outcome = move_file(&planned.source, &planned.destination, |s, d| {
+        match move_file(&planned.source, &planned.destination, |s, d| {
             copy_across_volumes(s, d)
-        })
-        .with_context(|| {
-            format!(
-                "moving {} to {}",
-                planned.source.display(),
-                planned.destination.display()
-            )
-        })?;
-
-        match outcome {
-            MoveOutcome::Renamed => summary.renamed += 1,
-            MoveOutcome::Copied => summary.copied += 1,
+        }) {
+            Ok(MoveOutcome::Renamed) => summary.renamed += 1,
+            Ok(MoveOutcome::Copied) => summary.copied += 1,
+            Err(source) => {
+                return Err(ExecuteError {
+                    summary: Summary::default(),
+                    source_path: planned.source.clone(),
+                    destination: planned.destination.clone(),
+                    source,
+                });
+            }
         }
     }
 

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -840,4 +840,35 @@ mod tests {
             "nothing should be moved when rename fails fatally"
         );
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn move_file_cleans_up_partial_destination_when_cross_volume_copy_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        std::fs::write(&src, b"payload").unwrap();
+        let dst = dir.path().join("b.txt");
+
+        let err = move_file_with(
+            &src,
+            &dst,
+            |_, _| Err(std::io::Error::from_raw_os_error(libc::EXDEV)),
+            |_s, d| {
+                // A copy that writes a truncated file, then fails partway.
+                std::fs::write(d, b"par").unwrap();
+                Err(std::io::Error::new(std::io::ErrorKind::Other, "disk full"))
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(
+            !dst.exists(),
+            "a failed cross-volume copy must not leave a truncated destination behind"
+        );
+        assert!(
+            src.exists(),
+            "source must remain after a failed cross-volume copy"
+        );
+    }
 }

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -434,16 +434,18 @@ fn already_in_destination(file: &Path, destination_canonical: Option<&Path>) -> 
 }
 
 /// Copy `source` to `destination` in chunks, invoking `on_progress` with the
-/// running byte total after each chunk. Source permissions are preserved.
+/// running byte total after each chunk. Source permissions and modification
+/// time are preserved.
 ///
 /// This is the building block for cross-volume moves: a caller wraps it with a
-/// progress bar and hands the result to [`execute_plan`]. Modification time is
-/// not preserved.
+/// progress bar and hands the result to [`execute_plan`]. The destination keeps
+/// the source's modification time so a moved file is indistinguishable from the
+/// original.
 ///
 /// # Errors
 ///
 /// Propagates any I/O error from reading the source, writing the destination,
-/// or applying permissions.
+/// applying permissions, or setting the destination timestamp.
 pub fn copy_file(
     source: &Path,
     destination: &Path,
@@ -469,9 +471,15 @@ pub fn copy_file(
     }
     writer.flush()?;
 
-    // Preserve permissions so an executable stays executable after the move.
-    let permissions = std::fs::metadata(source)?.permissions();
-    std::fs::set_permissions(destination, permissions)?;
+    // Preserve permissions and modification time so a moved file is
+    // indistinguishable from the original — important for cross-volume
+    // backup/archive moves, the primary use case. Set mtime last, after the
+    // data flush and the permission change (chmod bumps ctime, not mtime).
+    let metadata = std::fs::metadata(source)?;
+    std::fs::set_permissions(destination, metadata.permissions())?;
+    if let Ok(modified) = metadata.modified() {
+        writer.set_modified(modified)?;
+    }
 
     Ok(total)
 }

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -6,6 +6,9 @@
 //! collision-safe move planning, and a cross-volume move fallback that ordinary
 //! `rename(2)` cannot perform.
 
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+#![cfg_attr(not(test), warn(clippy::expect_used))]
+
 use std::path::{Path, PathBuf};
 
 pub use filewalker::FilterType;

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -534,7 +534,7 @@ pub fn execute_plan(
             Ok(MoveOutcome::Copied) => summary.copied += 1,
             Err(source) => {
                 return Err(ExecuteError {
-                    summary: Summary::default(),
+                    summary,
                     source_path: planned.source.clone(),
                     destination: planned.destination.clone(),
                     source,

--- a/src/bm/src/lib.rs
+++ b/src/bm/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 pub use filewalker::FilterType;
 
-/// The filename portion of a path, as an owned [`PathBuf`] of just the basename.
+/// The final path component (basename), borrowed as an [`OsStr`].
 ///
 /// Returns `None` for paths that have no final component (e.g. `/`).
 fn basename(path: &Path) -> Option<&std::ffi::OsStr> {

--- a/src/bm/src/main.rs
+++ b/src/bm/src/main.rs
@@ -128,7 +128,17 @@ fn run() -> Result<ExitCode> {
     }
 
     let start = Instant::now();
-    let summary = execute_plan(&plan, copy_across_volumes)?;
+    let summary = match execute_plan(&plan, copy_across_volumes) {
+        Ok(summary) => summary,
+        Err(err) => {
+            // A move failed mid-batch: surface what already moved before the
+            // error so a partial run isn't silent, then report the error.
+            if err.summary.moved() > 0 || err.summary.skipped > 0 {
+                print_interrupted(&err.summary, start.elapsed());
+            }
+            return Err(err.into());
+        }
+    };
     print_summary(&summary, start.elapsed());
 
     Ok(ExitCode::SUCCESS)
@@ -217,6 +227,18 @@ fn print_summary(summary: &Summary, duration: Duration) {
     println!(
         "Move complete: {moved} moved ({} renamed, {} copied across volumes), {} skipped in {:.2?} ({rate:.0} files/sec)",
         summary.renamed, summary.copied, summary.skipped, duration
+    );
+}
+
+/// Print the partial tally when a run stops early because a move failed.
+fn print_interrupted(summary: &Summary, duration: Duration) {
+    println!(
+        "Move interrupted: {} moved ({} renamed, {} copied across volumes), {} skipped in {:.2?} before the error below:",
+        summary.moved(),
+        summary.renamed,
+        summary.copied,
+        summary.skipped,
+        duration
     );
 }
 

--- a/src/bm/tests/integration.rs
+++ b/src/bm/tests/integration.rs
@@ -188,6 +188,45 @@ fn copy_file_preserves_modification_time() {
     );
 }
 
+#[test]
+fn execute_plan_reports_partial_summary_when_a_move_fails() {
+    use bm::{MovePlan, PlannedMove};
+
+    let dir = tempfile::tempdir().unwrap();
+    let src_a = dir.path().join("a.txt");
+    let src_b = dir.path().join("b.txt");
+    fs::write(&src_a, b"a").unwrap();
+    fs::write(&src_b, b"b").unwrap();
+
+    let good_dest = dir.path().join("a-moved.txt");
+    // Parent dir doesn't exist, so renaming here fails (ENOENT, not cross-device).
+    let bad_dest = dir.path().join("missing").join("b.txt");
+
+    let plan = MovePlan {
+        moves: vec![
+            PlannedMove {
+                source: src_a.clone(),
+                destination: good_dest.clone(),
+            },
+            PlannedMove {
+                source: src_b.clone(),
+                destination: bad_dest,
+            },
+        ],
+        skipped: Vec::new(),
+    };
+
+    let err = execute_plan(&plan, |_, _| panic!("no cross-volume copy expected")).unwrap_err();
+
+    assert_eq!(
+        err.summary.moved(),
+        1,
+        "the first successful move must be counted in the partial summary"
+    );
+    assert!(good_dest.exists(), "the first file was moved before the failure");
+    assert!(src_b.exists(), "the failed move leaves its source in place");
+}
+
 #[cfg(unix)]
 #[test]
 fn copy_file_preserves_unix_permissions() {

--- a/src/bm/tests/integration.rs
+++ b/src/bm/tests/integration.rs
@@ -164,6 +164,30 @@ fn copy_file_copies_contents_and_reports_progress() {
     assert_eq!(fs::read(&dst).unwrap(), data);
 }
 
+#[test]
+fn copy_file_preserves_modification_time() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("a.bin");
+    fs::write(&src, b"data").unwrap();
+    // A distinctive past mtime so "now" can't accidentally match without the fix.
+    let past = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+    std::fs::File::options()
+        .write(true)
+        .open(&src)
+        .unwrap()
+        .set_modified(past)
+        .unwrap();
+    let dst = dir.path().join("b.bin");
+
+    bm::copy_file(&src, &dst, |_| {}).unwrap();
+
+    let dst_mtime = fs::metadata(&dst).unwrap().modified().unwrap();
+    assert_eq!(
+        dst_mtime, past,
+        "destination must keep the source's modification time"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn copy_file_preserves_unix_permissions() {

--- a/src/bm/tests/integration.rs
+++ b/src/bm/tests/integration.rs
@@ -205,7 +205,7 @@ fn execute_plan_reports_partial_summary_when_a_move_fails() {
     let plan = MovePlan {
         moves: vec![
             PlannedMove {
-                source: src_a.clone(),
+                source: src_a,
                 destination: good_dest.clone(),
             },
             PlannedMove {
@@ -223,7 +223,10 @@ fn execute_plan_reports_partial_summary_when_a_move_fails() {
         1,
         "the first successful move must be counted in the partial summary"
     );
-    assert!(good_dest.exists(), "the first file was moved before the failure");
+    assert!(
+        good_dest.exists(),
+        "the first file was moved before the failure"
+    );
     assert!(src_b.exists(), "the failed move leaves its source in place");
 }
 


### PR DESCRIPTION
## Summary

Addresses the five code-review findings from the `bm` (Bulk Move) Rust port (merged in #290) that were not fixed before merge. Every fix is test-driven (red → green) and the branch passes `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and the full `bm` test suite (36 tests, 3 new).

## Findings fixed

- **Truncated destination on a failed cross-volume copy** — `move_file_with` now deletes the partial destination when `copy_across_volumes` fails partway, instead of leaving a corrupt file behind. The source is left intact.
- **Modification time not preserved on cross-volume moves** — `copy_file` now restores the source's mtime on the destination (it already preserved permissions), which matters for the backup/archive use case the tool advertises.
- **Partial tally discarded on a mid-batch error** — `execute_plan` now returns a structured `ExecuteError` carrying the partial `Summary`, and the CLI prints a `Move interrupted: …` line showing what moved before the failure.
- **Library lints** — added `#![cfg_attr(not(test), warn(clippy::unwrap_used))]` / `expect_used` to `lib.rs` (scoped off the inline test module), matching `main.rs`.
- **Doc fix** — corrected the `basename` doc comment, which claimed an owned `PathBuf` but returns `&OsStr`.

## Tests

New regression tests: partial-destination cleanup on copy failure, mtime preservation, and partial-summary-on-failure.

## Notes

Branched from the `bm` merge commit; these changes only touch `src/bm`, so they merge cleanly onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)