### PR TITLE
feat(gsw): adaptive CPU throttle for watch mode

### DIFF
--- a/plans/2026-06-26-gsw-adaptive-cpu-throttle-plan.md
+++ b/plans/2026-06-26-gsw-adaptive-cpu-throttle-plan.md
@@ -1,0 +1,306 @@
+# Plan: gsw — adaptive CPU throttle for watch mode
+
+> Source PRD/spec: `specs/2026-06-26-gsw-adaptive-cpu-throttle-design.md`
+
+Watch mode can pin a core to ~70% on a single project. The cost is the **git
+update** (`build_output` → `repo::collect_changes` plus rev-walks and a log
+walk). Two amplifiers drive it: the **1 s decay tick re-runs the entire walk**
+for a minute after any change even with zero file activity (the dominant
+idle-after-commit burn), and **sustained FS churn** fires a fresh full walk
+every debounce window, unbounded.
+
+The fix is two independent parts plus an escape hatch:
+
+- **Part A** decouples decay/resize re-renders from the git walk (cache the last
+  `Snapshot`, advance ages by a wall-clock offset at render time). Git is then
+  walked only on FS events and startup.
+- **Part B** gates the git walk with a pure, self-adjusting `Throttle`: after a
+  walk costing `D`, the next walk may start no earlier than
+  `walk_start + max(FLOOR, D / BUDGET)`, so under continuous churn the duty cycle
+  is exactly **1% of one core**; idle is ~0%.
+- **Manual refresh** (`r`) forces an immediate walk, the escape hatch for a long
+  cooldown.
+
+**Goal:** keep watch-mode CPU at **≤ 1% of one core** (hard ceiling; idle ~0%)
+while the live display stays smooth. The current cadence is the **floor** — the
+throttle may only ever slow updates, never speed them past today's behavior.
+
+---
+
+## Architectural decisions
+
+Durable decisions that apply across every phase. Method names below are the
+spec's shapes, not contracts — they may be renamed during TDD.
+
+### The collect/render seam (`build_output` split)
+
+`build_output(repo, cfg, dims) -> Result<Render>` splits into two functions so
+the expensive git work and the cheap render can be triggered independently:
+
+- **`collect_snapshot(repo, cfg) -> Result<Snapshot>`** — all the FS-driven git
+  work: `branch_name`, `resolve_base` + `base_status`, `last_commit_age`,
+  `collect_changes`, `collect_ages`, `build_snapshot`, `fetch_log`,
+  `upstream_status`. This is the unit the `Throttle` gates.
+- **`render_frame(snapshot, cfg, dims, age_offset) -> Render`** — the cheap,
+  terminal-size-dependent work: the row-budget split (`plan_section_caps`, the
+  `--max-files` handling, chrome math) plus `render()`. Its cost is bounded by
+  terminal rows, not repo size.
+
+`build_output` is retained as `collect_snapshot` followed by
+`render_frame(.., dims, Duration::ZERO)`, so one-shot mode is unchanged.
+
+### Age offset (Part A's render-time age advancement)
+
+A no-git re-render advances every displayed age by a single
+`age_offset = now − collected_at`. The three age sites that consume a `Duration`
+all grow linearly with wall time, so one offset is exact for all of them:
+
+1. **Header last-commit age** — `header_segments` / `snap.last_commit_age`.
+2. **File-row mtime age** — `render_row` / `entry.age` (drives the format string,
+   `colorize_age`, and `file_fade_factor`).
+3. **Log-row age** — `render_log_row` / `entry.age` (drives the format string and
+   every truecolor/ANSI fade colorizer).
+
+The offset is applied **at render time**, inside the `render_frame`/`render`
+path — `Snapshot`, `RenderEntry`, and `LogEntry` keep their existing `Duration`
+fields and their extensive tests intact. `age_offset = Duration::ZERO` must be an
+exact no-op: one-shot mode and the seed walk render with offset 0, so their
+output stays **byte-identical** to today. The existing `should_repaint`
+byte-identical suppression still absorbs no-op ticks.
+
+### The `Throttle` (Part B's pure state machine)
+
+A pure state machine in `watch.rs`. Owns no I/O; the loop feeds it `Instant`s and
+measured `Duration`s, which makes it fully unit-testable.
+
+- Constants: **`BUDGET = 0.01`** (1%, a hard-coded constant, not a dial),
+  **`FLOOR = 150 ms`** (today's debounce window). **No ceiling.**
+- Cooldown: after a walk that started at `walk_start` and took `D`,
+  **`next_allowed = walk_start + max(FLOOR, D / BUDGET)`**. `D / BUDGET = 100·D`.
+- Estimator: the **last measured `D`** sizes the next cooldown — no smoothing.
+  A slow walk instantly earns a long cooldown (conservative on the ceiling); an
+  EWMA could undershoot after a slowdown and is intentionally not used.
+- Deferral: during a cooldown, FS events do not walk — they set a `dirty` flag.
+  When the cooldown expires, if `dirty`, exactly one walk runs (reflecting the
+  latest coalesced state) and `dirty` clears.
+- Method shapes: `on_change(now) -> WalkNow | Defer`, `record(walk_start, D)`,
+  `next_allowed() -> Option<Instant>`, `force()`.
+
+### Loop state and the injected clock
+
+`event_loop` gains:
+
+- A **snapshot cache**: `Option<Snapshot>` + `collected_at: Instant` + the last
+  `Dimensions` (so resize can re-render the cached snapshot at new dimensions).
+- A **`Throttle`**.
+- An **injected clock** (`Fn() -> Instant`, real `Instant::now` in production) so
+  throttle/decay timing is deterministic in tests. The existing loop tests
+  already inject closures, so this extends a known seam.
+
+The loop's wait window becomes the earliest of the decay-tick cadence
+(`next_tick`) and, when a walk is deferred, the `Throttle`'s `next_allowed`.
+
+### Events and keys
+
+- A new **`Event::ForceRefresh`** variant, produced by an **`r`** key press in
+  `spawn_event_reader` (the reader thread already exists).
+- `Event::Resize` and the decay tick (a `recv_timeout` timeout) become **no-git**
+  re-renders of the cached snapshot.
+- `Event::FsChanged` remains the only git-walk trigger (besides startup and
+  forced refresh), now gated by the `Throttle`.
+
+### Non-goals (unchanged across all phases)
+
+- One-shot mode output stays **byte-identical**.
+- *What* is rendered does not change — only *how often* git is walked.
+- No configurable budget above 1%.
+
+---
+
+## Phase 1: Split `build_output` into `collect_snapshot` + `render_frame(age_offset)`
+
+**User stories**: byte-identical one-shot (non-goal guard); foundation for the
+smooth live display (Part A) and the gated walk (Part B).
+
+### What to build
+
+A pure refactor with no watch-loop changes. Carve `build_output` into
+`collect_snapshot(repo, cfg) -> Result<Snapshot>` (the git work) and
+`render_frame(snapshot, cfg, dims, age_offset: Duration) -> Render` (the
+row-budget split + `render()`), and thread `age_offset` through to the three age
+sites so a non-zero offset advances the header last-commit age, every file-row
+mtime age, and every log-row age in lockstep. `build_output` becomes
+`collect_snapshot` then `render_frame(.., Duration::ZERO)`. One-shot mode calls
+the same path with offset 0.
+
+The offset is added inside the render path (e.g. `render_frame` hands `render()`
+the offset, or applies it to a working copy of the ages it passes down) — the
+`Snapshot`/`RenderEntry`/`LogEntry` structs and their tests are untouched.
+
+### Acceptance criteria
+
+- [ ] `collect_snapshot(repo, cfg)` returns a `Snapshot` containing exactly what
+      `build_output` assembled today (branch, base, ahead/behind, last-commit
+      age, files, ages, log, upstream).
+- [ ] `render_frame(snapshot, cfg, dims, Duration::ZERO)` produces output
+      **byte-identical** to today's `build_output(repo, cfg, dims).output` for a
+      representative snapshot (regression test over the existing render fixtures).
+- [ ] A non-zero `age_offset` advances all three age sites: the header
+      last-commit age, each file-row age, and each log-row age each increase by
+      the offset (asserted on the rendered text / fade where observable).
+- [ ] `age_offset = Duration::ZERO` is an exact no-op at every site (no `+0`
+      formatting drift).
+- [ ] `gsw --one-shot` and piped output remain unchanged end-to-end.
+- [ ] `cargo test`, `cargo clippy`, and `cargo fmt --check` pass for `gsw`.
+
+---
+
+## Phase 2: Snapshot cache + age-offset re-render in the watch loop (Part A)
+
+**User stories**: stop pinning the CPU on the idle-after-commit decay tick; keep
+the live seconds/minutes counter and color fade ticking smoothly.
+
+### What to build
+
+Wire Part A into the live loop. Inject a clock (`Fn() -> Instant`) into
+`event_loop` and give the loop a snapshot cache (`Option<Snapshot>` +
+`collected_at: Instant` + last `Dimensions`). Re-route the four triggers:
+
+| Trigger | Needs git? | Action |
+|---|---|---|
+| Startup | yes | one `collect_snapshot` to seed the cache, render at offset 0 |
+| FS change | yes | `collect_snapshot` + re-seed cache, render at offset 0 |
+| Decay tick | no | `render_frame` from the cached snapshot, `age_offset = now − collected_at` |
+| Resize | no | `render_frame` from the cached snapshot at the new `Dimensions` |
+
+After this phase, **git is walked only on FS events and startup** — decay ticks
+and resizes never touch git. Throttling is still absent (FS churn is still
+unbounded; Part B handles that). The existing `next_tick` decay cadence and
+`should_repaint` suppression are preserved.
+
+### Acceptance criteria
+
+- [ ] A decay tick re-renders **without** invoking the injected git-collect
+      closure (asserted via a collect-call counter in the loop test).
+- [ ] A resize re-renders the cached snapshot at the new dimensions with **no**
+      git collect.
+- [ ] An FS change does call `collect_snapshot` and re-seeds `collected_at`.
+- [ ] On a no-git re-render the displayed ages advance by `now − collected_at`
+      (driven by the injected clock), and a tick whose text hasn't changed is
+      suppressed by `should_repaint` (no repaint).
+- [ ] Startup still seeds the cache and paints the first frame at offset 0
+      (byte-identical to today's first frame).
+- [ ] The existing event-loop tests (coalescing, suppression, quit, decay tick)
+      still pass after the clock/cache signature change.
+- [ ] Manual check: after a commit, the live counter keeps ticking but idle CPU
+      drops toward ~0% (no per-second git walk).
+
+---
+
+## Phase 3: Pure `Throttle` state machine (no wiring)
+
+**User stories**: foundation for the ≤1% ceiling under sustained churn.
+
+### What to build
+
+The pure `Throttle` state machine in `watch.rs`, fully unit-tested in isolation
+with injected `Instant`s and `Duration`s — no loop integration yet. It holds
+`BUDGET = 0.01`, `FLOOR = 150 ms`, the last `next_allowed`, and the `dirty` flag,
+and exposes `on_change(now)`, `record(walk_start, D)`, `next_allowed()`, and
+`force()`.
+
+### Acceptance criteria
+
+- [ ] Cooldown equals `100·D` for representative `D` (e.g. 30 ms → 3 s, 150 ms →
+      15 s, 500 ms → 50 s).
+- [ ] `FLOOR` clamps a sub-1.5 ms walk to a 150 ms cooldown (never faster than
+      today).
+- [ ] An `on_change` during an active cooldown returns `Defer` and sets `dirty`;
+      after expiry exactly **one** walk is owed, and `dirty` clears once consumed.
+- [ ] A slower `D` lengthens, and a faster `D` shortens, the next cooldown
+      (`record` recomputes purely from the new `D`).
+- [ ] `force()` makes a walk allowed immediately even mid-cooldown.
+- [ ] No ceiling: a one-off large `D` (e.g. 5 s) produces a proportionally large
+      cooldown (~500 s) with no cap.
+- [ ] `cargo test`/`clippy`/`fmt` pass; the state machine has no I/O dependency.
+
+---
+
+## Phase 4: Wire the `Throttle` into the loop — measure + defer (Part B)
+
+**User stories**: keep watch-mode CPU at ≤1% of one core under sustained FS churn.
+
+### What to build
+
+Drive the `Throttle` from the event loop. Measure each walk's wall-clock `D`
+with the injected clock around the `collect_snapshot` call and feed it to
+`record(walk_start, D)`. An FS event consults `on_change(now)`: if allowed, it
+walks now; if deferred, it sets `dirty` and the loop arms a wakeup at
+`next_allowed()`. The loop's wait window becomes the earliest of the decay-tick
+cadence and (when dirty) the cooldown expiry; when the cooldown expires with
+`dirty` set, exactly one walk runs reflecting the latest coalesced state.
+
+Because the cooldown has long since expired after idle, the first edit after a
+quiet period walks **immediately** — throttling engages only under *sustained*
+churn. The existing debounce coalescing still collapses a burst before the walk.
+
+### Acceptance criteria
+
+- [ ] An FS event after idle walks immediately, then the next walk is held off
+      until `walk_start + max(FLOOR, 100·D)`.
+- [ ] A burst of FS events during an active cooldown collapses to **one**
+      deferred walk that runs at cooldown expiry (collect-call counter proves a
+      single walk).
+- [ ] The deferred walk reflects the latest coalesced state and clears `dirty`.
+- [ ] The loop wakes at the correct earliest-of(decay-tick, cooldown-expiry)
+      time under the injected clock (deterministic, no real sleeping in tests).
+- [ ] Decay ticks during a cooldown still re-render from cache with **no** git
+      walk (Part A and Part B compose).
+- [ ] Under simulated continuous churn the duty cycle is ~`D / (100·D)` = 1%;
+      idle produces no walks.
+- [ ] Manual check: a dev-server / log-churn scenario holds watch-mode CPU at
+      ≤1% of one core while the display stays current within one cooldown.
+
+---
+
+## Phase 5: Manual refresh `r` key
+
+**User stories**: give the user an escape hatch when a long cooldown (e.g. after
+a transient-slow walk) would otherwise make them wait.
+
+### What to build
+
+Add an `r` key to `spawn_event_reader` that sends a new `Event::ForceRefresh`.
+The loop handles it by calling `throttle.force()` and immediately running a walk
+that re-measures `D` and resets the throttle from the fresh measurement —
+bypassing any active cooldown. Key-release events stay ignored, consistent with
+the existing `q`/Ctrl-C handling.
+
+### Acceptance criteria
+
+- [ ] Pressing `r` mid-cooldown forces an immediate `collect_snapshot` and
+      repaints (collect-call counter increments despite an unexpired cooldown).
+- [ ] The forced walk re-measures `D` and re-arms the cooldown from it (a
+      subsequent FS event is throttled against the fresh measurement, not the
+      stale one).
+- [ ] `r` on a clean/idle loop simply walks and renders (no error, no double
+      walk).
+- [ ] Key-release events for `r` are ignored (no spurious refresh on kitty /
+      Windows release reports).
+- [ ] The existing reader-driven events (`q`, Ctrl-C, resize) are unaffected.
+- [ ] Manual check: `r` produces an instant refresh during a long cooldown.
+
+---
+
+## Sequencing notes
+
+- **Phase 1 is a prerequisite** for both Phase 2 (needs `render_frame` + offset)
+  and Phase 4 (needs `collect_snapshot` as the gated unit).
+- **Phases 1–2 deliver Part A** (the dominant idle-after-commit win) and are
+  independently shippable even before Part B lands.
+- **Phases 3–4 deliver Part B**; Phase 3's pure machine is verifiable by unit
+  tests alone, and Phase 4 wires it in.
+- **Phase 5** is a thin escape-hatch slice on top of the wired throttle.
+- Every phase follows TDD red → commit → green → commit, and ends green
+  (`cargo test`/`clippy`/`fmt` for `gsw`). The loop tests already inject
+  closures, so the clock/cache/throttle signature churn is contained.

--- a/specs/2026-06-26-gsw-adaptive-cpu-throttle-design.md
+++ b/specs/2026-06-26-gsw-adaptive-cpu-throttle-design.md
@@ -1,0 +1,207 @@
+# gsw — adaptive CPU throttle for watch mode
+
+**Date:** 2026-06-26
+**Status:** Approved (design), pending implementation plan
+**Tool:** `src/gsw`
+
+## Problem
+
+In watch mode `gsw` can pin a core to ~70% on a single project. The cost is the
+**git update** — one call to `build_output` (`src/gsw/src/main.rs:338`), which
+runs a full `gix status` walk over the whole worktree plus per-file histogram
+blob diffs (`repo::collect_changes`, `src/gsw/src/repo.rs:229`), four commit
+rev-walks (ahead/behind vs base and vs upstream), and a 20-commit log walk. On a
+large or divergent repo that is easily 100–200 ms of CPU per update.
+
+`gsw` is **not** a fixed-interval poller. A git update fires on two triggers
+today:
+
+1. **Filesystem events** — a `notify` watcher on the worktree + git dir wakes the
+   loop, coalesced over a **150 ms debounce** window (`watch.rs::DEBOUNCE`).
+   Under continuous churn that is a full walk roughly every `150 ms + walk-time`.
+2. **A decay timer** — purely to keep the age text and color fade current, the
+   loop re-walks **every 1 s** when the freshest on-screen item is < 1 min old,
+   **every 60 s** when < 2 h old, and never once everything is ≥ 2 h
+   (`watch.rs::next_tick`). Each tick runs the *entire* walk via `build_output`.
+
+Two amplifiers turn that into 70%:
+
+- **The 1 s decay tick re-runs the entire walk every second** for a minute after
+  *any* change, even with zero file activity — the dominant idle-after-commit
+  burn.
+- **Sustained FS churn** (a dev server, log files, `.git` churn from another
+  tool) fires a fresh full walk every debounce window, unbounded.
+
+## Goal
+
+Keep watch-mode CPU at **≤ 1% of one core** as a hard ceiling (less is better;
+idle is ~0%), while keeping the live display smooth. The throttle must
+**self-adjust**: measure each git update and back off proportionally, so a repo
+that gets slower checks less often and one that gets faster checks more often.
+The current cadence is the **floor** — the throttle may only ever slow updates
+down, never speed them past today's behavior.
+
+### Non-goals
+
+- No change to one-shot mode output (must stay byte-identical).
+- No change to *what* is rendered — only *how often* git is walked.
+- No configurable budget above 1% (1% is a principled ceiling, not a dial).
+
+## Design
+
+Two independent parts. Neither alone suffices: A leaves churn-driven walks
+unbounded; B alone makes the live seconds-counter stutter. Together: smooth
+display, ≤1% under load, ~0% idle.
+
+### Part A — decouple decay re-renders from the git walk
+
+The decay tick exists only to advance the **age text and color fade**, which are
+pure functions of elapsed wall-clock time (`src/gsw/src/age.rs`). It does not
+need fresh git data.
+
+The watch loop will **cache the last `Snapshot`** together with the `Instant` it
+was collected at. The four refresh triggers split by whether they need git:
+
+| Trigger | Needs git? | Action |
+|---|---|---|
+| Startup | yes | one walk to seed the cache |
+| **FS change** | **yes** | re-walk git (throttled — Part B) |
+| Decay tick | no | re-render cached snapshot with advanced ages |
+| Resize | no | re-render cached snapshot at new dimensions |
+
+**Age advancement.** On a no-git re-render, every age is bumped by a single
+`age_offset = now − collected_at`. File mtime age, last-commit age, and log ages
+all grow linearly with wall time, so one offset is exact for all of them.
+One-shot mode and the seed walk render with `offset = 0`, so their output is
+byte-identical to today. The existing `should_repaint` byte-identical
+suppression still absorbs no-op ticks (e.g. an age whose text hasn't ticked
+over).
+
+This is deliberately lower-blast-radius than retyping every `Duration` field in
+`Snapshot`/`RenderEntry`/`LogEntry` to an absolute timestamp: the offset is
+applied at render time at the three age sites, leaving the structs and their
+extensive tests intact.
+
+After this part, **git is walked only on FS events (and startup)** — decay ticks
+and resizes never touch git.
+
+### Part B — adaptive throttle on the git walk
+
+A small **pure `Throttle` state machine** gates the git walk. It owns no I/O; the
+loop drives it and feeds it `Instant`s, which makes it fully unit-testable.
+
+**Measurement.** Wall-clock duration `D` of each walk, measured with `Instant`
+around the git-collect call. Wall-clock is the correct proxy for "% of one core"
+here — the walk is single-threaded and CPU-bound, and counting any I/O wait as
+"busy" only makes the throttle *more* conservative about the ceiling.
+
+**Cooldown.** After a walk that started at `walk_start` and took `D`, the next
+walk may start no earlier than:
+
+```
+next_allowed = walk_start + max(FLOOR, D / BUDGET)
+```
+
+- `BUDGET = 0.01` (1%, a hard-coded constant).
+- `FLOOR = 150 ms` (today's debounce window).
+- **No ceiling** — the 1% guarantee is absolute.
+
+**Deferral.** During a cooldown, FS events do not walk; they set a `dirty` flag.
+When the cooldown expires, if `dirty`, exactly one walk runs — reflecting the
+latest coalesced state — and `dirty` clears.
+
+**Estimator.** The **last measured `D`** sizes the next cooldown — no smoothing.
+This is the most literal reading of "measure each update and adjust," and it is
+conservative on the ceiling: a slow walk instantly earns a long cooldown. (An
+EWMA could *undershoot* after a slowdown and briefly exceed 1%, violating the
+hard ceiling, so it is intentionally not used. Easy to revisit if jitter is a
+problem in practice.)
+
+#### Why this meets the spec
+
+- `D / BUDGET = 100·D`, so under continuous churn a walk runs once per `100·D`
+  and burns `D` → **duty cycle = 1%** of one core. Idle → no FS events → ~0%.
+  1% is the ceiling; less is the norm.
+- **Self-adjusting:** the cooldown is recomputed from each walk's own `D`.
+  Slower repo → longer cooldown; faster repo → shorter.
+- **Floor = current cadence:** `100·D ≥ 150 ms` for any walk costing ≥ 1.5 ms
+  (every real repo), so the throttle only ever *slows* updates; sub-1.5 ms walks
+  stay pinned at the 150 ms floor. It can never check more often than today.
+- **Snappy after idle:** once idle, the cooldown has long since expired, so the
+  first edit triggers an *immediate* walk. Throttling engages only under
+  *sustained* churn.
+
+#### Staleness trade-off
+
+Under continuous churn a brand-new change waits up to one cooldown to appear:
+
+| Walk cost `D` | Cooldown (`100·D`) | Worst-case staleness | Duty cycle |
+|---|---|---|---|
+| 30 ms | 3 s | 3 s | 1% |
+| 150 ms | 15 s | 15 s | 1% |
+| 500 ms | 50 s | 50 s | 1% |
+
+A transient-slow walk (e.g. a one-off 5 s walk → ~500 s cooldown) causes one long
+stale window that self-corrects after the next walk re-measures. The
+**manual-refresh key** (below) is the escape hatch for that case, which is why
+no cooldown ceiling is needed.
+
+### Manual refresh
+
+Add a **`r`** key to the watch loop's key reader (`spawn_event_reader`,
+`watch.rs:498`). Pressing `r` forces an immediate git walk, bypassing the
+cooldown, and resets the throttle from the fresh measurement. Cheap (the reader
+thread already exists) and the user's escape hatch when a long cooldown would
+otherwise make them wait.
+
+## Components & boundaries
+
+- **`Throttle` (new, `watch.rs`)** — pure state machine. Inputs: `Instant`s and
+  measured `Duration`s. Methods (shape, not final names):
+  - `on_change(now) -> WalkNow | Defer` — decide whether an FS event walks now or
+    sets `dirty`.
+  - `record(walk_start, D)` — set the next cooldown.
+  - `next_allowed() -> Option<Instant>` — when a deferred walk may run.
+  - `force()` — bypass cooldown for manual refresh.
+  Holds `BUDGET`, `FLOOR`, last `next_allowed`, `dirty`.
+- **Snapshot cache (loop state)** — `Option<Snapshot>` + `collected_at: Instant`
+  + last `Dimensions`.
+- **Split of `build_output`** — separate the expensive git collection from the
+  cheap render:
+  - `collect_snapshot(repo, cfg) -> Snapshot` (the throttled, FS-driven git work).
+  - `render_frame(snapshot, cfg, dims, age_offset) -> Render` (cheap; used by
+    every trigger).
+- **`event_loop` (existing, `watch.rs:385`)** — extended with a controllable
+  clock (an injected `Fn() -> Instant`, real `Instant::now` in production) so the
+  throttle/decay timing is deterministic in tests, plus the snapshot cache and
+  `Throttle`.
+
+## Testing (TDD, red → commit → green → commit)
+
+- **`Throttle` unit tests** (no I/O, injected `Instant`s):
+  - cooldown equals `100·D` for representative `D`;
+  - `FLOOR` clamps sub-1.5 ms walks to 150 ms (never faster than today);
+  - an FS event during cooldown defers (`dirty`) and exactly one walk runs at
+    expiry;
+  - a slower `D` lengthens and a faster `D` shortens the next cooldown;
+  - `force()` bypasses an active cooldown.
+- **Age-offset re-render tests:**
+  - a decay tick advances ages **without** invoking the injected git-collect
+    closure;
+  - `render_frame` with `offset = 0` reproduces today's output (byte-identical
+    one-shot regression).
+- **Loop integration** (extends the existing injected-closure tests with the
+  controllable clock):
+  - decay tick → no git walk; FS event → walk then throttle;
+  - a burst during cooldown collapses to one deferred walk;
+  - `r` forces an immediate walk mid-cooldown.
+
+## Risks
+
+- **Loop signature churn:** threading a clock into `event_loop` updates the
+  existing loop tests. Contained — the tests already inject closures.
+- **Staleness under heavy churn** is by design and bounded by the cooldown;
+  `r` covers the pathological transient-slow case.
+- **Render cost on huge change sets:** `render_frame` runs per decay tick, but
+  its cost is bounded by terminal rows (the file list is capped to height), not
+  repo size — far below a git walk.

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -475,7 +475,10 @@ pub(crate) fn render_frame(
     } else {
         render_with_offset(snapshot, &opts, age_offset)
     };
-    let freshest_age = snapshot_freshest_age(snapshot);
+    // Advance the freshest age by the same offset so watch mode's decay-timer
+    // cadence stays in lockstep with the ages painted above. The uniform shift
+    // preserves which item is freshest, so the min() that picked it still holds.
+    let freshest_age = snapshot_freshest_age(snapshot).map(|d| d.saturating_add(age_offset));
     Render {
         output,
         freshest_age,

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -9,7 +9,9 @@ use clap::Parser;
 use colored::Colorize;
 
 use crate::git::FileEntry;
-use crate::render::{plan_section_caps, render, LogEntry, RenderOptions, Snapshot};
+use crate::render::{
+    plan_section_caps, render, render_with_offset, LogEntry, RenderOptions, Snapshot,
+};
 use crate::snapshot::build_snapshot;
 
 mod age;
@@ -328,18 +330,35 @@ fn snapshot_freshest_age(snapshot: &Snapshot) -> Option<Duration> {
         .min()
 }
 
-/// Walk the repository and render the full status output for `dims`.
+/// Walk the repository and render the full status frame for `dims`.
 ///
-/// Pure with respect to the terminal: it returns the rendered frame (and the
-/// freshest displayed-item age for the decay timer) and never touches stdout,
-/// so callers decide how to display it — one-shot prints it, watch mode paints
-/// it into the alternate screen. The row-budget split (file list vs. log
-/// section) is computed here from `dims.height`.
+/// Composes the two halves of the render pipeline: [`collect_snapshot`]
+/// assembles the repo state, then [`render_frame`] turns it into a frame at no
+/// age offset (`Duration::ZERO`). Because the offset is zero, the output is
+/// byte-identical to a direct render; watch mode instead calls the two halves
+/// separately so it can re-render a *cached* snapshot at a growing offset
+/// without re-walking the repo.
 pub(crate) fn build_output(
     repo: &gix::Repository,
     cfg: &RenderConfig,
     dims: watch::Dimensions,
 ) -> Result<Render> {
+    let snapshot = collect_snapshot(repo, cfg)?;
+    Ok(render_frame(&snapshot, cfg, dims, Duration::ZERO))
+}
+
+/// Walk the repository and assemble the fully-populated [`Snapshot`] — the
+/// git-work half of the render pipeline.
+///
+/// This is the expensive, side-effecting step: it queries the current branch,
+/// resolves the base ref and counts commits ahead/behind, reads the last-commit
+/// age, collects working-tree changes and their mtimes, and fetches the
+/// recent-commit log and upstream status. The result is a pure description of
+/// repository state, independent of the live terminal — turning it into a frame
+/// for a given [`watch::Dimensions`] is the separate, cheap [`render_frame`]
+/// half. Watch mode collects once per filesystem change and re-renders the
+/// cached snapshot many times. Uses only `cfg.base` and `cfg.log_lines`.
+pub(crate) fn collect_snapshot(repo: &gix::Repository, cfg: &RenderConfig) -> Result<Snapshot> {
     let branch = repo::branch_name(repo);
 
     let base = cfg.base.clone().unwrap_or_else(|| repo::resolve_base(repo));
@@ -371,6 +390,28 @@ pub(crate) fn build_output(
 
     snapshot.upstream = repo::upstream_status(repo);
 
+    Ok(snapshot)
+}
+
+/// Render an already-collected [`Snapshot`] into a frame for `dims`, advancing
+/// every displayed age — and the returned [`Render::freshest_age`] — by
+/// `age_offset`.
+///
+/// This is the cheap, terminal-shaped half of the pipeline. Given a snapshot
+/// from [`collect_snapshot`], it performs the row-budget split (file list vs.
+/// log section) from `dims.height`, builds the [`RenderOptions`], and produces
+/// the colored frame via [`render_with_offset`]. `age_offset` lets watch mode
+/// keep the painted ages and the decay-timer cadence ticking forward between
+/// git rescans without re-walking the repo; `Duration::ZERO` reproduces a
+/// freshly-collected frame byte-for-byte. Pure with respect to the terminal: it
+/// never touches stdout, so callers decide how to display the frame. Uses
+/// `cfg.max_files`, `cfg.bar_width`, and `cfg.truecolor`.
+pub(crate) fn render_frame(
+    snapshot: &Snapshot,
+    cfg: &RenderConfig,
+    dims: watch::Dimensions,
+    age_offset: Duration,
+) -> Render {
     let terminal_width = dims.width;
     let terminal_height = dims.height;
 
@@ -425,12 +466,20 @@ pub(crate) fn build_output(
         truecolor: cfg.truecolor,
     };
 
-    let output = render(&snapshot, &opts);
-    let freshest_age = snapshot_freshest_age(&snapshot);
-    Ok(Render {
+    // One-shot mode and the watch seed walk render at offset zero, which is
+    // exactly the public `render` entry — route them through it so their output
+    // stays the byte-identical call the pre-split `build_output` made. Only the
+    // live decay/resize re-renders advance ages and take the offset-aware path.
+    let output = if age_offset.is_zero() {
+        render(snapshot, &opts)
+    } else {
+        render_with_offset(snapshot, &opts, age_offset)
+    };
+    let freshest_age = snapshot_freshest_age(snapshot);
+    Render {
         output,
         freshest_age,
-    })
+    }
 }
 
 /// Fetch the `n` most recent commits as [`LogEntry`] records via gix.
@@ -587,6 +636,75 @@ mod tests {
         // be disabled, which the caller infers from `None`.
         let snap = snapshot_with(None, &[None, None]);
         assert_eq!(snapshot_freshest_age(&snap), None);
+    }
+
+    #[test]
+    fn render_frame_applies_age_offset_to_output_and_freshest_age() {
+        // render_frame must advance BOTH the painted ages and the returned
+        // freshest_age by `age_offset`, so watch mode's decay-timer cadence and
+        // the frame on screen stay in lockstep between git rescans. The commit
+        // (10s) is the freshest item; a file at 40s stays older under any
+        // uniform offset, so the freshest age tracks the commit before and
+        // after the shift.
+        let snap = Snapshot {
+            branch: "b".into(),
+            base: "main".into(),
+            commits_ahead: 0,
+            commits_behind: 0,
+            last_commit_age: Some(Duration::from_secs(10)),
+            files: vec![RenderEntry {
+                path: "f.rs".into(),
+                orig_path: None,
+                status: FileStatus::Modified,
+                staged: false,
+                adds: 1,
+                dels: 0,
+                binary: false,
+                age: Some(Duration::from_secs(40)),
+            }],
+            log: Vec::new(),
+            upstream: None,
+        };
+        let cfg = RenderConfig {
+            base: None,
+            max_files: None,
+            bar_width: 6,
+            log_lines: 0,
+            truecolor: false,
+            width_offset: 0,
+        };
+        let dims = watch::Dimensions {
+            width: 80,
+            height: 40,
+        };
+
+        // No offset: the header shows the un-advanced commit age and the
+        // freshest age is the raw commit age.
+        let frame = render_frame(&snap, &cfg, dims, Duration::ZERO);
+        assert_eq!(
+            frame.freshest_age,
+            Some(Duration::from_secs(10)),
+            "with no offset the freshest age is the raw 10s commit age",
+        );
+        assert!(
+            frame.output.contains("10s"),
+            "header should show the un-advanced commit age: {:?}",
+            frame.output,
+        );
+
+        // A 50s offset advances the commit age to 60s ("1m0s") in the header
+        // AND the returned freshest_age to 60s, in lockstep.
+        let frame = render_frame(&snap, &cfg, dims, Duration::from_secs(50));
+        assert_eq!(
+            frame.freshest_age,
+            Some(Duration::from_secs(60)),
+            "freshest_age must advance by the offset (10s + 50s = 60s)",
+        );
+        assert!(
+            frame.output.contains("1m0s"),
+            "header should show the advanced commit age (1m0s): {:?}",
+            frame.output,
+        );
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -159,6 +159,22 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     lines.join("\n")
 }
 
+/// Produce the colored, multi-line frame with every displayed age advanced
+/// by `age_offset`.
+///
+/// `age_offset` is added (saturating) to the header's last-commit age, every
+/// file row's mtime age, and every commit-log row's age before formatting and
+/// fading. `Duration::ZERO` is an exact no-op, leaving the output
+/// byte-identical to [`render`].
+pub(crate) fn render_with_offset(
+    snapshot: &Snapshot,
+    opts: &RenderOptions,
+    age_offset: Duration,
+) -> String {
+    let _ = age_offset;
+    render(snapshot, opts)
+}
+
 /// Visible gap between the short hash and the subject in a log row.
 const LOG_HASH_SUBJECT_SEP: &str = "  ";
 
@@ -2539,6 +2555,65 @@ mod tests {
         assert!(
             plain.contains("ahead of main, 87 behind • last commit"),
             "behind segment should sit between the base name and the suffix: {plain}",
+        );
+    }
+
+    #[test]
+    fn age_offset_advances_header_file_and_log_ages() {
+        // A render-time age offset advances every displayed age by a single
+        // Duration: the header's last-commit age, each file row's mtime age,
+        // and each commit-log row's age. The three base ages are picked so the
+        // advanced strings can't collide with the un-advanced ones.
+        let mut snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
+        snap.last_commit_age = Some(Duration::from_secs(10)); // header: "10s"
+        snap.files[0].age = Some(Duration::from_secs(20)); // file row: "20s"
+        snap.log = vec![LogEntry {
+            hash: "abc1234".into(),
+            subject: "test".into(),
+            age: Duration::from_secs(100),
+        }]; // log: "1m40s"
+        let mut o = opts();
+        o.log_lines = 5; // so the log section renders
+
+        let advanced = strip_ansi(&render_with_offset(&snap, &o, Duration::from_secs(50)));
+        assert!(
+            advanced.contains("1m0s"),
+            "header age 10s + 50s offset should render as 1m0s: {advanced}",
+        );
+        assert!(
+            advanced.contains("1m10s"),
+            "file age 20s + 50s offset should render as 1m10s: {advanced}",
+        );
+        assert!(
+            advanced.contains("2m30s"),
+            "log age 1m40s + 50s offset should render as 2m30s: {advanced}",
+        );
+
+        let base = strip_ansi(&render(&snap, &o));
+        assert!(base.contains("10s"), "header age unoffset is 10s: {base}");
+        assert!(base.contains("20s"), "file age unoffset is 20s: {base}");
+        assert!(base.contains("1m40s"), "log age unoffset is 1m40s: {base}");
+    }
+
+    #[test]
+    fn age_offset_zero_is_an_exact_noop() {
+        // Offset ZERO must leave the full colored output byte-identical to
+        // today's render — d.saturating_add(ZERO) == d for every age, so no
+        // formatted age and no fade color byte changes. One-shot mode and the
+        // seed walk render at ZERO and rely on this exactness.
+        let mut snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
+        snap.last_commit_age = Some(Duration::from_secs(10));
+        snap.files[0].age = Some(Duration::from_secs(20));
+        snap.log = vec![LogEntry {
+            hash: "abc1234".into(),
+            subject: "test".into(),
+            age: Duration::from_secs(100),
+        }];
+        let mut o = opts();
+        o.log_lines = 5;
+        assert_eq!(
+            render_with_offset(&snap, &o, Duration::ZERO),
+            render(&snap, &o),
         );
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -89,14 +89,34 @@ const SEP_ADDS_DELS: usize = 1;
 const SEP_DELS_AGE: usize = 3;
 
 /// Produce the colored, multi-line frame.
+///
+/// Thin delegator to [`render_with_offset`] at `Duration::ZERO`, i.e. with no
+/// age advance — the output is byte-identical to the historical `render`. The
+/// 2-arg shape is preserved so existing call sites and tests stay unchanged.
 pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
+    render_with_offset(snapshot, opts, Duration::ZERO)
+}
+
+/// Produce the colored, multi-line frame with every displayed age advanced
+/// by `age_offset`.
+///
+/// `age_offset` is added (saturating) to the header's last-commit age, every
+/// file row's mtime age, and every commit-log row's age before they are
+/// formatted and faded. `Duration::ZERO` is an exact no-op
+/// (`d.saturating_add(ZERO) == d`), leaving the output byte-identical to
+/// [`render`].
+pub(crate) fn render_with_offset(
+    snapshot: &Snapshot,
+    opts: &RenderOptions,
+    age_offset: Duration,
+) -> String {
     let mut lines = Vec::new();
 
     let HeaderSegments {
         prefix,
         behind,
         suffix,
-    } = header_segments(snapshot);
+    } = header_segments(snapshot, age_offset);
     // The whole header is bold as before; the optional behind segment is
     // additionally warning-colored (yellow) to flag that the branch needs a
     // rebase. When `behind` is `None` the prefix+suffix reproduce today's
@@ -128,7 +148,12 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     let log_rendered = opts.log_lines > 0 && !snapshot.log.is_empty();
     if log_rendered {
         for entry in snapshot.log.iter().take(opts.log_lines) {
-            lines.push(render_log_row(entry, opts.terminal_width, opts.truecolor));
+            lines.push(render_log_row(
+                entry,
+                opts.terminal_width,
+                opts.truecolor,
+                age_offset,
+            ));
         }
     }
 
@@ -140,7 +165,7 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
             lines.push(render_separator(opts.terminal_width));
         }
         for entry in snapshot.files.iter().take(display_count) {
-            lines.push(render_row(entry, opts, max_change, path_width));
+            lines.push(render_row(entry, opts, max_change, path_width, age_offset));
         }
 
         let hidden = snapshot.files.len().saturating_sub(display_count);
@@ -159,29 +184,20 @@ pub fn render(snapshot: &Snapshot, opts: &RenderOptions) -> String {
     lines.join("\n")
 }
 
-/// Produce the colored, multi-line frame with every displayed age advanced
-/// by `age_offset`.
-///
-/// `age_offset` is added (saturating) to the header's last-commit age, every
-/// file row's mtime age, and every commit-log row's age before formatting and
-/// fading. `Duration::ZERO` is an exact no-op, leaving the output
-/// byte-identical to [`render`].
-pub(crate) fn render_with_offset(
-    snapshot: &Snapshot,
-    opts: &RenderOptions,
-    age_offset: Duration,
-) -> String {
-    let _ = age_offset;
-    render(snapshot, opts)
-}
-
 /// Visible gap between the short hash and the subject in a log row.
 const LOG_HASH_SUBJECT_SEP: &str = "  ";
 
-fn render_log_row(entry: &LogEntry, width: usize, truecolor: bool) -> String {
+/// Render one commit-log row.
+///
+/// `age_offset` is added (saturating) to the commit's age before it is
+/// formatted and used to drive the hash/subject/age fades, so the whole row
+/// ages forward by a single shared `Duration`. `Duration::ZERO` leaves the
+/// row byte-identical to the un-offset render.
+fn render_log_row(entry: &LogEntry, width: usize, truecolor: bool, age_offset: Duration) -> String {
     // Layout: `{hash}  {subject…}   {age}` — the rightmost AGE_FIELD cells
     // hold the right-aligned age, matching the file-row age column exactly.
     // The subject is padded to fill the gap so the age column lines up.
+    let effective_age = entry.age.saturating_add(age_offset);
     let hash_width = UnicodeWidthStr::width(entry.hash.as_str());
     let hash_sep_width = LOG_HASH_SUBJECT_SEP.chars().count();
     let sep_to_age = " ".repeat(SEP_DELS_AGE);
@@ -192,12 +208,12 @@ fn render_log_row(entry: &LogEntry, width: usize, truecolor: bool) -> String {
     let subject_truncated = truncate_right(&entry.subject, subject_budget);
     let subject_padded = pad_right(&subject_truncated, subject_budget);
 
-    let age_raw = format_age_detailed(entry.age);
+    let age_raw = format_age_detailed(effective_age);
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
 
-    let hash_str = colorize_log_hash(&entry.hash, entry.age, truecolor);
-    let subject_str = colorize_log_subject(&subject_padded, entry.age, truecolor);
-    let age_str = colorize_log_age(&age_field, entry.age, truecolor);
+    let hash_str = colorize_log_hash(&entry.hash, effective_age, truecolor);
+    let subject_str = colorize_log_subject(&subject_padded, effective_age, truecolor);
+    let age_str = colorize_log_age(&age_field, effective_age, truecolor);
     format!("{hash_str}{LOG_HASH_SUBJECT_SEP}{subject_str}{sep_to_age}{age_str}")
 }
 
@@ -230,7 +246,13 @@ struct HeaderSegments {
     suffix: String,
 }
 
-fn header_segments(snap: &Snapshot) -> HeaderSegments {
+/// Split the header into independently-styleable pieces.
+///
+/// `age_offset` is added (saturating) to the last-commit age before it is
+/// formatted, so the header's `last commit {age} ago` advances in lockstep
+/// with the file and log ages. `Duration::ZERO` leaves the age unchanged. An
+/// unknown last-commit age (`None`) stays `?` regardless of the offset.
+fn header_segments(snap: &Snapshot, age_offset: Duration) -> HeaderSegments {
     let commit_word = if snap.commits_ahead == 1 {
         "commit"
     } else {
@@ -238,6 +260,7 @@ fn header_segments(snap: &Snapshot) -> HeaderSegments {
     };
     let age = snap
         .last_commit_age
+        .map(|a| a.saturating_add(age_offset))
         .map_or_else(|| "?".to_string(), format_age_detailed);
     let upstream_field = snap
         .upstream
@@ -264,14 +287,24 @@ fn render_separator(width: usize) -> String {
     "─".repeat(width).dimmed().to_string()
 }
 
+/// Render one file row.
+///
+/// `age_offset` is added (saturating) to the file's mtime age before it is
+/// formatted, faded, and used to drive the column styling, so the row ages
+/// forward by a single shared `Duration`. A `None` age (deleted file, unstat'd
+/// untracked dir) stays `None` and renders at the dark floor regardless of the
+/// offset. `Duration::ZERO` leaves the row byte-identical to the un-offset
+/// render.
 fn render_row(
     entry: &RenderEntry,
     opts: &RenderOptions,
     max_change: u32,
     path_width: usize,
+    age_offset: Duration,
 ) -> String {
     let (icon, letter) = icon_and_letter(entry);
-    let factor = file_fade_factor(entry.age);
+    let effective_age = entry.age.map(|a| a.saturating_add(age_offset));
+    let factor = file_fade_factor(effective_age);
     let truecolor = opts.truecolor;
 
     let path_display_raw = match &entry.orig_path {
@@ -291,9 +324,9 @@ fn render_row(
     ) {
         let gutter_width = right_block_width(opts.bar_width) - AGE_FIELD;
         let gutter = " ".repeat(gutter_width);
-        let age = entry.age.map(format_age_detailed).unwrap_or_default();
+        let age = effective_age.map(format_age_detailed).unwrap_or_default();
         let age_field = format!("{age:>width$}", width = AGE_FIELD);
-        let age_str = colorize_age(&age_field, entry.age, factor, truecolor);
+        let age_str = colorize_age(&age_field, effective_age, factor, truecolor);
         return format!("{icon_str} {letter_str} {path_str}{gutter}{age_str}");
     }
 
@@ -332,9 +365,9 @@ fn render_row(
         dels_field
     };
 
-    let age_raw = entry.age.map(format_age_detailed).unwrap_or_default();
+    let age_raw = effective_age.map(format_age_detailed).unwrap_or_default();
     let age_field = format!("{age_raw:>width$}", width = AGE_FIELD);
-    let age_str = colorize_age(&age_field, entry.age, factor, truecolor);
+    let age_str = colorize_age(&age_field, effective_age, factor, truecolor);
 
     let sep_bar_adds = " ".repeat(SEP_BAR_ADDS);
     let sep_adds_dels = " ".repeat(SEP_ADDS_DELS);
@@ -2601,6 +2634,15 @@ mod tests {
         // today's render — d.saturating_add(ZERO) == d for every age, so no
         // formatted age and no fade color byte changes. One-shot mode and the
         // seed walk render at ZERO and rely on this exactness.
+        //
+        // Force `colored` on under the shared override guard so the
+        // comparison exercises the actual ANSI bytes and a concurrent test
+        // toggling the process-global override can't flip it between our two
+        // render calls and make identical frames compare unequal.
+        let _guard = COLORED_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        colored::control::set_override(true);
         let mut snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
         snap.last_commit_age = Some(Duration::from_secs(10));
         snap.files[0].age = Some(Duration::from_secs(20));
@@ -2611,9 +2653,9 @@ mod tests {
         }];
         let mut o = opts();
         o.log_lines = 5;
-        assert_eq!(
-            render_with_offset(&snap, &o, Duration::ZERO),
-            render(&snap, &o),
-        );
+        let with_offset = render_with_offset(&snap, &o, Duration::ZERO);
+        let baseline = render(&snap, &o);
+        colored::control::unset_override();
+        assert_eq!(with_offset, baseline);
     }
 }

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -290,8 +290,11 @@ impl Throttle {
     /// Arm the next cooldown from a walk that started at `walk_start` and took
     /// `cost`: the next walk is gated until `walk_start + cost / BUDGET`. Purely
     /// last-write-wins — each call replaces any prior cooldown, no averaging.
+    /// Clears any pending deferred walk: a freshly-recorded walk reflects the
+    /// latest coalesced state, so no walk is owed afterward (see [`Self::dirty`]).
     fn record(&mut self, walk_start: Instant, cost: Duration) {
         self.next_allowed_at = Some(walk_start + cooldown(cost));
+        self.dirty = false;
     }
 
     /// The instant a pending deferred walk should fire — the cooldown's expiry —

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -345,6 +345,16 @@ fn cooldown(cost: Duration) -> Duration {
         .max(FLOOR)
 }
 
+/// The loop's wait window: the soonest of the decay-tick cadence
+/// (`decay_tick`) and a pending deferred walk's remaining cooldown
+/// (`deferred_walk`), or `None` to block until an event arrives. Both inputs
+/// are already expressed as durations from now; a `None` from either source
+/// means that source imposes no deadline.
+fn wait_window(decay_tick: Option<Duration>, deferred_walk: Option<Duration>) -> Option<Duration> {
+    let _ = deferred_walk;
+    decay_tick
+}
+
 /// Events the watch loop reacts to. The main thread owns all rendering and
 /// blocks on a single channel carrying these.
 ///
@@ -598,7 +608,8 @@ where
         // size, a bare timeout is a decay tick.
         let mut saw_fs = false;
         let mut saw_resize = false;
-        let woke_for_tick = match (hooks.next_tick)(freshest) {
+        let wait = wait_window((hooks.next_tick)(freshest), None);
+        let woke_for_tick = match wait {
             Some(interval) => match rx.recv_timeout(interval) {
                 Ok(Event::Quit) => break,
                 Ok(Event::FsChanged) => {
@@ -870,6 +881,27 @@ mod tests {
             None,
             "a month-old freshest item produces no ticks",
         );
+    }
+
+    #[test]
+    fn wait_window_picks_the_earliest_deadline() {
+        // The loop waits on the SOONER of the decay-tick cadence and a pending
+        // deferred walk's remaining cooldown. A `None` from either source means
+        // it imposes no deadline; both `None` means block until an event arrives.
+        let short = Duration::from_secs(5);
+        let long = Duration::from_secs(60);
+
+        // Earliest of two present deadlines wins, regardless of argument order.
+        assert_eq!(wait_window(Some(long), Some(short)), Some(short));
+        assert_eq!(wait_window(Some(short), Some(long)), Some(short));
+        assert_eq!(wait_window(Some(short), Some(short)), Some(short));
+
+        // One source absent: the other's deadline stands.
+        assert_eq!(wait_window(Some(short), None), Some(short));
+        assert_eq!(wait_window(None, Some(short)), Some(short));
+
+        // Neither source imposes a deadline: block until an event arrives.
+        assert_eq!(wait_window(None, None), None);
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -309,6 +309,13 @@ impl Throttle {
             None
         }
     }
+
+    /// Force the next walk to be allowed immediately, lifting any active
+    /// cooldown gate — the manual-refresh escape hatch (Phase 5's `r` key) for
+    /// a long cooldown the user doesn't want to wait out. Leaves [`Self::dirty`]
+    /// untouched (the forced walk's subsequent [`Self::record`] clears it); this
+    /// only opens the gate so the next [`Self::on_change`] returns [`Walk::Now`].
+    fn force(&mut self) {}
 }
 
 /// Cooldown for a walk costing `cost`: `max(FLOOR, cost / BUDGET)` (= `max(FLOOR,
@@ -1016,6 +1023,32 @@ mod tests {
             throttle.next_allowed(),
             None,
             "the owed walk is consumed by the record; no walk is owed afterward",
+        );
+    }
+
+    #[test]
+    fn force_allows_an_immediate_walk_mid_cooldown() {
+        // `force` is the manual-refresh escape hatch (Phase 5's `r` key): when a
+        // long cooldown is still gating walks, the user can demand an immediate
+        // one and bypass the unexpired cooldown. A 150 ms walk gates the next for
+        // 100·150 ms = 15 s, so a change 1 s in is normally deferred — but after
+        // `force` that SAME mid-cooldown instant must walk now. Instants derive
+        // from one base — deterministic and parallel-safe, no sleeping.
+        let t0 = Instant::now();
+
+        let mut throttle = Throttle::new();
+        throttle.record(t0, Duration::from_millis(150)); // cooldown until t0 + 15 s
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_secs(1)),
+            Walk::Defer,
+            "a change 1 s into the 15 s cooldown is deferred — we're genuinely mid-cooldown",
+        );
+
+        throttle.force();
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_secs(1)),
+            Walk::Now,
+            "after force, the same mid-cooldown instant walks immediately — the gate is lifted",
         );
     }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -603,6 +603,7 @@ where
     Tick: Fn(Option<Duration>) -> Option<Duration>,
 {
     let mut freshest = initial_freshest;
+    let mut throttle = Throttle::new();
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
         // after `interval` of quiet for a tick.
@@ -661,27 +662,37 @@ where
             }
         }
 
-        // Only a filesystem change walks git. A resize re-renders the cached
-        // snapshot at the freshly-queried dimensions; a decay tick re-renders it
-        // at the cached dimensions. Both advance every displayed age by the
-        // wall-clock elapsed since the snapshot was collected (Part A). A
-        // filesystem change in a coalesced burst wins over a co-arriving resize
-        // — the fresh walk already renders at the current dimensions.
-        let render = if saw_fs {
+        // Read the clock once for this wake: the throttle decision, a walk's
+        // start, and any age offset all key off the same instant.
+        let now = (hooks.clock)();
+
+        // Only a filesystem change walks git, and only when the throttle admits
+        // it. An FS change during an active cooldown is deferred — `on_change`
+        // sets the throttle's dirty flag and we fall through to a cheap cached
+        // re-render (Part A) instead of walking. A resize or decay tick never
+        // walks. A filesystem walk in a coalesced burst wins over a co-arriving
+        // resize: the fresh walk already renders at the current dimensions.
+        let walk_now = saw_fs && matches!(throttle.on_change(now), Walk::Now);
+
+        let render = if walk_now {
             cache.dims = (hooks.dimensions)();
-            // Re-seed the cache's collection time so a later decay tick or resize
-            // advances ages from *this* walk, not the previous one. Taken before
-            // the walk so it marks the walk's start.
-            cache.collected_at = (hooks.clock)();
+            // Re-seed the collection time to the walk's start so a later decay
+            // tick or resize advances ages from *this* walk, not the previous
+            // one. Measure the walk's wall-clock cost around collect and feed it
+            // to the throttle, which arms the next cooldown (= 100·cost) from it.
+            cache.collected_at = now;
             cache.snapshot = (hooks.collect)()?;
+            let cost = (hooks.clock)().saturating_duration_since(now);
+            throttle.record(now, cost);
             (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
         } else if saw_resize {
             cache.dims = (hooks.dimensions)();
-            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
+            let age_offset = now.saturating_duration_since(cache.collected_at);
             (hooks.render)(&cache.snapshot, cache.dims, age_offset)
         } else {
-            // Decay tick: no event arrived, just the recv_timeout window elapsed.
-            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
+            // Decay tick, or an FS change the throttle deferred: re-render the
+            // cached snapshot, advancing every displayed age by the elapsed time.
+            let age_offset = now.saturating_duration_since(cache.collected_at);
             (hooks.render)(&cache.snapshot, cache.dims, age_offset)
         };
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -977,6 +977,46 @@ mod tests {
     }
 
     #[test]
+    fn recording_a_walk_consumes_the_pending_deferred_walk() {
+        // A completed walk reflects the LATEST coalesced state, so recording it
+        // must consume the single owed walk and reset the deferral — otherwise
+        // the throttle would believe a walk is owed forever. Any number of
+        // mid-cooldown changes collapse to exactly one owed walk at the original
+        // expiry (they neither double up nor move it), and the next `record`
+        // clears it. A 150 ms walk gates the next for 100·150 ms = 15 s. Instants
+        // derive from one base — deterministic and parallel-safe, no sleeping.
+        let t0 = Instant::now();
+
+        let mut throttle = Throttle::new();
+        throttle.record(t0, Duration::from_millis(150)); // next_allowed_at = t0 + 15 s
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_secs(1)),
+            Walk::Defer,
+            "a change 1 s into the 15 s cooldown is deferred, not walked",
+        );
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_secs(2)),
+            Walk::Defer,
+            "a second mid-cooldown change coalesces into the same owed walk",
+        );
+        assert_eq!(
+            throttle.next_allowed(),
+            Some(t0 + Duration::from_secs(15)),
+            "still exactly one walk owed at the original expiry — coalesced, not doubled or moved",
+        );
+
+        // The owed walk runs at expiry and is recorded: that walk reflects the
+        // latest coalesced state, so the single owed walk is consumed and the
+        // deferral resets — nothing is pending afterward.
+        throttle.record(t0 + Duration::from_secs(15), Duration::from_millis(150));
+        assert_eq!(
+            throttle.next_allowed(),
+            None,
+            "the owed walk is consumed by the record; no walk is owed afterward",
+        );
+    }
+
+    #[test]
     fn should_react_accepts_a_tracked_or_untracked_non_ignored_worktree_path() {
         // An edit to a normal source file under the worktree must wake the
         // loop — it's exactly what gsw exists to show.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -254,6 +254,10 @@ const FLOOR: Duration = Duration::from_millis(150);
 struct Throttle {
     /// Earliest instant the next walk may start. `None` = a walk is allowed now.
     next_allowed_at: Option<Instant>,
+    /// Set when a change arrives during an active cooldown: a walk has been
+    /// deferred and exactly one coalesced walk is now owed at the cooldown's
+    /// expiry. Cleared (in a later slice) once that owed walk is performed.
+    dirty: bool,
 }
 
 #[allow(
@@ -264,6 +268,7 @@ impl Throttle {
     fn new() -> Self {
         Self {
             next_allowed_at: None,
+            dirty: false,
         }
     }
 
@@ -281,6 +286,15 @@ impl Throttle {
     /// last-write-wins — each call replaces any prior cooldown, no averaging.
     fn record(&mut self, walk_start: Instant, cost: Duration) {
         self.next_allowed_at = Some(walk_start + cooldown(cost));
+    }
+
+    /// The instant a pending deferred walk should fire — the cooldown's expiry —
+    /// or `None` when no walk is owed. A change that arrives mid-cooldown is
+    /// deferred (it sets the dirty flag) and registers exactly one coalesced
+    /// walk at expiry; the Phase-4 loop reads this to arm a throttle wakeup only
+    /// when one is actually owed, and stays asleep otherwise.
+    fn next_allowed(&self) -> Option<Instant> {
+        None
     }
 }
 
@@ -918,6 +932,37 @@ mod tests {
             throttle.on_change(t0 + Duration::from_millis(150)),
             Walk::Now,
             "allowed exactly at the 150 ms floor, never faster than today's debounce",
+        );
+    }
+
+    #[test]
+    fn a_change_during_an_active_cooldown_pends_a_deferred_walk() {
+        // Deferring a mid-cooldown change must NOT walk immediately — instead it
+        // registers exactly one pending walk at the cooldown's expiry, so a burst
+        // of changes coalesces into a single owed walk. `next_allowed()` exposes
+        // WHEN that owed walk should fire (so the Phase-4 loop can arm a wakeup),
+        // and is `None` until a deferral actually owes one. A 150 ms walk gates
+        // the next for 100·150 ms = 15 s, so the owed walk lands at t0 + 15 s.
+        // Instants derive from one base — deterministic and parallel-safe.
+        let t0 = Instant::now();
+
+        let mut throttle = Throttle::new();
+        throttle.record(t0, Duration::from_millis(150));
+        assert_eq!(
+            throttle.next_allowed(),
+            None,
+            "a recorded-but-unchanged throttle owes no walk yet — nothing is pending",
+        );
+
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_secs(1)),
+            Walk::Defer,
+            "a change 1 s into the 15 s cooldown is deferred, not walked",
+        );
+        assert_eq!(
+            throttle.next_allowed(),
+            Some(t0 + Duration::from_secs(15)),
+            "that deferred change now owes one coalesced walk at the cooldown's expiry",
         );
     }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -351,8 +351,11 @@ fn cooldown(cost: Duration) -> Duration {
 /// are already expressed as durations from now; a `None` from either source
 /// means that source imposes no deadline.
 fn wait_window(decay_tick: Option<Duration>, deferred_walk: Option<Duration>) -> Option<Duration> {
-    let _ = deferred_walk;
-    decay_tick
+    match (decay_tick, deferred_walk) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, None) => a,
+        (None, b) => b,
+    }
 }
 
 /// Events the watch loop reacts to. The main thread owns all rendering and

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -882,6 +882,30 @@ mod tests {
     }
 
     #[test]
+    fn floor_clamps_a_fast_walk_to_the_minimum_cooldown() {
+        // A nearly-free walk has a tiny 100·cost cooldown, which would let the
+        // throttle update FASTER than today's 150 ms debounce window. The FLOOR
+        // clamps it: watch-mode updates can never be quicker than today even
+        // when a walk costs almost nothing. A 1 ms walk's un-floored cooldown is
+        // 100·1 ms = 100 ms; the floor must extend it out to 150 ms. Instants are
+        // derived from one base, so the test is deterministic and parallel-safe.
+        let t0 = Instant::now();
+
+        let mut throttle = Throttle::new();
+        throttle.record(t0, Duration::from_millis(1));
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_millis(100)),
+            Walk::Defer,
+            "still gated past the un-floored 100 ms cooldown — the floor extends it",
+        );
+        assert_eq!(
+            throttle.on_change(t0 + Duration::from_millis(150)),
+            Walk::Now,
+            "allowed exactly at the 150 ms floor, never faster than today's debounce",
+        );
+    }
+
+    #[test]
     fn should_react_accepts_a_tracked_or_untracked_non_ignored_worktree_path() {
         // An edit to a normal source file under the worktree must wake the
         // loop — it's exactly what gsw exists to show.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1101,6 +1101,54 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_resize_renders_cached_snapshot_at_new_dims_without_collecting() {
+        // A terminal resize must re-render the CACHED snapshot at the new
+        // dimensions without walking git (Part A): the collect hook never runs
+        // and the render hook is handed the freshly-queried dimensions.
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::Resize).expect("queue resize");
+        drop(tx);
+
+        let new_dims = Dimensions {
+            width: 123,
+            height: 45,
+        };
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut seen_dims: Option<Dimensions> = None;
+        let now = Instant::now();
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(now),
+            None,
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, dims: Dimensions, _offset: Duration| {
+                    seen_dims = Some(dims);
+                    frame("resized")
+                },
+                dimensions: || new_dims,
+                paint: |_output: &str| Ok(()),
+                clock: || now,
+                next_tick: timer_off,
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(collects, 0, "a resize must not walk git");
+        assert_eq!(
+            seen_dims,
+            Some(new_dims),
+            "a resize must re-render at the freshly-queried dimensions",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -361,6 +361,9 @@ enum Event {
     Resize,
     /// The user asked to quit (`q` or Ctrl-C).
     Quit,
+    /// The user asked to force an immediate refresh (`r`), bypassing the
+    /// throttle cooldown.
+    ForceRefresh,
 }
 
 /// Run the live watch loop: take over the alternate screen, seed the snapshot
@@ -616,6 +619,7 @@ where
                     saw_resize = true;
                     false
                 }
+                Ok(Event::ForceRefresh) => false,
                 Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
@@ -629,6 +633,7 @@ where
                     saw_resize = true;
                     false
                 }
+                Ok(Event::ForceRefresh) => false,
                 Err(_) => break,
             },
         };
@@ -645,6 +650,7 @@ where
                     }
                     Ok(Event::FsChanged) => saw_fs = true,
                     Ok(Event::Resize) => saw_resize = true,
+                    Ok(Event::ForceRefresh) => {}
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
@@ -742,37 +748,60 @@ fn current_dimensions(width_offset: usize) -> Dimensions {
     )
 }
 
-/// Spawn the crossterm event-reader thread. It blocks on `event::read`,
-/// translating `q`/Ctrl-C into [`Event::Quit`] and terminal resizes into
-/// [`Event::Resize`], and exits when the receiver is gone or reading fails.
+/// The pure, unit-testable core of [`spawn_event_reader`]: map one crossterm
+/// terminal event to the [`Event`] the watch loop should react to, or `None`
+/// when the event is irrelevant. Keeping the key→event decision here —
+/// terminal-free and side-effect-free — lets it be tested without a pty while
+/// the reader thread stays a thin `event::read` → `classify_input` → `tx.send`
+/// loop.
+///
+/// - A key *release* is ignored (kitty/Windows report them; only a press acts).
+/// - `q`, or Ctrl-C, requests a [`Event::Quit`].
+/// - `r` forces an immediate refresh ([`Event::ForceRefresh`]), bypassing the
+///   throttle cooldown.
+/// - A terminal resize becomes [`Event::Resize`].
+/// - Everything else is ignored.
+fn classify_input(event: CtEvent) -> Option<Event> {
+    match event {
+        CtEvent::Key(KeyEvent {
+            code,
+            modifiers,
+            kind,
+            ..
+        }) => {
+            if kind == KeyEventKind::Release {
+                // Ignore key releases (kitty/Windows report them); only a press acts.
+                None
+            } else if code == KeyCode::Char('q') {
+                Some(Event::Quit)
+            } else if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+                Some(Event::Quit)
+            } else if code == KeyCode::Char('r') {
+                None
+            } else {
+                None
+            }
+        }
+        CtEvent::Resize(_, _) => Some(Event::Resize),
+        _ => None,
+    }
+}
+
+/// Spawn the crossterm event-reader thread. It blocks on `event::read`, routes
+/// each event through [`classify_input`] (which maps `q`/Ctrl-C to
+/// [`Event::Quit`], `r` to [`Event::ForceRefresh`], and terminal resizes to
+/// [`Event::Resize`]), forwards any resulting [`Event`], and exits when the
+/// receiver is gone or reading fails.
 fn spawn_event_reader(tx: Sender<Event>) {
     thread::spawn(move || loop {
         match event::read() {
-            Ok(CtEvent::Key(KeyEvent {
-                code,
-                modifiers,
-                kind,
-                ..
-            })) => {
-                // Ignore key-release events (kitty/Windows report them); only
-                // a press should quit.
-                if kind == KeyEventKind::Release {
-                    continue;
-                }
-                let quit = matches!(code, KeyCode::Char('q'))
-                    || (modifiers.contains(KeyModifiers::CONTROL)
-                        && matches!(code, KeyCode::Char('c')));
-                if quit && tx.send(Event::Quit).is_err() {
-                    break;
+            Ok(ct_event) => {
+                if let Some(event) = classify_input(ct_event) {
+                    if tx.send(event).is_err() {
+                        break;
+                    }
                 }
             }
-            Ok(CtEvent::Resize(_, _)) => {
-                if tx.send(Event::Resize).is_err() {
-                    break;
-                }
-            }
-            Ok(_) => {}
-            // The terminal closed or reading failed: nothing more to read.
             Err(_) => break,
         }
     });
@@ -1105,6 +1134,14 @@ mod tests {
             Walk::Now,
             "after force, the same mid-cooldown instant walks immediately — the gate is lifted",
         );
+    }
+
+    #[test]
+    fn classify_input_maps_the_r_key_to_force_refresh() {
+        // Pressing `r` is the manual-refresh escape hatch: the input classifier
+        // must turn an `r` key PRESS into Event::ForceRefresh.
+        let r_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert!(matches!(classify_input(r_press), Some(Event::ForceRefresh)));
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -428,7 +428,7 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
 /// contracts verified there:
 ///
 /// - a burst of filesystem events between renders collapses into **one** collect
-///   and at most one paint (coalescing);
+///   (re-seeding the cache) and at most one paint (coalescing);
 /// - a decay tick re-renders from cache with **no** collect, advancing every age
 ///   by `clock() - collected_at`, and repaints only if the frame changed;
 /// - a resize re-renders the cached snapshot at the new dimensions with **no**
@@ -518,6 +518,10 @@ where
         // — the fresh walk already renders at the current dimensions.
         let render = if saw_fs {
             cache.dims = (hooks.dimensions)();
+            // Re-seed the cache's collection time so a later decay tick or resize
+            // advances ages from *this* walk, not the previous one. Taken before
+            // the walk so it marks the walk's start.
+            cache.collected_at = (hooks.clock)();
             cache.snapshot = (hooks.collect)()?;
             (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
         } else if saw_resize {

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1602,6 +1602,77 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_throttles_walks_after_an_idle_change() {
+        // Part B: the FIRST change after idle walks immediately — the throttle
+        // imposes no cooldown until a walk is recorded. That walk costs D = 10 ms,
+        // arming a cooldown of 100·D = 1 s (the walk occupies 10 ms of every 1 s
+        // it gates — a 1% duty cycle). A second change 100 ms in is DURING the
+        // cooldown, so it must be deferred (no git walk). A third change at
+        // base + 2 s is past the cooldown, so it walks again. Three FS changes
+        // across the cooldown boundary therefore collapse to exactly TWO walks.
+        //
+        // The injected clock is a short clamped sequence — once exhausted, every
+        // further read saturates at base + 2 s (well past expiry) — so the test
+        // is fully deterministic and never sleeps on the clock. The three changes
+        // are delivered one per loop iteration (via the render hook) so they land
+        // in separate debounce windows instead of coalescing into one walk.
+        let base = Instant::now();
+        let times = [
+            base,                              // first walk start
+            base + Duration::from_millis(10),  // first walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_millis(100), // second change: mid-cooldown → deferred
+            base + Duration::from_secs(2), // third change: past expiry → walks; trailing reads clamp here
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue first change");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut changes_sent = 1_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            None, // decay timer off: isolate the throttle from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    // Deliver the next change in its own iteration so the three
+                    // never coalesce; quit once all three have been processed.
+                    if changes_sent < 3 {
+                        changes_sent += 1;
+                        let _ = tx.send(Event::FsChanged);
+                    } else {
+                        let _ = tx.send(Event::Quit);
+                    }
+                    frame(&format!("frame {changes_sent}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: timer_off,
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 2,
+            "three FS changes across the cooldown boundary must walk exactly \
+             twice — the mid-cooldown change is deferred",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -772,12 +772,12 @@ fn classify_input(event: CtEvent) -> Option<Event> {
             if kind == KeyEventKind::Release {
                 // Ignore key releases (kitty/Windows report them); only a press acts.
                 None
-            } else if code == KeyCode::Char('q') {
-                Some(Event::Quit)
-            } else if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+            } else if code == KeyCode::Char('q')
+                || (modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c'))
+            {
                 Some(Event::Quit)
             } else if code == KeyCode::Char('r') {
-                None
+                Some(Event::ForceRefresh)
             } else {
                 None
             }
@@ -793,16 +793,15 @@ fn classify_input(event: CtEvent) -> Option<Event> {
 /// [`Event::Resize`]), forwards any resulting [`Event`], and exits when the
 /// receiver is gone or reading fails.
 fn spawn_event_reader(tx: Sender<Event>) {
-    thread::spawn(move || loop {
-        match event::read() {
-            Ok(ct_event) => {
-                if let Some(event) = classify_input(ct_event) {
-                    if tx.send(event).is_err() {
-                        break;
-                    }
+    thread::spawn(move || {
+        // Loop until reading fails (terminal closed) — the `while let` exits on
+        // `Err` — or a forwarded send fails because the receiver is gone.
+        while let Ok(ct_event) = event::read() {
+            if let Some(event) = classify_input(ct_event) {
+                if tx.send(event).is_err() {
+                    break;
                 }
             }
-            Err(_) => break,
         }
     });
 }
@@ -1142,6 +1141,43 @@ mod tests {
         // must turn an `r` key PRESS into Event::ForceRefresh.
         let r_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
         assert!(matches!(classify_input(r_press), Some(Event::ForceRefresh)));
+    }
+
+    #[test]
+    fn classify_input_handles_keys_and_ignores_releases() {
+        // Regression guard for the rest of the classifier's contract once `r`
+        // joined it: a key RELEASE is dropped (kitty/Windows emit them and only
+        // a press should act), `q` and Ctrl-C still quit, a resize still maps to
+        // a repaint, and an unrelated key is ignored.
+
+        // A key release — even of a key we act on — is ignored.
+        let r_release = CtEvent::Key(KeyEvent {
+            kind: KeyEventKind::Release,
+            ..KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)
+        });
+        assert!(
+            classify_input(r_release).is_none(),
+            "a key release must be ignored — only a press acts",
+        );
+
+        // `q` and Ctrl-C both request a quit.
+        let q_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(matches!(classify_input(q_press), Some(Event::Quit)));
+        let ctrl_c = CtEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(matches!(classify_input(ctrl_c), Some(Event::Quit)));
+
+        // A resize becomes a repaint at the new dimensions.
+        assert!(matches!(
+            classify_input(CtEvent::Resize(80, 24)),
+            Some(Event::Resize)
+        ));
+
+        // An unrelated key press is ignored.
+        let x_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(
+            classify_input(x_press).is_none(),
+            "an unrelated key must be ignored",
+        );
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -488,12 +488,17 @@ where
             }
         }
 
-        // NOTE (red step, behavior-preserving): every wake re-collects and
-        // renders at offset 0, exactly as before the cache seam existed. The
-        // green step routes the decay tick to a no-git re-render of the cache.
-        cache.dims = (hooks.dimensions)();
-        cache.snapshot = (hooks.collect)()?;
-        let render = (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO);
+        // Only a filesystem change walks git. A decay tick re-renders the cached
+        // snapshot with no git work, advancing every displayed age by the
+        // wall-clock elapsed since the snapshot was collected (Part A).
+        let render = if woke_for_tick {
+            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
+            (hooks.render)(&cache.snapshot, cache.dims, age_offset)
+        } else {
+            cache.dims = (hooks.dimensions)();
+            cache.snapshot = (hooks.collect)()?;
+            (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
+        };
 
         if should_repaint(&render.output, displayed) {
             (hooks.paint)(&render.output)?;
@@ -1005,7 +1010,10 @@ mod tests {
         .expect("loop");
 
         assert_eq!(renders, 1, "a decay tick must trigger exactly one render");
-        assert_eq!(paints, 1, "the tick-driven render must repaint the new frame");
+        assert_eq!(
+            paints, 1,
+            "the tick-driven render must repaint the new frame"
+        );
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -210,6 +210,10 @@ const DEBOUNCE: Duration = Duration::from_millis(150);
 
 /// Whether a filesystem change may walk git right now, or must wait out the
 /// adaptive cooldown. Returned by [`Throttle::on_change`].
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Walk {
     /// The cooldown has expired (or none is armed): walk git now.
@@ -221,6 +225,10 @@ enum Walk {
 /// Fraction of one core git walks may occupy under sustained churn (1%). A walk
 /// costing `D` is followed by a cooldown of `D / BUDGET`, so the duty cycle
 /// settles at `BUDGET`. Hard-coded, not a user dial.
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
 const BUDGET: f64 = 0.01;
 
 /// Pure, time-injected throttle that gates git walks to the [`BUDGET`] duty
@@ -228,11 +236,19 @@ const BUDGET: f64 = 0.01;
 /// (= 100·`D`), so an expensive repo automatically backs off and a cheap one
 /// stays responsive — all decided here with injected instants, no clock of its
 /// own.
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
 struct Throttle {
     /// Earliest instant the next walk may start. `None` = a walk is allowed now.
     next_allowed_at: Option<Instant>,
 }
 
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
 impl Throttle {
     fn new() -> Self {
         Self {
@@ -240,16 +256,38 @@ impl Throttle {
         }
     }
 
-    fn on_change(&mut self, _now: Instant) -> Walk {
-        // RED stub: always allow. The real cooldown gate arrives in the green
-        // commit; this exists only so the test compiles and fails on behavior.
-        Walk::Now
+    /// Decide whether a change arriving at `now` may walk git: [`Walk::Now`] once
+    /// the armed cooldown has elapsed (or none is armed), otherwise [`Walk::Defer`].
+    fn on_change(&mut self, now: Instant) -> Walk {
+        match self.next_allowed_at {
+            Some(allowed_at) if now < allowed_at => Walk::Defer,
+            _ => Walk::Now,
+        }
     }
 
-    fn record(&mut self, _walk_start: Instant, _cost: Duration) {
-        // RED stub: arm nothing. The real arithmetic arrives in the green commit.
-        self.next_allowed_at = None;
+    /// Arm the next cooldown from a walk that started at `walk_start` and took
+    /// `cost`: the next walk is gated until `walk_start + cost / BUDGET`. Purely
+    /// last-write-wins — each call replaces any prior cooldown, no averaging.
+    fn record(&mut self, walk_start: Instant, cost: Duration) {
+        self.next_allowed_at = Some(walk_start + cooldown(cost));
     }
+}
+
+/// Cooldown for a walk costing `cost`: `cost / BUDGET` (= 100·`cost`), so the
+/// sustained git duty cycle settles at [`BUDGET`]. The integer multiply by the
+/// reciprocal (not `Duration::mul_f64`) keeps it nanosecond-exact, so the
+/// [`Walk::Defer`]/[`Walk::Now`] boundary lands precisely at `walk_start +
+/// cost / BUDGET`; a cost large enough to overflow saturates at [`Duration::MAX`].
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
+fn cooldown(cost: Duration) -> Duration {
+    // = 1 / BUDGET (0.01); an exact integer scale avoids the nanosecond drift
+    // `Duration::mul_f64` would introduce at the on_change boundary.
+    const COOLDOWN_MULTIPLIER: u32 = 100;
+    cost.checked_mul(COOLDOWN_MULTIPLIER)
+        .unwrap_or(Duration::MAX)
 }
 
 /// Events the watch loop reacts to. The main thread owns all rendering and

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -210,10 +210,6 @@ const DEBOUNCE: Duration = Duration::from_millis(150);
 
 /// Whether a filesystem change may walk git right now, or must wait out the
 /// adaptive cooldown. Returned by [`Throttle::on_change`].
-#[allow(
-    dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
-)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Walk {
     /// The cooldown has expired (or none is armed): walk git now.
@@ -227,7 +223,9 @@ enum Walk {
 /// settles at `BUDGET`. Hard-coded, not a user dial.
 #[allow(
     dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+    reason = "Names the 1% duty-cycle target for the docs and spec; `cooldown` \
+              applies the exact integer reciprocal (100) to avoid float drift, so \
+              the constant itself is never read."
 )]
 const BUDGET: f64 = 0.01;
 
@@ -236,10 +234,6 @@ const BUDGET: f64 = 0.01;
 /// result UP to `FLOOR` — so adaptive throttling can only ever make watch-mode
 /// updates *slower* (for an expensive repo), never faster than they already are
 /// under today's debounce. A nearly-free walk therefore still settles at 150 ms.
-#[allow(
-    dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
-)]
 const FLOOR: Duration = Duration::from_millis(150);
 
 /// Pure, time-injected throttle that gates git walks to the [`BUDGET`] duty
@@ -247,23 +241,15 @@ const FLOOR: Duration = Duration::from_millis(150);
 /// (= 100·`D`), so an expensive repo automatically backs off and a cheap one
 /// stays responsive — all decided here with injected instants, no clock of its
 /// own.
-#[allow(
-    dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
-)]
 struct Throttle {
     /// Earliest instant the next walk may start. `None` = a walk is allowed now.
     next_allowed_at: Option<Instant>,
     /// Set when a change arrives during an active cooldown: a walk has been
     /// deferred and exactly one coalesced walk is now owed at the cooldown's
-    /// expiry. Cleared (in a later slice) once that owed walk is performed.
+    /// expiry. Cleared by [`Self::record`] once that owed walk is performed.
     dirty: bool,
 }
 
-#[allow(
-    dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
-)]
 impl Throttle {
     fn new() -> Self {
         Self {
@@ -315,6 +301,10 @@ impl Throttle {
     /// a long cooldown the user doesn't want to wait out. Leaves [`Self::dirty`]
     /// untouched (the forced walk's subsequent [`Self::record`] clears it); this
     /// only opens the gate so the next [`Self::on_change`] returns [`Walk::Now`].
+    #[allow(
+        dead_code,
+        reason = "Wired by Phase 5's manual-refresh `r` key, not yet in the loop."
+    )]
     fn force(&mut self) {
         // Clearing the gate is exactly the "a walk is allowed now" state, so the
         // next on_change short-circuits to Walk::Now regardless of how much
@@ -330,10 +320,6 @@ impl Throttle {
 /// nanosecond-exact, so the [`Walk::Defer`]/[`Walk::Now`] boundary lands precisely
 /// at `walk_start + cost / BUDGET` once that exceeds the floor; a cost large enough
 /// to overflow saturates at [`Duration::MAX`].
-#[allow(
-    dead_code,
-    reason = "Unused until Phase 4 wires the Throttle into the event loop."
-)]
 fn cooldown(cost: Duration) -> Duration {
     // = 1 / BUDGET (0.01); an exact integer scale avoids the nanosecond drift
     // `Duration::mul_f64` would introduce at the on_change boundary.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -315,7 +315,12 @@ impl Throttle {
     /// a long cooldown the user doesn't want to wait out. Leaves [`Self::dirty`]
     /// untouched (the forced walk's subsequent [`Self::record`] clears it); this
     /// only opens the gate so the next [`Self::on_change`] returns [`Walk::Now`].
-    fn force(&mut self) {}
+    fn force(&mut self) {
+        // Clearing the gate is exactly the "a walk is allowed now" state, so the
+        // next on_change short-circuits to Walk::Now regardless of how much
+        // cooldown remained. dirty is left as-is — the forced walk's record clears it.
+        self.next_allowed_at = None;
+    }
 }
 
 /// Cooldown for a walk costing `cost`: `max(FLOOR, cost / BUDGET)` (= `max(FLOOR,

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -231,6 +231,17 @@ enum Walk {
 )]
 const BUDGET: f64 = 0.01;
 
+/// Minimum cooldown, equal to today's [`DEBOUNCE`] window (150 ms). When a walk
+/// is cheap enough that 100·`cost` falls below this, [`cooldown`] clamps the
+/// result UP to `FLOOR` — so adaptive throttling can only ever make watch-mode
+/// updates *slower* (for an expensive repo), never faster than they already are
+/// under today's debounce. A nearly-free walk therefore still settles at 150 ms.
+#[allow(
+    dead_code,
+    reason = "Unused until Phase 4 wires the Throttle into the event loop."
+)]
+const FLOOR: Duration = Duration::from_millis(150);
+
 /// Pure, time-injected throttle that gates git walks to the [`BUDGET`] duty
 /// cycle. After a walk costing `D`, the next walk is held off for `D / BUDGET`
 /// (= 100·`D`), so an expensive repo automatically backs off and a cheap one
@@ -273,11 +284,13 @@ impl Throttle {
     }
 }
 
-/// Cooldown for a walk costing `cost`: `cost / BUDGET` (= 100·`cost`), so the
-/// sustained git duty cycle settles at [`BUDGET`]. The integer multiply by the
-/// reciprocal (not `Duration::mul_f64`) keeps it nanosecond-exact, so the
-/// [`Walk::Defer`]/[`Walk::Now`] boundary lands precisely at `walk_start +
-/// cost / BUDGET`; a cost large enough to overflow saturates at [`Duration::MAX`].
+/// Cooldown for a walk costing `cost`: `max(FLOOR, cost / BUDGET)` (= `max(FLOOR,
+/// 100·cost)`), so the sustained git duty cycle settles at [`BUDGET`] while the
+/// [`FLOOR`] keeps a nearly-free walk from updating faster than today's debounce.
+/// The integer multiply by the reciprocal (not `Duration::mul_f64`) keeps it
+/// nanosecond-exact, so the [`Walk::Defer`]/[`Walk::Now`] boundary lands precisely
+/// at `walk_start + cost / BUDGET` once that exceeds the floor; a cost large enough
+/// to overflow saturates at [`Duration::MAX`].
 #[allow(
     dead_code,
     reason = "Unused until Phase 4 wires the Throttle into the event loop."
@@ -286,8 +299,11 @@ fn cooldown(cost: Duration) -> Duration {
     // = 1 / BUDGET (0.01); an exact integer scale avoids the nanosecond drift
     // `Duration::mul_f64` would introduce at the on_change boundary.
     const COOLDOWN_MULTIPLIER: u32 = 100;
+    // Clamp UP to FLOOR: a sub-1.5 ms walk's 100·cost is under 150 ms, so it
+    // settles at the floor; anything ≥ 1.5 ms already clears it and is unaffected.
     cost.checked_mul(COOLDOWN_MULTIPLIER)
         .unwrap_or(Duration::MAX)
+        .max(FLOOR)
 }
 
 /// Events the watch loop reacts to. The main thread owns all rendering and

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -612,8 +612,14 @@ where
         // size, a bare timeout is a decay tick.
         let mut saw_fs = false;
         let mut saw_resize = false;
-        let wait = wait_window((hooks.next_tick)(freshest), None);
-        let woke_for_tick = match wait {
+        // Wait window: the soonest of the decay-tick cadence and, when a walk was
+        // deferred during a cooldown, that cooldown's expiry. The clock is read
+        // for the deferred deadline only when one is actually pending.
+        let deferred_wait = throttle
+            .next_allowed()
+            .map(|expiry| expiry.saturating_duration_since((hooks.clock)()));
+        let wait = wait_window((hooks.next_tick)(freshest), deferred_wait);
+        let woke_for_timeout = match wait {
             Some(interval) => match rx.recv_timeout(interval) {
                 Ok(Event::Quit) => break,
                 Ok(Event::FsChanged) => {
@@ -644,7 +650,7 @@ where
         // Coalesce a filesystem burst: keep draining until the channel stays
         // quiet for a full `debounce`. A tick has no burst behind it.
         let mut quitting = false;
-        if !woke_for_tick {
+        if !woke_for_timeout {
             loop {
                 match rx.recv_timeout(debounce) {
                     Ok(Event::Quit) => {
@@ -666,13 +672,21 @@ where
         // start, and any age offset all key off the same instant.
         let now = (hooks.clock)();
 
-        // Only a filesystem change walks git, and only when the throttle admits
-        // it. An FS change during an active cooldown is deferred — `on_change`
-        // sets the throttle's dirty flag and we fall through to a cheap cached
-        // re-render (Part A) instead of walking. A resize or decay tick never
-        // walks. A filesystem walk in a coalesced burst wins over a co-arriving
-        // resize: the fresh walk already renders at the current dimensions.
-        let walk_now = saw_fs && matches!(throttle.on_change(now), Walk::Now);
+        // Does this wake walk git? An FS change the throttle admits, or — when a
+        // change was deferred during a cooldown — the single owed walk, fired by
+        // the timeout the loop armed at the cooldown's expiry. `on_change` defers
+        // a mid-cooldown FS change (setting the throttle's dirty flag) and we
+        // fall through to a cheap cached re-render (Part A) instead of walking. A
+        // resize or a plain decay tick never walks. A filesystem walk in a
+        // coalesced burst wins over a co-arriving resize: the fresh walk already
+        // renders at the current dimensions.
+        let walk_now = if saw_fs {
+            matches!(throttle.on_change(now), Walk::Now)
+        } else if woke_for_timeout {
+            throttle.next_allowed().is_some()
+        } else {
+            false
+        };
 
         let render = if walk_now {
             cache.dims = (hooks.dimensions)();
@@ -1704,7 +1718,7 @@ mod tests {
             base,                              // arming walk start
             base + Duration::from_millis(10),  // arming walk end → D = 10 ms → 1 s cooldown
             base + Duration::from_millis(100), // burst: mid-cooldown → deferred
-            base + Duration::from_secs(2),     // owed-walk wake: past expiry; trailing reads clamp here
+            base + Duration::from_secs(2), // owed-walk wake: past expiry; trailing reads clamp here
         ];
         let clock_calls = std::cell::Cell::new(0_usize);
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1906,6 +1906,76 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_force_refresh_walks_immediately_mid_cooldown() {
+        // Phase 5: pressing `r` (Event::ForceRefresh) mid-cooldown must force an
+        // immediate git walk, bypassing the active cooldown. An arming FS walk costs
+        // D = 10 ms, arming a 100·D = 1 s cooldown (expiry = base + 1 s). A force
+        // refresh arrives at base + 100 ms — genuinely mid-cooldown — and must walk
+        // anyway. Across the sequence git is therefore walked exactly TWICE: the
+        // arming walk and the forced walk. The injected clock is a short clamped
+        // sequence (trailing reads saturate at the last entry), so the test is
+        // deterministic and never sleeps on the clock.
+        let base = Instant::now();
+        let times = [
+            base,                              // arming walk start
+            base + Duration::from_millis(10),  // arming walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_millis(100), // force-refresh wake: mid-cooldown
+            base + Duration::from_millis(110), // forced walk end
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue arming change");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut stage = 0_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            None, // decay timer off: isolate the throttle from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    stage += 1;
+                    match stage {
+                        // After the arming walk: a manual refresh lands mid-cooldown.
+                        1 => {
+                            let _ = tx.send(Event::ForceRefresh);
+                        }
+                        // The forced walk's render (or, if force were unwired, the
+                        // deferred re-render): end the loop.
+                        _ => {
+                            let _ = tx.send(Event::Quit);
+                        }
+                    }
+                    frame(&format!("frame {stage}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: timer_off,
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 2,
+            "a force refresh mid-cooldown must walk despite the unexpired cooldown: \
+             the arming walk plus the forced walk",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::cursor::{Hide, MoveTo, Show};
@@ -25,9 +25,10 @@ use crossterm::terminal::{
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 
+use crate::render::Snapshot;
 use crate::{
-    build_output, effective_terminal_height, effective_terminal_width, Render, RenderConfig,
-    DEFAULT_TERMINAL_HEIGHT, DEFAULT_TERMINAL_WIDTH,
+    collect_snapshot, effective_terminal_height, effective_terminal_width, render_frame, Render,
+    RenderConfig, DEFAULT_TERMINAL_HEIGHT, DEFAULT_TERMINAL_WIDTH,
 };
 
 /// Which rendering mode `gsw` is running in. The mode — not ambient env
@@ -226,40 +227,56 @@ enum Event {
     Quit,
 }
 
-/// Run the live watch loop: take over the alternate screen, render once, then
-/// repaint on terminal resize until the user quits with `q` or Ctrl-C.
+/// Run the live watch loop: take over the alternate screen, seed the snapshot
+/// cache with one git walk, paint the first frame, then re-render on filesystem
+/// changes, terminal resizes, and decay-timer ticks until the user quits with
+/// `q` or Ctrl-C.
 ///
-/// The [`TerminalGuard`] restores the main screen and cursor on every exit
-/// path (normal return, error, or panic), so the terminal can never be left
-/// wedged. In this phase the only event producer is the crossterm reader
-/// thread; filesystem watching and the decay timer arrive in later phases.
+/// Filesystem changes walk git and re-seed the cache; decay ticks and resizes
+/// re-render the cached snapshot with no git work (Part A). The [`TerminalGuard`]
+/// restores the main screen and cursor on every exit path.
 pub(crate) fn run(repo: &gix::Repository, cfg: &RenderConfig) -> Result<()> {
     let _guard = TerminalGuard::enter()?;
 
-    // Paint the first frame unconditionally (nothing is displayed yet) and seed
-    // the decay-timer cadence from how fresh that frame is.
-    let first = compute_output(repo, cfg)?;
+    // Seed the cache with one git walk and paint the first frame at offset 0,
+    // byte-identical to a one-shot render of the same state. That frame's
+    // freshest age seeds the decay-timer cadence.
+    let dims = current_dimensions(cfg.width_offset);
+    let collected_at = Instant::now();
+    let snapshot = collect_snapshot(repo, cfg)?;
+    let first = render_frame(&snapshot, cfg, dims, Duration::ZERO);
     paint_output(&first.output)?;
     let mut displayed = first.output;
     let initial_freshest = first.freshest_age;
 
+    let cache = SnapshotCache {
+        snapshot,
+        collected_at,
+        dims,
+    };
+
     let (tx, rx) = mpsc::channel();
     spawn_event_reader(tx.clone());
 
-    // The filesystem watcher must outlive the loop — dropping it stops
-    // watching — so keep it bound here. `None` only when there is no worktree
-    // to watch, which `repo::open` already rules out for watch mode.
+    // The filesystem watcher must outlive the loop — dropping it stops watching.
     let _watcher = spawn_fs_watcher(repo, tx)?;
 
     event_loop(
         &rx,
         DEBOUNCE,
         &mut displayed,
+        cache,
         initial_freshest,
-        || compute_output(repo, cfg),
-        paint_output,
-        // No freshest item (empty/clean repo) → disable the timer entirely.
-        |freshest| freshest.and_then(next_tick),
+        LoopHooks {
+            collect: || collect_snapshot(repo, cfg),
+            render: |snap: &Snapshot, dims: Dimensions, offset: Duration| {
+                render_frame(snap, cfg, dims, offset)
+            },
+            dimensions: || current_dimensions(cfg.width_offset),
+            paint: |output: &str| paint_output(output),
+            clock: Instant::now,
+            next_tick: |freshest: Option<Duration>| freshest.and_then(next_tick),
+        },
     )
 }
 
@@ -358,55 +375,90 @@ fn global_excludes_path(repo: &gix::Repository) -> Option<PathBuf> {
     Some(config_home.join("git").join("ignore"))
 }
 
-/// The render loop's terminal-free core: wait for a filesystem event *or* a
-/// decay-timer tick, coalesce any burst within the `debounce` window, then
-/// recompute once and repaint only if the output actually changed.
+/// The cached repository [`Snapshot`] plus the metadata Part A needs to
+/// re-render it without re-walking git. A decay tick or resize repaints from
+/// this cache, advancing every displayed age by `now - collected_at`; only a
+/// filesystem change re-collects and re-seeds it.
+struct SnapshotCache {
+    /// The most recently collected repository state.
+    snapshot: Snapshot,
+    /// When `snapshot` was collected, against the loop's injected clock. The age
+    /// offset for a no-git re-render is `clock() - collected_at`.
+    collected_at: Instant,
+    /// The dimensions `snapshot` was last rendered at, so a resize can re-render
+    /// the cached snapshot at the new size without collecting.
+    dims: Dimensions,
+}
+
+/// The side-effecting hooks the watch loop drives, bundled so the loop stays one
+/// testable function instead of taking a fistful of closures. Production wires
+/// these to the real git collect, render, terminal-size query, painter, and
+/// clock; tests inject counters and a controllable clock to assert which hooks
+/// ran — and with what age offset — without a TTY or real time.
+struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
+    /// Walk the repo into a fresh [`Snapshot`] (the expensive git work).
+    collect: Collect,
+    /// Render a snapshot at the given dimensions, advancing ages by the offset.
+    render: RenderFn,
+    /// Query the current terminal dimensions (re-evaluated on resize).
+    dimensions: Dims,
+    /// Paint a finished frame.
+    paint: Paint,
+    /// Read the current instant (real `Instant::now` in production).
+    clock: Clock,
+    /// Map the freshest displayed age to the decay-tick interval (`None` = off).
+    next_tick: Tick,
+}
+
+/// The render loop's terminal-free core: wait for a filesystem event, a resize,
+/// or a decay-timer tick, then update the screen. Only a filesystem change walks
+/// git; a tick or resize re-renders the *cached* [`Snapshot`] (Part A), so the
+/// idle-after-commit decay tick no longer pins a core re-walking an unchanged
+/// repo.
 ///
-/// The decay timer needs no thread of its own: `next_tick` turns the freshest
-/// displayed-item age (`initial_freshest`, then refreshed from every render's
-/// [`Render::freshest_age`]) into the `recv_timeout` window, so a timeout *is*
-/// a tick and the cadence is recomputed after every render. `None` from
-/// `next_tick` disables the timer — the loop blocks indefinitely on events.
+/// The decay timer needs no thread of its own: `next_tick` (in `hooks`) turns
+/// the freshest displayed-item age into the `recv_timeout` window, so a timeout
+/// *is* a tick and the cadence is recomputed after every render. `None` disables
+/// the timer — the loop blocks indefinitely on events.
 ///
-/// `compute` produces the current [`Render`] (a status walk plus its freshest
-/// age); `paint` displays the frame. Pulling these out as closures keeps the
-/// loop testable without a TTY, real filesystem events, or real time — a test
-/// feeds a pre-loaded channel and an injected `next_tick`, and asserts how many
-/// times each ran. The contract verified there:
+/// `hooks` bundles the side effects (collect, render, terminal-size query, paint,
+/// clock, tick cadence) so the loop is one function testable without a TTY or
+/// real time: a test feeds a pre-loaded channel, a controllable clock, and
+/// counters, then asserts which hooks ran and with what age offset. The
+/// contracts verified there:
 ///
-/// - a burst of events between renders collapses into **one** `compute` and at
-///   most one `paint` (coalescing);
-/// - a decay tick (a `recv_timeout` timeout) drives a `compute` with no
-///   coalescing, and repaints only if the frame changed;
-/// - a recompute whose output is byte-identical to what's displayed does the
-///   `compute` (the status walk happened) but **no** `paint` (suppression);
-/// - [`Event::Quit`] ends the loop, as does every sender hanging up
-///   (`recv` / `recv_timeout` returning disconnected).
-fn event_loop<C, P, T>(
+/// - a burst of filesystem events between renders collapses into **one** collect
+///   and at most one paint (coalescing);
+/// - a decay tick re-renders from cache with **no** collect, advancing every age
+///   by `clock() - collected_at`, and repaints only if the frame changed;
+/// - a recompute whose output is byte-identical to what's displayed paints
+///   nothing (suppression);
+/// - [`Event::Quit`] ends the loop, as does every sender hanging up.
+fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick>(
     rx: &Receiver<Event>,
     debounce: Duration,
     displayed: &mut String,
+    mut cache: SnapshotCache,
     initial_freshest: Option<Duration>,
-    mut compute: C,
-    mut paint: P,
-    next_tick: T,
+    mut hooks: LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick>,
 ) -> Result<()>
 where
-    C: FnMut() -> Result<Render>,
-    P: FnMut(&str) -> Result<()>,
-    T: Fn(Option<Duration>) -> Option<Duration>,
+    Collect: FnMut() -> Result<Snapshot>,
+    RenderFn: FnMut(&Snapshot, Dimensions, Duration) -> Render,
+    Dims: Fn() -> Dimensions,
+    Paint: FnMut(&str) -> Result<()>,
+    Clock: Fn() -> Instant,
+    Tick: Fn(Option<Duration>) -> Option<Duration>,
 {
     let mut freshest = initial_freshest;
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
-        // after `interval` of quiet for a tick. `recv` / `recv_timeout` error
-        // only once every sender has hung up, which — like an explicit Quit —
-        // means we're done.
-        let woke_for_tick = match next_tick(freshest) {
+        // after `interval` of quiet for a tick.
+        let woke_for_tick = match (hooks.next_tick)(freshest) {
             Some(interval) => match rx.recv_timeout(interval) {
                 Ok(Event::Quit) => break,
                 Ok(_) => false,
-                Err(RecvTimeoutError::Timeout) => true, // the interval elapsed: a decay tick
+                Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
             None => match rx.recv() {
@@ -417,10 +469,7 @@ where
         };
 
         // Coalesce a filesystem burst: keep draining until the channel stays
-        // quiet for a full `debounce`, folding every further wake-up into this
-        // one batch. A Quit seen mid-drain still renders the pending batch,
-        // then exits; a disconnect (all senders gone) does the same. A decay
-        // tick has no burst behind it, so it skips coalescing and renders now.
+        // quiet for a full `debounce`. A tick has no burst behind it.
         let mut quitting = false;
         if !woke_for_tick {
             loop {
@@ -429,8 +478,8 @@ where
                         quitting = true;
                         break;
                     }
-                    Ok(_) => {} // another change — fold it in and keep draining
-                    Err(RecvTimeoutError::Timeout) => break, // window elapsed
+                    Ok(_) => {}
+                    Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
                         break;
@@ -439,12 +488,15 @@ where
             }
         }
 
-        // One status walk per coalesced batch, and a repaint only when the
-        // result actually differs from what's on screen. The fresh age feeds
-        // the next iteration's tick cadence.
-        let render = compute()?;
+        // NOTE (red step, behavior-preserving): every wake re-collects and
+        // renders at offset 0, exactly as before the cache seam existed. The
+        // green step routes the decay tick to a no-git re-render of the cache.
+        cache.dims = (hooks.dimensions)();
+        cache.snapshot = (hooks.collect)()?;
+        let render = (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO);
+
         if should_repaint(&render.output, displayed) {
-            paint(&render.output)?;
+            (hooks.paint)(&render.output)?;
             *displayed = render.output;
         }
         freshest = render.freshest_age;
@@ -454,13 +506,6 @@ where
         }
     }
     Ok(())
-}
-
-/// Recompute the full render (frame plus its freshest displayed-item age) for
-/// the current terminal size.
-fn compute_output(repo: &gix::Repository, cfg: &RenderConfig) -> Result<Render> {
-    let dims = current_dimensions(cfg.width_offset);
-    build_output(repo, cfg, dims)
 }
 
 /// Paint `output` into the alternate screen, replacing whatever frame is there.
@@ -770,185 +815,281 @@ mod tests {
         }
     }
 
+    /// A minimal [`Snapshot`] for loop tests that don't inspect snapshot contents
+    /// (the injected render hook returns a canned frame regardless).
+    fn empty_snapshot() -> Snapshot {
+        Snapshot {
+            branch: "b".into(),
+            base: "main".into(),
+            commits_ahead: 0,
+            commits_behind: 0,
+            last_commit_age: None,
+            files: Vec::new(),
+            log: Vec::new(),
+            upstream: None,
+        }
+    }
+
+    /// Dimensions used by loop tests that don't exercise resize.
+    const TEST_DIMS: Dimensions = Dimensions {
+        width: 80,
+        height: 24,
+    };
+
+    /// A [`SnapshotCache`] seeded at `collected_at` with an empty snapshot and
+    /// [`TEST_DIMS`].
+    fn seeded_cache(collected_at: Instant) -> SnapshotCache {
+        SnapshotCache {
+            snapshot: empty_snapshot(),
+            collected_at,
+            dims: TEST_DIMS,
+        }
+    }
+
     #[test]
     fn event_loop_coalesces_a_burst_into_one_repaint() {
         // A `git commit` is a storm of `.git/` writes; an editor save is a
         // write+rename. Either way the burst must collapse into a single
-        // status walk and a single repaint, not one per event.
+        // collect and a single repaint, not one per event.
         let (tx, rx) = mpsc::channel();
         for _ in 0..5 {
             tx.send(Event::FsChanged).expect("queue event");
         }
-        drop(tx); // loop ends once the coalesced batch is rendered
+        drop(tx);
 
         let mut displayed = String::new();
-        let mut computes = 0_usize;
+        let mut collects = 0_usize;
         let mut paints = 0_usize;
+        let now = Instant::now();
         event_loop(
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
+            seeded_cache(now),
             None,
-            || {
-                computes += 1;
-                Ok(frame("frame"))
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| frame("frame"),
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || now,
+                next_tick: timer_off,
             },
-            |_output| {
-                paints += 1;
-                Ok(())
-            },
-            timer_off,
         )
         .expect("loop");
 
-        assert_eq!(computes, 1, "a coalesced burst must walk status once");
+        assert_eq!(collects, 1, "a coalesced burst must walk status once");
         assert_eq!(paints, 1, "a coalesced burst must repaint once");
         assert_eq!(displayed, "frame");
     }
 
     #[test]
     fn event_loop_suppresses_when_recompute_is_unchanged() {
-        // FS churn that doesn't change the visible state (e.g. `.git/objects`
-        // writes during a commit that we already reflect) must still do the
-        // status walk but produce no repaint.
+        // FS churn that doesn't change the visible state must still collect but
+        // produce no repaint.
         let (tx, rx) = mpsc::channel();
         tx.send(Event::FsChanged).expect("queue event");
         drop(tx);
 
         let mut displayed = "unchanged".to_string();
-        let mut computes = 0_usize;
+        let mut collects = 0_usize;
         let mut paints = 0_usize;
+        let now = Instant::now();
         event_loop(
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
+            seeded_cache(now),
             None,
-            || {
-                computes += 1;
-                Ok(frame("unchanged"))
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| frame("unchanged"),
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || now,
+                next_tick: timer_off,
             },
-            |_output| {
-                paints += 1;
-                Ok(())
-            },
-            timer_off,
         )
         .expect("loop");
 
-        assert_eq!(computes, 1, "a wake-up still does the status walk");
+        assert_eq!(collects, 1, "a wake-up still does the status walk");
         assert_eq!(paints, 0, "byte-identical output must not repaint");
     }
 
     #[test]
     fn event_loop_quit_as_first_event_exits_without_rendering() {
-        // `q` / Ctrl-C before anything else changes must exit cleanly without
-        // a stray recompute or repaint.
+        // `q` / Ctrl-C before anything else changes must exit cleanly without a
+        // stray collect or repaint.
         let (tx, rx) = mpsc::channel();
         tx.send(Event::Quit).expect("queue quit");
         drop(tx);
 
         let mut displayed = String::new();
-        let mut computes = 0_usize;
+        let mut collects = 0_usize;
         let mut paints = 0_usize;
+        let now = Instant::now();
         event_loop(
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
+            seeded_cache(now),
             None,
-            || {
-                computes += 1;
-                Ok(frame("frame"))
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| frame("frame"),
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || now,
+                next_tick: timer_off,
             },
-            |_output| {
-                paints += 1;
-                Ok(())
-            },
-            timer_off,
         )
         .expect("loop");
 
-        assert_eq!(computes, 0, "Quit must not trigger a recompute");
+        assert_eq!(collects, 0, "Quit must not trigger a collect");
         assert_eq!(paints, 0, "Quit must not trigger a repaint");
     }
 
     #[test]
     fn event_loop_tick_triggers_a_render() {
-        // With no filesystem events at all, the decay timer must still wake the
-        // loop and re-render so the age text and color fade stay current. We
-        // model a tick with a tiny injected interval; the compute closure
+        // With no filesystem events, the decay timer must still wake the loop and
+        // re-render so the age text and color fade stay current. The render hook
         // queues a Quit so the loop ends right after the tick-driven render.
         let (tx, rx) = mpsc::channel();
         let mut displayed = String::new();
-        let mut computes = 0_usize;
+        let mut renders = 0_usize;
         let mut paints = 0_usize;
+        let now = Instant::now();
         event_loop(
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
+            seeded_cache(now),
             Some(Duration::ZERO),
-            || {
-                computes += 1;
-                // End the loop right after this first tick-driven render. `tx`
-                // outlives the call, so the channel stays open across the tick.
-                let _ = tx.send(Event::Quit);
-                Ok(Render {
-                    output: format!("tick {computes}"),
-                    freshest_age: Some(Duration::ZERO),
-                })
+            LoopHooks {
+                collect: || Ok(empty_snapshot()),
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    renders += 1;
+                    // End the loop right after this first tick-driven render.
+                    let _ = tx.send(Event::Quit);
+                    frame(&format!("tick {renders}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || now,
+                // Tiny interval so the tick fires fast; the cadence-vs-age
+                // mapping is covered by the next_tick tests.
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
             },
-            |_output| {
-                paints += 1;
-                Ok(())
-            },
-            // Tiny interval so the tick fires fast instead of waiting a real
-            // second; the cadence-vs-age mapping is covered by next_tick tests.
-            |_freshest| Some(Duration::from_millis(5)),
         )
         .expect("loop");
 
-        assert_eq!(
-            computes, 1,
-            "a decay tick must trigger exactly one recompute"
-        );
-        assert_eq!(
-            paints, 1,
-            "the tick-driven render must repaint the new frame"
-        );
+        assert_eq!(renders, 1, "a decay tick must trigger exactly one render");
+        assert_eq!(paints, 1, "the tick-driven render must repaint the new frame");
     }
 
     #[test]
     fn event_loop_tick_with_unchanged_render_does_not_repaint() {
-        // A decay tick recomputes, but if the freshly-rendered frame is
-        // byte-identical to what's displayed (the age text hasn't ticked over
-        // yet), it must do the status walk and skip the repaint — the same
-        // suppression that absorbs no-op filesystem churn.
+        // A decay tick re-renders, but if the frame is byte-identical to what's
+        // displayed it must skip the repaint — the same suppression that absorbs
+        // no-op filesystem churn.
         let (tx, rx) = mpsc::channel();
         let mut displayed = "steady".to_string();
-        let mut computes = 0_usize;
+        let mut renders = 0_usize;
         let mut paints = 0_usize;
+        let now = Instant::now();
         event_loop(
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
+            seeded_cache(now),
             Some(Duration::from_secs(30)),
-            || {
-                computes += 1;
-                let _ = tx.send(Event::Quit);
-                Ok(Render {
-                    output: "steady".to_string(),
-                    freshest_age: Some(Duration::from_secs(30)),
-                })
+            LoopHooks {
+                collect: || Ok(empty_snapshot()),
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    renders += 1;
+                    let _ = tx.send(Event::Quit);
+                    frame("steady")
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || now,
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
             },
-            |_output| {
-                paints += 1;
-                Ok(())
-            },
-            |_freshest| Some(Duration::from_millis(5)),
         )
         .expect("loop");
 
-        assert_eq!(computes, 1, "the tick still does the status walk");
+        assert_eq!(renders, 1, "the tick still renders");
         assert_eq!(paints, 0, "an unchanged tick render must not repaint");
+    }
+
+    #[test]
+    fn event_loop_tick_renders_cached_snapshot_without_collecting() {
+        // A decay tick must NOT re-walk git: it re-renders the CACHED snapshot,
+        // advancing every displayed age by `now - collected_at` (Part A). With a
+        // clock 50s past collection, the render hook must see a 50s offset and
+        // the git-collect hook must never run.
+        let (tx, rx) = mpsc::channel();
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut renders = 0_usize;
+        let mut seen_offset: Option<Duration> = None;
+        let collected_at = Instant::now();
+        let clock_at = collected_at + Duration::from_secs(50);
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(collected_at),
+            Some(Duration::ZERO),
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, offset: Duration| {
+                    renders += 1;
+                    seen_offset = Some(offset);
+                    let _ = tx.send(Event::Quit);
+                    frame(&format!("tick {renders}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || clock_at,
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(collects, 0, "a decay tick must not walk git");
+        assert_eq!(
+            seen_offset,
+            Some(Duration::from_secs(50)),
+            "the no-git re-render must advance ages by now - collected_at",
+        );
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1684,6 +1684,88 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_defers_a_cooldown_burst_into_one_walk_at_expiry() {
+        // Part B coalescing: an arming walk starts a cooldown; a BURST of FS
+        // changes that all land during that cooldown must not each walk — they
+        // collapse into exactly ONE deferred walk that the loop runs when the
+        // cooldown expires. Across the whole sequence git is walked twice: the
+        // arming walk, then the single owed walk. The collect counter proves the
+        // burst added exactly one walk, not one per event.
+        //
+        // The arming walk costs D = 10 ms → a 1 s cooldown (expiry = base + 1 s).
+        // The burst lands at base + 100 ms (mid-cooldown → deferred). The owed
+        // walk fires at base + 2 s, past expiry, on a zero-length timeout (the
+        // injected clock reports "now" already past expiry, so the loop never
+        // sleeps it out). A 5 ms decay timer is enabled so the loop still wakes
+        // periodically — proving the owed walk runs at the cooldown's expiry, not
+        // merely on the next tick.
+        let base = Instant::now();
+        let times = [
+            base,                              // arming walk start
+            base + Duration::from_millis(10),  // arming walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_millis(100), // burst: mid-cooldown → deferred
+            base + Duration::from_secs(2),     // owed-walk wake: past expiry; trailing reads clamp here
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue arming change");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut stage = 0_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            Some(Duration::ZERO),
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    stage += 1;
+                    match stage {
+                        // After the arming walk: fire a burst of three changes
+                        // that coalesce inside one debounce window.
+                        1 => {
+                            for _ in 0..3 {
+                                let _ = tx.send(Event::FsChanged);
+                            }
+                        }
+                        // The deferred re-render of the coalesced burst: do
+                        // nothing, let the cooldown expire so the owed walk fires.
+                        2 => {}
+                        // The owed walk at expiry (or, if throttling were absent,
+                        // a tick): end the loop.
+                        _ => {
+                            let _ = tx.send(Event::Quit);
+                        }
+                    }
+                    frame(&format!("frame {stage}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 2,
+            "an arming walk plus a mid-cooldown burst must walk exactly twice: \
+             the arming walk and one coalesced owed walk at the cooldown's expiry",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -301,10 +301,6 @@ impl Throttle {
     /// a long cooldown the user doesn't want to wait out. Leaves [`Self::dirty`]
     /// untouched (the forced walk's subsequent [`Self::record`] clears it); this
     /// only opens the gate so the next [`Self::on_change`] returns [`Walk::Now`].
-    #[allow(
-        dead_code,
-        reason = "Wired by Phase 5's manual-refresh `r` key, not yet in the loop."
-    )]
     fn force(&mut self) {
         // Clearing the gate is exactly the "a walk is allowed now" state, so the
         // next on_change short-circuits to Walk::Now regardless of how much
@@ -601,6 +597,7 @@ where
         // size, a bare timeout is a decay tick.
         let mut saw_fs = false;
         let mut saw_resize = false;
+        let mut saw_force = false;
         // Wait window: the soonest of the decay-tick cadence and, when a walk was
         // deferred during a cooldown, that cooldown's expiry. The clock is read
         // for the deferred deadline only when one is actually pending.
@@ -619,7 +616,10 @@ where
                     saw_resize = true;
                     false
                 }
-                Ok(Event::ForceRefresh) => false,
+                Ok(Event::ForceRefresh) => {
+                    saw_force = true;
+                    false
+                }
                 Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
@@ -633,7 +633,10 @@ where
                     saw_resize = true;
                     false
                 }
-                Ok(Event::ForceRefresh) => false,
+                Ok(Event::ForceRefresh) => {
+                    saw_force = true;
+                    false
+                }
                 Err(_) => break,
             },
         };
@@ -650,7 +653,7 @@ where
                     }
                     Ok(Event::FsChanged) => saw_fs = true,
                     Ok(Event::Resize) => saw_resize = true,
-                    Ok(Event::ForceRefresh) => {}
+                    Ok(Event::ForceRefresh) => saw_force = true,
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
@@ -664,15 +667,22 @@ where
         // start, and any age offset all key off the same instant.
         let now = (hooks.clock)();
 
-        // Does this wake walk git? An FS change the throttle admits, or — when a
-        // change was deferred during a cooldown — the single owed walk, fired by
-        // the timeout the loop armed at the cooldown's expiry. `on_change` defers
-        // a mid-cooldown FS change (setting the throttle's dirty flag) and we
-        // fall through to a cheap cached re-render (Part A) instead of walking. A
-        // resize or a plain decay tick never walks. A filesystem walk in a
-        // coalesced burst wins over a co-arriving resize: the fresh walk already
-        // renders at the current dimensions.
-        let walk_now = if saw_fs {
+        // Does this wake walk git? A manual refresh (`r`) forces one
+        // unconditionally, bypassing the cooldown. Otherwise an FS change the
+        // throttle admits, or — when a change was deferred during a cooldown —
+        // the single owed walk, fired by the timeout the loop armed at the
+        // cooldown's expiry. `on_change` defers a mid-cooldown FS change (setting
+        // the throttle's dirty flag) and we fall through to a cheap cached
+        // re-render (Part A) instead of walking. A resize or a plain decay tick
+        // never walks. A filesystem walk in a coalesced burst wins over a
+        // co-arriving resize: the fresh walk already renders at the current
+        // dimensions.
+        let walk_now = if saw_force {
+            // Manual refresh (`r`): lift the cooldown gate and walk now. The walk
+            // branch re-measures cost and re-arms the throttle from it.
+            throttle.force();
+            true
+        } else if saw_fs {
             matches!(throttle.on_change(now), Walk::Now)
         } else if woke_for_timeout {
             // Only the OWED walk fires here, and only once its cooldown has
@@ -1973,6 +1983,124 @@ mod tests {
             "a force refresh mid-cooldown must walk despite the unexpired cooldown: \
              the arming walk plus the forced walk",
         );
+    }
+
+    #[test]
+    fn event_loop_force_refresh_rearms_throttle_from_fresh_measurement() {
+        // Phase 5 acceptance: a forced walk must re-measure its cost and re-arm the
+        // cooldown from it, exactly like an ordinary FS walk — so a *subsequent* FS
+        // change is throttled against the FRESH measurement. The forced walk costs
+        // D = 10 ms, arming a 100·D = 1 s cooldown. An FS change then lands at
+        // base + 100 ms, genuinely mid-cooldown, and must be DEFERRED — proving the
+        // forced walk re-armed the throttle. Across the sequence git is walked
+        // exactly ONCE (the forced walk); if `force` had failed to re-arm, the FS
+        // change would have walked too and collects would be 2. The injected clock
+        // is a short clamped sequence, so the test is deterministic and never sleeps.
+        let base = Instant::now();
+        let times = [
+            base,                              // forced walk start
+            base + Duration::from_millis(10),  // forced walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_millis(100), // FS-change wake: mid-cooldown → deferred
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::ForceRefresh).expect("queue forced refresh");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut stage = 0_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            None, // decay timer off: isolate the throttle from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    stage += 1;
+                    match stage {
+                        // After the forced walk: an FS change lands mid-cooldown.
+                        1 => {
+                            let _ = tx.send(Event::FsChanged);
+                        }
+                        // The deferred re-render of that FS change: end the loop.
+                        _ => {
+                            let _ = tx.send(Event::Quit);
+                        }
+                    }
+                    frame(&format!("frame {stage}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: timer_off,
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 1,
+            "the forced walk re-arms the cooldown from its fresh cost, so a later \
+             mid-cooldown FS change is deferred: only the forced walk runs. If force \
+             failed to re-arm, the FS change would walk too and collects would be 2.",
+        );
+    }
+
+    #[test]
+    fn event_loop_force_refresh_on_idle_walks_once() {
+        // Phase 5 acceptance: pressing `r` on a clean/idle loop simply walks once
+        // and repaints once — no error, no double walk. With a constant clock and
+        // the decay timer off, the single queued ForceRefresh drives exactly one
+        // collect and one paint before the render hook quits.
+        let base = Instant::now();
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::ForceRefresh).expect("queue forced refresh");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut paints = 0_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            None, // decay timer off: isolate the forced walk from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    // End the loop right after the forced walk's render.
+                    let _ = tx.send(Event::Quit);
+                    frame("forced")
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| {
+                    paints += 1;
+                    Ok(())
+                },
+                clock: || base,
+                next_tick: timer_off,
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 1,
+            "a forced refresh on an idle loop walks git once"
+        );
+        assert_eq!(paints, 1, "the forced walk repaints exactly once");
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1780,6 +1780,69 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_decay_tick_during_cooldown_does_not_walk() {
+        // Part A and Part B compose: while a cooldown is active (a deferred walk
+        // is owed), a plain decay tick — which fires on the SHORTER decay cadence,
+        // before the cooldown expires — must re-render the cached snapshot WITHOUT
+        // walking git. Only the owed walk, once its cooldown has actually expired,
+        // walks. A constant injected clock pins "now" at `base`, so the 150 ms
+        // FLOOR cooldown (the arming walk costs 0) is never reached: the arming
+        // walk is the ONLY walk; the deferred change and the decay tick during the
+        // cooldown add none.
+        let base = Instant::now();
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue arming change");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut stage = 0_usize;
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            Some(Duration::ZERO),
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Ok(empty_snapshot())
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    stage += 1;
+                    match stage {
+                        // After the arming walk: one FS change lands mid-cooldown
+                        // (it is deferred, setting the dirty flag).
+                        1 => {
+                            let _ = tx.send(Event::FsChanged);
+                        }
+                        // The deferred re-render: do nothing, let a decay tick fire
+                        // while the cooldown is still active.
+                        2 => {}
+                        // The decay tick during the cooldown (or, if the guard were
+                        // missing, a wrongful owed walk): end the loop.
+                        _ => {
+                            let _ = tx.send(Event::Quit);
+                        }
+                    }
+                    frame(&format!("frame {stage}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || base,
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(
+            collects, 1,
+            "a decay tick that fires during an active cooldown must re-render \
+             from cache without walking git — only the arming walk runs",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -431,6 +431,8 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
 ///   and at most one paint (coalescing);
 /// - a decay tick re-renders from cache with **no** collect, advancing every age
 ///   by `clock() - collected_at`, and repaints only if the frame changed;
+/// - a resize re-renders the cached snapshot at the new dimensions with **no**
+///   collect;
 /// - a recompute whose output is byte-identical to what's displayed paints
 ///   nothing (suppression);
 /// - [`Event::Quit`] ends the loop, as does every sender hanging up.
@@ -454,16 +456,35 @@ where
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
         // after `interval` of quiet for a tick.
+        // Track *which* triggers arrived so the render below can route them: a
+        // filesystem change walks git, a resize re-renders the cache at the new
+        // size, a bare timeout is a decay tick.
+        let mut saw_fs = false;
+        let mut saw_resize = false;
         let woke_for_tick = match (hooks.next_tick)(freshest) {
             Some(interval) => match rx.recv_timeout(interval) {
                 Ok(Event::Quit) => break,
-                Ok(_) => false,
+                Ok(Event::FsChanged) => {
+                    saw_fs = true;
+                    false
+                }
+                Ok(Event::Resize) => {
+                    saw_resize = true;
+                    false
+                }
                 Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
             None => match rx.recv() {
                 Ok(Event::Quit) => break,
-                Ok(_) => false,
+                Ok(Event::FsChanged) => {
+                    saw_fs = true;
+                    false
+                }
+                Ok(Event::Resize) => {
+                    saw_resize = true;
+                    false
+                }
                 Err(_) => break,
             },
         };
@@ -478,7 +499,8 @@ where
                         quitting = true;
                         break;
                     }
-                    Ok(_) => {}
+                    Ok(Event::FsChanged) => saw_fs = true,
+                    Ok(Event::Resize) => saw_resize = true,
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
@@ -488,16 +510,24 @@ where
             }
         }
 
-        // Only a filesystem change walks git. A decay tick re-renders the cached
-        // snapshot with no git work, advancing every displayed age by the
-        // wall-clock elapsed since the snapshot was collected (Part A).
-        let render = if woke_for_tick {
-            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
-            (hooks.render)(&cache.snapshot, cache.dims, age_offset)
-        } else {
+        // Only a filesystem change walks git. A resize re-renders the cached
+        // snapshot at the freshly-queried dimensions; a decay tick re-renders it
+        // at the cached dimensions. Both advance every displayed age by the
+        // wall-clock elapsed since the snapshot was collected (Part A). A
+        // filesystem change in a coalesced burst wins over a co-arriving resize
+        // — the fresh walk already renders at the current dimensions.
+        let render = if saw_fs {
             cache.dims = (hooks.dimensions)();
             cache.snapshot = (hooks.collect)()?;
             (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
+        } else if saw_resize {
+            cache.dims = (hooks.dimensions)();
+            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
+            (hooks.render)(&cache.snapshot, cache.dims, age_offset)
+        } else {
+            // Decay tick: no event arrived, just the recv_timeout window elapsed.
+            let age_offset = (hooks.clock)().saturating_duration_since(cache.collected_at);
+            (hooks.render)(&cache.snapshot, cache.dims, age_offset)
         };
 
         if should_repaint(&render.output, displayed) {

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1179,6 +1179,68 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_fs_change_reseeds_collected_at() {
+        // After a filesystem change re-collects the snapshot, a later decay tick
+        // must measure its age offset from the NEW collection time, not the stale
+        // seed (Part A). We drive: FsChanged (collected at t+10s), then a tick
+        // (clock at t+15s) whose render must see a 5s offset — not 15s.
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue fs change");
+
+        let base = Instant::now();
+        // Clock returns t+10s for the FS collect, then t+15s for the tick.
+        let times = [
+            base + Duration::from_secs(10),
+            base + Duration::from_secs(15),
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let mut displayed = String::new();
+        let mut offsets: Vec<Duration> = Vec::new();
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            Some(Duration::ZERO),
+            LoopHooks {
+                collect: || Ok(empty_snapshot()),
+                render: |_snap: &Snapshot, _dims: Dimensions, offset: Duration| {
+                    offsets.push(offset);
+                    // First render is the FS walk (offset 0); the next wake is a
+                    // decay tick. End the loop once the tick render has happened.
+                    if offsets.len() >= 2 {
+                        let _ = tx.send(Event::Quit);
+                    }
+                    frame(&format!("frame {}", offsets.len()))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: |_freshest| Some(Duration::from_millis(5)),
+            },
+        )
+        .expect("loop");
+
+        assert_eq!(offsets.len(), 2, "expected an FS render then a tick render");
+        assert_eq!(
+            offsets[0],
+            Duration::ZERO,
+            "the FS render is always at offset 0"
+        );
+        assert_eq!(
+            offsets[1],
+            Duration::from_secs(5),
+            "the tick after an FS change must measure its offset from the re-collected \
+             time (t+15 - t+10 = 5s), not from the stale seed",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -683,7 +683,11 @@ where
         let walk_now = if saw_fs {
             matches!(throttle.on_change(now), Walk::Now)
         } else if woke_for_timeout {
-            throttle.next_allowed().is_some()
+            // Only the OWED walk fires here, and only once its cooldown has
+            // actually expired: a plain decay tick that fires mid-cooldown (a
+            // shorter wait than the deferred deadline) re-renders from cache
+            // without walking, so Part A and Part B compose.
+            matches!(throttle.next_allowed(), Some(expiry) if now >= expiry)
         } else {
             false
         };

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -276,7 +276,13 @@ impl Throttle {
     /// the armed cooldown has elapsed (or none is armed), otherwise [`Walk::Defer`].
     fn on_change(&mut self, now: Instant) -> Walk {
         match self.next_allowed_at {
-            Some(allowed_at) if now < allowed_at => Walk::Defer,
+            Some(allowed_at) if now < allowed_at => {
+                // A change landed mid-cooldown: don't walk now, but remember that
+                // a change has happened which no walk has yet reflected, so one
+                // coalesced walk is owed when the cooldown expires.
+                self.dirty = true;
+                Walk::Defer
+            }
             _ => Walk::Now,
         }
     }
@@ -294,7 +300,11 @@ impl Throttle {
     /// walk at expiry; the Phase-4 loop reads this to arm a throttle wakeup only
     /// when one is actually owed, and stays asleep otherwise.
     fn next_allowed(&self) -> Option<Instant> {
-        None
+        if self.dirty {
+            self.next_allowed_at
+        } else {
+            None
+        }
     }
 }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -208,6 +208,50 @@ pub(crate) fn next_tick(freshest_age: Duration) -> Option<Duration> {
 /// arrives inside this window and collapses into a single repaint.
 const DEBOUNCE: Duration = Duration::from_millis(150);
 
+/// Whether a filesystem change may walk git right now, or must wait out the
+/// adaptive cooldown. Returned by [`Throttle::on_change`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Walk {
+    /// The cooldown has expired (or none is armed): walk git now.
+    Now,
+    /// A walk is still gated by the cooldown: skip the git work this time.
+    Defer,
+}
+
+/// Fraction of one core git walks may occupy under sustained churn (1%). A walk
+/// costing `D` is followed by a cooldown of `D / BUDGET`, so the duty cycle
+/// settles at `BUDGET`. Hard-coded, not a user dial.
+const BUDGET: f64 = 0.01;
+
+/// Pure, time-injected throttle that gates git walks to the [`BUDGET`] duty
+/// cycle. After a walk costing `D`, the next walk is held off for `D / BUDGET`
+/// (= 100·`D`), so an expensive repo automatically backs off and a cheap one
+/// stays responsive — all decided here with injected instants, no clock of its
+/// own.
+struct Throttle {
+    /// Earliest instant the next walk may start. `None` = a walk is allowed now.
+    next_allowed_at: Option<Instant>,
+}
+
+impl Throttle {
+    fn new() -> Self {
+        Self {
+            next_allowed_at: None,
+        }
+    }
+
+    fn on_change(&mut self, _now: Instant) -> Walk {
+        // RED stub: always allow. The real cooldown gate arrives in the green
+        // commit; this exists only so the test compiles and fails on behavior.
+        Walk::Now
+    }
+
+    fn record(&mut self, _walk_start: Instant, _cost: Duration) {
+        // RED stub: arm nothing. The real arithmetic arrives in the green commit.
+        self.next_allowed_at = None;
+    }
+}
+
 /// Events the watch loop reacts to. The main thread owns all rendering and
 /// blocks on a single channel carrying these.
 ///
@@ -732,6 +776,70 @@ mod tests {
             next_tick(Duration::from_secs(60 * 60 * 24 * 30)),
             None,
             "a month-old freshest item produces no ticks",
+        );
+    }
+
+    #[test]
+    fn cooldown_gates_the_next_walk_at_one_hundred_times_the_latest_cost() {
+        // BUDGET is a 1% duty cycle, so a walk costing D must be followed by a
+        // cooldown of D / 0.01 = 100·D before the next walk is allowed:
+        // on_change returns Defer until that instant and Now at/after it. The
+        // cooldown is recomputed PURELY from the latest record (last-write-wins,
+        // no smoothing) and has NO ceiling. All instants are derived from one
+        // base so the test is deterministic and parallel-safe — no real sleeping.
+        let t0 = Instant::now();
+
+        // Representative cost: a 150 ms walk gates the next for 100·150 ms = 15 s.
+        let mut representative = Throttle::new();
+        representative.record(t0, Duration::from_millis(150));
+        assert_eq!(
+            representative.on_change(t0 + Duration::from_secs(15) - Duration::from_nanos(1)),
+            Walk::Defer,
+            "still gated one nanosecond before 100× the 150 ms cost",
+        );
+        assert_eq!(
+            representative.on_change(t0 + Duration::from_secs(15)),
+            Walk::Now,
+            "allowed exactly at 100× the 150 ms cost",
+        );
+
+        // No ceiling: a 5 s walk gates the next for 100·5 s = 500 s, uncapped.
+        let mut costly = Throttle::new();
+        costly.record(t0, Duration::from_secs(5));
+        assert_eq!(
+            costly.on_change(t0 + Duration::from_secs(500) - Duration::from_nanos(1)),
+            Walk::Defer,
+            "an expensive walk yields a proportionally long, uncapped cooldown",
+        );
+        assert_eq!(
+            costly.on_change(t0 + Duration::from_secs(500)),
+            Walk::Now,
+            "allowed exactly at 100× the 5 s cost — no ceiling clamps it",
+        );
+
+        // Recompute-from-latest: a later record fully replaces the earlier one,
+        // gating from the LATEST walk start at 100× the LATEST cost.
+        let mut last_write_wins = Throttle::new();
+        let t1 = t0 + Duration::from_secs(1);
+        last_write_wins.record(t0, Duration::from_millis(500)); // would gate until t0 + 50 s
+        last_write_wins.record(t1, Duration::from_millis(30)); // replaced: gate until t1 + 3 s
+        assert_eq!(
+            last_write_wins.on_change(t1 + Duration::from_secs(3) - Duration::from_nanos(1)),
+            Walk::Defer,
+            "the gate follows the latest 30 ms cost (3 s from t1), not the prior 500 ms",
+        );
+        assert_eq!(
+            last_write_wins.on_change(t1 + Duration::from_secs(3)),
+            Walk::Now,
+            "allowed exactly at 100× the latest cost, measured from the latest walk start",
+        );
+
+        // A fresh throttle that has never recorded imposes no cooldown.
+        let mut fresh = Throttle::new();
+        assert_eq!(
+            fresh.on_change(t0),
+            Walk::Now,
+            "a throttle that has never walked allows a walk immediately",
         );
     }
 


### PR DESCRIPTION
## Why

`gsw` watch mode walked git on every filesystem event and on every decay/resize tick, burning CPU well out of proportion to how often the displayed state actually changed. This branch makes the watch loop spend CPU in proportion to real change, not to clock ticks or event volume.

## What changed

**Decouple rendering from collection.** `build_output` is split into `collect_snapshot` (the expensive git walk) and `render_frame` (cheap re-render of a cached snapshot). Decay ticks and terminal resizes now re-render the cached snapshot at the new dimensions / aged values instead of re-walking git. A render-time age offset advances all displayed ages (header, files, log) so the UI keeps ticking without collecting.

**Adaptive throttle.** A new `Throttle` gates filesystem-triggered git walks to a ~1% duty cycle — the next walk is held off for ~100× the latest walk's cost, clamped to a 150ms floor. Changes that land mid-cooldown pend a single *deferred* walk that runs once the cooldown expires; a coalesced burst collapses to one walk at expiry rather than one per event. Recording a walk consumes the pending deferred walk, and an FS change re-seeds the cache's collection time so subsequent ages stay correct. `wait_window` returns the earliest of the decay and deferred deadlines so the loop wakes exactly when it needs to.

**Manual force-refresh.** Pressing `r` maps to a force-refresh event in the input reader and calls `Throttle::force` to bypass an active cooldown, running an immediate walk mid-cooldown.

## Notes

- Built test-first throughout (red → green per commit).
- Includes the design doc (`specs/2026-06-26-gsw-adaptive-cpu-throttle-design.md`) and implementation plan (`plans/2026-06-26-gsw-adaptive-cpu-throttle-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)