### PR TITLE
fix(gsw): never wrap the elapsed time — add year/month units and fit the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,11 @@ containers/CI).
 - gsw (git status watch)
   - Compact one-shot pretty output of branch state, designed to be wrapped by `viddy` (or `watch`)
     for a continuously refreshing dashboard. Shows branch, ahead/behind, working-tree changes, and
-    a `git log --oneline` tail. Respects `COLUMNS` and preserves colors under watch wrappers.
+    a `git log --oneline` tail. Ages use two units and get coarser as they grow — `5m23s`,
+    `2h14m`, `3d12h`, `5y6mo` — so a repo untouched for years stays readable. Respects `COLUMNS`
+    and preserves colors under watch wrappers. Nothing it prints ever wraps: the age column is
+    fixed-width by contract, and the header shrinks to fit by dropping the tracking ref's name and
+    shortening the branch, always keeping the `last commit {age} ago` tail.
   - To install: `cargo install --git https://github.com/timmattison/tools gsw`
 - seescc (sccache stats viewer)
   - Self-refreshing terminal viewer for [sccache](https://github.com/mozilla/sccache) statistics —

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -15,6 +15,15 @@ pub enum AgeDim {
     Stale,
 }
 
+/// Maximum display width, in terminal columns, of any string
+/// [`format_age_detailed`] can return.
+///
+/// The age column is a fixed-width field, so this is a hard contract rather
+/// than a hint: a single column of overflow pushes the row past the terminal
+/// width and wraps its tail onto the next line. Every age — including ages
+/// derived from corrupt commit timestamps — must fit.
+pub const AGE_WIDTH: usize = 7;
+
 /// Format a duration with two units, e.g. `5m23s`, `2h14m`, `3d12h`.
 pub fn format_age_detailed(age: Duration) -> String {
     let secs = age.as_secs();
@@ -124,6 +133,93 @@ mod tests {
             format_age_detailed(Duration::from_secs(3 * 86400 + 12 * 3600)),
             "3d12h",
         );
+    }
+
+    /// Durations in the units the assertions below are written in. Kept
+    /// deliberately independent of the formatter's own constants so a wrong
+    /// constant in the implementation shows up as a failing expectation
+    /// rather than cancelling itself out.
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+
+    #[test]
+    fn detailed_age_years_and_months() {
+        // A repo untouched since early 2021 used to render as `2015d12h` —
+        // a four-digit day count nobody can convert in their head, and two
+        // columns wider than the age field. Years and months read at a
+        // glance and fit.
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(2015 * DAY + 12 * HOUR)),
+            "5y6mo",
+        );
+        // 700d = 1 Julian year (365.25d) + 334.75d, i.e. 10 whole months.
+        assert_eq!(format_age_detailed(Duration::from_secs(700 * DAY)), "1y10mo");
+    }
+
+    #[test]
+    fn detailed_age_switches_from_days_to_years_at_one_year() {
+        // A Julian year is 365.25 days, so 365d is still the day/hour pair
+        // and the first full year lands just past it.
+        assert_eq!(format_age_detailed(Duration::from_secs(365 * DAY)), "365d0h");
+        assert_eq!(format_age_detailed(Duration::from_secs(366 * DAY)), "1y0mo");
+    }
+
+    #[test]
+    fn detailed_age_keeps_both_units_out_to_ninety_nine_years() {
+        // The month remainder tops out at 11, so two-digit years still leave
+        // room for both units. `10y11mo` is the widest two-unit form.
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(10 * 31_557_600 + 11 * 2_629_800)),
+            "10y11mo",
+        );
+    }
+
+    #[test]
+    fn detailed_age_drops_the_minor_unit_rather_than_overflow() {
+        // Past 99 years the pair no longer fits the field. Dropping the
+        // months keeps the column honest; overflowing it would wrap the row.
+        let secs = 150 * 31_557_600 + 11 * 2_629_800;
+        assert_eq!(format_age_detailed(Duration::from_secs(secs)), "150y");
+    }
+
+    #[test]
+    fn detailed_age_saturates_on_an_implausible_timestamp() {
+        // A corrupt commit date can hand us an age of geologic proportions.
+        // It still has to fit the column, so it saturates with a `>` marker
+        // instead of printing all thirteen digits.
+        assert_eq!(format_age_detailed(Duration::from_secs(u64::MAX)), ">99999y");
+    }
+
+    #[test]
+    fn detailed_age_never_exceeds_the_age_column() {
+        // The contract behind AGE_WIDTH: no age, however old or however
+        // corrupt its timestamp, may be wider than the field it is printed
+        // into. Sweep every second through the first two hours (where the
+        // seconds/minutes forms live), then coarser steps out past 500 years,
+        // using odd strides so every digit-count regime gets sampled.
+        let check = |secs: u64| {
+            let formatted = format_age_detailed(Duration::from_secs(secs));
+            assert!(
+                formatted.chars().count() <= AGE_WIDTH,
+                "age {secs}s formatted as {formatted:?} ({} columns), wider than the \
+                 {AGE_WIDTH}-column age field — this wraps the row it sits in",
+                formatted.chars().count(),
+            );
+        };
+        for secs in 0..2 * HOUR {
+            check(secs);
+        }
+        for secs in (0..2 * 366 * DAY).step_by(59 * MINUTE as usize + 1) {
+            check(secs);
+        }
+        for secs in (0..500 * 366 * DAY).step_by(13 * HOUR as usize + 7) {
+            check(secs);
+        }
+        // The extremes, which no stride is guaranteed to land on.
+        for secs in [u64::MAX, u64::MAX - 1, 999_999 * 31_557_600] {
+            check(secs);
+        }
     }
 
     #[test]

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -24,18 +24,68 @@ pub enum AgeDim {
 /// derived from corrupt commit timestamps — must fit.
 pub const AGE_WIDTH: usize = 7;
 
-/// Format a duration with two units, e.g. `5m23s`, `2h14m`, `3d12h`.
+const SECS_PER_MINUTE: u64 = 60;
+const SECS_PER_HOUR: u64 = 60 * SECS_PER_MINUTE;
+const SECS_PER_DAY: u64 = 24 * SECS_PER_HOUR;
+/// A Julian year — 365.25 days. Averaging the leap day in keeps `Ny` within a
+/// day of what a calendar would say, which a flat 365 drifts away from fast
+/// (a decade off by two and a half days).
+const SECS_PER_YEAR: u64 = 365 * SECS_PER_DAY + SECS_PER_DAY / 4;
+/// A twelfth of a Julian year, so twelve months are exactly one year and the
+/// month remainder can never reach 12.
+const SECS_PER_MONTH: u64 = SECS_PER_YEAR / 12;
+
+/// Format a duration with two units, e.g. `5m23s`, `2h14m`, `3d12h`, `5y6mo`.
+///
+/// The result is never wider than [`AGE_WIDTH`] columns. Where both units
+/// won't fit — a three-digit year count, say — the minor unit is dropped
+/// rather than allowed to overflow the age column and wrap the row it sits
+/// in. An age too large even for the major unit alone (only reachable from a
+/// corrupt commit timestamp) saturates to `>99999y`.
 pub fn format_age_detailed(age: Duration) -> String {
     let secs = age.as_secs();
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 3600 {
-        format!("{}m{}s", secs / 60, secs % 60)
-    } else if secs < 86400 {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    let (major, minor) = if secs < SECS_PER_MINUTE {
+        ((secs, "s"), None)
+    } else if secs < SECS_PER_HOUR {
+        (
+            (secs / SECS_PER_MINUTE, "m"),
+            Some((secs % SECS_PER_MINUTE, "s")),
+        )
+    } else if secs < SECS_PER_DAY {
+        (
+            (secs / SECS_PER_HOUR, "h"),
+            Some((secs % SECS_PER_HOUR / SECS_PER_MINUTE, "m")),
+        )
+    } else if secs < SECS_PER_YEAR {
+        (
+            (secs / SECS_PER_DAY, "d"),
+            Some((secs % SECS_PER_DAY / SECS_PER_HOUR, "h")),
+        )
     } else {
-        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
+        (
+            (secs / SECS_PER_YEAR, "y"),
+            Some((secs % SECS_PER_YEAR / SECS_PER_MONTH, "mo")),
+        )
+    };
+
+    // Every candidate below is ASCII (digits plus a unit suffix), so byte
+    // length is display width.
+    let (major_value, major_unit) = major;
+    if let Some((minor_value, minor_unit)) = minor {
+        let pair = format!("{major_value}{major_unit}{minor_value}{minor_unit}");
+        if pair.len() <= AGE_WIDTH {
+            return pair;
+        }
     }
+    let alone = format!("{major_value}{major_unit}");
+    if alone.len() <= AGE_WIDTH {
+        return alone;
+    }
+    // Off the scale: keep the column honest and say so rather than print a
+    // count that doesn't fit. `>` plus the widest value that still fits.
+    let digits = AGE_WIDTH - 1 - major_unit.len();
+    let saturated = 10_u64.pow(u32::try_from(digits).unwrap_or(u32::MAX)) - 1;
+    format!(">{saturated}{major_unit}")
 }
 
 /// Classify an age into a display brightness bucket.
@@ -154,14 +204,20 @@ mod tests {
             "5y6mo",
         );
         // 700d = 1 Julian year (365.25d) + 334.75d, i.e. 10 whole months.
-        assert_eq!(format_age_detailed(Duration::from_secs(700 * DAY)), "1y10mo");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(700 * DAY)),
+            "1y10mo"
+        );
     }
 
     #[test]
     fn detailed_age_switches_from_days_to_years_at_one_year() {
         // A Julian year is 365.25 days, so 365d is still the day/hour pair
         // and the first full year lands just past it.
-        assert_eq!(format_age_detailed(Duration::from_secs(365 * DAY)), "365d0h");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(365 * DAY)),
+            "365d0h"
+        );
         assert_eq!(format_age_detailed(Duration::from_secs(366 * DAY)), "1y0mo");
     }
 
@@ -188,7 +244,10 @@ mod tests {
         // A corrupt commit date can hand us an age of geologic proportions.
         // It still has to fit the column, so it saturates with a `>` marker
         // instead of printing all thirteen digits.
-        assert_eq!(format_age_detailed(Duration::from_secs(u64::MAX)), ">99999y");
+        assert_eq!(
+            format_age_detailed(Duration::from_secs(u64::MAX)),
+            ">99999y"
+        );
     }
 
     #[test]
@@ -210,10 +269,14 @@ mod tests {
         for secs in 0..2 * HOUR {
             check(secs);
         }
-        for secs in (0..2 * 366 * DAY).step_by(59 * MINUTE as usize + 1) {
+        // Odd strides so the sweep can't march in step with a unit boundary
+        // and skip a whole digit-count regime.
+        const NEAR_HOURLY: usize = 59 * 60 + 1;
+        const HALF_DAILY: usize = 13 * 60 * 60 + 7;
+        for secs in (0..2 * 366 * DAY).step_by(NEAR_HOURLY) {
             check(secs);
         }
-        for secs in (0..500 * 366 * DAY).step_by(13 * HOUR as usize + 7) {
+        for secs in (0..500 * 366 * DAY).step_by(HALF_DAILY) {
             check(secs);
         }
         // The extremes, which no stride is guaranteed to land on.

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -83,8 +83,13 @@ pub fn format_age_detailed(age: Duration) -> String {
     }
     // Off the scale: keep the column honest and say so rather than print a
     // count that doesn't fit. `>` plus the widest value that still fits.
-    let digits = AGE_WIDTH - 1 - major_unit.len();
-    let saturated = 10_u64.pow(u32::try_from(digits).unwrap_or(u32::MAX)) - 1;
+    //
+    // Only the years arm can exceed AGE_WIDTH, so `major_unit` is "y" here and
+    // `digits` is AGE_WIDTH - 2 = 5 — the conversion is exact. The `0` fallback
+    // is unreachable, but keeps the field within width if the constants ever
+    // change, rather than handing `pow()` an exponent that would overflow.
+    let digits = u32::try_from(AGE_WIDTH - 1 - major_unit.len()).unwrap_or(0);
+    let saturated = 10_u64.pow(digits) - 1;
     format!(">{saturated}{major_unit}")
 }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1147,6 +1147,45 @@ mod tests {
         );
     }
 
+    /// An age old enough to overflow the pre-years age format: `2015d12h`
+    /// is eight columns, two more than the field used to reserve.
+    fn ancient() -> Duration {
+        Duration::from_secs(2015 * 24 * 60 * 60 + 12 * 60 * 60)
+    }
+
+    #[test]
+    fn no_line_exceeds_the_terminal_width_when_the_repo_is_ancient() {
+        // Regression: on a repo untouched for years every age rendered as
+        // `2015d12h`, two columns wider than the age field. Because the age
+        // is the last thing on the line, those two columns spilled past the
+        // terminal edge and wrapped onto the next row, shearing the display.
+        // Nothing gsw prints may be wider than the terminal.
+        let mut stale_file = entry("src/main.rs", FileStatus::Modified, false, 12, 3);
+        stale_file.age = Some(ancient());
+        let mut stale_untracked = entry("scratch/notes.txt", FileStatus::Untracked, false, 0, 0);
+        stale_untracked.age = Some(ancient());
+
+        let mut snap = snap_with(vec![stale_file, stale_untracked]);
+        snap.last_commit_age = Some(ancient());
+        snap.log = vec![LogEntry {
+            hash: "52ef922".into(),
+            subject: "an old commit that has been sitting here for a very long time".into(),
+            age: ancient(),
+        }];
+        let mut o = opts();
+        o.log_lines = 5;
+
+        let out = strip_ansi(&render(&snap, &o));
+        for line in out.lines() {
+            assert!(
+                UnicodeWidthStr::width(line) <= o.terminal_width,
+                "line is {} columns wide, past the {}-column terminal — it will wrap:\n  {line:?}",
+                UnicodeWidthStr::width(line),
+                o.terminal_width,
+            );
+        }
+    }
+
     #[test]
     fn header_mentions_branch_commits_and_age() {
         let out = strip_ansi(&render(&snap_with(vec![]), &opts()));

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use colored::{ColoredString, Colorize};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::age::{age_dim_level, age_fade_factor, fade_rgb, format_age_detailed, AgeDim};
+use crate::age::{
+    age_dim_level, age_fade_factor, fade_rgb, format_age_detailed, AgeDim, AGE_WIDTH,
+};
 use crate::bar::render_bar;
 use crate::git::FileStatus;
 
@@ -127,8 +129,10 @@ pub struct RenderOptions {
 /// Width of the "+adds" / "-dels" / age column fields.
 const ADDS_FIELD: usize = 5;
 const DELS_FIELD: usize = 4;
-/// Wide enough for `59m59s`, `23h59m`, `99d23h`. Older files overflow slightly.
-const AGE_FIELD: usize = 6;
+/// Sized to [`AGE_WIDTH`] — the widest string [`format_age_detailed`] can
+/// return — so no age can push a row past the terminal width and wrap. The
+/// two constants are one and the same on purpose: they cannot drift.
+const AGE_FIELD: usize = AGE_WIDTH;
 
 /// Visible separator characters between columns.
 const SEP_BAR_ADDS: usize = 2;

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1422,12 +1422,26 @@ mod tests {
 
     #[test]
     fn header_keeps_the_age_tail_when_squeezed() {
-        // Whatever else the header sheds to fit, the age survives intact.
-        let header = header_of(&snap_with_overlong_header(), &opts());
-        assert!(
-            header.ends_with("• last commit 5m23s ago"),
-            "squeezed header should still end with the age tail: {header:?}",
-        );
+        // Whatever else the header sheds to fit, the age survives intact —
+        // at every width where the tail fits on the line at all. Past the
+        // point where shaving names can pay for the overflow, the cut has to
+        // come out of the branch and the ahead-count text, not out of the
+        // one field the header exists to carry.
+        let snap = snap_with_overlong_header();
+        for terminal_width in [100, 80, 60, 45, 40] {
+            let mut o = opts();
+            o.terminal_width = terminal_width;
+            let header = header_of(&snap, &o);
+            assert!(
+                header.ends_with("• last commit 5m23s ago"),
+                "header squeezed to {terminal_width} columns dropped the age tail: {header:?}",
+            );
+            assert!(
+                UnicodeWidthStr::width(header.as_str()) <= terminal_width,
+                "header is {} columns, past the {terminal_width}-column terminal: {header:?}",
+                UnicodeWidthStr::width(header.as_str()),
+            );
+        }
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -167,7 +167,7 @@ pub(crate) fn render_with_offset(
         prefix,
         behind,
         suffix,
-    } = header_segments(snapshot, age_offset);
+    } = header_segments(snapshot, age_offset, opts.terminal_width);
     // The whole header is bold as before; the optional behind segment is
     // additionally warning-colored (yellow) to flag that the branch needs a
     // rebase. When `behind` is `None` the prefix+suffix reproduce today's
@@ -178,7 +178,7 @@ pub(crate) fn render_with_offset(
     };
     lines.push(header_line);
     if let Some(op) = &snapshot.operation {
-        lines.push(render_operation_line(op));
+        lines.push(render_operation_line(op, opts.terminal_width));
     }
     lines.push(render_separator(opts.terminal_width));
 
@@ -300,33 +300,132 @@ struct HeaderSegments {
     suffix: String,
 }
 
-/// Split the header into independently-styleable pieces.
+impl HeaderSegments {
+    /// Display width of the assembled line.
+    fn width(&self) -> usize {
+        UnicodeWidthStr::width(self.prefix.as_str())
+            + self.behind.as_deref().map_or(0, UnicodeWidthStr::width)
+            + UnicodeWidthStr::width(self.suffix.as_str())
+    }
+
+    /// Cut the line down to `width` columns, tail first.
+    ///
+    /// The ladder in [`header_segments`] normally lands inside the terminal
+    /// without reaching this; it is the backstop for widths so narrow that
+    /// even floored names don't fit, where something has to give. A cut line
+    /// beats a wrapped one: wrapping shifts every row below it.
+    fn clamp(self, width: usize) -> Self {
+        let prefix = truncate_to_budget(&self.prefix, width);
+        let mut left = width - UnicodeWidthStr::width(prefix.as_str());
+        let behind = self.behind.map(|seg| {
+            let cut = truncate_to_budget(&seg, left);
+            left -= UnicodeWidthStr::width(cut.as_str());
+            cut
+        });
+        let suffix = truncate_to_budget(&self.suffix, left);
+        Self {
+            prefix,
+            behind,
+            suffix,
+        }
+    }
+}
+
+/// How much of the upstream field the header has room for.
+#[derive(Clone, Copy)]
+enum UpstreamDetail {
+    /// `• ↑2 ↓0 origin/topic` — the counts and the tracking ref's name.
+    Full,
+    /// `• ↑2 ↓0` — counts only. The name is nearly always `origin/{branch}`,
+    /// i.e. a second copy of something already on the line, so it is the
+    /// cheapest thing to give up.
+    CountsOnly,
+    /// Field omitted entirely.
+    Omitted,
+}
+
+/// Columns a branch or base name keeps when the header is squeezed. Below
+/// this a name stops being recognizable, so the header sheds whole fields
+/// instead of shaving further.
+const HEADER_NAME_FLOOR: usize = 10;
+
+/// Split the header into independently-styleable pieces, sized to fit
+/// `width` columns.
+///
+/// The header is a single line of free text with the last-commit age at its
+/// end, so anything that overflows takes the age with it onto a wrapped
+/// second line. When the natural header is too wide it is shrunk in order of
+/// what costs the reader least: the tracking ref's name (a duplicate of the
+/// branch), then the branch and base names shaved toward
+/// [`HEADER_NAME_FLOOR`] longest-first, then the upstream field entirely,
+/// then a hard cut. The `• last commit {age} ago` tail is never the thing
+/// that gives way.
 ///
 /// `age_offset` is added (saturating) to the last-commit age before it is
 /// formatted, so the header's `last commit {age} ago` advances in lockstep
 /// with the file and log ages. `Duration::ZERO` leaves the age unchanged. An
 /// unknown last-commit age (`None`) stays `?` regardless of the offset.
-fn header_segments(snap: &Snapshot, age_offset: Duration) -> HeaderSegments {
+fn header_segments(snap: &Snapshot, age_offset: Duration, width: usize) -> HeaderSegments {
+    let age = snap
+        .last_commit_age
+        .map(|a| a.saturating_add(age_offset))
+        .map_or_else(|| "?".to_string(), format_age_detailed);
+    let compose = |branch: &str, base: &str, detail: UpstreamDetail| {
+        compose_header(snap, branch, base, &age, detail)
+    };
+
+    let full = compose(&snap.branch, &snap.base, UpstreamDetail::Full);
+    if full.width() <= width {
+        return full;
+    }
+    let counts_only = compose(&snap.branch, &snap.base, UpstreamDetail::CountsOnly);
+    if counts_only.width() <= width {
+        return counts_only;
+    }
+
+    let (branch, base) = shave_names(
+        &snap.branch,
+        &snap.base,
+        counts_only.width().saturating_sub(width),
+    );
+    let shaved = compose(&branch, &base, UpstreamDetail::CountsOnly);
+    if shaved.width() <= width {
+        return shaved;
+    }
+    let bare = compose(&branch, &base, UpstreamDetail::Omitted);
+    if bare.width() <= width {
+        return bare;
+    }
+    bare.clamp(width)
+}
+
+/// Build the header segments from an already-sized branch name, base name and
+/// upstream detail level.
+fn compose_header(
+    snap: &Snapshot,
+    branch: &str,
+    base: &str,
+    age: &str,
+    detail: UpstreamDetail,
+) -> HeaderSegments {
     let commit_word = if snap.commits_ahead == 1 {
         "commit"
     } else {
         "commits"
     };
-    let age = snap
-        .last_commit_age
-        .map(|a| a.saturating_add(age_offset))
-        .map_or_else(|| "?".to_string(), format_age_detailed);
     let upstream_field = snap
         .upstream
         .as_ref()
-        .map(|u| format!(" • ↑{} ↓{} {}", u.ahead, u.behind, u.name))
+        .map(|u| match detail {
+            UpstreamDetail::Full => format!(" • ↑{} ↓{} {}", u.ahead, u.behind, u.name),
+            UpstreamDetail::CountsOnly => format!(" • ↑{} ↓{}", u.ahead, u.behind),
+            UpstreamDetail::Omitted => String::new(),
+        })
         .unwrap_or_default();
     let prefix = format!(
         "gsw • {branch} • {n} {word} ahead of {base}",
-        branch = snap.branch,
         n = snap.commits_ahead,
         word = commit_word,
-        base = snap.base,
     );
     let behind = (snap.commits_behind > 0).then(|| format!(", {} behind", snap.commits_behind));
     let suffix = format!("{upstream_field} • last commit {age} ago");
@@ -335,6 +434,31 @@ fn header_segments(snap: &Snapshot, age_offset: Duration) -> HeaderSegments {
         behind,
         suffix,
     }
+}
+
+/// Shave `branch` and `base` until they give back `over` columns between
+/// them, always taking from whichever is currently longer so the two converge
+/// on a similar length instead of one being cut to the bone while the other
+/// keeps every character. Neither drops below [`HEADER_NAME_FLOOR`]; when
+/// that leaves `over` unmet, the next rung of the caller's ladder covers it.
+fn shave_names(branch: &str, base: &str, over: usize) -> (String, String) {
+    let mut branch_width = UnicodeWidthStr::width(branch);
+    let mut base_width = UnicodeWidthStr::width(base);
+    for _ in 0..over {
+        let longer = if branch_width >= base_width {
+            &mut branch_width
+        } else {
+            &mut base_width
+        };
+        if *longer <= HEADER_NAME_FLOOR {
+            break;
+        }
+        *longer -= 1;
+    }
+    (
+        truncate_middle(branch, branch_width),
+        truncate_middle(base, base_width),
+    )
 }
 
 fn render_separator(width: usize) -> String {
@@ -347,10 +471,11 @@ fn render_separator(width: usize) -> String {
 /// The label (`⚠ merge`, `⚠ rebase 3/10`) is yellow + bold — matching the
 /// header's "behind" warning segment — and the trailing
 /// ` · {n} conflict[s] to resolve` clause, present only when `conflicts > 0`,
-/// is red + bold to flag the pending action. Like the header, the line is free
-/// text and is never width-truncated. Color/NO_COLOR handling falls out of the
-/// `colored` global override set in `main`.
-fn render_operation_line(op: &Operation) -> String {
+/// is red + bold to flag the pending action. The line is cut to `width` so it
+/// can't wrap and shift every row below it; the label outranks the clause for
+/// the columns available. Color/NO_COLOR handling falls out of the `colored`
+/// global override set in `main`.
+fn render_operation_line(op: &Operation, width: usize) -> String {
     let (label, conflicts) = match op {
         Operation::Merge { conflicts } => ("⚠ merge".to_string(), *conflicts),
         Operation::Rebase { step, conflicts } => {
@@ -361,6 +486,8 @@ fn render_operation_line(op: &Operation) -> String {
             (label, *conflicts)
         }
     };
+    let label = truncate_to_budget(&label, width);
+    let left = width - UnicodeWidthStr::width(label.as_str());
     let label_styled = label.yellow().bold();
     if conflicts > 0 {
         let word = if conflicts == 1 {
@@ -368,11 +495,13 @@ fn render_operation_line(op: &Operation) -> String {
         } else {
             "conflicts"
         };
-        let clause = format!(" · {conflicts} {word} to resolve").red().bold();
-        format!("{label_styled}{clause}")
-    } else {
-        label_styled.to_string()
+        let clause_text = truncate_to_budget(&format!(" · {conflicts} {word} to resolve"), left);
+        if !clause_text.is_empty() {
+            let clause = clause_text.red().bold();
+            return format!("{label_styled}{clause}");
+        }
     }
+    label_styled.to_string()
 }
 
 /// Render one file row.
@@ -848,6 +977,66 @@ fn truncate_left(s: &str, max_width: usize) -> String {
         result.push(*c);
     }
     result
+}
+
+/// Truncate `s` to `max_width` display columns by dropping from the middle,
+/// joining the head and tail that survive with `…`. Branch names share long
+/// prefixes (`feature/…`, `origin/…`) and carry the part that identifies them
+/// at the end, so keeping both ends beats keeping either one alone. UTF-8
+/// safe: budgets are spent in display columns, never bytes.
+fn truncate_middle(s: &str, max_width: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+    let ellipsis_width = 1_usize;
+    let Some(keep) = max_width.checked_sub(ellipsis_width) else {
+        // Not even room for the marker.
+        return String::new();
+    };
+    // The odd column, if there is one, goes to the head: `feature/` prefixes
+    // are what the eye lands on first.
+    let head_budget = keep.div_ceil(2);
+    let tail_budget = keep - head_budget;
+
+    let mut head = String::new();
+    let mut spent = 0_usize;
+    for c in s.chars() {
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if spent + cw > head_budget {
+            break;
+        }
+        spent += cw;
+        head.push(c);
+    }
+    let chars: Vec<char> = s.chars().collect();
+    let mut tail_start = chars.len();
+    let mut spent = 0_usize;
+    for (i, c) in chars.iter().enumerate().rev() {
+        let cw = UnicodeWidthChar::width(*c).unwrap_or(0);
+        if spent + cw > tail_budget {
+            break;
+        }
+        spent += cw;
+        tail_start = i;
+    }
+    // Zero-width characters cost nothing, so both walks can run past each
+    // other and duplicate the middle. Keep the halves disjoint.
+    let tail_start = tail_start.max(head.chars().count());
+
+    let mut result = head;
+    result.push('…');
+    result.extend(&chars[tail_start..]);
+    result
+}
+
+/// [`truncate_right`], but a zero budget yields nothing rather than a lone
+/// `…` — which would itself be one column too wide.
+fn truncate_to_budget(s: &str, budget: usize) -> String {
+    if budget == 0 {
+        String::new()
+    } else {
+        truncate_right(s, budget)
+    }
 }
 
 /// Center `text` within `width` display columns, padding with spaces.
@@ -1558,6 +1747,74 @@ mod tests {
         );
         let stripped = strip_ansi(&out);
         assert!(stripped.contains(".rs"));
+    }
+
+    #[test]
+    fn truncate_middle_keeps_both_ends_and_fits_the_budget() {
+        assert_eq!(truncate_middle("feature/topic", 20), "feature/topic");
+        // 13 columns: the marker plus six to either side.
+        assert_eq!(truncate_middle("feature/some-topic", 13), "featur…-topic");
+        // 12 leaves an odd eleven to split, and the extra goes to the head.
+        assert_eq!(truncate_middle("feature/some-topic", 12), "featur…topic");
+    }
+
+    #[test]
+    fn truncate_middle_counts_columns_not_characters() {
+        // Each CJK glyph is one char but two columns. A routine that counted
+        // chars would hand back double the requested width, and one that
+        // sliced bytes would panic mid-codepoint.
+        let name = "日本語のとても長い名前";
+        for budget in 0..=UnicodeWidthStr::width(name) + 2 {
+            let cut = truncate_middle(name, budget);
+            assert!(
+                UnicodeWidthStr::width(cut.as_str()) <= budget,
+                "budget {budget} produced {cut:?} ({} columns)",
+                UnicodeWidthStr::width(cut.as_str()),
+            );
+        }
+    }
+
+    #[test]
+    fn truncate_middle_degrades_to_nothing_before_overflowing() {
+        // One column has room for the marker alone; zero has room for
+        // nothing, and must not emit a marker that would itself overflow.
+        assert_eq!(truncate_middle("feature/topic", 1), "…");
+        assert_eq!(truncate_middle("feature/topic", 0), "");
+    }
+
+    #[test]
+    fn shave_names_takes_from_the_longer_name_first() {
+        // The base is short, so the branch absorbs the whole reduction.
+        let (branch, base) = shave_names("feature/a-very-long-branch-name", "main", 10);
+        assert_eq!(UnicodeWidthStr::width(branch.as_str()), 21);
+        assert_eq!(base, "main");
+
+        // Both are long: shaving alternates so they converge rather than one
+        // being cut to the floor while the other keeps every character.
+        let (branch, base) = shave_names(
+            "feature/a-very-long-branch-name",
+            "release/a-very-long-base-name",
+            20,
+        );
+        let (bw, sw) = (
+            UnicodeWidthStr::width(branch.as_str()),
+            UnicodeWidthStr::width(base.as_str()),
+        );
+        assert_eq!(bw + sw, 31 + 29 - 20, "the full reduction should be taken");
+        assert!(
+            bw.abs_diff(sw) <= 1,
+            "the two names should converge, got {bw} and {sw}",
+        );
+    }
+
+    #[test]
+    fn shave_names_stops_at_the_floor() {
+        // Past the floor a name stops being recognizable, so shaving stops
+        // and the caller's next rung (dropping whole fields, then cutting)
+        // takes over.
+        let (branch, base) = shave_names("feature/a-very-long-branch-name", "main", 1_000);
+        assert_eq!(UnicodeWidthStr::width(branch.as_str()), HEADER_NAME_FLOOR);
+        assert_eq!(base, "main", "a name already under the floor is untouched");
     }
 
     #[test]

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1190,6 +1190,144 @@ mod tests {
         }
     }
 
+    /// A branch name far too long for an 80-column header, with a
+    /// distinguishing tail so middle-truncation is visible.
+    const LONG_BRANCH: &str = "feature/really-long-branch-name-that-goes-on-forever";
+
+    /// A snapshot whose header cannot possibly fit: long branch, long
+    /// tracking ref, and a behind segment on top.
+    fn snap_with_overlong_header() -> Snapshot {
+        let mut snap = snap_with(vec![]);
+        snap.branch = LONG_BRANCH.into();
+        snap.upstream = Some(UpstreamStatus {
+            name: format!("origin/{LONG_BRANCH}"),
+            ahead: 2,
+            behind: 0,
+        });
+        snap
+    }
+
+    /// The header line of a rendered frame, ANSI stripped.
+    fn header_of(snap: &Snapshot, opts: &RenderOptions) -> String {
+        strip_ansi(&render(snap, opts))
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    #[test]
+    fn header_never_exceeds_the_terminal_width() {
+        // The header is the one line gsw draws as free text, so a long branch
+        // or tracking-ref name used to run straight past the terminal edge —
+        // dropping the `last commit {age} ago` tail, the very thing the eye
+        // goes to, onto a second line.
+        let header = header_of(&snap_with_overlong_header(), &opts());
+        assert!(
+            UnicodeWidthStr::width(header.as_str()) <= opts().terminal_width,
+            "header is {} columns wide, past the {}-column terminal:\n  {header:?}",
+            UnicodeWidthStr::width(header.as_str()),
+            opts().terminal_width,
+        );
+    }
+
+    #[test]
+    fn header_keeps_the_age_tail_when_squeezed() {
+        // Whatever else the header sheds to fit, the age survives intact.
+        let header = header_of(&snap_with_overlong_header(), &opts());
+        assert!(
+            header.ends_with("• last commit 5m23s ago"),
+            "squeezed header should still end with the age tail: {header:?}",
+        );
+    }
+
+    #[test]
+    fn header_truncates_the_branch_from_the_middle() {
+        // Branch names share long prefixes (`feature/…`) and carry the part
+        // that identifies them at the end, so a squeezed name keeps both ends
+        // rather than either alone.
+        let header = header_of(&snap_with_overlong_header(), &opts());
+        assert!(
+            header.contains("feature") && header.contains("forever"),
+            "truncated branch should keep both ends: {header:?}",
+        );
+        assert!(
+            header.contains('…'),
+            "truncated branch should be marked with an ellipsis: {header:?}",
+        );
+    }
+
+    #[test]
+    fn header_sheds_the_upstream_name_before_shaving_the_branch() {
+        // The tracking ref's name is almost always `origin/{branch}` — pure
+        // duplication — so it goes first. The ahead/behind counts are small
+        // and actionable, so they stay, and a branch name that fits is left
+        // untouched.
+        let mut snap = snap_with(vec![]);
+        snap.upstream = Some(UpstreamStatus {
+            name: format!("origin/{LONG_BRANCH}"),
+            ahead: 2,
+            behind: 1,
+        });
+        let header = header_of(&snap, &opts());
+        assert!(
+            !header.contains(LONG_BRANCH),
+            "the redundant tracking-ref name should be the first thing dropped: {header:?}",
+        );
+        assert!(
+            header.contains("↑2 ↓1"),
+            "the ahead/behind counts should survive the name being dropped: {header:?}",
+        );
+        assert!(
+            header.contains("gsw • gsv •") && !header.contains('…'),
+            "a branch that already fits should not be truncated: {header:?}",
+        );
+    }
+
+    #[test]
+    fn header_fits_a_multibyte_branch_name() {
+        // Double-width glyphs cost two columns each while counting as one
+        // char, so a fitting routine that measures chars instead of columns
+        // overflows here — and one that slices bytes panics outright.
+        let mut snap = snap_with_overlong_header();
+        snap.branch = "feature/日本語のとても長い名前のブランチ/forever".into();
+        let header = header_of(&snap, &opts());
+        assert!(
+            UnicodeWidthStr::width(header.as_str()) <= opts().terminal_width,
+            "header with double-width glyphs is {} columns, past the {}-column terminal:\n  {header:?}",
+            UnicodeWidthStr::width(header.as_str()),
+            opts().terminal_width,
+        );
+    }
+
+    #[test]
+    fn no_line_exceeds_a_very_narrow_terminal() {
+        // Past the point where shedding fields and shaving names can help,
+        // the header and the operation line are cut rather than allowed to
+        // spill. A 30-column terminal is well past that point.
+        let mut snap = snap_with_overlong_header();
+        snap.commits_behind = 87;
+        snap.operation = Some(Operation::Rebase {
+            step: Some(StepProgress {
+                current: 3,
+                total: 10,
+            }),
+            conflicts: 12,
+        });
+        let mut o = opts();
+        o.terminal_width = 30;
+
+        let out = strip_ansi(&render(&snap, &o));
+        for line in out.lines() {
+            assert!(
+                UnicodeWidthStr::width(line) <= o.terminal_width,
+                "line is {} columns wide, past the {}-column terminal — it will wrap:\n  {line:?}",
+                UnicodeWidthStr::width(line),
+                o.terminal_width,
+            );
+        }
+    }
+
     #[test]
     fn header_mentions_branch_commits_and_age() {
         let out = strip_ansi(&render(&snap_with(vec![]), &opts()));

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -308,21 +308,28 @@ impl HeaderSegments {
             + UnicodeWidthStr::width(self.suffix.as_str())
     }
 
-    /// Cut the line down to `width` columns, tail first.
+    /// Cut the line down to `width` columns, reserving the age tail.
     ///
     /// The ladder in [`header_segments`] normally lands inside the terminal
     /// without reaching this; it is the backstop for widths so narrow that
     /// even floored names don't fit, where something has to give. A cut line
     /// beats a wrapped one: wrapping shifts every row below it.
+    ///
+    /// What gives is the identity text — the branch name and the ahead-count
+    /// clause — because the `last commit {age} ago` tail is the field the
+    /// header exists to carry. Only a terminal too narrow for the tail alone
+    /// cuts into the tail itself.
     fn clamp(self, width: usize) -> Self {
-        let prefix = truncate_to_budget(&self.prefix, width);
-        let mut left = width - UnicodeWidthStr::width(prefix.as_str());
-        let behind = self.behind.map(|seg| {
-            let cut = truncate_to_budget(&seg, left);
-            left -= UnicodeWidthStr::width(cut.as_str());
-            cut
-        });
-        let suffix = truncate_to_budget(&self.suffix, left);
+        let suffix = truncate_to_budget(&self.suffix, width);
+        let identity_budget = width - UnicodeWidthStr::width(suffix.as_str());
+        let prefix = truncate_to_budget(&self.prefix, identity_budget);
+        let left = identity_budget - UnicodeWidthStr::width(prefix.as_str());
+        // A cut prefix ends mid-phrase, and `, 87 behind` hanging off an
+        // ellipsis reads as nonsense — so the segment survives whole or not
+        // at all.
+        let behind = self
+            .behind
+            .filter(|seg| UnicodeWidthStr::width(seg.as_str()) <= left);
         Self {
             prefix,
             behind,

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -773,9 +773,10 @@ fn an_ancient_repo_never_wraps_a_line_past_the_terminal_width() {
     // A dirty working tree so the file-row age column renders too.
     fs::write(p.join("b.txt"), "untracked\n").unwrap();
 
-    // gsw reserves one column for a watch wrapper's scrollbar, so the
-    // effective render width is COLUMNS - 1.
     const COLUMNS: usize = 80;
+    /// gsw reserves one column for a watch wrapper's scrollbar, so the
+    /// effective render width is one less than the terminal's.
+    const RENDER_WIDTH: usize = COLUMNS - 1;
     let output = gsw_command(p)
         .args(["--no-color", "--log-lines", "5"])
         .env("COLUMNS", COLUMNS.to_string())
@@ -787,10 +788,9 @@ fn an_ancient_repo_never_wraps_a_line_past_the_terminal_width() {
     for line in out.lines() {
         let width = unicode_width::UnicodeWidthStr::width(line);
         assert!(
-            width <= COLUMNS - 1,
-            "line is {width} columns wide, past the {}-column render width — \
-             it wraps onto the next row:\n  {line:?}\nfull output:\n{out}",
-            COLUMNS - 1,
+            width <= RENDER_WIDTH,
+            "line is {width} columns wide, past the {RENDER_WIDTH}-column render \
+             width — it wraps onto the next row:\n  {line:?}\nfull output:\n{out}",
         );
     }
 

--- a/src/gsw/tests/integration.rs
+++ b/src/gsw/tests/integration.rs
@@ -738,3 +738,72 @@ fn shows_merge_indicator_with_conflict_count_during_a_conflicted_merge() {
         "indicator should report the singular conflict count: {out}",
     );
 }
+
+/// Commit everything staged with both git dates pinned to `date`, so the
+/// commit's age is deterministic instead of "however old the fixture is".
+fn commit_dated(dir: &Path, message: &str, date: &str) {
+    let mut cmd = Command::new("git");
+    cmd.args(["commit", "-q", "-m", message])
+        .env("GIT_AUTHOR_DATE", date)
+        .env("GIT_COMMITTER_DATE", date)
+        .current_dir(dir);
+    let status = scrub_git_env(&mut cmd)
+        .status()
+        .expect("failed to invoke git commit");
+    assert!(status.success(), "dated git commit failed");
+}
+
+#[test]
+fn an_ancient_repo_never_wraps_a_line_past_the_terminal_width() {
+    // Regression, end to end: a repo whose last commit is years old rendered
+    // its age as `2015d12h` — eight columns in a field sized for six. The age
+    // sits at the right edge of the header, the file rows and the commit-log
+    // rows, so the overflow spilled past the terminal edge and wrapped onto
+    // the next line, shearing every affected row. Drive the real binary at a
+    // fixed width and assert nothing is wider than the terminal.
+    let dir = setup_repo();
+    let p = dir.path();
+    fs::write(p.join("a.txt"), "changed\n").unwrap();
+    run_git(p, &["add", "a.txt"]);
+    commit_dated(
+        p,
+        "an old commit that has been sitting here for a very long time",
+        "2011-03-04T05:06:07",
+    );
+    // A dirty working tree so the file-row age column renders too.
+    fs::write(p.join("b.txt"), "untracked\n").unwrap();
+
+    // gsw reserves one column for a watch wrapper's scrollbar, so the
+    // effective render width is COLUMNS - 1.
+    const COLUMNS: usize = 80;
+    let output = gsw_command(p)
+        .args(["--no-color", "--log-lines", "5"])
+        .env("COLUMNS", COLUMNS.to_string())
+        .output()
+        .expect("failed to invoke gsw");
+    assert!(output.status.success(), "gsw exited non-zero");
+    let out = String::from_utf8_lossy(&output.stdout).to_string();
+
+    for line in out.lines() {
+        let width = unicode_width::UnicodeWidthStr::width(line);
+        assert!(
+            width <= COLUMNS - 1,
+            "line is {width} columns wide, past the {}-column render width — \
+             it wraps onto the next row:\n  {line:?}\nfull output:\n{out}",
+            COLUMNS - 1,
+        );
+    }
+
+    // And the age itself reads in years+months rather than a day count. The
+    // fixture commit is from 2011, so this holds however long from now the
+    // suite runs.
+    let age = out
+        .split_once("last commit ")
+        .and_then(|(_, rest)| rest.split_once(" ago"))
+        .map(|(age, _)| age)
+        .expect("header should carry a `last commit {age} ago` field");
+    assert!(
+        age.contains('y') && age.ends_with("mo"),
+        "a commit from 2011 should render as years+months, got {age:?}",
+    );
+}


### PR DESCRIPTION
## Problem

Running `gsw` on a repo untouched for years rendered its age as `2015d12h` — eight columns in a field sized for six (`AGE_FIELD = 6`, with the telling comment *"Older files overflow slightly"*). Because the age is the last thing on every row, that overflow ran straight off the terminal edge and wrapped the `h` onto the next line, shearing the display. A four-digit day count is also just hard to read: nobody converts 2015 days to "five and a half years" in their head.

The header had the same class of bug from a different cause: it was drawn as free text and **never measured** against the terminal width, so a long branch or tracking-ref name pushed the `last commit {age} ago` tail — the thing the eye goes to — onto a wrapped second line.

## Fix

**Age units.** `format_age_detailed` gains a years+months pair, continuing the existing two-unit ladder: `5m23s` → `2h14m` → `3d12h` → `5y6mo`. A Julian year (365.25d) keeps the year count within a day of the calendar. The reported `2015d12h` now reads **`5y6mo`**.

**Width contract.** The formatter now guarantees its output is never wider than `AGE_WIDTH`, and the layout's `AGE_FIELD` *is* `AGE_WIDTH` rather than an independent constant that could drift. Past 99 years the minor unit is dropped (`150y`) rather than allowed to overflow; an age from a corrupt commit timestamp saturates to `>99999y` instead of printing thirteen digits. The column widened 6 → 7, which buys back more than it costs the path column: `123d5h` and `364d23h` keep both units, and years+months survive to 99 years.

**Header fitting.** The header now shrinks to fit, in order of what costs the reader least: the tracking ref's name (nearly always `origin/{branch}`, a duplicate of what's already on the line), then the branch and base names shaved from the middle toward a 10-column floor, then the upstream field entirely, then a hard cut as a backstop. The `last commit {age} ago` tail is budgeted first and survives down to a 29-column terminal. Branch names truncate from the middle (`feature/rea…-on-forever`) so both the shared prefix and the identifying tail survive, and all budgets are spent in display columns so double-width glyphs cost what they actually cost. The in-progress merge/rebase line is cut to width for the same reason — it sits above the separator, so wrapping it would shift every row below.

```
w= 79  gsw • feature/rea…-on-forever • 0 commits ahead of HEAD • last commit 5y6mo ago
w= 59  gsw • featu…ever • 0 commits ahead… • last commit 5y6mo ago
w= 29  gsw … • last commit 5y6mo ago
```

## Testing

TDD red→green throughout. Coverage at three levels:

- **Unit** — years+months formatting, the day→year boundary, the `AGE_WIDTH` contract swept across every second of the first two hours and coarser strides past 500 years, plus the truncation/shave helpers (including double-width CJK, where a char-counting or byte-slicing implementation would overflow or panic).
- **Render** — no rendered line exceeds the terminal width when every age is ancient; the header fits at every width and keeps its age tail.
- **End-to-end** — the real `gsw` binary against a repo whose last commit is dated 2011, at a fixed `COLUMNS`.

Full workspace suite green; `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)