### PR TITLE
tvfind: discover smart TVs on the local network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2321,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2342,6 +2368,7 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -7892,6 +7919,22 @@ dependencies = [
  "clipboardmon",
  "env_logger",
  "url",
+]
+
+[[package]]
+name = "tvfind"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buildinfo",
+ "clap",
+ "comfy-table",
+ "futures",
+ "get_if_addrs",
+ "mockito",
+ "reqwest",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       selection, custom port ranges, and can include privileged ports. Useful for development servers, testing 
       environments, and service configuration.
     - To install: `cargo install --git https://github.com/timmattison/tools freeport`
+- tvfind
+    - Finds smart TVs on your network and reports vendor, model, room name and firmware version. Queries each host
+      directly on the two ports TV firmware answers on — Roku ECP (8060) and Chromecast built-in (8008) — rather than
+      relying on SSDP or mDNS, which access points routinely filter between radios. Filter to one brand with
+      `--vendor tcl`. When nmap is installed it also cross-checks the ARP table against the OUI database to flag
+      televisions that are powered off and therefore answering nothing.
+    - To install: `cargo install --git https://github.com/timmattison/tools tvfind`
 - wl
     - Shows which process is listening on a given port. Useful for identifying what program is using a specific port
       on your system. Supports verbose output to show detailed socket information.

--- a/TLDR.md
+++ b/TLDR.md
@@ -68,6 +68,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `thermal-watch` | Shows whether an Apple Silicon Mac decreases its clock under sustained load, measuring the P-cluster frequency against the DVFS table of the chip rather than trusting the thermal pressure level. |
 | `tsm` | Terminal Session Manager — records every shell command to JSONL logs you can search and replay. |
 | `tubeboard` | Extracts the video ID from a YouTube URL on the clipboard. |
+| `tvfind` | Finds smart TVs on the local network. Probes the Roku and Chromecast ports directly, reports vendor, model, room name and firmware, and flags sets that are powered off. |
 | `unescapeboard` | Unescapes one level of `\"`-style escaping in clipboard text. |
 | `update-aws-credentials` | Writes AWS SSO clipboard credentials into your AWS config file. |
 | `uuidplz` | Prints a random v4 UUID, or a repeatable v5 UUID seeded from a string, a file's contents, or stdin. |

--- a/src/tvfind/Cargo.toml
+++ b/src/tvfind/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tvfind"
+version = "0.1.0"
+edition.workspace = true
+description = "Finds smart TVs on the local network and identifies vendor, model and room name"
+
+[dependencies]
+anyhow.workspace = true
+buildinfo.workspace = true
+clap.workspace = true
+comfy-table.workspace = true
+futures.workspace = true
+get_if_addrs.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+mockito.workspace = true
+
+[lints]
+workspace = true

--- a/src/tvfind/README.md
+++ b/src/tvfind/README.md
@@ -28,7 +28,7 @@ tvfind [--subnet CIDR] [--vendor NAME] [--no-arp]
 
 | Flag | Meaning |
 | --- | --- |
-| `--subnet CIDR` | Subnet to scan. Defaults to the subnet of this machine's first non-loopback IPv4 interface. Blocks wider than a `/16` are refused. |
+| `--subnet CIDR` | Subnet to scan. Defaults to the first IPv4 interface of this machine that can reach a neighbour. Blocks wider than a `/16` are refused. |
 | `--vendor NAME` | Report only TVs whose manufacturer contains `NAME`, case-insensitively. Omit to list every TV found. Also narrows the powered-off report to that vendor. |
 | `--no-arp` | Skip the ARP cross-check that reports televisions which are powered off. |
 
@@ -120,6 +120,26 @@ would be missed entirely.
 Every host is reported once. macOS `arp` prints a separate line for each
 interface that reaches a neighbour, so a machine on three networks lists every
 one of them three times.
+
+### The subnet that is scanned by default
+
+Without `--subnet`, `tvfind` reads the interfaces of this machine and takes the
+first IPv4 interface that can reach a neighbour. Loopback is skipped, and so is
+any interface whose netmask holds one or two addresses. Such an interface is a
+point-to-point link and not a LAN.
+
+That second rule is what keeps a VPN out of the result. Tailscale and most
+WireGuard clients present a `utun` address with the netmask 255.255.255.255,
+which is a `/32`. A `/32` holds one address, this machine, so a scan of it
+reaches nothing. The operating system owns the order the interfaces arrive in
+and is free to list the VPN before the LAN, so the order alone cannot be
+trusted to pick the right one.
+
+The address is not examined, only the netmask. A LAN that uses public
+addressing is still a LAN, and `tvfind` scans it.
+
+When no interface qualifies, `tvfind` names the interfaces it skipped and asks
+for `--subnet`.
 
 ## Installation
 

--- a/src/tvfind/README.md
+++ b/src/tvfind/README.md
@@ -1,0 +1,78 @@
+# tvfind
+
+Find smart TVs on the local network and identify them.
+
+```
+$ tvfind --vendor tcl
+Scanning 192.168.0.0/23 (510 hosts) for TVs...
+┌───────────────┬─────────────────┬────────┬──────────────┬───────────┬─────────────┐
+│ IP            ┆ Name            ┆ Vendor ┆ Model        ┆ Platform  ┆ Software    │
+╞═══════════════╪═════════════════╪════════╪══════════════╪═══════════╪═════════════╡
+│ 192.168.0.119 ┆ Office - top    ┆ TCL    ┆ 43S435       ┆ Roku TV   ┆ 15.0.4      │
+│ 192.168.0.248 ┆ Bedroom         ┆ TCL    ┆ 43S405       ┆ Roku TV   ┆ 15.2.4      │
+│ 192.168.1.88  ┆ Office - bottom ┆ TCL    ┆ 43S435       ┆ Roku TV   ┆ 15.1.4      │
+│ 192.168.1.165 ┆ Living Room     ┆ TCL    ┆ Smart TV Pro ┆ Google TV ┆ 3.72.446070 │
+└───────────────┴─────────────────┴────────┴──────────────┴───────────┴─────────────┘
+
+Probably a TV but answering nothing (powered off?):
+
+  192.168.1.193    28:7b:11:59:af:27   Hui Zhou Gaoshengda Technology
+  192.168.1.217    d0:65:b3:a8:60:33   TCL King Electrical Appliances(Huizhou)Co.
+```
+
+## Usage
+
+```
+tvfind [--subnet CIDR] [--vendor NAME] [--no-arp]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--subnet CIDR` | Subnet to scan. Defaults to the subnet of this machine's first non-loopback IPv4 interface. Blocks wider than a `/16` are refused. |
+| `--vendor NAME` | Report only TVs whose manufacturer contains `NAME`, case-insensitively. Omit to list every TV found. |
+| `--no-arp` | Skip the ARP cross-check that reports televisions which are powered off. |
+
+## How it works
+
+Two firmware families cover essentially every consumer smart TV that answers on
+a LAN, and each publishes an authoritative vendor string:
+
+| Platform | Port | Endpoint | Identifying field |
+| --- | --- | --- | --- |
+| Roku TV | 8060 | `/query/device-info` | `<vendor-name>` |
+| Google TV | 8008 | `/ssdp/device-desc.xml` | `<manufacturer>` |
+
+Google TVs are additionally asked for `/setup/eureka_info`, which carries the
+name the owner assigned. That request is best-effort: if it fails, the UPnP
+document alone still identifies the set.
+
+### Why not SSDP or mDNS?
+
+Because discovery multicast is unreliable in practice. Access points routinely
+filter multicast between the 2.4 GHz and 5 GHz radios, so an SSDP `M-SEARCH`
+finds only the subset of TVs sharing a radio with the machine running the scan —
+while every one of them answers correctly when addressed directly. `tvfind`
+therefore probes hosts directly and treats discovery protocols as unavailable.
+
+### Televisions that are powered off
+
+A TV in standby refuses every TCP connection but still answers ARP, so it is
+invisible to a port scan yet plainly present in the neighbour table. When nmap's
+`nmap-mac-prefixes` database is installed, `tvfind` resolves each unexplained
+neighbour's MAC prefix and reports the ones registered to the vendor being
+looked for.
+
+This lookup understands contract manufacturers. TCL sets, for example, register
+MAC blocks to their Huizhou ODM rather than to TCL itself, so a `--vendor tcl`
+filter matches those too. Without that alias a powered-off TCL TV would be
+missed entirely.
+
+## Installation
+
+```bash
+cargo install --git https://github.com/timmattison/tools tvfind
+```
+
+The powered-off report additionally requires `nmap` (for its OUI database) and
+`arp`. Both are optional — without them the scan still runs, it just cannot
+account for sets that are switched off.

--- a/src/tvfind/README.md
+++ b/src/tvfind/README.md
@@ -14,7 +14,7 @@ Scanning 192.168.0.0/23 (510 hosts) for TVs...
 │ 192.168.1.165 ┆ Living Room     ┆ TCL    ┆ Smart TV Pro ┆ Google TV ┆ 3.72.446070 │
 └───────────────┴─────────────────┴────────┴──────────────┴───────────┴─────────────┘
 
-Probably a TV but answering nothing (powered off?):
+Registered to a vendor that matches "tcl", but answered no probe (powered off?):
 
   192.168.1.193    28:7b:11:59:af:27   Hui Zhou Gaoshengda Technology
   192.168.1.217    d0:65:b3:a8:60:33   TCL King Electrical Appliances(Huizhou)Co.
@@ -29,7 +29,7 @@ tvfind [--subnet CIDR] [--vendor NAME] [--no-arp]
 | Flag | Meaning |
 | --- | --- |
 | `--subnet CIDR` | Subnet to scan. Defaults to the subnet of this machine's first non-loopback IPv4 interface. Blocks wider than a `/16` are refused. |
-| `--vendor NAME` | Report only TVs whose manufacturer contains `NAME`, case-insensitively. Omit to list every TV found. |
+| `--vendor NAME` | Report only TVs whose manufacturer contains `NAME`, case-insensitively. Omit to list every TV found. Also narrows the powered-off report to that vendor. |
 | `--no-arp` | Skip the ARP cross-check that reports televisions which are powered off. |
 
 ## How it works
@@ -46,6 +46,28 @@ Google TVs are additionally asked for `/setup/eureka_info`, which carries the
 name the owner assigned. That request is best-effort: if it fails, the UPnP
 document alone still identifies the set.
 
+### Answering the port is not enough
+
+Neither port belongs to televisions alone, so a device that answers must also
+prove it is a television.
+
+**Roku.** Every Roku streaming player — the Express, the Streaming Stick, the
+Streambar — answers ECP with the same document a Roku TV does, under the same
+vendor string. Roku settles it in the document itself, so `tvfind` reports a
+Roku device only when it declares `<is-tv>true</is-tv>`.
+
+**Google TV.** Port 8008 is Chromecast built-in, not Google TV. Every speaker
+with Chromecast built-in answers there and publishes a `<manufacturer>`. No
+field of the UPnP document, of `/setup/eureka_info`, or of
+`/setup/eureka_info?options=detail` states whether the device has a display, so
+the screen is proved another way: a DIAL server only lists an application the
+device can actually run, and `tvfind` asks for two that need a display —
+`Netflix` and `YouTube`. A device that offers neither is not reported.
+
+That test proves a **screen**, not a television. A streaming box or a smart
+display that offers a video app passes it, which is the known limit of what
+port 8008 can tell you.
+
 ### Why not SSDP or mDNS?
 
 Because discovery multicast is unreliable in practice. Access points routinely
@@ -59,13 +81,32 @@ therefore probes hosts directly and treats discovery protocols as unavailable.
 A TV in standby refuses every TCP connection but still answers ARP, so it is
 invisible to a port scan yet plainly present in the neighbour table. When nmap's
 `nmap-mac-prefixes` database is installed, `tvfind` resolves each unexplained
-neighbour's MAC prefix and reports the ones registered to the vendor being
-looked for.
+neighbour's MAC prefix and reports the ones registered to a television maker.
 
-This lookup understands contract manufacturers. TCL sets, for example, register
-MAC blocks to their Huizhou ODM rather than to TCL itself, so a `--vendor tcl`
-filter matches those too. Without that alias a powered-off TCL TV would be
-missed entirely.
+An OUI lookup names the company an address block belongs to, and nothing more.
+It cannot say what the device is. The heading of this report therefore states
+that evidence and no more, and two rules keep the list short:
+
+- **With `--vendor`, the filter is used as given.** The filter is your own
+  judgement about what you are looking for.
+- **Without `--vendor`, only a television brand qualifies.** Otherwise every
+  neighbour in the table appears, which says nothing about televisions. On a
+  home network that is the difference between one line and a hundred.
+
+Brands are matched as whole words inside the registered name, because the
+registry routinely leads with a city or a parent company — `Huizhou TCL
+Communication Electron`, `Sichuan Changhong Electric`. Whole words are also what
+separate `LG Electronics` from `LG Innotek`, which supplies camera and radio
+modules to other makers.
+
+The list understands contract manufacturers. TCL sets, for example, register MAC
+blocks to their Huizhou ODM rather than to TCL itself, so both `--vendor tcl`
+and the unfiltered report match them. Without that alias a powered-off TCL TV
+would be missed entirely.
+
+Every host is reported once. macOS `arp` prints a separate line for each
+interface that reaches a neighbour, so a machine on three networks lists every
+one of them three times.
 
 ## Installation
 

--- a/src/tvfind/README.md
+++ b/src/tvfind/README.md
@@ -68,6 +68,10 @@ That test proves a **screen**, not a television. A streaming box or a smart
 display that offers a video app passes it, which is the known limit of what
 port 8008 can tell you.
 
+A device that fails either test still has power. `tvfind` records that the
+device answered. Thus a device that these tests refuse can never come back as a
+television that is powered off.
+
 ### Why not SSDP or mDNS?
 
 Because discovery multicast is unreliable in practice. Access points routinely
@@ -80,8 +84,17 @@ therefore probes hosts directly and treats discovery protocols as unavailable.
 
 A TV in standby refuses every TCP connection but still answers ARP, so it is
 invisible to a port scan yet plainly present in the neighbour table. When nmap's
-`nmap-mac-prefixes` database is installed, `tvfind` resolves each unexplained
-neighbour's MAC prefix and reports the ones registered to a television maker.
+`nmap-mac-prefixes` database is installed, `tvfind` resolves the MAC prefix of
+each neighbour that answered nothing and reports the ones registered to a
+television maker.
+
+**A host that answered any probe is never in this list**, whatever the probe
+found there. A completed TCP handshake proves that the device has power, and a
+device with power is not powered off. The rule matters most for the devices the
+two tests above refuse: nmap registers every Roku address block to the bare name
+`Roku`, so a Roku streaming player matches a television brand. The player
+answers port 8060, therefore it is a host with power, and it stays out of this
+report.
 
 An OUI lookup names the company an address block belongs to, and nothing more.
 It cannot say what the device is. The heading of this report therefore states

--- a/src/tvfind/README.md
+++ b/src/tvfind/README.md
@@ -88,6 +88,10 @@ invisible to a port scan yet plainly present in the neighbour table. When nmap's
 each neighbour that answered nothing and reports the ones registered to a
 television maker.
 
+This report needs the `arp` command as well as that database. When either one
+is missing, `tvfind` prints one line that names it. See
+[Installation](#installation).
+
 **A host that answered any probe is never in this list**, whatever the probe
 found there. A completed TCP handshake proves that the device has power, and a
 device with power is not powered off. The rule matters most for the devices the
@@ -148,5 +152,10 @@ cargo install --git https://github.com/timmattison/tools tvfind
 ```
 
 The powered-off report additionally requires `nmap` (for its OUI database) and
-`arp`. Both are optional — without them the scan still runs, it just cannot
-account for sets that are switched off.
+`arp`. Both are optional. Without them the scan still runs, but it cannot
+account for sets that are switched off. `tvfind` names the tool that is missing
+in one line, so the report never disappears without a reason.
+
+Most Linux distributions now ship iproute2 and do not install `net-tools`, which
+is the package that supplies `arp`. macOS and the BSDs supply `arp` with the
+system, so an absence there is a question of the `PATH`.

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -72,8 +72,10 @@ fn bounds_of(cidr: &str) -> Result<(u32, u32)> {
 /// Render the CIDR that `address` sits in, given its `netmask`.
 #[must_use]
 pub fn subnet_from(address: Ipv4Addr, netmask: Ipv4Addr) -> String {
-    let _ = (address, netmask);
-    String::new()
+    let mask = u32::from(netmask);
+    let network = Ipv4Addr::from(u32::from(address) & mask);
+
+    format!("{network}/{}", mask.count_ones())
 }
 
 /// The CIDR of the first non-loopback IPv4 interface on this machine.
@@ -82,7 +84,16 @@ pub fn subnet_from(address: Ipv4Addr, netmask: Ipv4Addr) -> String {
 ///
 /// Returns an error if no usable IPv4 interface is present.
 pub fn local_subnet() -> Result<String> {
-    Ok(String::new())
+    let interfaces = get_if_addrs::get_if_addrs().context("could not enumerate interfaces")?;
+
+    interfaces
+        .iter()
+        .filter(|interface| !interface.is_loopback())
+        .find_map(|interface| match interface.addr {
+            get_if_addrs::IfAddr::V4(ref v4) => Some(subnet_from(v4.ip, v4.netmask)),
+            get_if_addrs::IfAddr::V6(_) => None,
+        })
+        .context("no non-loopback IPv4 interface found; pass --subnet explicitly")
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -78,31 +78,77 @@ pub fn subnet_from(address: Ipv4Addr, netmask: Ipv4Addr) -> String {
     format!("{network}/{}", mask.count_ones())
 }
 
+/// Least number of host bits an interface needs before `tvfind` scans it.
+///
+/// A netmask with no host bits gives a `/32`, which holds one address: this
+/// machine. A netmask with one host bit gives a `/31`, which holds two: this
+/// machine and the far end of a point-to-point link. Neither describes a LAN,
+/// and a television sits on a LAN.
+const MIN_HOST_BITS: u32 = 2;
+
+/// Whether `netmask` leaves room for a neighbour to probe.
+fn holds_a_neighbour(netmask: Ipv4Addr) -> bool {
+    ADDRESS_BITS - u32::from(netmask).count_ones() >= MIN_HOST_BITS
+}
+
+/// Every non-loopback IPv4 interface of `interfaces`, with its netmask.
+fn ipv4_interfaces(
+    interfaces: &[get_if_addrs::Interface],
+) -> impl Iterator<Item = (&str, &get_if_addrs::Ifv4Addr)> {
+    interfaces
+        .iter()
+        .filter(|interface| !interface.is_loopback())
+        .filter_map(|interface| match interface.addr {
+            get_if_addrs::IfAddr::V4(ref v4) => Some((interface.name.as_str(), v4)),
+            get_if_addrs::IfAddr::V6(_) => None,
+        })
+}
+
 /// The CIDR to scan, chosen from the interfaces the operating system reports.
 ///
 /// `interfaces` arrives in the order the operating system gives, and that order
 /// is not a ranking. `tvfind` takes the first IPv4 interface that is not
 /// loopback and whose netmask leaves room for a neighbour. It skips an
 /// interface that holds one or two addresses, because a VPN presents such an
-/// interface and a scan of it reaches nothing.
+/// interface and a scan of it reaches nothing. Tailscale and most WireGuard
+/// clients present a `utun` address with the netmask 255.255.255.255.
+///
+/// The address itself is not examined. A LAN is free to use public addressing,
+/// and a scan of it is as valid as a scan of a private block.
 ///
 /// Returns `None` if no interface qualifies.
 #[must_use]
 pub fn subnet_of(interfaces: &[get_if_addrs::Interface]) -> Option<String> {
-    let _ = interfaces;
-    todo!("the subnet is not yet chosen by the room an interface leaves for a neighbour")
+    ipv4_interfaces(interfaces)
+        .find(|(_, v4)| holds_a_neighbour(v4.netmask))
+        .map(|(_, v4)| subnet_from(v4.ip, v4.netmask))
 }
 
 /// Why the interfaces of this machine gave no subnet to scan.
 ///
-/// The message names each interface that was skipped for a single-address
-/// netmask. That is the case a user cannot see from the outside.
+/// The message names each interface that was skipped for a netmask with no room
+/// for a neighbour. That is the case a user cannot see from the outside.
 fn no_subnet_reason(interfaces: &[get_if_addrs::Interface]) -> String {
-    let _ = interfaces;
-    todo!("the error does not yet report an interface that was skipped")
+    let skipped: Vec<&str> = ipv4_interfaces(interfaces)
+        .filter(|(_, v4)| !holds_a_neighbour(v4.netmask))
+        .map(|(name, _)| name)
+        .collect();
+
+    if skipped.is_empty() {
+        return "found no non-loopback IPv4 interface. Pass --subnet explicitly.".to_owned();
+    }
+
+    format!(
+        "found no IPv4 interface with room for a neighbour. \
+         Skipped {}, because the netmask holds too few addresses to scan. \
+         A VPN interface has such a netmask. Pass --subnet explicitly.",
+        skipped.join(", ")
+    )
 }
 
-/// The CIDR of the first non-loopback IPv4 interface on this machine.
+/// The CIDR of the first IPv4 interface of this machine that a scan can reach.
+///
+/// See [`subnet_of`] for the rule that chooses the interface.
 ///
 /// # Errors
 ///
@@ -110,14 +156,7 @@ fn no_subnet_reason(interfaces: &[get_if_addrs::Interface]) -> String {
 pub fn local_subnet() -> Result<String> {
     let interfaces = get_if_addrs::get_if_addrs().context("could not enumerate interfaces")?;
 
-    interfaces
-        .iter()
-        .filter(|interface| !interface.is_loopback())
-        .find_map(|interface| match interface.addr {
-            get_if_addrs::IfAddr::V4(ref v4) => Some(subnet_from(v4.ip, v4.netmask)),
-            get_if_addrs::IfAddr::V6(_) => None,
-        })
-        .context("no non-loopback IPv4 interface found; pass --subnet explicitly")
+    subnet_of(&interfaces).with_context(|| no_subnet_reason(&interfaces))
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -1,0 +1,27 @@
+//! IPv4 CIDR arithmetic and discovery of the subnet this machine sits on.
+
+use std::net::Ipv4Addr;
+
+use anyhow::Result;
+
+/// Expand a CIDR block into the host addresses worth probing.
+///
+/// The network and broadcast addresses are omitted for any block wider than a
+/// `/31`, since no host answers on them.
+///
+/// # Errors
+///
+/// Returns an error if `cidr` is not `A.B.C.D/bits` with `bits` in `0..=32`.
+pub fn hosts_in(cidr: &str) -> Result<Vec<Ipv4Addr>> {
+    let _ = cidr;
+    Ok(Vec::new())
+}
+
+/// The CIDR of the first non-loopback IPv4 interface on this machine.
+///
+/// # Errors
+///
+/// Returns an error if no usable IPv4 interface is present.
+pub fn local_subnet() -> Result<String> {
+    Ok(String::new())
+}

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -165,7 +165,10 @@ mod tests {
     fn renders_a_non_octet_aligned_netmask_as_its_prefix_length() {
         // 255.255.254.0 is the /23 this machine's own network uses.
         assert_eq!(
-            subnet_from(Ipv4Addr::new(192, 168, 0, 128), Ipv4Addr::new(255, 255, 254, 0)),
+            subnet_from(
+                Ipv4Addr::new(192, 168, 0, 128),
+                Ipv4Addr::new(255, 255, 254, 0)
+            ),
             "192.168.0.0/23"
         );
     }

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -78,6 +78,30 @@ pub fn subnet_from(address: Ipv4Addr, netmask: Ipv4Addr) -> String {
     format!("{network}/{}", mask.count_ones())
 }
 
+/// The CIDR to scan, chosen from the interfaces the operating system reports.
+///
+/// `interfaces` arrives in the order the operating system gives, and that order
+/// is not a ranking. `tvfind` takes the first IPv4 interface that is not
+/// loopback and whose netmask leaves room for a neighbour. It skips an
+/// interface that holds one or two addresses, because a VPN presents such an
+/// interface and a scan of it reaches nothing.
+///
+/// Returns `None` if no interface qualifies.
+#[must_use]
+pub fn subnet_of(interfaces: &[get_if_addrs::Interface]) -> Option<String> {
+    let _ = interfaces;
+    todo!("the subnet is not yet chosen by the room an interface leaves for a neighbour")
+}
+
+/// Why the interfaces of this machine gave no subnet to scan.
+///
+/// The message names each interface that was skipped for a single-address
+/// netmask. That is the case a user cannot see from the outside.
+fn no_subnet_reason(interfaces: &[get_if_addrs::Interface]) -> String {
+    let _ = interfaces;
+    todo!("the error does not yet report an interface that was skipped")
+}
+
 /// The CIDR of the first non-loopback IPv4 interface on this machine.
 ///
 /// # Errors
@@ -199,6 +223,104 @@ mod tests {
         assert!(
             hosts_in(&cidr).is_ok(),
             "local_subnet produced an unscannable CIDR: {cidr}"
+        );
+    }
+
+    /// One IPv4 interface, in the shape `get_if_addrs` reports.
+    fn ipv4_interface(name: &str, ip: [u8; 4], netmask: [u8; 4]) -> get_if_addrs::Interface {
+        get_if_addrs::Interface {
+            name: name.to_owned(),
+            addr: get_if_addrs::IfAddr::V4(get_if_addrs::Ifv4Addr {
+                ip: Ipv4Addr::from(ip),
+                netmask: Ipv4Addr::from(netmask),
+                broadcast: None,
+            }),
+        }
+    }
+
+    /// The wired LAN of this machine, a `/23`.
+    fn en0() -> get_if_addrs::Interface {
+        ipv4_interface("en0", [192, 168, 0, 128], [255, 255, 254, 0])
+    }
+
+    /// A second adapter on the same LAN.
+    fn en1() -> get_if_addrs::Interface {
+        ipv4_interface("en1", [192, 168, 1, 131], [255, 255, 254, 0])
+    }
+
+    /// A Tailscale interface. Its netmask holds one address: itself.
+    fn utun2() -> get_if_addrs::Interface {
+        ipv4_interface("utun2", [100, 122, 91, 17], [255, 255, 255, 255])
+    }
+
+    #[test]
+    fn takes_the_lan_when_a_vpn_interface_follows_it() {
+        // The order `get_if_addrs` gave on this machine.
+        assert_eq!(
+            subnet_of(&[en0(), utun2(), en1()]).as_deref(),
+            Some("192.168.0.0/23")
+        );
+    }
+
+    #[test]
+    fn takes_the_lan_when_a_vpn_interface_comes_first() {
+        // The operating system owns the enumeration order and can give this one
+        // instead. It made the scan report `100.122.91.17/32 (1 host)`.
+        assert_eq!(
+            subnet_of(&[utun2(), en0(), en1()]).as_deref(),
+            Some("192.168.0.0/23")
+        );
+    }
+
+    #[test]
+    fn skips_a_point_to_point_slash_31() {
+        // A /31 holds this machine and the far end of a link. A television is
+        // not the far end of a point-to-point link.
+        let ppp0 = ipv4_interface("ppp0", [10, 8, 0, 1], [255, 255, 255, 254]);
+
+        assert_eq!(subnet_of(&[ppp0, en0()]).as_deref(), Some("192.168.0.0/23"));
+    }
+
+    #[test]
+    fn skips_the_loopback_interface() {
+        let lo0 = ipv4_interface("lo0", [127, 0, 0, 1], [255, 0, 0, 0]);
+
+        assert_eq!(subnet_of(&[lo0, en0()]).as_deref(), Some("192.168.0.0/23"));
+    }
+
+    #[test]
+    fn reports_no_subnet_when_every_interface_holds_a_single_address() {
+        let utun4 = ipv4_interface("utun4", [10, 3, 5, 9], [255, 255, 255, 255]);
+
+        assert_eq!(subnet_of(&[utun2(), utun4]), None);
+    }
+
+    #[test]
+    fn tells_the_user_to_pass_subnet_when_no_interface_qualifies() {
+        let reason = no_subnet_reason(&[utun2()]);
+
+        assert!(
+            reason.contains("--subnet"),
+            "the error must name the flag that gets past it, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn names_the_single_address_interface_it_skipped() {
+        let reason = no_subnet_reason(&[utun2()]);
+
+        assert!(
+            reason.contains("utun2"),
+            "the error must name the interface it skipped, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn separates_a_skipped_interface_from_no_interface_at_all() {
+        assert_ne!(
+            no_subnet_reason(&[]),
+            no_subnet_reason(&[utun2()]),
+            "an interface that was skipped must change what the user is told"
         );
     }
 }

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -2,7 +2,10 @@
 
 use std::net::Ipv4Addr;
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
+
+/// Number of address bits in an IPv4 address.
+const ADDRESS_BITS: u32 = 32;
 
 /// Expand a CIDR block into the host addresses worth probing.
 ///
@@ -13,8 +16,44 @@ use anyhow::Result;
 ///
 /// Returns an error if `cidr` is not `A.B.C.D/bits` with `bits` in `0..=32`.
 pub fn hosts_in(cidr: &str) -> Result<Vec<Ipv4Addr>> {
-    let _ = cidr;
-    Ok(Vec::new())
+    let (network, broadcast) = bounds_of(cidr)?;
+
+    // Anything wider than a /31 reserves its first and last address.
+    let (first, last) = if broadcast - network >= 2 {
+        (network + 1, broadcast - 1)
+    } else {
+        (network, broadcast)
+    };
+
+    Ok((first..=last).map(Ipv4Addr::from).collect())
+}
+
+/// The network and broadcast addresses of `cidr`, as host-order integers.
+fn bounds_of(cidr: &str) -> Result<(u32, u32)> {
+    let (base, prefix) = cidr
+        .split_once('/')
+        .with_context(|| format!("expected a CIDR of the form A.B.C.D/bits, got `{cidr}`"))?;
+
+    let base: Ipv4Addr = base
+        .parse()
+        .with_context(|| format!("`{base}` is not an IPv4 address"))?;
+    let prefix: u32 = prefix
+        .parse()
+        .with_context(|| format!("`{prefix}` is not a prefix length"))?;
+    if prefix > ADDRESS_BITS {
+        bail!("prefix length /{prefix} exceeds /{ADDRESS_BITS}");
+    }
+
+    // A /0 would shift by the full width, which overflows rather than yielding 0.
+    let host_bits = ADDRESS_BITS - prefix;
+    let mask = if host_bits == ADDRESS_BITS {
+        0
+    } else {
+        u32::MAX << host_bits
+    };
+
+    let network = u32::from(base) & mask;
+    Ok((network, network | !mask))
 }
 
 /// The CIDR of the first non-loopback IPv4 interface on this machine.

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -112,4 +112,21 @@ mod tests {
     fn rejects_a_malformed_address() {
         assert!(hosts_in("not-an-ip/24").is_err());
     }
+
+    #[test]
+    fn refuses_a_block_too_large_to_scan() {
+        // A /8 is 16.7M addresses: hours of probing and gigabytes of Vec.
+        let error = hosts_in("10.0.0.0/8").unwrap_err().to_string();
+
+        assert!(
+            error.contains("too large"),
+            "error should explain the block is oversized, got: {error}"
+        );
+    }
+
+    #[test]
+    fn still_accepts_the_widest_supported_block() {
+        // Pins the cutoff so the size guard cannot creep tighter than a /16.
+        assert_eq!(hosts_in("10.1.0.0/16").unwrap().len(), 65_534);
+    }
 }

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -25,3 +25,52 @@ pub fn hosts_in(cidr: &str) -> Result<Vec<Ipv4Addr>> {
 pub fn local_subnet() -> Result<String> {
     Ok(String::new())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_a_slash_23_into_every_usable_host() {
+        let hosts = hosts_in("192.168.0.0/23").unwrap();
+
+        assert_eq!(
+            hosts.len(),
+            510,
+            "a /23 spans 512 addresses, less network and broadcast"
+        );
+        assert_eq!(hosts.first().copied(), Some(Ipv4Addr::new(192, 168, 0, 1)));
+        assert_eq!(hosts.last().copied(), Some(Ipv4Addr::new(192, 168, 1, 254)));
+    }
+
+    #[test]
+    fn keeps_the_sole_address_of_a_slash_32() {
+        let hosts = hosts_in("10.0.0.7/32").unwrap();
+
+        assert_eq!(hosts, vec![Ipv4Addr::new(10, 0, 0, 7)]);
+    }
+
+    #[test]
+    fn masks_a_host_address_down_to_its_network() {
+        // `192.168.1.165/23` names a host inside the block, not the base.
+        let hosts = hosts_in("192.168.1.165/23").unwrap();
+
+        assert_eq!(hosts.first().copied(), Some(Ipv4Addr::new(192, 168, 0, 1)));
+        assert_eq!(hosts.len(), 510);
+    }
+
+    #[test]
+    fn rejects_a_cidr_without_a_prefix_length() {
+        assert!(hosts_in("192.168.0.0").is_err());
+    }
+
+    #[test]
+    fn rejects_a_prefix_length_above_32() {
+        assert!(hosts_in("192.168.0.0/33").is_err());
+    }
+
+    #[test]
+    fn rejects_a_malformed_address() {
+        assert!(hosts_in("not-an-ip/24").is_err());
+    }
+}

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -7,6 +7,13 @@ use anyhow::{bail, Context, Result};
 /// Number of address bits in an IPv4 address.
 const ADDRESS_BITS: u32 = 32;
 
+/// Widest block that may be scanned, as an address count.
+///
+/// A `/16` is already 65k hosts and minutes of probing; anything wider is
+/// almost certainly a typo rather than an intent, and enumerating it would
+/// cost gigabytes before the first packet went out.
+const MAX_BLOCK_ADDRESSES: u64 = 1 << 16;
+
 /// Expand a CIDR block into the host addresses worth probing.
 ///
 /// The network and broadcast addresses are omitted for any block wider than a
@@ -14,9 +21,15 @@ const ADDRESS_BITS: u32 = 32;
 ///
 /// # Errors
 ///
-/// Returns an error if `cidr` is not `A.B.C.D/bits` with `bits` in `0..=32`.
+/// Returns an error if `cidr` is not `A.B.C.D/bits` with `bits` in `0..=32`,
+/// or if the block spans more than [`MAX_BLOCK_ADDRESSES`] addresses.
 pub fn hosts_in(cidr: &str) -> Result<Vec<Ipv4Addr>> {
     let (network, broadcast) = bounds_of(cidr)?;
+
+    let span = u64::from(broadcast - network) + 1;
+    if span > MAX_BLOCK_ADDRESSES {
+        bail!("`{cidr}` is too large to scan: {span} addresses, limit is {MAX_BLOCK_ADDRESSES}");
+    }
 
     // Anything wider than a /31 reserves its first and last address.
     let (first, last) = if broadcast - network >= 2 {

--- a/src/tvfind/src/cidr.rs
+++ b/src/tvfind/src/cidr.rs
@@ -69,6 +69,13 @@ fn bounds_of(cidr: &str) -> Result<(u32, u32)> {
     Ok((network, network | !mask))
 }
 
+/// Render the CIDR that `address` sits in, given its `netmask`.
+#[must_use]
+pub fn subnet_from(address: Ipv4Addr, netmask: Ipv4Addr) -> String {
+    let _ = (address, netmask);
+    String::new()
+}
+
 /// The CIDR of the first non-loopback IPv4 interface on this machine.
 ///
 /// # Errors
@@ -141,5 +148,43 @@ mod tests {
     fn still_accepts_the_widest_supported_block() {
         // Pins the cutoff so the size guard cannot creep tighter than a /16.
         assert_eq!(hosts_in("10.1.0.0/16").unwrap().len(), 65_534);
+    }
+
+    #[test]
+    fn renders_a_non_octet_aligned_netmask_as_its_prefix_length() {
+        // 255.255.254.0 is the /23 this machine's own network uses.
+        assert_eq!(
+            subnet_from(Ipv4Addr::new(192, 168, 0, 128), Ipv4Addr::new(255, 255, 254, 0)),
+            "192.168.0.0/23"
+        );
+    }
+
+    #[test]
+    fn renders_a_plain_class_c_netmask() {
+        assert_eq!(
+            subnet_from(Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(255, 255, 255, 0)),
+            "10.0.0.0/24"
+        );
+    }
+
+    #[test]
+    fn masks_the_address_down_when_rendering() {
+        assert_eq!(
+            subnet_from(Ipv4Addr::new(172, 16, 5, 9), Ipv4Addr::new(255, 240, 0, 0)),
+            "172.16.0.0/12"
+        );
+    }
+
+    #[test]
+    fn reports_a_local_subnet_that_can_actually_be_scanned() {
+        let Ok(cidr) = local_subnet() else {
+            // No usable IPv4 interface, e.g. an isolated build sandbox.
+            return;
+        };
+
+        assert!(
+            hosts_in(&cidr).is_ok(),
+            "local_subnet produced an unscannable CIDR: {cidr}"
+        );
     }
 }

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -75,3 +75,81 @@ pub fn parse_google_tv(ip: Ipv4Addr, desc_xml: &str, eureka_json: Option<&str>) 
     let _ = (ip, desc_xml, eureka_json);
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim `/query/device-info` response from a TCL 43S435 Roku TV.
+    const ROKU_DEVICE_INFO: &str = r"<device-info>
+<udn>29badd40-cd5a-50ab-b7c8-1b1cd0834f2c</udn>
+<serial-number>X000002403FJ</serial-number>
+<device-id>S02ST0C403FJ</device-id>
+<vendor-name>TCL</vendor-name>
+<model-name>43S435</model-name>
+<model-number>C134X</model-number>
+<is-tv>true</is-tv>
+<screen-size>43</screen-size>
+<friendly-device-name>Office - top</friendly-device-name>
+<user-device-name>Office - top</user-device-name>
+<user-device-location>Office</user-device-location>
+<software-version>15.0.4</software-version>
+</device-info>";
+
+    fn ip() -> Ipv4Addr {
+        Ipv4Addr::new(192, 168, 0, 119)
+    }
+
+    #[test]
+    fn reads_vendor_model_name_and_version_from_a_roku_tv() {
+        let tv = parse_roku_device_info(ip(), ROKU_DEVICE_INFO).expect("should identify a Roku TV");
+
+        assert_eq!(tv.ip, ip());
+        assert_eq!(tv.platform, Platform::RokuTv);
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.model, "43S435");
+        assert_eq!(tv.name, "Office - top");
+        assert_eq!(tv.software, "15.0.4");
+    }
+
+    #[test]
+    fn prefers_the_user_assigned_name_over_the_friendly_name() {
+        let xml = ROKU_DEVICE_INFO.replace(
+            "<friendly-device-name>Office - top</friendly-device-name>",
+            "<friendly-device-name>Roku Express</friendly-device-name>",
+        );
+
+        let tv = parse_roku_device_info(ip(), &xml).expect("should identify a Roku TV");
+
+        assert_eq!(tv.name, "Office - top");
+    }
+
+    #[test]
+    fn falls_back_to_the_friendly_name_when_no_name_was_assigned() {
+        let xml = ROKU_DEVICE_INFO.replace(
+            "<user-device-name>Office - top</user-device-name>",
+            "<user-device-name></user-device-name>",
+        );
+
+        let tv = parse_roku_device_info(ip(), &xml).expect("should identify a Roku TV");
+
+        assert_eq!(tv.name, "Office - top");
+    }
+
+    #[test]
+    fn keeps_multibyte_device_names_intact() {
+        let xml = ROKU_DEVICE_INFO.replace(
+            "<user-device-name>Office - top</user-device-name>",
+            "<user-device-name>リビング 🎉</user-device-name>",
+        );
+
+        let tv = parse_roku_device_info(ip(), &xml).expect("should identify a Roku TV");
+
+        assert_eq!(tv.name, "リビング 🎉");
+    }
+
+    #[test]
+    fn rejects_a_payload_that_is_not_a_roku_device_info_document() {
+        assert!(parse_roku_device_info(ip(), "<html><body>404</body></html>").is_none());
+    }
+}

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -49,6 +49,16 @@ pub struct Tv {
     pub software: String,
 }
 
+impl Tv {
+    /// The cells describing this TV, in table-column order.
+    ///
+    /// A field the device left blank renders as a dash so columns stay legible.
+    #[must_use]
+    pub fn display_row(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
 /// Text of the first `<tag>…</tag>` in a flat XML document.
 ///
 /// Discovery documents are machine-generated and single-level, so splitting on
@@ -282,5 +292,43 @@ mod tests {
     #[test]
     fn rejects_a_payload_that_names_no_manufacturer() {
         assert!(parse_google_tv(google_ip(), "<html><body>404</body></html>", None).is_none());
+    }
+
+    #[test]
+    fn renders_every_field_of_a_roku_tv_in_column_order() {
+        let tv = parse_roku_device_info(ip(), ROKU_DEVICE_INFO).expect("should identify");
+
+        assert_eq!(
+            tv.display_row(),
+            [
+                "192.168.0.119",
+                "Office - top",
+                "TCL",
+                "43S435",
+                "Roku TV",
+                "15.0.4"
+            ]
+            .map(String::from)
+        );
+    }
+
+    #[test]
+    fn labels_a_google_tv_row_with_its_platform() {
+        let tv = parse_google_tv(google_ip(), GOOGLE_TV_DESC, None).expect("should identify");
+        let row = tv.display_row();
+
+        assert_eq!(row.get(4).map(String::as_str), Some("Google TV"));
+    }
+
+    #[test]
+    fn renders_a_field_the_device_left_blank_as_a_dash() {
+        let xml = ROKU_DEVICE_INFO.replace(
+            "<software-version>15.0.4</software-version>",
+            "<software-version></software-version>",
+        );
+        let tv = parse_roku_device_info(ip(), &xml).expect("should identify");
+        let row = tv.display_row();
+
+        assert_eq!(row.last().map(String::as_str), Some("-"));
     }
 }

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -132,10 +132,13 @@ pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
 }
 
 /// Whether a DIAL `/apps/<app>` document reports that the device offers `app`.
+///
+/// A DIAL server answers 404 for an application it does not carry, so reaching
+/// this function at all is most of the answer. The name is compared anyway, so
+/// that a courtesy page or a redirect cannot be read as an installed app.
 #[must_use]
 pub fn dial_app_installed(xml: &str, app: &str) -> bool {
-    let _ = (xml, app);
-    todo!("no screen test exists yet")
+    xml.contains("<service") && xml_tag(xml, "name") == app
 }
 
 /// Parse a Google TV UPnP description, enriched with `/setup/eureka_info`.

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -104,8 +104,37 @@ pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
 /// Returns `None` when the payload is not a UPnP device description.
 #[must_use]
 pub fn parse_google_tv(ip: Ipv4Addr, desc_xml: &str, eureka_json: Option<&str>) -> Option<Tv> {
-    let _ = (ip, desc_xml, eureka_json);
-    None
+    let vendor = xml_tag(desc_xml, "manufacturer");
+    if vendor.is_empty() {
+        return None;
+    }
+
+    // Renaming a set updates its cast name but can leave the UPnP document
+    // holding the original, so the cast name wins when both are present.
+    let cast: Option<serde_json::Value> =
+        eureka_json.and_then(|json| serde_json::from_str(json).ok());
+    let cast_field = |key: &str| -> String {
+        cast.as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_owned()
+    };
+
+    let mut name = cast_field("name");
+    if name.is_empty() {
+        name = xml_tag(desc_xml, "friendlyName");
+    }
+
+    Some(Tv {
+        ip,
+        platform: Platform::GoogleTv,
+        vendor,
+        model: xml_tag(desc_xml, "modelName"),
+        name,
+        software: cast_field("cast_build_revision"),
+    })
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -1,0 +1,77 @@
+//! Turn a TV's own discovery documents into an identified device.
+//!
+//! Two firmware families cover essentially every consumer smart TV that
+//! answers on the LAN, and each publishes an authoritative vendor string:
+//!
+//! * **Roku TV** — Roku's External Control Protocol on `tcp/8060`.
+//!   `GET /query/device-info` returns XML whose `<vendor-name>` is set by the
+//!   panel manufacturer (`TCL`, `Hisense`, `Roku`, ...).
+//! * **Google TV / Chromecast built-in** — `tcp/8008`.
+//!   `GET /ssdp/device-desc.xml` returns UPnP XML carrying `<manufacturer>`,
+//!   and `GET /setup/eureka_info` returns the name the user assigned.
+
+use std::net::Ipv4Addr;
+
+/// Firmware family a TV was identified through.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Platform {
+    /// Identified over Roku ECP on port 8060.
+    RokuTv,
+    /// Identified over Chromecast built-in on port 8008.
+    GoogleTv,
+}
+
+impl Platform {
+    /// Human-readable name for table output.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::RokuTv => "Roku TV",
+            Self::GoogleTv => "Google TV",
+        }
+    }
+}
+
+/// A television positively identified from its own discovery documents.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Tv {
+    /// Address the device answered on.
+    pub ip: Ipv4Addr,
+    /// Which firmware family identified it.
+    pub platform: Platform,
+    /// Manufacturer as reported by the device itself.
+    pub vendor: String,
+    /// Model designation, e.g. `43S435`.
+    pub model: String,
+    /// Name the user assigned, e.g. `Living Room`.
+    pub name: String,
+    /// Firmware or cast build version.
+    pub software: String,
+}
+
+/// Text of the first `<tag>…</tag>` in a flat XML document.
+fn xml_tag(xml: &str, tag: &str) -> String {
+    let _ = (xml, tag);
+    String::new()
+}
+
+/// Parse a Roku ECP `/query/device-info` response.
+///
+/// Returns `None` when the payload is not a Roku device-info document.
+#[must_use]
+pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
+    let _ = (ip, xml);
+    None
+}
+
+/// Parse a Google TV UPnP description, enriched with `/setup/eureka_info`.
+///
+/// `eureka_json` is best-effort: the UPnP document alone is enough to identify
+/// the device, and the cast payload only supplies a better display name.
+///
+/// Returns `None` when the payload is not a UPnP device description.
+#[must_use]
+pub fn parse_google_tv(ip: Ipv4Addr, desc_xml: &str, eureka_json: Option<&str>) -> Option<Tv> {
+    let _ = (ip, desc_xml, eureka_json);
+    None
+}

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -92,10 +92,20 @@ fn xml_tag(xml: &str, tag: &str) -> String {
 
 /// Parse a Roku ECP `/query/device-info` response.
 ///
-/// Returns `None` when the payload is not a Roku device-info document.
+/// Roku's streaming players — the Express, the Streaming Stick, the Streambar —
+/// answer ECP with the same document a Roku TV does, so the vendor string alone
+/// cannot tell a television from a set-top box. Roku settles it in the document:
+/// only a television reports `<is-tv>true</is-tv>`.
+///
+/// Returns `None` when the payload is not a Roku device-info document, or when
+/// it describes a Roku device that is not a television.
 #[must_use]
 pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
     if !xml.contains("<device-info>") {
+        return None;
+    }
+
+    if !xml_tag(xml, "is-tv").eq_ignore_ascii_case("true") {
         return None;
     }
 

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -50,9 +50,19 @@ pub struct Tv {
 }
 
 /// Text of the first `<tag>…</tag>` in a flat XML document.
+///
+/// Discovery documents are machine-generated and single-level, so splitting on
+/// the delimiters is both sufficient and cheaper than a full parser. Splitting
+/// rather than slicing also keeps every boundary on a `char`, so multi-byte
+/// device names survive intact.
 fn xml_tag(xml: &str, tag: &str) -> String {
-    let _ = (xml, tag);
-    String::new()
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+
+    xml.split_once(open.as_str())
+        .and_then(|(_, rest)| rest.split_once(close.as_str()))
+        .map(|(value, _)| value.trim().to_owned())
+        .unwrap_or_default()
 }
 
 /// Parse a Roku ECP `/query/device-info` response.
@@ -60,8 +70,30 @@ fn xml_tag(xml: &str, tag: &str) -> String {
 /// Returns `None` when the payload is not a Roku device-info document.
 #[must_use]
 pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
-    let _ = (ip, xml);
-    None
+    if !xml.contains("<device-info>") {
+        return None;
+    }
+
+    let vendor = xml_tag(xml, "vendor-name");
+    if vendor.is_empty() {
+        return None;
+    }
+
+    // A set the owner has named reports it in `user-device-name`; one still on
+    // factory defaults leaves that empty and only fills `friendly-device-name`.
+    let mut name = xml_tag(xml, "user-device-name");
+    if name.is_empty() {
+        name = xml_tag(xml, "friendly-device-name");
+    }
+
+    Some(Tv {
+        ip,
+        platform: Platform::RokuTv,
+        vendor,
+        model: xml_tag(xml, "model-name"),
+        name,
+        software: xml_tag(xml, "software-version"),
+    })
 }
 
 /// Parse a Google TV UPnP description, enriched with `/setup/eureka_info`.

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -55,7 +55,22 @@ impl Tv {
     /// A field the device left blank renders as a dash so columns stay legible.
     #[must_use]
     pub fn display_row(&self) -> Vec<String> {
-        Vec::new()
+        let or_dash = |value: &str| {
+            if value.is_empty() {
+                "-".to_owned()
+            } else {
+                value.to_owned()
+            }
+        };
+
+        vec![
+            self.ip.to_string(),
+            or_dash(&self.name),
+            or_dash(&self.vendor),
+            or_dash(&self.model),
+            self.platform.label().to_owned(),
+            or_dash(&self.software),
+        ]
     }
 }
 

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -184,4 +184,74 @@ mod tests {
     fn rejects_a_payload_that_is_not_a_roku_device_info_document() {
         assert!(parse_roku_device_info(ip(), "<html><body>404</body></html>").is_none());
     }
+
+    /// Verbatim `/ssdp/device-desc.xml` from a TCL Google TV.
+    const GOOGLE_TV_DESC: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <specVersion><major>1</major><minor>0</minor></specVersion>
+  <URLBase>http://192.168.1.165:8008</URLBase>
+  <device>
+    <deviceType>urn:dial-multiscreen-org:device:dial:1</deviceType>
+    <friendlyName>Living Room</friendlyName>
+    <manufacturer>TCL</manufacturer>
+    <modelName>Smart TV Pro</modelName>
+    <UDN>uuid:1bee973d-e7a0-9858-38cd-a2a5a11119c1</UDN>
+  </device>
+</root>"#;
+
+    /// Trimmed `/setup/eureka_info` from the same set.
+    const GOOGLE_TV_EUREKA: &str =
+        r#"{"build_version":"446070","cast_build_revision":"3.72.446070","name":"Living Room"}"#;
+
+    fn google_ip() -> Ipv4Addr {
+        Ipv4Addr::new(192, 168, 1, 165)
+    }
+
+    #[test]
+    fn reads_vendor_model_and_cast_build_from_a_google_tv() {
+        let tv = parse_google_tv(google_ip(), GOOGLE_TV_DESC, Some(GOOGLE_TV_EUREKA))
+            .expect("should identify a Google TV");
+
+        assert_eq!(tv.ip, google_ip());
+        assert_eq!(tv.platform, Platform::GoogleTv);
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.model, "Smart TV Pro");
+        assert_eq!(tv.name, "Living Room");
+        assert_eq!(tv.software, "3.72.446070");
+    }
+
+    #[test]
+    fn prefers_the_cast_name_over_the_upnp_friendly_name() {
+        // A renamed set updates its cast name while UPnP keeps the old one.
+        let eureka = r#"{"name":"Den","cast_build_revision":"3.72.446070"}"#;
+
+        let tv = parse_google_tv(google_ip(), GOOGLE_TV_DESC, Some(eureka))
+            .expect("should identify a Google TV");
+
+        assert_eq!(tv.name, "Den");
+    }
+
+    #[test]
+    fn identifies_a_google_tv_even_when_the_cast_endpoint_is_unavailable() {
+        let tv = parse_google_tv(google_ip(), GOOGLE_TV_DESC, None)
+            .expect("UPnP alone should be enough to identify");
+
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.name, "Living Room");
+        assert_eq!(tv.software, "");
+    }
+
+    #[test]
+    fn survives_a_malformed_cast_payload() {
+        let tv = parse_google_tv(google_ip(), GOOGLE_TV_DESC, Some("not json at all"))
+            .expect("a bad cast payload must not lose the UPnP identification");
+
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.name, "Living Room");
+    }
+
+    #[test]
+    fn rejects_a_payload_that_names_no_manufacturer() {
+        assert!(parse_google_tv(google_ip(), "<html><body>404</body></html>", None).is_none());
+    }
 }

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -369,7 +369,10 @@ mod tests {
 
     #[test]
     fn sees_no_application_in_a_not_found_response() {
-        assert!(!dial_app_installed("<html><body>404</body></html>", "Netflix"));
+        assert!(!dial_app_installed(
+            "<html><body>404</body></html>",
+            "Netflix"
+        ));
         assert!(!dial_app_installed("", "Netflix"));
     }
 

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -239,6 +239,30 @@ mod tests {
         assert!(parse_roku_device_info(ip(), "<html><body>404</body></html>").is_none());
     }
 
+    /// A Roku streaming player answers ECP with the same document a TV does.
+    /// Only `is-tv` separates the two.
+    const ROKU_STREAMING_STICK: &str = r"<device-info>
+<udn>1e9c2c85-7a4f-5a1e-9b3f-84d4c9b0f2a1</udn>
+<vendor-name>Roku</vendor-name>
+<model-name>Roku Express</model-name>
+<is-tv>false</is-tv>
+<is-stick>true</is-stick>
+<friendly-device-name>Roku Express</friendly-device-name>
+<software-version>15.2.4</software-version>
+</device-info>";
+
+    #[test]
+    fn rejects_a_roku_streaming_player_that_is_not_a_television() {
+        assert!(parse_roku_device_info(ip(), ROKU_STREAMING_STICK).is_none());
+    }
+
+    #[test]
+    fn rejects_a_roku_device_that_declares_no_is_tv_field() {
+        let xml = ROKU_DEVICE_INFO.replace("<is-tv>true</is-tv>\n", "");
+
+        assert!(parse_roku_device_info(ip(), &xml).is_none());
+    }
+
     /// Verbatim `/ssdp/device-desc.xml` from a TCL Google TV.
     const GOOGLE_TV_DESC: &str = r#"<?xml version="1.0" encoding="utf-8"?>
 <root xmlns="urn:schemas-upnp-org:device-1-0">

--- a/src/tvfind/src/identify.rs
+++ b/src/tvfind/src/identify.rs
@@ -131,6 +131,13 @@ pub fn parse_roku_device_info(ip: Ipv4Addr, xml: &str) -> Option<Tv> {
     })
 }
 
+/// Whether a DIAL `/apps/<app>` document reports that the device offers `app`.
+#[must_use]
+pub fn dial_app_installed(xml: &str, app: &str) -> bool {
+    let _ = (xml, app);
+    todo!("no screen test exists yet")
+}
+
 /// Parse a Google TV UPnP description, enriched with `/setup/eureka_info`.
 ///
 /// `eureka_json` is best-effort: the UPnP document alone is enough to identify
@@ -341,6 +348,33 @@ mod tests {
     #[test]
     fn rejects_a_payload_that_names_no_manufacturer() {
         assert!(parse_google_tv(google_ip(), "<html><body>404</body></html>", None).is_none());
+    }
+
+    /// Verbatim `/apps/Netflix` response from a TCL Google TV.
+    const NETFLIX_DIAL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<service xmlns="urn:dial-multiscreen-org:schemas:dial">
+  <name>Netflix</name>
+  <options allowStop="true"/>
+  <state>stopped</state>
+  <port>9080</port><capabilities>websocket</capabilities>
+</service>"#;
+
+    #[test]
+    fn sees_a_video_application_a_cast_device_offers() {
+        assert!(dial_app_installed(NETFLIX_DIAL, "Netflix"));
+    }
+
+    #[test]
+    fn sees_no_application_in_a_not_found_response() {
+        assert!(!dial_app_installed("<html><body>404</body></html>", "Netflix"));
+        assert!(!dial_app_installed("", "Netflix"));
+    }
+
+    #[test]
+    fn does_not_credit_a_device_with_an_application_it_did_not_name() {
+        // A DIAL server that lacks the app answers 404, but a body naming some
+        // other app must never be read as this one.
+        assert!(!dial_app_installed(NETFLIX_DIAL, "YouTube"));
     }
 
     #[test]

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -1,0 +1,33 @@
+//! `tvfind` — find smart TVs on the local network and identify them.
+
+mod cidr;
+mod identify;
+mod oui;
+mod scan;
+mod vendor;
+
+use anyhow::Result;
+use buildinfo::version_string;
+use clap::Parser;
+
+/// Find smart TVs on the local network
+#[derive(Parser, Debug)]
+#[clap(author, version = version_string!(), about)]
+struct Args {
+    /// Subnet to scan in CIDR form (default: the subnet of this machine)
+    #[clap(long, value_name = "CIDR")]
+    subnet: Option<String>,
+
+    /// Only report TVs whose manufacturer contains this text, e.g. `tcl`
+    #[clap(long, value_name = "NAME", default_value = "")]
+    vendor: String,
+
+    /// Skip the ARP cross-check that finds powered-off TVs
+    #[clap(long)]
+    no_arp: bool,
+}
+
+fn main() -> Result<()> {
+    let _args = Args::parse();
+    Ok(())
+}

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -23,8 +23,8 @@ use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
 use futures::stream::{self, StreamExt};
 use reqwest::Client;
 
-use identify::Tv;
-use scan::{fetch_google_tv, fetch_roku, is_port_open, Probe, PROBE_PORTS, ROKU_ECP_PORT};
+use identify::{Platform, Tv};
+use scan::{probe, Probe, PROBE_PORTS};
 
 /// Probes in flight at once. High enough to sweep a /23 in seconds, low enough
 /// to stay well inside the open-file limit.
@@ -58,11 +58,11 @@ async fn main() -> Result<()> {
     let hosts = cidr::hosts_in(&subnet)?;
     eprintln!("Scanning {subnet} ({}) for TVs...", host_count(hosts.len()));
 
-    let tvs = find_tvs(&hosts, &args.vendor).await;
-    report_tvs(&tvs);
+    let found = scan_hosts(&hosts, &args.vendor).await;
+    report_tvs(&found.tvs);
 
     if !args.no_arp {
-        report_powered_off(&tvs, &args.vendor);
+        report_powered_off(&found.answered, &args.vendor);
     }
 
     Ok(())
@@ -105,43 +105,46 @@ impl ScanResult {
     /// stays in `answered` whatever the probe found there, because a host that
     /// completed a TCP handshake has power.
     fn from_probes(probes: Vec<Probe>, vendor_filter: &str) -> Self {
-        let _ = (probes, vendor_filter);
-        todo!("a sweep does not yet collect the addresses that answered")
+        let answered: HashSet<Ipv4Addr> = probes
+            .iter()
+            .filter(|found| found.answered)
+            .map(|found| found.ip)
+            .collect();
+
+        let mut tvs: Vec<Tv> = probes
+            .into_iter()
+            .filter_map(|found| found.tv)
+            .filter(|tv| vendor::matches(&tv.vendor, vendor_filter))
+            .collect();
+        tvs.sort_by_key(|tv| tv.ip);
+
+        Self { tvs, answered }
     }
 }
 
-/// Probe every host on both TV ports and identify whatever answers.
-async fn find_tvs(hosts: &[Ipv4Addr], vendor_filter: &str) -> Vec<Tv> {
+/// Probe every host on both TV ports and record what each probe found.
+async fn scan_hosts(hosts: &[Ipv4Addr], vendor_filter: &str) -> ScanResult {
     let client = Client::new();
 
-    let targets: Vec<(Ipv4Addr, u16)> = hosts
+    let targets: Vec<(Ipv4Addr, u16, Platform)> = hosts
         .iter()
-        .flat_map(|ip| PROBE_PORTS.iter().map(move |port| (*ip, *port)))
+        .flat_map(|ip| {
+            PROBE_PORTS
+                .iter()
+                .map(move |(port, platform)| (*ip, *port, *platform))
+        })
         .collect();
 
-    let mut tvs: Vec<Tv> = stream::iter(targets)
-        .map(|(ip, port)| {
+    let probes: Vec<Probe> = stream::iter(targets)
+        .map(|(ip, port, platform)| {
             let client = client.clone();
-            async move {
-                if !is_port_open(ip, port).await {
-                    return None;
-                }
-                let base_url = format!("http://{ip}:{port}");
-                if port == ROKU_ECP_PORT {
-                    fetch_roku(&client, &base_url, ip).await
-                } else {
-                    fetch_google_tv(&client, &base_url, ip).await
-                }
-            }
+            async move { probe(&client, ip, port, platform).await }
         })
         .buffer_unordered(MAX_CONCURRENT_PROBES)
-        .filter_map(|found| async move { found })
         .collect()
         .await;
 
-    tvs.retain(|tv| vendor::matches(&tv.vendor, vendor_filter));
-    tvs.sort_by_key(|tv| tv.ip);
-    tvs
+    ScanResult::from_probes(probes, vendor_filter)
 }
 
 /// Print the identified televisions as a table.
@@ -169,9 +172,13 @@ fn report_tvs(tvs: &[Tv]) {
 /// Report neighbours whose MAC belongs to the wanted vendor but which answered
 /// nothing — almost always a set that is powered off.
 ///
+/// `answered` holds every address that answered a probe, and not only the
+/// addresses that proved to be televisions. A host that answered has power, so
+/// it is never powered off, whatever the probe found there.
+///
 /// Every step here is best-effort: without `arp` or nmap's OUI database there
 /// is simply nothing extra to say, which is not a reason to fail the scan.
-fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
+fn report_powered_off(answered: &HashSet<Ipv4Addr>, vendor_filter: &str) {
     let Some(arp_output) = arp_table() else {
         return;
     };
@@ -180,8 +187,7 @@ fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
         return;
     };
 
-    let identified: HashSet<Ipv4Addr> = tvs.iter().map(|tv| tv.ip).collect();
-    let candidates = oui::unresponsive_candidates(&arp_output, &db, &identified, vendor_filter);
+    let candidates = oui::unresponsive_candidates(&arp_output, &db, answered, vendor_filter);
     if candidates.is_empty() {
         return;
     }

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -118,14 +118,7 @@ fn report_tvs(tvs: &[Tv]) {
         ]);
 
     for tv in tvs {
-        table.add_row(vec![
-            tv.ip.to_string(),
-            tv.name.clone(),
-            tv.vendor.clone(),
-            tv.model.clone(),
-            tv.platform.label().to_owned(),
-            tv.software.clone(),
-        ]);
+        table.add_row(tv.display_row());
     }
 
     println!("{table}");

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -12,6 +12,7 @@ mod scan;
 mod vendor;
 
 use std::collections::HashSet;
+use std::env;
 use std::fs;
 use std::net::Ipv4Addr;
 use std::process::Command;
@@ -29,6 +30,9 @@ use scan::{probe, Probe, PROBE_PORTS};
 /// Probes in flight at once. High enough to sweep a /23 in seconds, low enough
 /// to stay well inside the open-file limit.
 const MAX_CONCURRENT_PROBES: usize = 256;
+
+/// Name `std::env::consts::OS` gives Linux.
+const LINUX_OS: &str = "linux";
 
 /// Find smart TVs on the local network
 #[derive(Parser, Debug)]
@@ -98,8 +102,11 @@ fn powered_off_heading(vendor_filter: &str) -> String {
 /// other system supplies `arp` itself, thus an absence there is a question of
 /// the PATH.
 fn missing_arp_hint(os: &str) -> &'static str {
-    let _ = os;
-    todo!("a missing arp command still returns in silence")
+    if os == LINUX_OS {
+        "(install net-tools to get arp and also spot TVs that are powered off)"
+    } else {
+        "(put arp on the PATH to also spot TVs that are powered off)"
+    }
 }
 
 /// What one sweep of the subnet found.
@@ -188,10 +195,13 @@ fn report_tvs(tvs: &[Tv]) {
 /// addresses that proved to be televisions. A host that answered has power, so
 /// it is never powered off, whatever the probe found there.
 ///
-/// Every step here is best-effort: without `arp` or nmap's OUI database there
-/// is simply nothing extra to say, which is not a reason to fail the scan.
+/// Every step here is best-effort. A missing `arp` command and a missing OUI
+/// database are not reasons to fail the scan. Each one prints one line that
+/// names the tool, because a report that does not appear looks the same as a
+/// network with no powered-off sets.
 fn report_powered_off(answered: &HashSet<Ipv4Addr>, vendor_filter: &str) {
     let Some(arp_output) = arp_table() else {
+        eprintln!("{}", missing_arp_hint(env::consts::OS));
         return;
     };
     let Some(db) = oui_database() else {

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         None => cidr::local_subnet()?,
     };
     let hosts = cidr::hosts_in(&subnet)?;
-    eprintln!("Scanning {subnet} ({} hosts) for TVs...", hosts.len());
+    eprintln!("Scanning {subnet} ({}) for TVs...", host_count(hosts.len()));
 
     let tvs = find_tvs(&hosts, &args.vendor).await;
     report_tvs(&tvs);
@@ -70,8 +70,8 @@ async fn main() -> Result<()> {
 
 /// Describe a host count for the scan banner, e.g. `1 host` or `510 hosts`.
 fn host_count(hosts: usize) -> String {
-    let _ = hosts;
-    String::new()
+    let plural = if hosts == 1 { "" } else { "s" };
+    format!("{hosts} host{plural}")
 }
 
 /// Probe every host on both TV ports and identify whatever answers.
@@ -159,6 +159,20 @@ fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
     }
 }
 
+/// The system ARP table, or `None` if `arp` is unavailable.
+fn arp_table() -> Option<String> {
+    let output = Command::new("arp").args(["-a", "-n"]).output().ok()?;
+    String::from_utf8(output.stdout).ok()
+}
+
+/// nmap's OUI database from the first path that exists.
+fn oui_database() -> Option<std::collections::HashMap<String, String>> {
+    oui::OUI_DB_PATHS
+        .iter()
+        .find_map(|path| fs::read_to_string(path).ok())
+        .map(|text| oui::parse_db(&text))
+}
+
 #[cfg(test)]
 mod tests {
     use super::host_count;
@@ -177,18 +191,4 @@ mod tests {
     fn describes_an_empty_range_in_the_plural() {
         assert_eq!(host_count(0), "0 hosts");
     }
-}
-
-/// The system ARP table, or `None` if `arp` is unavailable.
-fn arp_table() -> Option<String> {
-    let output = Command::new("arp").args(["-a", "-n"]).output().ok()?;
-    String::from_utf8(output.stdout).ok()
-}
-
-/// nmap's OUI database from the first path that exists.
-fn oui_database() -> Option<std::collections::HashMap<String, String>> {
-    oui::OUI_DB_PATHS
-        .iter()
-        .find_map(|path| fs::read_to_string(path).ok())
-        .map(|text| oui::parse_db(&text))
 }

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -68,6 +68,12 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Describe a host count for the scan banner, e.g. `1 host` or `510 hosts`.
+fn host_count(hosts: usize) -> String {
+    let _ = hosts;
+    String::new()
+}
+
 /// Probe every host on both TV ports and identify whatever answers.
 async fn find_tvs(hosts: &[Ipv4Addr], vendor_filter: &str) -> Vec<Tv> {
     let client = Client::new();
@@ -150,6 +156,26 @@ fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
             "  {:<16} {:<19} {}",
             candidate.ip, candidate.mac, candidate.vendor
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_count;
+
+    #[test]
+    fn describes_a_single_host_in_the_singular() {
+        assert_eq!(host_count(1), "1 host");
+    }
+
+    #[test]
+    fn describes_several_hosts_in_the_plural() {
+        assert_eq!(host_count(510), "510 hosts");
+    }
+
+    #[test]
+    fn describes_an_empty_range_in_the_plural() {
+        assert_eq!(host_count(0), "0 hosts");
     }
 }
 

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -24,7 +24,7 @@ use futures::stream::{self, StreamExt};
 use reqwest::Client;
 
 use identify::Tv;
-use scan::{fetch_google_tv, fetch_roku, is_port_open, PROBE_PORTS, ROKU_ECP_PORT};
+use scan::{fetch_google_tv, fetch_roku, is_port_open, Probe, PROBE_PORTS, ROKU_ECP_PORT};
 
 /// Probes in flight at once. High enough to sweep a /23 in seconds, low enough
 /// to stay well inside the open-file limit.
@@ -88,6 +88,26 @@ fn powered_off_heading(vendor_filter: &str) -> String {
     };
 
     format!("\nRegistered to {registrant}, but answered no probe (powered off?):\n")
+}
+
+/// What one sweep of the subnet found.
+struct ScanResult {
+    /// Televisions identified, after the vendor filter.
+    tvs: Vec<Tv>,
+    /// Every address that answered a probe, television or not.
+    answered: HashSet<Ipv4Addr>,
+}
+
+impl ScanResult {
+    /// Fold the probes of one sweep into televisions and answering addresses.
+    ///
+    /// The vendor filter narrows the televisions only. An address that answered
+    /// stays in `answered` whatever the probe found there, because a host that
+    /// completed a TCP handshake has power.
+    fn from_probes(probes: Vec<Probe>, vendor_filter: &str) -> Self {
+        let _ = (probes, vendor_filter);
+        todo!("a sweep does not yet collect the addresses that answered")
+    }
 }
 
 /// Probe every host on both TV ports and identify whatever answers.
@@ -191,7 +211,101 @@ fn oui_database() -> Option<std::collections::HashMap<String, String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{host_count, powered_off_heading};
+    use std::net::Ipv4Addr;
+
+    use super::identify::{Platform, Tv};
+    use super::scan::Probe;
+    use super::{host_count, powered_off_heading, ScanResult};
+
+    /// A television as the Roku path reports one.
+    fn a_tv(ip: Ipv4Addr, vendor: &str) -> Tv {
+        Tv {
+            ip,
+            platform: Platform::RokuTv,
+            vendor: vendor.to_owned(),
+            model: "43S435".to_owned(),
+            name: "Office".to_owned(),
+            software: "15.0.4".to_owned(),
+        }
+    }
+
+    #[test]
+    fn counts_a_host_that_answered_without_proving_a_television_as_answered() {
+        // A Roku streaming player answers the ECP port and is rejected as a
+        // television. It has power, so it is not powered off.
+        let player = Ipv4Addr::new(192, 168, 0, 77);
+        let television = Ipv4Addr::new(192, 168, 0, 119);
+        let silent = Ipv4Addr::new(192, 168, 0, 217);
+        let probes = vec![
+            Probe {
+                ip: player,
+                answered: true,
+                tv: None,
+            },
+            Probe {
+                ip: television,
+                answered: true,
+                tv: Some(a_tv(television, "TCL")),
+            },
+            Probe {
+                ip: silent,
+                answered: false,
+                tv: None,
+            },
+        ];
+
+        let found = ScanResult::from_probes(probes, "");
+
+        assert!(
+            found.answered.contains(&player),
+            "a Roku streaming player has power"
+        );
+        assert!(found.answered.contains(&television));
+        assert!(
+            !found.answered.contains(&silent),
+            "a host that refused the handshake answered nothing"
+        );
+    }
+
+    #[test]
+    fn keeps_a_television_the_vendor_filter_removed_among_the_addresses_that_answered() {
+        let sony = Ipv4Addr::new(192, 168, 0, 33);
+        let probes = vec![Probe {
+            ip: sony,
+            answered: true,
+            tv: Some(a_tv(sony, "Sony")),
+        }];
+
+        let found = ScanResult::from_probes(probes, "tcl");
+
+        assert!(found.tvs.is_empty(), "the filter keeps a Sony set out");
+        assert!(found.answered.contains(&sony), "the set still has power");
+    }
+
+    #[test]
+    fn orders_the_televisions_by_address() {
+        let high = Ipv4Addr::new(192, 168, 0, 248);
+        let low = Ipv4Addr::new(192, 168, 0, 119);
+        let probes = vec![
+            Probe {
+                ip: high,
+                answered: true,
+                tv: Some(a_tv(high, "TCL")),
+            },
+            Probe {
+                ip: low,
+                answered: true,
+                tv: Some(a_tv(low, "TCL")),
+            },
+        ];
+
+        let found = ScanResult::from_probes(probes, "");
+
+        assert_eq!(
+            found.tvs.iter().map(|tv| tv.ip).collect::<Vec<_>>(),
+            vec![low, high]
+        );
+    }
 
     #[test]
     fn says_what_an_unfiltered_candidate_actually_has_in_common_with_a_tv() {

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -1,4 +1,9 @@
 //! `tvfind` — find smart TVs on the local network and identify them.
+//!
+//! Televisions are addressed directly on the two ports their firmware answers
+//! on rather than discovered over SSDP or mDNS. Access points routinely filter
+//! multicast between radios, which hides sets that reply perfectly well when
+//! asked directly.
 
 mod cidr;
 mod identify;
@@ -6,9 +11,24 @@ mod oui;
 mod scan;
 mod vendor;
 
+use std::collections::HashSet;
+use std::fs;
+use std::net::Ipv4Addr;
+use std::process::Command;
+
 use anyhow::Result;
 use buildinfo::version_string;
 use clap::Parser;
+use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use futures::stream::{self, StreamExt};
+use reqwest::Client;
+
+use identify::Tv;
+use scan::{fetch_google_tv, fetch_roku, is_port_open, PROBE_PORTS, ROKU_ECP_PORT};
+
+/// Probes in flight at once. High enough to sweep a /23 in seconds, low enough
+/// to stay well inside the open-file limit.
+const MAX_CONCURRENT_PROBES: usize = 256;
 
 /// Find smart TVs on the local network
 #[derive(Parser, Debug)]
@@ -27,7 +47,129 @@ struct Args {
     no_arp: bool,
 }
 
-fn main() -> Result<()> {
-    let _args = Args::parse();
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let subnet = match args.subnet {
+        Some(ref explicit) => explicit.clone(),
+        None => cidr::local_subnet()?,
+    };
+    let hosts = cidr::hosts_in(&subnet)?;
+    eprintln!("Scanning {subnet} ({} hosts) for TVs...", hosts.len());
+
+    let tvs = find_tvs(&hosts, &args.vendor).await;
+    report_tvs(&tvs);
+
+    if !args.no_arp {
+        report_powered_off(&tvs, &args.vendor);
+    }
+
     Ok(())
+}
+
+/// Probe every host on both TV ports and identify whatever answers.
+async fn find_tvs(hosts: &[Ipv4Addr], vendor_filter: &str) -> Vec<Tv> {
+    let client = Client::new();
+
+    let targets: Vec<(Ipv4Addr, u16)> = hosts
+        .iter()
+        .flat_map(|ip| PROBE_PORTS.iter().map(move |port| (*ip, *port)))
+        .collect();
+
+    let mut tvs: Vec<Tv> = stream::iter(targets)
+        .map(|(ip, port)| {
+            let client = client.clone();
+            async move {
+                if !is_port_open(ip, port).await {
+                    return None;
+                }
+                let base_url = format!("http://{ip}:{port}");
+                if port == ROKU_ECP_PORT {
+                    fetch_roku(&client, &base_url, ip).await
+                } else {
+                    fetch_google_tv(&client, &base_url, ip).await
+                }
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_PROBES)
+        .filter_map(|found| async move { found })
+        .collect()
+        .await;
+
+    tvs.retain(|tv| vendor::matches(&tv.vendor, vendor_filter));
+    tvs.sort_by_key(|tv| tv.ip);
+    tvs
+}
+
+/// Print the identified televisions as a table.
+fn report_tvs(tvs: &[Tv]) {
+    if tvs.is_empty() {
+        println!("No TVs answered.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            "IP", "Name", "Vendor", "Model", "Platform", "Software",
+        ]);
+
+    for tv in tvs {
+        table.add_row(vec![
+            tv.ip.to_string(),
+            tv.name.clone(),
+            tv.vendor.clone(),
+            tv.model.clone(),
+            tv.platform.label().to_owned(),
+            tv.software.clone(),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+/// Report neighbours whose MAC belongs to the wanted vendor but which answered
+/// nothing — almost always a set that is powered off.
+///
+/// Every step here is best-effort: without `arp` or nmap's OUI database there
+/// is simply nothing extra to say, which is not a reason to fail the scan.
+fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
+    let Some(arp_output) = arp_table() else {
+        return;
+    };
+    let Some(db) = oui_database() else {
+        eprintln!("(install nmap to also spot TVs that are powered off)");
+        return;
+    };
+
+    let identified: HashSet<Ipv4Addr> = tvs.iter().map(|tv| tv.ip).collect();
+    let candidates = oui::unresponsive_candidates(&arp_output, &db, &identified, vendor_filter);
+    if candidates.is_empty() {
+        return;
+    }
+
+    println!("\nProbably a TV but answering nothing (powered off?):\n");
+    for candidate in candidates {
+        println!(
+            "  {:<16} {:<19} {}",
+            candidate.ip, candidate.mac, candidate.vendor
+        );
+    }
+}
+
+/// The system ARP table, or `None` if `arp` is unavailable.
+fn arp_table() -> Option<String> {
+    let output = Command::new("arp").args(["-a", "-n"]).output().ok()?;
+    String::from_utf8(output.stdout).ok()
+}
+
+/// nmap's OUI database from the first path that exists.
+fn oui_database() -> Option<std::collections::HashMap<String, String>> {
+    oui::OUI_DB_PATHS
+        .iter()
+        .find_map(|path| fs::read_to_string(path).ok())
+        .map(|text| oui::parse_db(&text))
 }

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -74,6 +74,12 @@ fn host_count(hosts: usize) -> String {
     format!("{hosts} host{plural}")
 }
 
+/// Heading for the powered-off report.
+fn powered_off_heading(vendor_filter: &str) -> String {
+    let _ = vendor_filter;
+    String::new()
+}
+
 /// Probe every host on both TV ports and identify whatever answers.
 async fn find_tvs(hosts: &[Ipv4Addr], vendor_filter: &str) -> Vec<Tv> {
     let client = Client::new();
@@ -175,7 +181,27 @@ fn oui_database() -> Option<std::collections::HashMap<String, String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::host_count;
+    use super::{host_count, powered_off_heading};
+
+    #[test]
+    fn says_what_an_unfiltered_candidate_actually_has_in_common_with_a_tv() {
+        // The evidence is the address block, not the device. Saying more than
+        // that is what put a router and a speaker under a "probably a TV" list.
+        let heading = powered_off_heading("");
+
+        assert!(
+            heading.contains("television maker"),
+            "the heading must name the evidence, got {heading:?}"
+        );
+        assert!(!heading.contains("Probably a TV"));
+    }
+
+    #[test]
+    fn names_the_filter_the_user_gave_in_the_heading() {
+        let heading = powered_off_heading("tcl");
+
+        assert!(heading.contains("tcl"), "got {heading:?}");
+    }
 
     #[test]
     fn describes_a_single_host_in_the_singular() {

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -75,9 +75,19 @@ fn host_count(hosts: usize) -> String {
 }
 
 /// Heading for the powered-off report.
+///
+/// An OUI lookup identifies the company a hardware address block belongs to,
+/// and nothing more, so the heading names that evidence rather than asserting
+/// the device is a television.
 fn powered_off_heading(vendor_filter: &str) -> String {
-    let _ = vendor_filter;
-    String::new()
+    let filter = vendor_filter.trim();
+    let registrant = if filter.is_empty() {
+        "a television maker".to_owned()
+    } else {
+        format!("a vendor that matches \"{filter}\"")
+    };
+
+    format!("\nRegistered to {registrant}, but answered no probe (powered off?):\n")
 }
 
 /// Probe every host on both TV ports and identify whatever answers.
@@ -156,7 +166,7 @@ fn report_powered_off(tvs: &[Tv], vendor_filter: &str) {
         return;
     }
 
-    println!("\nProbably a TV but answering nothing (powered off?):\n");
+    println!("{}", powered_off_heading(vendor_filter));
     for candidate in candidates {
         println!(
             "  {:<16} {:<19} {}",

--- a/src/tvfind/src/main.rs
+++ b/src/tvfind/src/main.rs
@@ -90,6 +90,18 @@ fn powered_off_heading(vendor_filter: &str) -> String {
     format!("\nRegistered to {registrant}, but answered no probe (powered off?):\n")
 }
 
+/// Hint printed when the `arp` command cannot be run.
+///
+/// `os` names the operating system, as `std::env::consts::OS` spells it. A
+/// Linux distribution that ships iproute2 gets `arp` from the `net-tools`
+/// package, and many such distributions do not install that package. Every
+/// other system supplies `arp` itself, thus an absence there is a question of
+/// the PATH.
+fn missing_arp_hint(os: &str) -> &'static str {
+    let _ = os;
+    todo!("a missing arp command still returns in silence")
+}
+
 /// What one sweep of the subnet found.
 struct ScanResult {
     /// Televisions identified, after the vendor filter.
@@ -221,7 +233,7 @@ mod tests {
 
     use super::identify::{Platform, Tv};
     use super::scan::Probe;
-    use super::{host_count, powered_off_heading, ScanResult};
+    use super::{host_count, missing_arp_hint, powered_off_heading, ScanResult};
 
     /// A television as the Roku path reports one.
     fn a_tv(ip: Ipv4Addr, vendor: &str) -> Tv {
@@ -331,6 +343,33 @@ mod tests {
         let heading = powered_off_heading("tcl");
 
         assert!(heading.contains("tcl"), "got {heading:?}");
+    }
+
+    #[test]
+    fn names_the_package_that_supplies_arp_on_linux() {
+        // A distribution that ships iproute2 carries no arp command until
+        // net-tools is installed, and the powered-off report needs arp.
+        let hint = missing_arp_hint("linux");
+
+        assert!(hint.contains("net-tools"), "got {hint:?}");
+        assert!(hint.contains("arp"), "got {hint:?}");
+        assert!(
+            hint.contains("powered off"),
+            "the hint must name the report that was lost, got {hint:?}"
+        );
+    }
+
+    #[test]
+    fn points_at_the_path_on_a_system_that_supplies_arp_itself() {
+        // macOS installs arp with the system, so there is no package to name.
+        let hint = missing_arp_hint("macos");
+
+        assert!(hint.contains("arp"), "got {hint:?}");
+        assert!(hint.contains("PATH"), "got {hint:?}");
+        assert!(
+            !hint.contains("net-tools"),
+            "macOS has no net-tools package, got {hint:?}"
+        );
     }
 
     #[test]

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -258,64 +258,52 @@ mod tests {
 
     #[test]
     fn reports_a_neighbour_whose_mac_belongs_to_the_wanted_vendor() {
-        let found = unresponsive_candidates(
-            CANDIDATE_ARP,
-            &candidate_db(),
-            &HashSet::new(),
-            "tcl",
-        );
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "tcl");
 
-        assert!(found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 1, 217)));
+        assert!(found
+            .iter()
+            .any(|c| c.ip == Ipv4Addr::new(192, 168, 1, 217)));
     }
 
     #[test]
     fn reports_a_neighbour_registered_to_the_contract_manufacturer() {
-        let found = unresponsive_candidates(
-            CANDIDATE_ARP,
-            &candidate_db(),
-            &HashSet::new(),
-            "tcl",
-        );
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "tcl");
 
-        assert!(found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
+        assert!(found
+            .iter()
+            .any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
     }
 
     #[test]
     fn omits_a_neighbour_already_identified_as_a_television() {
         let identified = HashSet::from([Ipv4Addr::new(192, 168, 0, 248)]);
 
-        let found =
-            unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &identified, "tcl");
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &identified, "tcl");
 
-        assert!(!found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
+        assert!(!found
+            .iter()
+            .any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
     }
 
     #[test]
     fn omits_neighbours_belonging_to_other_vendors() {
-        let found = unresponsive_candidates(
-            CANDIDATE_ARP,
-            &candidate_db(),
-            &HashSet::new(),
-            "tcl",
-        );
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "tcl");
 
         assert_eq!(found.len(), 2, "only the two TCL-family MACs should remain");
     }
 
     #[test]
     fn names_the_vendor_the_prefix_is_registered_to() {
-        let found = unresponsive_candidates(
-            CANDIDATE_ARP,
-            &candidate_db(),
-            &HashSet::new(),
-            "tcl",
-        );
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "tcl");
         let tcl_king = found
             .iter()
             .find(|c| c.ip == Ipv4Addr::new(192, 168, 1, 217))
             .expect("the TCL King neighbour should be reported");
 
-        assert_eq!(tcl_king.vendor, "TCL King Electrical Appliances(Huizhou)Co.");
+        assert_eq!(
+            tcl_king.vendor,
+            "TCL King Electrical Appliances(Huizhou)Co."
+        );
     }
 
     #[test]

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -51,8 +51,21 @@ pub fn unresponsive_candidates(
     identified: &HashSet<Ipv4Addr>,
     vendor_filter: &str,
 ) -> Vec<Candidate> {
-    let _ = (arp_output, db, identified, vendor_filter);
-    Vec::new()
+    let mut candidates: Vec<Candidate> = parse_arp_table(arp_output)
+        .into_iter()
+        .filter(|neighbour| !identified.contains(&neighbour.ip))
+        .filter_map(|neighbour| {
+            let vendor = db.get(&mac_prefix(&neighbour.mac)?)?;
+            crate::vendor::matches(vendor, vendor_filter).then(|| Candidate {
+                ip: neighbour.ip,
+                mac: neighbour.mac,
+                vendor: vendor.clone(),
+            })
+        })
+        .collect();
+
+    candidates.sort_by_key(|candidate| candidate.ip);
+    candidates
 }
 
 /// Normalise a MAC address to its 6-hex-digit uppercase OUI prefix.

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -3,6 +3,9 @@
 //! A TV in standby refuses every TCP connection but still answers ARP, so it
 //! is invisible to a port scan yet plainly present in the neighbour table.
 //! Resolving its MAC prefix against nmap's OUI database recovers it.
+//!
+//! Only a neighbour that answered no probe is a candidate. A device that
+//! completed a TCP handshake has power, whatever the exchange after it found.
 
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
@@ -40,20 +43,24 @@ pub struct Candidate {
     pub vendor: String,
 }
 
-/// Neighbours matching `vendor_filter` by MAC that no probe identified.
+/// Neighbours matching `vendor_filter` by MAC that answered no probe.
 ///
-/// `identified` holds the addresses already confirmed as televisions, so a TV
-/// that answered is never also reported as a silent candidate.
+/// `answered` holds every address that answered a probe, and not only the
+/// addresses that proved to be televisions. A host that answered has power, so
+/// it is never a powered-off candidate. That difference is what keeps a Roku
+/// streaming player out of the list: the player answers the Roku port, fails
+/// the `is-tv` test, and is registered to the address block of a television
+/// maker.
 #[must_use]
 pub fn unresponsive_candidates(
     arp_output: &str,
     db: &HashMap<String, String>,
-    identified: &HashSet<Ipv4Addr>,
+    answered: &HashSet<Ipv4Addr>,
     vendor_filter: &str,
 ) -> Vec<Candidate> {
     let mut candidates: Vec<Candidate> = parse_arp_table(arp_output)
         .into_iter()
-        .filter(|neighbour| !identified.contains(&neighbour.ip))
+        .filter(|neighbour| !answered.contains(&neighbour.ip))
         .filter_map(|neighbour| {
             let vendor = db.get(&mac_prefix(&neighbour.mac)?)?;
             crate::vendor::wanted_as_television(vendor, vendor_filter).then(|| Candidate {

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -7,6 +7,11 @@
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
+/// Octets of a MAC address that make up the vendor prefix.
+const OUI_OCTETS: usize = 3;
+/// Hex digits in a normalised OUI prefix.
+const OUI_PREFIX_LEN: usize = OUI_OCTETS * 2;
+
 /// Locations nmap's OUI database may live, newest Homebrew layout first.
 pub const OUI_DB_PATHS: &[&str] = &[
     "/opt/homebrew/share/nmap/nmap-mac-prefixes",
@@ -31,15 +36,33 @@ pub struct Neighbour {
 /// Returns `None` if `mac` does not have at least three hex octets.
 #[must_use]
 pub fn mac_prefix(mac: &str) -> Option<String> {
-    let _ = mac;
-    None
+    let mut prefix = String::with_capacity(OUI_PREFIX_LEN);
+
+    for octet in mac.split(':').take(OUI_OCTETS) {
+        if octet.is_empty() || octet.len() > 2 || !octet.chars().all(|c| c.is_ascii_hexdigit()) {
+            return None;
+        }
+        // `arp` drops leading zeros, so 'f' has to become "0F".
+        for _ in octet.len()..2 {
+            prefix.push('0');
+        }
+        prefix.push_str(&octet.to_ascii_uppercase());
+    }
+
+    (prefix.len() == OUI_PREFIX_LEN).then_some(prefix)
 }
 
 /// Parse nmap's `nmap-mac-prefixes` into a prefix-to-vendor map.
 #[must_use]
 pub fn parse_db(text: &str) -> HashMap<String, String> {
-    let _ = text;
-    HashMap::new()
+    text.lines()
+        .filter_map(|line| line.trim().split_once(char::is_whitespace))
+        .filter(|(prefix, _)| {
+            // Longer MA-M/MA-S assignments cannot be resolved from three octets.
+            prefix.len() == OUI_PREFIX_LEN && prefix.chars().all(|c| c.is_ascii_hexdigit())
+        })
+        .map(|(prefix, vendor)| (prefix.to_ascii_uppercase(), vendor.trim().to_owned()))
+        .collect()
 }
 
 /// Parse the output of `arp -a -n` into neighbours.

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -105,9 +105,16 @@ pub fn parse_db(text: &str) -> HashMap<String, String> {
         .collect()
 }
 
-/// Parse the output of `arp -a -n` into neighbours.
+/// Parse the output of `arp -a -n` into neighbours, one for each address.
+///
+/// macOS prints a separate line for every interface that reaches a host, so a
+/// machine on three networks lists each neighbour three times. Keying on the
+/// address collapses those repeats while keeping two addresses that share one
+/// hardware address, which is how a router with several addresses appears.
 #[must_use]
 pub fn parse_arp_table(text: &str) -> Vec<Neighbour> {
+    let mut seen = HashSet::new();
+
     text.lines()
         .filter_map(|line| {
             // `? (192.168.0.1) at 70:a7:41:66:7c:39 on en0 ifscope [ethernet]`
@@ -124,6 +131,10 @@ pub fn parse_arp_table(text: &str) -> Vec<Neighbour> {
             // behind broadcast or multicast, so probing them is wasted work.
             let first_octet = u8::from_str_radix(mac.split(':').next()?, 16).ok()?;
             if first_octet & 1 == 1 {
+                return None;
+            }
+
+            if !seen.insert(ip) {
                 return None;
             }
 

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -56,7 +56,7 @@ pub fn unresponsive_candidates(
         .filter(|neighbour| !identified.contains(&neighbour.ip))
         .filter_map(|neighbour| {
             let vendor = db.get(&mac_prefix(&neighbour.mac)?)?;
-            crate::vendor::matches(vendor, vendor_filter).then(|| Candidate {
+            crate::vendor::wanted_as_television(vendor, vendor_filter).then(|| Candidate {
                 ip: neighbour.ip,
                 mac: neighbour.mac,
                 vendor: vendor.clone(),

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -129,6 +129,53 @@ mod tests {
         assert!(!db.contains_key(""));
     }
 
+    /// Representative `arp -a -n` output from macOS.
+    const ARP_TABLE: &str = "? (192.168.0.1) at 70:a7:41:66:7c:39 on en0 ifscope [ethernet]
+? (192.168.1.50) at 0:f:e7:83:b8:eb on en0 ifscope [ethernet]
+? (192.168.0.43) at (incomplete) on en0 [ethernet]
+? (192.168.0.0) at ff:ff:ff:ff:ff:ff on en0 ifscope [ethernet]
+? (224.0.0.251) at 1:0:5e:0:0:fb on en0 ifscope permanent [ethernet]
+? (192.168.1.217) at d0:65:b3:a8:60:33 on en0 ifscope [ethernet]
+";
+
+    #[test]
+    fn reads_the_address_and_hardware_address_of_each_neighbour() {
+        let neighbours = parse_arp_table(ARP_TABLE);
+
+        assert_eq!(
+            neighbours.first(),
+            Some(&Neighbour {
+                ip: Ipv4Addr::new(192, 168, 0, 1),
+                mac: "70:a7:41:66:7c:39".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn skips_entries_whose_resolution_never_completed() {
+        let neighbours = parse_arp_table(ARP_TABLE);
+
+        assert!(!neighbours
+            .iter()
+            .any(|n| n.ip == Ipv4Addr::new(192, 168, 0, 43)));
+    }
+
+    #[test]
+    fn skips_broadcast_and_multicast_entries() {
+        let neighbours = parse_arp_table(ARP_TABLE);
+
+        // No host lives behind a group address, so probing one is wasted work.
+        assert!(!neighbours.iter().any(|n| n.mac.starts_with("ff:ff")));
+        assert!(!neighbours.iter().any(|n| n.mac.starts_with("1:0:5e")));
+    }
+
+    #[test]
+    fn keeps_every_genuine_unicast_neighbour() {
+        let neighbours = parse_arp_table(ARP_TABLE);
+
+        assert_eq!(neighbours.len(), 3);
+    }
+
     #[test]
     fn skips_longer_ma_m_assignments_that_are_not_oui_prefixes() {
         // 28-bit and 36-bit IEEE blocks appear with 7- or 9-character keys and

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -239,6 +239,34 @@ mod tests {
         assert_eq!(neighbours.len(), 3);
     }
 
+    /// One host reachable over three interfaces, as macOS `arp` prints it.
+    const MULTI_INTERFACE_ARP: &str =
+        "? (192.168.0.1) at 70:a7:41:66:7c:39 on en0 ifscope [ethernet]
+? (192.168.0.1) at 70:a7:41:66:7c:39 on en8 ifscope [ethernet]
+? (192.168.0.1) at 70:a7:41:66:7c:39 on en1 ifscope [ethernet]
+? (192.168.0.2) at 70:a7:41:66:7c:39 on en8 ifscope [ethernet]
+";
+
+    #[test]
+    fn reports_a_host_once_however_many_interfaces_reach_it() {
+        let neighbours = parse_arp_table(MULTI_INTERFACE_ARP);
+
+        let first = neighbours
+            .iter()
+            .filter(|n| n.ip == Ipv4Addr::new(192, 168, 0, 1))
+            .count();
+        assert_eq!(first, 1, "one address must yield one neighbour");
+    }
+
+    #[test]
+    fn keeps_two_addresses_that_share_one_hardware_address() {
+        // A router answers for several addresses off one interface. Each is a
+        // separate neighbour, so deduplication must key on the address.
+        let neighbours = parse_arp_table(MULTI_INTERFACE_ARP);
+
+        assert_eq!(neighbours.len(), 2);
+    }
+
     /// The OUI database entries the candidate fixture depends on.
     fn candidate_db() -> HashMap<String, String> {
         parse_db(

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -48,3 +48,71 @@ pub fn parse_arp_table(text: &str) -> Vec<Neighbour> {
     let _ = text;
     Vec::new()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn takes_the_first_three_octets_as_the_prefix() {
+        assert_eq!(mac_prefix("34:51:80:d0:83:d2").as_deref(), Some("345180"));
+    }
+
+    #[test]
+    fn pads_octets_that_arp_printed_without_leading_zeros() {
+        // macOS `arp` abbreviates: 0:f:e7 is really 00:0f:e7.
+        assert_eq!(mac_prefix("0:f:e7:83:b8:eb").as_deref(), Some("000FE7"));
+    }
+
+    #[test]
+    fn rejects_an_address_with_too_few_octets() {
+        assert!(mac_prefix("34:51").is_none());
+    }
+
+    #[test]
+    fn rejects_an_address_that_is_not_hexadecimal() {
+        assert!(mac_prefix("(incomplete)").is_none());
+        assert!(mac_prefix("zz:yy:xx:00:00:00").is_none());
+    }
+
+    /// Representative lines from nmap's `nmap-mac-prefixes`.
+    const OUI_DB: &str = "# Auto-generated from the IEEE registry
+345180 TCL King Electrical Appliances (Huizhou)
+2CD974 Hui Zhou Gaoshengda Technology
+5CAAFD Sonos
+
+8C1F64233 TCL Operations Polska SP. Z O.O.
+";
+
+    #[test]
+    fn maps_each_prefix_to_its_registered_vendor() {
+        let db = parse_db(OUI_DB);
+
+        assert_eq!(
+            db.get("345180").map(String::as_str),
+            Some("TCL King Electrical Appliances (Huizhou)")
+        );
+        assert_eq!(
+            db.get("2CD974").map(String::as_str),
+            Some("Hui Zhou Gaoshengda Technology")
+        );
+    }
+
+    #[test]
+    fn skips_comments_and_blank_lines() {
+        let db = parse_db(OUI_DB);
+
+        assert!(!db.keys().any(|prefix| prefix.starts_with('#')));
+        assert!(!db.contains_key(""));
+    }
+
+    #[test]
+    fn skips_longer_ma_m_assignments_that_are_not_oui_prefixes() {
+        // 28-bit and 36-bit IEEE blocks appear with 7- or 9-character keys and
+        // cannot be resolved from the first three octets of a MAC.
+        let db = parse_db(OUI_DB);
+
+        assert!(!db.contains_key("8C1F64233"));
+        assert_eq!(db.len(), 3);
+    }
+}

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -1,0 +1,50 @@
+//! MAC address vendor lookup, used to spot televisions that are powered off.
+//!
+//! A TV in standby refuses every TCP connection but still answers ARP, so it
+//! is invisible to a port scan yet plainly present in the neighbour table.
+//! Resolving its MAC prefix against nmap's OUI database recovers it.
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+/// Locations nmap's OUI database may live, newest Homebrew layout first.
+pub const OUI_DB_PATHS: &[&str] = &[
+    "/opt/homebrew/share/nmap/nmap-mac-prefixes",
+    "/usr/local/share/nmap/nmap-mac-prefixes",
+    "/usr/share/nmap/nmap-mac-prefixes",
+];
+
+/// An ARP neighbour that did not answer any probe.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Neighbour {
+    /// Address held in the neighbour table.
+    pub ip: Ipv4Addr,
+    /// Hardware address as printed by `arp`.
+    pub mac: String,
+}
+
+/// Normalise a MAC address to its 6-hex-digit uppercase OUI prefix.
+///
+/// macOS `arp` prints octets without leading zeros (`0:f:e7:83:b8:eb`), so
+/// each octet is padded before the prefix is assembled.
+///
+/// Returns `None` if `mac` does not have at least three hex octets.
+#[must_use]
+pub fn mac_prefix(mac: &str) -> Option<String> {
+    let _ = mac;
+    None
+}
+
+/// Parse nmap's `nmap-mac-prefixes` into a prefix-to-vendor map.
+#[must_use]
+pub fn parse_db(text: &str) -> HashMap<String, String> {
+    let _ = text;
+    HashMap::new()
+}
+
+/// Parse the output of `arp -a -n` into neighbours.
+#[must_use]
+pub fn parse_arp_table(text: &str) -> Vec<Neighbour> {
+    let _ = text;
+    Vec::new()
+}

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -332,6 +332,27 @@ mod tests {
     }
 
     #[test]
+    fn reports_only_television_brands_when_no_vendor_filter_was_given() {
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "");
+
+        assert!(
+            !found.iter().any(|c| c.vendor.contains("Ubiquiti")),
+            "a router is not a television"
+        );
+        assert!(
+            !found.iter().any(|c| c.vendor.contains("Sonos")),
+            "a speaker is not a television"
+        );
+    }
+
+    #[test]
+    fn still_reports_a_television_brand_when_no_vendor_filter_was_given() {
+        let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "");
+
+        assert_eq!(found.len(), 2, "both TCL-family MACs must survive");
+    }
+
+    #[test]
     fn names_the_vendor_the_prefix_is_registered_to() {
         let found = unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &HashSet::new(), "tcl");
         let tcl_king = found

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -68,8 +68,31 @@ pub fn parse_db(text: &str) -> HashMap<String, String> {
 /// Parse the output of `arp -a -n` into neighbours.
 #[must_use]
 pub fn parse_arp_table(text: &str) -> Vec<Neighbour> {
-    let _ = text;
-    Vec::new()
+    text.lines()
+        .filter_map(|line| {
+            // `? (192.168.0.1) at 70:a7:41:66:7c:39 on en0 ifscope [ethernet]`
+            let (_, rest) = line.split_once('(')?;
+            let (address, rest) = rest.split_once(')')?;
+            let ip: Ipv4Addr = address.parse().ok()?;
+
+            let (_, rest) = rest.split_once(" at ")?;
+            let mac = rest.split_whitespace().next()?;
+            // Rejects placeholders such as `(incomplete)`.
+            mac_prefix(mac)?;
+
+            // Group addresses set the low bit of the first octet. Nothing sits
+            // behind broadcast or multicast, so probing them is wasted work.
+            let first_octet = u8::from_str_radix(mac.split(':').next()?, 16).ok()?;
+            if first_octet & 1 == 1 {
+                return None;
+            }
+
+            Some(Neighbour {
+                ip,
+                mac: mac.to_owned(),
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/oui.rs
+++ b/src/tvfind/src/oui.rs
@@ -4,7 +4,7 @@
 //! is invisible to a port scan yet plainly present in the neighbour table.
 //! Resolving its MAC prefix against nmap's OUI database recovers it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 
 /// Octets of a MAC address that make up the vendor prefix.
@@ -26,6 +26,33 @@ pub struct Neighbour {
     pub ip: Ipv4Addr,
     /// Hardware address as printed by `arp`.
     pub mac: String,
+}
+
+/// A neighbour whose MAC belongs to the vendor being looked for, but which
+/// answered no probe — almost always a set that is powered off.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Candidate {
+    /// Address held in the neighbour table.
+    pub ip: Ipv4Addr,
+    /// Hardware address as printed by `arp`.
+    pub mac: String,
+    /// Vendor the MAC prefix is registered to.
+    pub vendor: String,
+}
+
+/// Neighbours matching `vendor_filter` by MAC that no probe identified.
+///
+/// `identified` holds the addresses already confirmed as televisions, so a TV
+/// that answered is never also reported as a silent candidate.
+#[must_use]
+pub fn unresponsive_candidates(
+    arp_output: &str,
+    db: &HashMap<String, String>,
+    identified: &HashSet<Ipv4Addr>,
+    vendor_filter: &str,
+) -> Vec<Candidate> {
+    let _ = (arp_output, db, identified, vendor_filter);
+    Vec::new()
 }
 
 /// Normalise a MAC address to its 6-hex-digit uppercase OUI prefix.
@@ -197,6 +224,85 @@ mod tests {
         let neighbours = parse_arp_table(ARP_TABLE);
 
         assert_eq!(neighbours.len(), 3);
+    }
+
+    /// The OUI database entries the candidate fixture depends on.
+    fn candidate_db() -> HashMap<String, String> {
+        parse_db(
+            "D065B3 TCL King Electrical Appliances(Huizhou)Co.
+2CD974 Hui Zhou Gaoshengda Technology
+70A741 Ubiquiti Inc
+5CAAFD Sonos
+",
+        )
+    }
+
+    const CANDIDATE_ARP: &str = "? (192.168.0.1) at 70:a7:41:66:7c:39 on en0 ifscope [ethernet]
+? (192.168.0.46) at 5c:aa:fd:59:b5:f6 on en0 ifscope [ethernet]
+? (192.168.0.248) at 2c:d9:74:11:bf:36 on en0 ifscope [ethernet]
+? (192.168.1.217) at d0:65:b3:a8:60:33 on en0 ifscope [ethernet]
+";
+
+    #[test]
+    fn reports_a_neighbour_whose_mac_belongs_to_the_wanted_vendor() {
+        let found = unresponsive_candidates(
+            CANDIDATE_ARP,
+            &candidate_db(),
+            &HashSet::new(),
+            "tcl",
+        );
+
+        assert!(found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 1, 217)));
+    }
+
+    #[test]
+    fn reports_a_neighbour_registered_to_the_contract_manufacturer() {
+        let found = unresponsive_candidates(
+            CANDIDATE_ARP,
+            &candidate_db(),
+            &HashSet::new(),
+            "tcl",
+        );
+
+        assert!(found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
+    }
+
+    #[test]
+    fn omits_a_neighbour_already_identified_as_a_television() {
+        let identified = HashSet::from([Ipv4Addr::new(192, 168, 0, 248)]);
+
+        let found =
+            unresponsive_candidates(CANDIDATE_ARP, &candidate_db(), &identified, "tcl");
+
+        assert!(!found.iter().any(|c| c.ip == Ipv4Addr::new(192, 168, 0, 248)));
+    }
+
+    #[test]
+    fn omits_neighbours_belonging_to_other_vendors() {
+        let found = unresponsive_candidates(
+            CANDIDATE_ARP,
+            &candidate_db(),
+            &HashSet::new(),
+            "tcl",
+        );
+
+        assert_eq!(found.len(), 2, "only the two TCL-family MACs should remain");
+    }
+
+    #[test]
+    fn names_the_vendor_the_prefix_is_registered_to() {
+        let found = unresponsive_candidates(
+            CANDIDATE_ARP,
+            &candidate_db(),
+            &HashSet::new(),
+            "tcl",
+        );
+        let tcl_king = found
+            .iter()
+            .find(|c| c.ip == Ipv4Addr::new(192, 168, 1, 217))
+            .expect("the TCL King neighbour should be reported");
+
+        assert_eq!(tcl_king.vendor, "TCL King Electrical Appliances(Huizhou)Co.");
     }
 
     #[test]

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -146,6 +146,24 @@ mod tests {
         mock.assert_async().await;
     }
 
+    /// `/apps/Netflix` as a TCL Google TV answers it.
+    const NETFLIX_DIAL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<service xmlns="urn:dial-multiscreen-org:schemas:dial">
+  <name>Netflix</name>
+  <options allowStop="true"/>
+  <state>stopped</state>
+</service>"#;
+
+    /// Answer the DIAL screen test the way a device with a display does.
+    async fn mock_a_screen(server: &mut mockito::Server) -> mockito::Mock {
+        server
+            .mock("GET", "/apps/Netflix")
+            .with_status(200)
+            .with_body(NETFLIX_DIAL)
+            .create_async()
+            .await
+    }
+
     #[tokio::test]
     async fn fetches_and_identifies_a_google_tv() {
         let mut server = mockito::Server::new_async().await;
@@ -161,6 +179,7 @@ mod tests {
             .with_body(r#"{"name":"Living Room","cast_build_revision":"3.72.446070"}"#)
             .create_async()
             .await;
+        let _screen = mock_a_screen(&mut server).await;
 
         let tv = fetch_google_tv(&Client::new(), &server.url(), ip())
             .await
@@ -187,6 +206,7 @@ mod tests {
             .with_status(500)
             .create_async()
             .await;
+        let _screen = mock_a_screen(&mut server).await;
 
         let tv = fetch_google_tv(&Client::new(), &server.url(), ip())
             .await
@@ -196,5 +216,70 @@ mod tests {
         eureka.assert_async().await;
         assert_eq!(tv.vendor, "TCL");
         assert_eq!(tv.name, "Living Room");
+    }
+
+    #[tokio::test]
+    async fn treats_a_cast_device_with_no_video_application_as_no_tv() {
+        // A speaker with Chromecast built-in publishes the same UPnP document a
+        // TV does. Only its refusal to run a video app separates the two.
+        let mut server = mockito::Server::new_async().await;
+        let _desc = server
+            .mock("GET", "/ssdp/device-desc.xml")
+            .with_status(200)
+            .with_body(GOOGLE_TV_DESC.replace("Smart TV Pro", "Google Home").as_str())
+            .create_async()
+            .await;
+        let _eureka = server
+            .mock("GET", "/setup/eureka_info")
+            .with_status(200)
+            .with_body(r#"{"name":"Kitchen speaker"}"#)
+            .create_async()
+            .await;
+        let _no_apps = server
+            .mock("GET", mockito::Matcher::Regex(r"^/apps/.*$".to_owned()))
+            .with_status(404)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+
+        assert!(fetch_google_tv(&Client::new(), &server.url(), ip())
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn asks_a_second_video_application_when_the_first_is_absent() {
+        // Not every set carries Netflix, so one refusal must not end the test.
+        let mut server = mockito::Server::new_async().await;
+        let _desc = server
+            .mock("GET", "/ssdp/device-desc.xml")
+            .with_status(200)
+            .with_body(GOOGLE_TV_DESC)
+            .create_async()
+            .await;
+        let _eureka = server
+            .mock("GET", "/setup/eureka_info")
+            .with_status(404)
+            .create_async()
+            .await;
+        let netflix = server
+            .mock("GET", "/apps/Netflix")
+            .with_status(404)
+            .create_async()
+            .await;
+        let youtube = server
+            .mock("GET", "/apps/YouTube")
+            .with_status(200)
+            .with_body(NETFLIX_DIAL.replace("Netflix", "YouTube").as_str())
+            .create_async()
+            .await;
+
+        let tv = fetch_google_tv(&Client::new(), &server.url(), ip())
+            .await
+            .expect("a second video app should still prove a screen");
+
+        netflix.assert_async().await;
+        youtube.assert_async().await;
+        assert_eq!(tv.vendor, "TCL");
     }
 }

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -18,8 +18,12 @@ use crate::identify::{dial_app_installed, parse_google_tv, parse_roku_device_inf
 pub const ROKU_ECP_PORT: u16 = 8060;
 /// Chromecast built-in, present on Google TV sets.
 pub const GOOGLETV_CAST_PORT: u16 = 8008;
-/// Ports probed on every host, in the order they are reported.
-pub const PROBE_PORTS: &[u16] = &[ROKU_ECP_PORT, GOOGLETV_CAST_PORT];
+/// Ports probed on every host, each with the firmware family that answers on
+/// it, in the order they are reported.
+pub const PROBE_PORTS: &[(u16, Platform)] = &[
+    (ROKU_ECP_PORT, Platform::RokuTv),
+    (GOOGLETV_CAST_PORT, Platform::GoogleTv),
+];
 
 /// DIAL applications that need a display to be of any use.
 ///
@@ -113,8 +117,25 @@ pub struct Probe {
 /// Chromecast built-in answers the cast port. Both devices have power, so
 /// neither belongs in the powered-off report.
 pub async fn probe(client: &Client, ip: Ipv4Addr, port: u16, platform: Platform) -> Probe {
-    let _ = (client, ip, port, platform);
-    todo!("a probe does not yet report a host that answered but is not a television")
+    if !is_port_open(ip, port).await {
+        return Probe {
+            ip,
+            answered: false,
+            tv: None,
+        };
+    }
+
+    let base_url = format!("http://{ip}:{port}");
+    let tv = match platform {
+        Platform::RokuTv => fetch_roku(client, &base_url, ip).await,
+        Platform::GoogleTv => fetch_google_tv(client, &base_url, ip).await,
+    };
+
+    Probe {
+        ip,
+        answered: true,
+        tv,
+    }
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -9,6 +9,8 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use reqwest::Client;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
 
 use crate::identify::{parse_google_tv, parse_roku_device_info, Tv};
 
@@ -26,26 +28,38 @@ pub const HTTP_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Whether a TCP connection to `ip:port` completes within [`CONNECT_TIMEOUT`].
 pub async fn is_port_open(ip: Ipv4Addr, port: u16) -> bool {
-    let _ = (ip, port);
-    false
+    matches!(
+        timeout(CONNECT_TIMEOUT, TcpStream::connect((ip, port))).await,
+        Ok(Ok(_))
+    )
+}
+
+/// Body of a successful `GET`, or `None` for any transport or status failure.
+async fn get_text(client: &Client, url: &str) -> Option<String> {
+    let response = client.get(url).timeout(HTTP_TIMEOUT).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response.text().await.ok()
 }
 
 /// Fetch and parse a Roku ECP device-info document from `base_url`.
 ///
 /// `base_url` is the scheme and authority only, e.g. `http://192.168.0.119:8060`.
 pub async fn fetch_roku(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option<Tv> {
-    let _ = (client, base_url, ip);
-    let _ = parse_roku_device_info;
-    None
+    let xml = get_text(client, &format!("{base_url}/query/device-info")).await?;
+    parse_roku_device_info(ip, &xml)
 }
 
 /// Fetch and parse a Google TV UPnP description from `base_url`.
 ///
 /// `base_url` is the scheme and authority only, e.g. `http://192.168.1.165:8008`.
 pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option<Tv> {
-    let _ = (client, base_url, ip);
-    let _ = parse_google_tv;
-    None
+    let desc = get_text(client, &format!("{base_url}/ssdp/device-desc.xml")).await?;
+    // The cast endpoint only supplies a nicer name, so its failure is survivable.
+    let eureka = get_text(client, &format!("{base_url}/setup/eureka_info")).await;
+
+    parse_google_tv(ip, &desc, eureka.as_deref())
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -12,7 +12,7 @@ use reqwest::Client;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 
-use crate::identify::{dial_app_installed, parse_google_tv, parse_roku_device_info, Tv};
+use crate::identify::{dial_app_installed, parse_google_tv, parse_roku_device_info, Platform, Tv};
 
 /// Roku External Control Protocol.
 pub const ROKU_ECP_PORT: u16 = 8060;
@@ -90,6 +90,31 @@ pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> O
 
     let tv = parse_google_tv(ip, &desc, eureka.as_deref())?;
     has_screen(client, base_url).await.then_some(tv)
+}
+
+/// What one probe of one host on one port found.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Probe {
+    /// Address that was probed.
+    pub ip: Ipv4Addr,
+    /// Whether the TCP handshake completed.
+    pub answered: bool,
+    /// The television, if the host proved that it is one.
+    pub tv: Option<Tv>,
+}
+
+/// Probe `ip` on `port` and report what the exchange found.
+///
+/// `platform` names the firmware family that answers on `port`, so the map from
+/// a port to its family stays in one place.
+///
+/// A host that completes the TCP handshake answered, even if it is not a
+/// television. A Roku streaming player answers the ECP port and a speaker with
+/// Chromecast built-in answers the cast port. Both devices have power, so
+/// neither belongs in the powered-off report.
+pub async fn probe(client: &Client, ip: Ipv4Addr, port: u16, platform: Platform) -> Probe {
+    let _ = (client, ip, port, platform);
+    todo!("a probe does not yet report a host that answered but is not a television")
 }
 
 #[cfg(test)]
@@ -315,5 +340,113 @@ mod tests {
         netflix.assert_async().await;
         youtube.assert_async().await;
         assert_eq!(tv.vendor, "TCL");
+    }
+
+    /// A Roku streaming player answers ECP with the same document a TV does.
+    /// Only `is-tv` separates the two.
+    const ROKU_STREAMING_STICK: &str = r"<device-info>
+<vendor-name>Roku</vendor-name>
+<model-name>Roku Express</model-name>
+<is-tv>false</is-tv>
+<friendly-device-name>Roku Express</friendly-device-name>
+<software-version>15.2.4</software-version>
+</device-info>";
+
+    /// The port a mock server listens on, for a probe of `127.0.0.1`.
+    fn mock_port(server: &mockito::Server) -> u16 {
+        server.socket_address().port()
+    }
+
+    #[tokio::test]
+    async fn records_a_roku_streaming_player_as_a_host_that_answered() {
+        // The player is not a television, but it has power. A host with power
+        // must never appear in the powered-off report.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/query/device-info")
+            .with_status(200)
+            .with_body(ROKU_STREAMING_STICK)
+            .create_async()
+            .await;
+        let port = mock_port(&server);
+
+        let found = probe(&Client::new(), Ipv4Addr::LOCALHOST, port, Platform::RokuTv).await;
+
+        mock.assert_async().await;
+        assert!(found.answered, "the TCP handshake completed");
+        assert_eq!(found.tv, None, "a streaming player is not a television");
+        assert_eq!(found.ip, Ipv4Addr::LOCALHOST);
+    }
+
+    #[tokio::test]
+    async fn records_a_roku_television_as_a_host_that_answered_with_a_tv() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/query/device-info")
+            .with_status(200)
+            .with_body(ROKU_DEVICE_INFO)
+            .create_async()
+            .await;
+        let port = mock_port(&server);
+
+        let found = probe(&Client::new(), Ipv4Addr::LOCALHOST, port, Platform::RokuTv).await;
+
+        assert!(found.answered);
+        let tv = found.tv.expect("should identify the TV");
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.platform, Platform::RokuTv);
+    }
+
+    #[tokio::test]
+    async fn records_a_cast_speaker_as_a_host_that_answered() {
+        // A speaker with Chromecast built-in answers the cast port and fails
+        // the screen test. It has power, so it did answer.
+        let mut server = mockito::Server::new_async().await;
+        let _desc = server
+            .mock("GET", "/ssdp/device-desc.xml")
+            .with_status(200)
+            .with_body(
+                GOOGLE_TV_DESC
+                    .replace("Smart TV Pro", "Google Home")
+                    .as_str(),
+            )
+            .create_async()
+            .await;
+        let _eureka = server
+            .mock("GET", "/setup/eureka_info")
+            .with_status(200)
+            .with_body(r#"{"name":"Kitchen speaker"}"#)
+            .create_async()
+            .await;
+        let _no_apps = server
+            .mock("GET", mockito::Matcher::Regex(r"^/apps/.*$".to_owned()))
+            .with_status(404)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        let port = mock_port(&server);
+
+        let found = probe(
+            &Client::new(),
+            Ipv4Addr::LOCALHOST,
+            port,
+            Platform::GoogleTv,
+        )
+        .await;
+
+        assert!(found.answered, "the TCP handshake completed");
+        assert_eq!(found.tv, None, "a speaker is not a television");
+    }
+
+    #[tokio::test]
+    async fn records_a_closed_port_as_a_host_that_did_not_answer() {
+        let (listener, port) = ephemeral_port();
+        drop(listener);
+
+        let found = probe(&Client::new(), Ipv4Addr::LOCALHOST, port, Platform::RokuTv).await;
+
+        assert!(!found.answered);
+        assert_eq!(found.tv, None);
+        assert_eq!(found.ip, Ipv4Addr::LOCALHOST);
     }
 }

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -47,3 +47,135 @@ pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> O
     let _ = parse_google_tv;
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROKU_DEVICE_INFO: &str = r"<device-info>
+<vendor-name>TCL</vendor-name>
+<model-name>43S435</model-name>
+<is-tv>true</is-tv>
+<user-device-name>Office - top</user-device-name>
+<software-version>15.0.4</software-version>
+</device-info>";
+
+    const GOOGLE_TV_DESC: &str = r"<root>
+  <device>
+    <friendlyName>Living Room</friendlyName>
+    <manufacturer>TCL</manufacturer>
+    <modelName>Smart TV Pro</modelName>
+  </device>
+</root>";
+
+    fn ip() -> Ipv4Addr {
+        Ipv4Addr::new(192, 168, 0, 119)
+    }
+
+    /// Bind an ephemeral port so concurrent runs of this suite never collide.
+    fn ephemeral_port() -> (std::net::TcpListener, u16) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("should bind");
+        let port = listener.local_addr().expect("should have an address").port();
+        (listener, port)
+    }
+
+    #[tokio::test]
+    async fn sees_a_port_that_is_being_listened_on() {
+        let (_listener, port) = ephemeral_port();
+
+        assert!(is_port_open(Ipv4Addr::LOCALHOST, port).await);
+    }
+
+    #[tokio::test]
+    async fn sees_a_port_with_nothing_behind_it_as_closed() {
+        let (listener, port) = ephemeral_port();
+        drop(listener);
+
+        assert!(!is_port_open(Ipv4Addr::LOCALHOST, port).await);
+    }
+
+    #[tokio::test]
+    async fn fetches_and_identifies_a_roku_tv() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/query/device-info")
+            .with_status(200)
+            .with_body(ROKU_DEVICE_INFO)
+            .create_async()
+            .await;
+
+        let tv = fetch_roku(&Client::new(), &server.url(), ip())
+            .await
+            .expect("should identify the TV");
+
+        mock.assert_async().await;
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.name, "Office - top");
+        assert_eq!(tv.ip, ip());
+    }
+
+    #[tokio::test]
+    async fn treats_a_non_roku_responder_on_the_ecp_port_as_no_tv() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/query/device-info")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        assert!(fetch_roku(&Client::new(), &server.url(), ip()).await.is_none());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetches_and_identifies_a_google_tv() {
+        let mut server = mockito::Server::new_async().await;
+        let desc = server
+            .mock("GET", "/ssdp/device-desc.xml")
+            .with_status(200)
+            .with_body(GOOGLE_TV_DESC)
+            .create_async()
+            .await;
+        let eureka = server
+            .mock("GET", "/setup/eureka_info")
+            .with_status(200)
+            .with_body(r#"{"name":"Living Room","cast_build_revision":"3.72.446070"}"#)
+            .create_async()
+            .await;
+
+        let tv = fetch_google_tv(&Client::new(), &server.url(), ip())
+            .await
+            .expect("should identify the TV");
+
+        desc.assert_async().await;
+        eureka.assert_async().await;
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.model, "Smart TV Pro");
+        assert_eq!(tv.software, "3.72.446070");
+    }
+
+    #[tokio::test]
+    async fn identifies_a_google_tv_whose_cast_endpoint_refuses() {
+        let mut server = mockito::Server::new_async().await;
+        let desc = server
+            .mock("GET", "/ssdp/device-desc.xml")
+            .with_status(200)
+            .with_body(GOOGLE_TV_DESC)
+            .create_async()
+            .await;
+        let eureka = server
+            .mock("GET", "/setup/eureka_info")
+            .with_status(500)
+            .create_async()
+            .await;
+
+        let tv = fetch_google_tv(&Client::new(), &server.url(), ip())
+            .await
+            .expect("UPnP alone should be enough");
+
+        desc.assert_async().await;
+        eureka.assert_async().await;
+        assert_eq!(tv.vendor, "TCL");
+        assert_eq!(tv.name, "Living Room");
+    }
+}

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -256,7 +256,11 @@ mod tests {
         let _desc = server
             .mock("GET", "/ssdp/device-desc.xml")
             .with_status(200)
-            .with_body(GOOGLE_TV_DESC.replace("Smart TV Pro", "Google Home").as_str())
+            .with_body(
+                GOOGLE_TV_DESC
+                    .replace("Smart TV Pro", "Google Home")
+                    .as_str(),
+            )
             .create_async()
             .await;
         let _eureka = server

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -89,7 +89,10 @@ mod tests {
     /// Bind an ephemeral port so concurrent runs of this suite never collide.
     fn ephemeral_port() -> (std::net::TcpListener, u16) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("should bind");
-        let port = listener.local_addr().expect("should have an address").port();
+        let port = listener
+            .local_addr()
+            .expect("should have an address")
+            .port();
         (listener, port)
     }
 
@@ -137,7 +140,9 @@ mod tests {
             .create_async()
             .await;
 
-        assert!(fetch_roku(&Client::new(), &server.url(), ip()).await.is_none());
+        assert!(fetch_roku(&Client::new(), &server.url(), ip())
+            .await
+            .is_none());
         mock.assert_async().await;
     }
 

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -1,0 +1,49 @@
+//! Probing the network for televisions.
+//!
+//! Devices are addressed directly rather than discovered over SSDP or mDNS.
+//! Access points routinely filter multicast between bands and between the
+//! 2.4 GHz and 5 GHz radios, which silently hides TVs that answer perfectly
+//! well when asked directly.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use reqwest::Client;
+
+use crate::identify::{parse_google_tv, parse_roku_device_info, Tv};
+
+/// Roku External Control Protocol.
+pub const ROKU_ECP_PORT: u16 = 8060;
+/// Chromecast built-in, present on Google TV sets.
+pub const GOOGLETV_CAST_PORT: u16 = 8008;
+/// Ports probed on every host, in the order they are reported.
+pub const PROBE_PORTS: &[u16] = &[ROKU_ECP_PORT, GOOGLETV_CAST_PORT];
+
+/// How long to wait for a TCP handshake before treating a host as closed.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_millis(1200);
+/// How long to wait for a discovery document once connected.
+pub const HTTP_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Whether a TCP connection to `ip:port` completes within [`CONNECT_TIMEOUT`].
+pub async fn is_port_open(ip: Ipv4Addr, port: u16) -> bool {
+    let _ = (ip, port);
+    false
+}
+
+/// Fetch and parse a Roku ECP device-info document from `base_url`.
+///
+/// `base_url` is the scheme and authority only, e.g. `http://192.168.0.119:8060`.
+pub async fn fetch_roku(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option<Tv> {
+    let _ = (client, base_url, ip);
+    let _ = parse_roku_device_info;
+    None
+}
+
+/// Fetch and parse a Google TV UPnP description from `base_url`.
+///
+/// `base_url` is the scheme and authority only, e.g. `http://192.168.1.165:8008`.
+pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option<Tv> {
+    let _ = (client, base_url, ip);
+    let _ = parse_google_tv;
+    None
+}

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -163,6 +163,11 @@ mod tests {
     }
 
     /// Bind an ephemeral port so concurrent runs of this suite never collide.
+    ///
+    /// The caller must hold the listener for the full test. The operating
+    /// system releases the port as soon as the listener goes out of scope, and
+    /// a different test in this binary then binds it. Use [`CLOSED_PORT`] to
+    /// test a port that nothing listens on.
     fn ephemeral_port() -> (std::net::TcpListener, u16) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("should bind");
         let port = listener
@@ -171,6 +176,16 @@ mod tests {
             .port();
         (listener, port)
     }
+
+    /// A port that nothing listens on, in every concurrent run of this suite.
+    ///
+    /// Port 0 is not a valid destination port, so no process listens on it and
+    /// no test claims it. A released ephemeral port gives a different result:
+    /// each mockito server in this binary binds a port from the same range, and
+    /// the tests run on many threads. A server that takes the released port
+    /// between the release and the connect makes the port read as open. That
+    /// failure comes from thread timing, not from the code under test.
+    const CLOSED_PORT: u16 = 0;
 
     #[tokio::test]
     async fn sees_a_port_that_is_being_listened_on() {
@@ -181,10 +196,7 @@ mod tests {
 
     #[tokio::test]
     async fn sees_a_port_with_nothing_behind_it_as_closed() {
-        let (listener, port) = ephemeral_port();
-        drop(listener);
-
-        assert!(!is_port_open(Ipv4Addr::LOCALHOST, port).await);
+        assert!(!is_port_open(Ipv4Addr::LOCALHOST, CLOSED_PORT).await);
     }
 
     #[tokio::test]
@@ -461,10 +473,13 @@ mod tests {
 
     #[tokio::test]
     async fn records_a_closed_port_as_a_host_that_did_not_answer() {
-        let (listener, port) = ephemeral_port();
-        drop(listener);
-
-        let found = probe(&Client::new(), Ipv4Addr::LOCALHOST, port, Platform::RokuTv).await;
+        let found = probe(
+            &Client::new(),
+            Ipv4Addr::LOCALHOST,
+            CLOSED_PORT,
+            Platform::RokuTv,
+        )
+        .await;
 
         assert!(!found.answered);
         assert_eq!(found.tv, None);

--- a/src/tvfind/src/scan.rs
+++ b/src/tvfind/src/scan.rs
@@ -12,7 +12,7 @@ use reqwest::Client;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 
-use crate::identify::{parse_google_tv, parse_roku_device_info, Tv};
+use crate::identify::{dial_app_installed, parse_google_tv, parse_roku_device_info, Tv};
 
 /// Roku External Control Protocol.
 pub const ROKU_ECP_PORT: u16 = 8060;
@@ -20,6 +20,17 @@ pub const ROKU_ECP_PORT: u16 = 8060;
 pub const GOOGLETV_CAST_PORT: u16 = 8008;
 /// Ports probed on every host, in the order they are reported.
 pub const PROBE_PORTS: &[u16] = &[ROKU_ECP_PORT, GOOGLETV_CAST_PORT];
+
+/// DIAL applications that need a display to be of any use.
+///
+/// Every device with Chromecast built-in answers on [`GOOGLETV_CAST_PORT`] and
+/// publishes a manufacturer, a speaker as readily as a television. None of the
+/// UPnP document, `/setup/eureka_info`, or `?options=detail` carries a
+/// device-type field, so the screen has to be proved another way: a DIAL server
+/// only lists an application the device can actually run, and none of these
+/// runs without a display. Asking for two rather than one keeps a set that
+/// carries neither Netflix nor YouTube from being missed for the wrong reason.
+pub const SCREEN_APPS: &[&str] = &["Netflix", "YouTube"];
 
 /// How long to wait for a TCP handshake before treating a host as closed.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_millis(1200);
@@ -51,7 +62,25 @@ pub async fn fetch_roku(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option
     parse_roku_device_info(ip, &xml)
 }
 
+/// Whether the DIAL server at `base_url` offers any of [`SCREEN_APPS`].
+///
+/// Asking stops at the first application the device confirms.
+async fn has_screen(client: &Client, base_url: &str) -> bool {
+    for app in SCREEN_APPS {
+        let Some(body) = get_text(client, &format!("{base_url}/apps/{app}")).await else {
+            continue;
+        };
+        if dial_app_installed(&body, app) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Fetch and parse a Google TV UPnP description from `base_url`.
+///
+/// The device must also pass the DIAL screen test, because every speaker with
+/// Chromecast built-in publishes the same UPnP document a television does.
 ///
 /// `base_url` is the scheme and authority only, e.g. `http://192.168.1.165:8008`.
 pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> Option<Tv> {
@@ -59,7 +88,8 @@ pub async fn fetch_google_tv(client: &Client, base_url: &str, ip: Ipv4Addr) -> O
     // The cast endpoint only supplies a nicer name, so its failure is survivable.
     let eureka = get_text(client, &format!("{base_url}/setup/eureka_info")).await;
 
-    parse_google_tv(ip, &desc, eureka.as_deref())
+    let tv = parse_google_tv(ip, &desc, eureka.as_deref())?;
+    has_screen(client, base_url).await.then_some(tv)
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -18,3 +18,43 @@ pub fn matches(vendor: &str, filter: &str) -> bool {
     let _ = (vendor, filter);
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_filter_accepts_every_vendor() {
+        assert!(matches("TCL", ""));
+        assert!(matches("Hisense", ""));
+        assert!(matches("", ""));
+    }
+
+    #[test]
+    fn matches_a_brand_regardless_of_case() {
+        assert!(matches("TCL", "tcl"));
+        assert!(matches("tcl", "TCL"));
+    }
+
+    #[test]
+    fn matches_a_brand_buried_in_a_registered_company_name() {
+        assert!(matches("TCL King Electrical Appliances(Huizhou)Co.", "tcl"));
+    }
+
+    #[test]
+    fn rejects_an_unrelated_vendor() {
+        assert!(!matches("Sonos", "tcl"));
+        assert!(!matches("Hui Zhou Gaoshengda Technology", "hisense"));
+    }
+
+    #[test]
+    fn matches_the_contract_manufacturer_that_builds_the_brands_panels() {
+        // TCL sets register MACs to their Huizhou ODM, not to TCL itself.
+        assert!(matches("Hui Zhou Gaoshengda Technology", "tcl"));
+    }
+
+    #[test]
+    fn ignores_surrounding_whitespace_in_the_filter() {
+        assert!(matches("TCL", "  tcl  "));
+    }
+}

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -15,8 +15,21 @@ const ODM_ALIASES: &[(&str, &[&str])] = &[("tcl", &["gaoshengda"])];
 /// aliases for the filter are matched too.
 #[must_use]
 pub fn matches(vendor: &str, filter: &str) -> bool {
-    let _ = (vendor, filter);
-    false
+    let filter = filter.trim().to_lowercase();
+    if filter.is_empty() {
+        return true;
+    }
+
+    let vendor = vendor.to_lowercase();
+    if vendor.contains(&filter) {
+        return true;
+    }
+
+    ODM_ALIASES
+        .iter()
+        .filter(|(brand, _)| *brand == filter)
+        .flat_map(|(_, factories)| factories.iter())
+        .any(|factory| vendor.contains(factory))
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -1,0 +1,20 @@
+//! Matching user-supplied vendor filters against reported manufacturer names.
+
+/// Contract-manufacturer names that ship panels under a better-known brand.
+///
+/// A TV reports its brand over HTTP, but the MAC it registers belongs to
+/// whichever factory built it. Without these aliases an OUI lookup for a
+/// powered-off `TCL` set would miss, because the address block is registered
+/// to the Huizhou ODM rather than to TCL itself.
+const ODM_ALIASES: &[(&str, &[&str])] = &[("tcl", &["gaoshengda"])];
+
+/// Whether `vendor` satisfies `filter`, case-insensitively.
+///
+/// An empty filter matches everything. Matching is by substring so that
+/// `tcl` matches `TCL King Electrical Appliances(Huizhou)Co.`, and known ODM
+/// aliases for the filter are matched too.
+#[must_use]
+pub fn matches(vendor: &str, filter: &str) -> bool {
+    let _ = (vendor, filter);
+    false
+}

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -32,19 +32,88 @@ pub fn matches(vendor: &str, filter: &str) -> bool {
         .any(|factory| vendor.contains(factory))
 }
 
+/// Manufacturers that build televisions, and the contract factories that build
+/// their panels.
+///
+/// An OUI lookup names the company an address block is registered to, and
+/// nothing more, so this list is what turns "some device" into "a device from a
+/// company that makes televisions". Entries are matched as whole words, which
+/// is what separates `LG Electronics` from `LG Innotek` — a supplier of camera
+/// and radio modules to other makers — and `Vizio` from `Viziontech`.
+///
+/// General-purpose contract manufacturers such as Compal and Wistron are
+/// deliberately absent. They build far more laptops than televisions, so their
+/// blocks would report mostly non-televisions.
+const TELEVISION_BRANDS: &[&str] = &[
+    "amtran",
+    "changhong",
+    "funai",
+    "hisense",
+    "hitachi",
+    "hui zhou gaoshengda",
+    "konka",
+    "lg electronics",
+    "panasonic",
+    "philips",
+    "roku",
+    "samsung",
+    "sceptre",
+    "sharp",
+    "skyworth",
+    "sony",
+    "tcl",
+    "top victory",
+    "toshiba",
+    "tp vision",
+    "vizio",
+];
+
+/// Split a name into lowercase alphanumeric words.
+///
+/// The registry punctuates inconsistently — `Appliances(Huizhou)Co.` has no
+/// space at all — so every non-alphanumeric character divides a word.
+fn words(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+/// Whether `phrase` appears in `name` as a run of whole words.
+fn contains_phrase(name: &[String], phrase: &str) -> bool {
+    let phrase = words(phrase);
+    if phrase.is_empty() || phrase.len() > name.len() {
+        return false;
+    }
+    name.windows(phrase.len()).any(|window| window == phrase)
+}
+
 /// Whether `vendor` names a manufacturer that builds televisions.
+///
+/// The brand is matched anywhere in the registered name, because the registry
+/// routinely leads with a city or a parent company — `Huizhou TCL
+/// Communication Electron`, `Sichuan Changhong Electric`.
 #[must_use]
 pub fn is_television_brand(vendor: &str) -> bool {
-    let _ = vendor;
-    todo!("no television brand list exists yet")
+    let name = words(vendor);
+    TELEVISION_BRANDS
+        .iter()
+        .any(|brand| contains_phrase(&name, brand))
 }
 
 /// Whether a neighbour registered to `vendor` is worth reporting as a possible
 /// television, given the user's `filter`.
+///
+/// A filter is the user's own judgement and is obeyed as given. Without one,
+/// only a television brand qualifies — otherwise every neighbour in the ARP
+/// table would be reported, which says nothing about televisions at all.
 #[must_use]
 pub fn wanted_as_television(vendor: &str, filter: &str) -> bool {
-    let _ = (vendor, filter);
-    todo!("no television brand list exists yet")
+    if filter.trim().is_empty() {
+        is_television_brand(vendor)
+    } else {
+        matches(vendor, filter)
+    }
 }
 
 #[cfg(test)]

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -32,9 +32,80 @@ pub fn matches(vendor: &str, filter: &str) -> bool {
         .any(|factory| vendor.contains(factory))
 }
 
+/// Whether `vendor` names a manufacturer that builds televisions.
+#[must_use]
+pub fn is_television_brand(vendor: &str) -> bool {
+    let _ = vendor;
+    todo!("no television brand list exists yet")
+}
+
+/// Whether a neighbour registered to `vendor` is worth reporting as a possible
+/// television, given the user's `filter`.
+#[must_use]
+pub fn wanted_as_television(vendor: &str, filter: &str) -> bool {
+    let _ = (vendor, filter);
+    todo!("no television brand list exists yet")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recognises_a_television_brand_that_opens_the_registered_name() {
+        assert!(is_television_brand("TCL King Electrical Appliances(Huizhou)Co."));
+        assert!(is_television_brand("Hisense Visual Technology"));
+        assert!(is_television_brand("Vizio"));
+    }
+
+    #[test]
+    fn recognises_a_television_brand_buried_inside_the_registered_name() {
+        // The IEEE registry often leads with the city or the parent company.
+        assert!(is_television_brand("Huizhou TCL Communication Electron"));
+        assert!(is_television_brand("Shenzhen Skyworth Digital  Technology"));
+        assert!(is_television_brand("Sichuan Changhong Electric"));
+    }
+
+    #[test]
+    fn recognises_the_contract_factory_that_builds_a_brands_panels() {
+        assert!(is_television_brand("Hui Zhou Gaoshengda Technology"));
+    }
+
+    #[test]
+    fn rejects_a_vendor_that_builds_no_televisions() {
+        assert!(!is_television_brand("Ubiquiti"));
+        assert!(!is_television_brand("Espressif Inc."));
+        assert!(!is_television_brand("Sonos"));
+        assert!(!is_television_brand("Murata Manufacturing"));
+        assert!(!is_television_brand("Apple"));
+    }
+
+    #[test]
+    fn tells_a_television_maker_from_a_component_supplier_of_the_same_group() {
+        // LG Innotek supplies camera and radio modules to other makers, so a
+        // substring test for `lg` would report every one of them as a TV.
+        assert!(is_television_brand("LG Electronics"));
+        assert!(!is_television_brand("LG Innotek"));
+    }
+
+    #[test]
+    fn matches_a_brand_as_a_whole_word_only() {
+        // `Viziontech` merely opens with the letters of `Vizio`.
+        assert!(!is_television_brand("Viziontech UK"));
+    }
+
+    #[test]
+    fn reports_only_television_brands_when_no_filter_was_given() {
+        assert!(wanted_as_television("TCL King Electrical Appliances", ""));
+        assert!(!wanted_as_television("Ubiquiti", ""));
+    }
+
+    #[test]
+    fn obeys_an_explicit_filter_even_for_a_vendor_that_builds_no_televisions() {
+        // The filter is the user's own judgement, so it is used as given.
+        assert!(wanted_as_television("Ubiquiti", "ubiquiti"));
+        assert!(!wanted_as_television("Sonos", "tcl"));
+    }
 
     #[test]
     fn an_empty_filter_accepts_every_vendor() {

--- a/src/tvfind/src/vendor.rs
+++ b/src/tvfind/src/vendor.rs
@@ -122,7 +122,9 @@ mod tests {
 
     #[test]
     fn recognises_a_television_brand_that_opens_the_registered_name() {
-        assert!(is_television_brand("TCL King Electrical Appliances(Huizhou)Co."));
+        assert!(is_television_brand(
+            "TCL King Electrical Appliances(Huizhou)Co."
+        ));
         assert!(is_television_brand("Hisense Visual Technology"));
         assert!(is_television_brand("Vizio"));
     }


### PR DESCRIPTION
## Summary

Adds `tvfind`, a Rust CLI that finds smart TVs on the local network — including ones that are powered off — so you can locate a set by vendor without hunting through a router's DHCP table.

## How it works

- Derives the subnet from the local interface (or takes an explicit CIDR), capped at 65536 addresses so a fat-fingered `/8` can't hang the scan.
- Probes hosts concurrently and fetches discovery documents: Roku's ECP `device-info` and UPnP + Google Cast info for Google TVs.
- Cross-references the ARP neighbour table against nmap's OUI database, so sets that are asleep or powered off still show up by vendor.
- Case-insensitive vendor filtering with ODM aliases (a "TCL" set that reports its ODM still matches).
- Results render as a table; the scan banner pluralises the host count.

## Testing

Built test-first throughout — every module landed as a `test: red` commit followed by its `green` counterpart. Covers CIDR expansion and the oversized-block guard, OUI prefix normalisation and database parsing, ARP table parsing, Roku and Google TV document identification, vendor matching, and table rendering.

## Docs

`src/tvfind/README.md` documents usage and flags; the repo `README.md` lists the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)