### PR TITLE
fix(swt): correct the green-check contract and make merge usable from a worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target
 .env.local
 .claude/
 .op-cache.json
+# swt's green-check escape hatch: per-developer, never committed.
+.swt-check

--- a/README.md
+++ b/README.md
@@ -353,10 +353,16 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
     each Claude model. Useful for reconciling spend or estimating burn across date ranges.
   - To install: `cargo install --git https://github.com/timmattison/tools claude-usage`
 - swt (subagent worktree)
-  - Subagent worktree helper for parallel TDD. `swt create <name>` verifies HEAD is green and spins
-    up an isolated worktree on a new branch; `swt merge <path>` verifies the subagent is green,
-    rebases if the parent advanced, fast-forward-merges, and cleans up. Concurrent merges are
-    serialized via `.git/swt.lock`. Drop a `./.swt-check` script to override the default green check.
+  - Subagent worktree helper for parallel TDD. `swt create <name>` (names limited to
+    `[A-Za-z0-9._-]`) builds an isolated worktree on a new branch and runs the green check inside
+    that fresh checkout, so uncommitted parent changes can't fake a pass; worktree and branch are
+    torn back down if the check fails or the run is interrupted. `swt merge <path>` refuses unless
+    both worktrees are clean — tracked changes in the parent, untracked included in the subagent,
+    whose directory gets deleted — and both pass the green check; it then rebases if the parent
+    advanced, fast-forward-merges, and cleans up. Concurrent merges serialize on a `swt.lock` in the
+    repo's shared git dir, so runs started from sibling worktrees block each other. To replace the
+    default check, drop a `.swt-check` executable at the parent repo root (gitignored, so it stays
+    per-developer); it runs with the worktree being checked as its working directory.
   - To install: symlink `swt/swt.ts` from a clone of this repo into your `PATH`
     (e.g. `ln -s "$PWD/swt/swt.ts" ~/.local/bin/swt`). Requires `npx`/`tsx`.
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ A shared Rust library for monitoring and transforming clipboard content. Provide
   - Subagent worktree helper for parallel TDD. `swt create <name>` (names limited to
     `[A-Za-z0-9._-]`) builds an isolated worktree on a new branch and runs the green check inside
     that fresh checkout, so uncommitted parent changes can't fake a pass; worktree and branch are
-    torn back down if the check fails or the run is interrupted. `swt merge <path>` refuses unless
+    torn back down if the check fails, or if the run is interrupted by a signal it can handle —
+    teardown ignores further Ctrl-Cs so a second one can't strand what the first asked to remove,
+    though nothing survives `kill -9`. `swt merge <path>` refuses unless
     both worktrees are clean — tracked changes in the parent, untracked included in the subagent,
     whose directory gets deleted — and both pass the green check; it then rebases if the parent
     advanced, fast-forward-merges, and cleans up. Concurrent merges serialize on a `swt.lock` in the

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -52,6 +52,12 @@ declare const worktreeNameBrand: unique symbol;
  */
 export type WorktreeName = string & { readonly [worktreeNameBrand]: "WorktreeName" };
 
+/** Characters a worktree name may be built from. */
+const WORKTREE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/** Names that match the pattern but are still meaningless as a path component. */
+const RESERVED_WORKTREE_NAMES = new Set([".", ".."]);
+
 /** Human-readable statement of what a worktree name may contain. */
 export const WORKTREE_NAME_RULE =
   "allowed: letters, digits, '.', '_' and '-'; must not start with '-', and must not be '.' or '..'";
@@ -68,5 +74,8 @@ export const WORKTREE_NAME_RULE =
  * @returns The branded name, or null if it violates {@link WORKTREE_NAME_RULE}.
  */
 export function validateWorktreeName(name: string): WorktreeName | null {
+  if (!WORKTREE_NAME_PATTERN.test(name)) return null;
+  if (name.startsWith("-")) return null;
+  if (RESERVED_WORKTREE_NAMES.has(name)) return null;
   return name as WorktreeName;
 }

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -43,6 +43,20 @@ export const gitMust = (args: string[], cwd?: string): string => {
   return r.out.trim();
 };
 
+/**
+ * Reports a worktree's uncommitted state as git's own porcelain listing.
+ *
+ * @param cwd - Worktree root to inspect.
+ * @param opts - `includeUntracked` decides whether untracked files count as dirt.
+ * @returns The trimmed porcelain output; empty string means clean.
+ * @throws If git itself fails, carrying git's combined output as the message.
+ */
+export function worktreeDirt(cwd: string, opts: { includeUntracked: boolean }): string {
+  const r = git(["status", "--porcelain"], cwd);
+  if (!r.ok) throw new Error(r.out);
+  return r.out.trim();
+}
+
 declare const worktreeNameBrand: unique symbol;
 
 /**

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -42,3 +42,31 @@ export const gitMust = (args: string[], cwd?: string): string => {
   }
   return r.out.trim();
 };
+
+declare const worktreeNameBrand: unique symbol;
+
+/**
+ * A worktree base name that has passed `validateWorktreeName` and is therefore
+ * safe to splice into a branch name and a filesystem path. The brand makes the
+ * check unskippable: nothing else in the codebase can produce this type.
+ */
+export type WorktreeName = string & { readonly [worktreeNameBrand]: "WorktreeName" };
+
+/** Human-readable statement of what a worktree name may contain. */
+export const WORKTREE_NAME_RULE =
+  "allowed: letters, digits, '.', '_' and '-'; must not start with '-', and must not be '.' or '..'";
+
+/**
+ * Checks that a caller-supplied worktree base name is safe to turn into a
+ * branch name and a worktree path.
+ *
+ * Passing git argv arrays already removes the injection risk, but an unchecked
+ * name still yields nonsense: `../..` escapes the worktree parent directory,
+ * a leading `-` is read as an option, and `/` silently nests the branch.
+ *
+ * @param name - Raw name as supplied on the command line.
+ * @returns The branded name, or null if it violates {@link WORKTREE_NAME_RULE}.
+ */
+export function validateWorktreeName(name: string): WorktreeName | null {
+  return name as WorktreeName;
+}

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -11,10 +11,30 @@
 // shell strings by design and live in ./green-check.ts.)
 
 import { spawnSync } from "node:child_process";
+import type { SpawnOptions, SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import type { Result } from "./green-check.ts";
 
 /**
+ * `spawnSync`'s options with `detached` added back.
+ *
+ * Node honors `detached` for `spawnSync` — it reaches the same spawn path as the
+ * asynchronous `spawn` — but says so nowhere: the option is documented only for
+ * `spawn`, and `@types/node` likewise declares it on `SpawnOptions` while
+ * omitting it from `SpawnSyncOptions`. Borrowing the field from `SpawnOptions`
+ * rather than restating `detached?: boolean` keeps this pinned to Node's own
+ * declaration, and lets the extension collapse into a harmless no-op on the day
+ * `@types/node` declares the option where it is actually accepted.
+ */
+type ShieldableSpawnSyncOptions = SpawnSyncOptionsWithStringEncoding &
+  Pick<SpawnOptions, "detached">;
+
+/**
  * Runs git and captures its combined output.
+ *
+ * Exported only so the process-group guard in the test suite can exercise this
+ * exact call rather than a hand-rolled imitation of it; production callers want
+ * {@link git}, {@link gitMust} or {@link removeWorktree}, which fix `shielded`
+ * to the value their situation calls for.
  *
  * @param args - Arguments to git, one array element per argv entry.
  * @param cwd - Directory to run git in; defaults to the current working directory.
@@ -23,8 +43,18 @@ import type { Result } from "./green-check.ts";
  *   the right call for teardown and the wrong one for everything else.
  * @returns Git's success flag and its combined stdout/stderr.
  */
-const runGit = (args: string[], cwd: string | undefined, shielded: boolean): Result => {
-  const r = spawnSync("git", args, { cwd, encoding: "utf8", detached: shielded });
+export const runGit = (args: string[], cwd: string | undefined, shielded: boolean): Result => {
+  // `detached` is the whole shield, and it rests on undocumented behavior:
+  // verified to work on Node 26, but absent from `spawnSync`'s documented
+  // options, so a future release could drop the pass-through and turn this line
+  // into a silent no-op. Nothing would throw — teardown's git would simply move
+  // back into swt's process group, where a second Ctrl-C kills it mid-`worktree
+  // remove` and orphans both the worktree and the branch it still claims (see
+  // {@link removeWorktree}). The "a shielded git runs outside swt's process
+  // group" test in swt.test.ts is what makes that regression a test failure
+  // instead of a bug that quietly comes back.
+  const options: ShieldableSpawnSyncOptions = { cwd, encoding: "utf8", detached: shielded };
+  const r = spawnSync("git", args, options);
   return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
 };
 

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -1,0 +1,44 @@
+// git — the single entrance for running git from swt.
+//
+// Every git command goes through here as an argv array handed straight to
+// spawnSync, with no shell in between. That is deliberate and load-bearing:
+// branch names and worktree paths are built from caller-supplied argv, so a
+// shell in the middle turns `swt create 'a; rm -rf ~'` into arbitrary code
+// execution, and even a benign space silently word-splits into the wrong branch
+// and the wrong path. There is intentionally NO string-command variant exported
+// here — adding a new git call means adding an argv array, which cannot be
+// injected into. (Green-check commands are different: those are user-authored
+// shell strings by design and live in ./green-check.ts.)
+
+import { spawnSync } from "node:child_process";
+import type { Result } from "./green-check.ts";
+
+/**
+ * Runs a git command, capturing its combined output. Arguments are passed to
+ * git directly rather than through a shell, so spaces, `;`, `$(…)` and every
+ * other metacharacter in `args` are always literal argument text.
+ *
+ * @param args - Arguments to git, one array element per argv entry.
+ * @param cwd - Directory to run git in; defaults to the current working directory.
+ * @returns Git's success flag and its combined stdout/stderr.
+ */
+export const git = (args: string[], cwd?: string): Result => {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
+};
+
+/**
+ * Runs a git command, aborting the process with git's output on failure.
+ *
+ * @param args - Arguments to git, one array element per argv entry.
+ * @param cwd - Directory to run git in; defaults to the current working directory.
+ * @returns Git's trimmed combined output.
+ */
+export const gitMust = (args: string[], cwd?: string): string => {
+  const r = git(args, cwd);
+  if (!r.ok) {
+    process.stderr.write(r.out);
+    process.exit(1);
+  }
+  return r.out.trim();
+};

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -14,18 +14,33 @@ import { spawnSync } from "node:child_process";
 import type { Result } from "./green-check.ts";
 
 /**
+ * Runs git and captures its combined output.
+ *
+ * @param args - Arguments to git, one array element per argv entry.
+ * @param cwd - Directory to run git in; defaults to the current working directory.
+ * @param shielded - Whether to put git in a process group of its own, out of
+ *   reach of a signal aimed at swt's. See {@link removeWorktree} for why that is
+ *   the right call for teardown and the wrong one for everything else.
+ * @returns Git's success flag and its combined stdout/stderr.
+ */
+const runGit = (args: string[], cwd: string | undefined, shielded: boolean): Result => {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", detached: shielded });
+  return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
+};
+
+/**
  * Runs a git command, capturing its combined output. Arguments are passed to
  * git directly rather than through a shell, so spaces, `;`, `$(…)` and every
  * other metacharacter in `args` are always literal argument text.
+ *
+ * Interruptible: a Ctrl-C reaches this git the same way it reaches swt, which is
+ * what you want for work the user is waiting on and can abandon.
  *
  * @param args - Arguments to git, one array element per argv entry.
  * @param cwd - Directory to run git in; defaults to the current working directory.
  * @returns Git's success flag and its combined stdout/stderr.
  */
-export const git = (args: string[], cwd?: string): Result => {
-  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
-  return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
-};
+export const git = (args: string[], cwd?: string): Result => runGit(args, cwd, false);
 
 /**
  * Runs a git command, aborting the process with git's output on failure.
@@ -54,14 +69,23 @@ export const gitMust = (args: string[], cwd?: string): string => {
  * still lying around too, which is the difference between a usable recovery
  * instruction and a wrong one.
  *
+ * Best-effort is not the same as abandonable, though, so unlike every other git
+ * call in swt these two run in a process group of their own. Teardown is most
+ * often what a Ctrl-C *asked for*, and a terminal sends Ctrl-C to the whole
+ * foreground process group — so an impatient second one would kill the very
+ * command that is carrying out the first. Cut between these two calls, that
+ * leaves the worst possible state: a worktree that survived and a branch that
+ * cannot be deleted while it does. Out of the group, teardown finishes on its
+ * own terms, and finishes even if swt itself is killed once it has started.
+ *
  * @param root - Repository worktree to run git from; never the one being removed.
  * @param path - Worktree directory to delete.
  * @param branch - Branch checked out in that worktree.
  * @returns Ok only when both commands succeeded; `out` is their combined output.
  */
 export function removeWorktree(root: string, path: string, branch: string): Result {
-  const removed = git(["worktree", "remove", "--force", path], root);
-  const deleted = git(["branch", "-D", branch], root);
+  const removed = runGit(["worktree", "remove", "--force", path], root, true);
+  const deleted = runGit(["branch", "-D", branch], root, true);
   return { ok: removed.ok && deleted.ok, out: removed.out + deleted.out };
 }
 

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -52,7 +52,9 @@ export const gitMust = (args: string[], cwd?: string): string => {
  * @throws If git itself fails, carrying git's combined output as the message.
  */
 export function worktreeDirt(cwd: string, opts: { includeUntracked: boolean }): string {
-  const r = git(["status", "--porcelain"], cwd);
+  const args = ["status", "--porcelain"];
+  if (!opts.includeUntracked) args.push("--untracked-files=no");
+  const r = git(args, cwd);
   if (!r.ok) throw new Error(r.out);
   return r.out.trim();
 }

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -44,6 +44,20 @@ export const gitMust = (args: string[], cwd?: string): string => {
 };
 
 /**
+ * Tears down a worktree and the branch checked out in it, forcing both.
+ *
+ * @param root - Repository worktree to run git from; never the one being removed.
+ * @param path - Worktree directory to delete.
+ * @param branch - Branch checked out in that worktree.
+ * @returns The teardown outcome.
+ */
+export function removeWorktree(root: string, path: string, branch: string): Result {
+  git(["worktree", "remove", "--force", path], root);
+  git(["branch", "-D", branch], root);
+  return { ok: true, out: "" };
+}
+
+/**
  * Reports a worktree's uncommitted state as git's own porcelain listing.
  *
  * @param cwd - Worktree root to inspect.

--- a/swt/git.ts
+++ b/swt/git.ts
@@ -46,15 +46,23 @@ export const gitMust = (args: string[], cwd?: string): string => {
 /**
  * Tears down a worktree and the branch checked out in it, forcing both.
  *
+ * Teardown is best-effort by nature — git refuses to remove a working tree whose
+ * `.git` link has gone missing, and refuses to delete a branch a registered
+ * worktree still claims — so the outcome is *reported* rather than assumed. Both
+ * commands are attempted even when the first fails, and both outputs come back:
+ * a caller shown only the first complaint would not know whether the branch is
+ * still lying around too, which is the difference between a usable recovery
+ * instruction and a wrong one.
+ *
  * @param root - Repository worktree to run git from; never the one being removed.
  * @param path - Worktree directory to delete.
  * @param branch - Branch checked out in that worktree.
- * @returns The teardown outcome.
+ * @returns Ok only when both commands succeeded; `out` is their combined output.
  */
 export function removeWorktree(root: string, path: string, branch: string): Result {
-  git(["worktree", "remove", "--force", path], root);
-  git(["branch", "-D", branch], root);
-  return { ok: true, out: "" };
+  const removed = git(["worktree", "remove", "--force", path], root);
+  const deleted = git(["branch", "-D", branch], root);
+  return { ok: removed.ok && deleted.ok, out: removed.out + deleted.out };
 }
 
 /**

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -8,8 +8,10 @@
 // Green check (always runs inside the worktree being checked, never the parent):
 //   - ./.swt-check at repo root (escape hatch — used alone if present)
 //   Otherwise, runs whichever apply, additively (Tauri repos have both):
-//   - package.json present: `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then
-//     typecheck/lint/test (whichever scripts exist)
+//   - package.json declaring at least one of typecheck/tsc/lint/test:
+//     `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then those checks.
+//     A package.json with none of those scripts contributes nothing — the install
+//     alone verifies nothing and must never stand in for a check.
 //   - Cargo.toml at repo root and/or src-tauri/Cargo.toml: cargo check + test + clippy per manifest
 //   If nothing applies: error (drop a .swt-check).
 
@@ -64,15 +66,23 @@ export function buildCheckPlan(cwd: string): string[] | null {
   const cmds: string[] = [];
 
   if (existsSync(join(cwd, "package.json"))) {
-    // Fresh worktrees have no node_modules; install before checking.
-    if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
-      cmds.push("pnpm install --frozen-lockfile");
-    }
     const scripts = pkgScripts(cwd);
-    if (scripts.has("typecheck")) cmds.push("pnpm typecheck");
-    else if (scripts.has("tsc")) cmds.push("pnpm exec tsc --noEmit");
-    if (scripts.has("lint")) cmds.push("pnpm lint");
-    if (scripts.has("test")) cmds.push("pnpm test --run");
+    const jsChecks: string[] = [];
+    if (scripts.has("typecheck")) jsChecks.push("pnpm typecheck");
+    else if (scripts.has("tsc")) jsChecks.push("pnpm exec tsc --noEmit");
+    if (scripts.has("lint")) jsChecks.push("pnpm lint");
+    if (scripts.has("test")) jsChecks.push("pnpm test --run");
+
+    // The install verifies nothing on its own — it exists only so the js checks
+    // can run in a fresh worktree, which has no node_modules. A plan of just an
+    // install would report green having checked nothing, so it rides along with
+    // the js checks or not at all.
+    if (jsChecks.length > 0) {
+      if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
+        cmds.push("pnpm install --frozen-lockfile");
+      }
+      cmds.push(...jsChecks);
+    }
   }
 
   // Rust checks run alongside package.json checks — Tauri repos have both.

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -2,13 +2,14 @@
 //
 // This module owns the whole definition of the green check: detecting which
 // toolchains a worktree uses (pnpm / cargo / Tauri), assembling the command
-// plan, and running it. Callers see only `isGreen(target, configRoot)` (and
-// `buildCheckPlan` for inspection/testing) — the pnpm/cargo/Tauri detection
-// stays hidden here.
+// plan, and running it. Callers see only `isGreen(target, configRoot)`; the
+// detection stays hidden here. (`buildCheckPlan` and `pkgScripts` are exported
+// for inspection and tests, `shellQuote` because swt prints shell commands too.)
 //
 // Green check (always runs inside the worktree being checked, never the parent):
-//   - .swt-check at `configRoot` — the parent repo root, because the escape hatch
-//     is an uncommitted file and so is absent from a fresh checkout of HEAD. Used
+//   - .swt-check at `configRoot`, which defaults to `target` but is the *parent*
+//     repo root when swt checks a worktree: the escape hatch is a gitignored,
+//     per-developer file, so it is absent from a fresh checkout of HEAD. Used
 //     alone if present, as an absolute shell-quoted path, still run in `target`.
 //   Otherwise, detected from `target` and run there, whichever apply, additively
 //   (Tauri repos have both):

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -57,10 +57,13 @@ export function pkgScripts(cwd: string): Set<string> {
  * Determines the ordered list of shell commands that constitute the green check
  * for a worktree, based on the files present at its root.
  *
- * @param cwd - Worktree root to inspect.
+ * @param target - Worktree root to inspect and to run the check in.
+ * @param configRoot - Directory the `.swt-check` override is looked up in;
+ *   defaults to `target`.
  * @returns The commands to run in order, or null if no check applies.
  */
-export function buildCheckPlan(cwd: string): string[] | null {
+export function buildCheckPlan(target: string, configRoot: string = target): string[] | null {
+  const cwd = target;
   if (existsSync(join(cwd, ".swt-check"))) return ["./.swt-check"];
 
   const cmds: string[] = [];
@@ -101,10 +104,13 @@ export function buildCheckPlan(cwd: string): string[] | null {
 /**
  * Runs the green check for a worktree, stopping at the first failing command.
  *
- * @param cwd - Worktree root to check; every command runs in this directory.
+ * @param target - Worktree root to check; every command runs in this directory.
+ * @param configRoot - Directory the `.swt-check` override is looked up in;
+ *   defaults to `target`.
  * @returns Ok result when every command passed, otherwise the first failure.
  */
-export function isGreen(cwd: string): Result {
+export function isGreen(target: string, configRoot: string = target): Result {
+  const cwd = target;
   const plan = buildCheckPlan(cwd);
   if (!plan) {
     return {

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -2,12 +2,16 @@
 //
 // This module owns the whole definition of the green check: detecting which
 // toolchains a worktree uses (pnpm / cargo / Tauri), assembling the command
-// plan, and running it. Callers see only `isGreen(cwd)` (and `buildCheckPlan`
-// for inspection/testing) — the pnpm/cargo/Tauri detection stays hidden here.
+// plan, and running it. Callers see only `isGreen(target, configRoot)` (and
+// `buildCheckPlan` for inspection/testing) — the pnpm/cargo/Tauri detection
+// stays hidden here.
 //
 // Green check (always runs inside the worktree being checked, never the parent):
-//   - ./.swt-check at repo root (escape hatch — used alone if present)
-//   Otherwise, runs whichever apply, additively (Tauri repos have both):
+//   - .swt-check at `configRoot` — the parent repo root, because the escape hatch
+//     is an uncommitted file and so is absent from a fresh checkout of HEAD. Used
+//     alone if present, as an absolute shell-quoted path, still run in `target`.
+//   Otherwise, detected from `target` and run there, whichever apply, additively
+//   (Tauri repos have both):
 //   - package.json declaring at least one of typecheck/tsc/lint/test:
 //     `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then those checks.
 //     A package.json with none of those scripts contributes nothing — the install
@@ -37,6 +41,20 @@ const streamCheck = (cmd: string, cwd: string): boolean => {
 };
 
 /**
+ * Wraps a string so `sh -c` sees exactly one literal argument.
+ *
+ * Check commands are shell strings by design, so the one piece swt splices into
+ * them — the absolute path of the `.swt-check` override — has to be quoted: a
+ * repo root containing a space, a quote or a `$` would otherwise word-split or
+ * expand. Single quotes suppress every expansion; the embedded-quote case is
+ * handled by closing, escaping, and reopening (`'` → `'\''`).
+ *
+ * @param s - Raw string to embed in a shell command.
+ * @returns The single-quoted form, safe to concatenate into a command line.
+ */
+const shellQuote = (s: string): string => `'${s.replaceAll("'", `'\\''`)}'`;
+
+/**
  * Reads the script names declared in a directory's package.json.
  *
  * @param cwd - Directory that may contain a package.json.
@@ -63,9 +81,15 @@ export function pkgScripts(cwd: string): Set<string> {
  * @returns The commands to run in order, or null if no check applies.
  */
 export function buildCheckPlan(target: string, configRoot: string = target): string[] | null {
-  const cwd = target;
-  if (existsSync(join(cwd, ".swt-check"))) return ["./.swt-check"];
+  // Resolved against configRoot, run in target. The escape hatch is documented as
+  // a file you *drop* at the repo root — uncommitted, and so absent from the fresh
+  // checkout of HEAD that `create` checks. Looking it up in the parent keeps that
+  // per-developer override working; running it in the target keeps the check
+  // honest about what it is verifying.
+  const override = join(configRoot, ".swt-check");
+  if (existsSync(override)) return [shellQuote(override)];
 
+  const cwd = target;
   const cmds: string[] = [];
 
   if (existsSync(join(cwd, "package.json"))) {
@@ -110,17 +134,16 @@ export function buildCheckPlan(target: string, configRoot: string = target): str
  * @returns Ok result when every command passed, otherwise the first failure.
  */
 export function isGreen(target: string, configRoot: string = target): Result {
-  const cwd = target;
-  const plan = buildCheckPlan(cwd);
+  const plan = buildCheckPlan(target, configRoot);
   if (!plan) {
     return {
       ok: false,
-      out: `No green-check defined. Drop a './.swt-check' executable at the repo root.\n`,
+      out: `No green-check defined. Drop a '.swt-check' executable at ${configRoot}.\n`,
     };
   }
-  process.stderr.write(`Running green check in ${cwd}…`);
+  process.stderr.write(`Running green check in ${target}…`);
   for (const cmd of plan) {
-    if (!streamCheck(cmd, cwd)) return { ok: false, out: `failed: ${cmd}\n` };
+    if (!streamCheck(cmd, target)) return { ok: false, out: `failed: ${cmd}\n` };
   }
   return { ok: true, out: "" };
 }

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -1,0 +1,110 @@
+// green-check — what "green" means for a repo, and how to verify it.
+//
+// This module owns the whole definition of the green check: detecting which
+// toolchains a worktree uses (pnpm / cargo / Tauri), assembling the command
+// plan, and running it. Callers see only `isGreen(cwd)` (and `buildCheckPlan`
+// for inspection/testing) — the pnpm/cargo/Tauri detection stays hidden here.
+//
+// Green check (always runs inside the worktree being checked, never the parent):
+//   - ./.swt-check at repo root (escape hatch — used alone if present)
+//   Otherwise, runs whichever apply, additively (Tauri repos have both):
+//   - package.json present: `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then
+//     typecheck/lint/test (whichever scripts exist)
+//   - Cargo.toml at repo root and/or src-tauri/Cargo.toml: cargo check + test + clippy per manifest
+//   If nothing applies: error (drop a .swt-check).
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Outcome of a shell command or check: success flag plus captured output. */
+export type Result = { ok: boolean; out: string };
+
+/**
+ * Runs a single check command, streaming stdout/stderr live so the user sees
+ * progress on long checks.
+ *
+ * @param cmd - Shell command to run.
+ * @param cwd - Directory to run it in.
+ * @returns True if the command exited 0.
+ */
+const streamCheck = (cmd: string, cwd: string): boolean => {
+  process.stderr.write(`\n  $ ${cmd}\n`);
+  const r = spawnSync("sh", ["-c", cmd], { cwd, stdio: "inherit" });
+  return r.status === 0;
+};
+
+/**
+ * Reads the script names declared in a directory's package.json.
+ *
+ * @param cwd - Directory that may contain a package.json.
+ * @returns The set of script names; empty if there is no package.json or it is unparseable.
+ */
+export function pkgScripts(cwd: string): Set<string> {
+  const p = join(cwd, "package.json");
+  if (!existsSync(p)) return new Set();
+  try {
+    const json = JSON.parse(readFileSync(p, "utf8"));
+    return new Set(Object.keys(json.scripts ?? {}));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Determines the ordered list of shell commands that constitute the green check
+ * for a worktree, based on the files present at its root.
+ *
+ * @param cwd - Worktree root to inspect.
+ * @returns The commands to run in order, or null if no check applies.
+ */
+export function buildCheckPlan(cwd: string): string[] | null {
+  if (existsSync(join(cwd, ".swt-check"))) return ["./.swt-check"];
+
+  const cmds: string[] = [];
+
+  if (existsSync(join(cwd, "package.json"))) {
+    // Fresh worktrees have no node_modules; install before checking.
+    if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
+      cmds.push("pnpm install --frozen-lockfile");
+    }
+    const scripts = pkgScripts(cwd);
+    if (scripts.has("typecheck")) cmds.push("pnpm typecheck");
+    else if (scripts.has("tsc")) cmds.push("pnpm exec tsc --noEmit");
+    if (scripts.has("lint")) cmds.push("pnpm lint");
+    if (scripts.has("test")) cmds.push("pnpm test --run");
+  }
+
+  // Rust checks run alongside package.json checks — Tauri repos have both.
+  // "" = root Cargo.toml (no --manifest-path needed); otherwise point at the manifest.
+  const cargoManifests: string[] = [];
+  if (existsSync(join(cwd, "Cargo.toml"))) cargoManifests.push("");
+  if (existsSync(join(cwd, "src-tauri", "Cargo.toml"))) cargoManifests.push("src-tauri/Cargo.toml");
+  for (const manifest of cargoManifests) {
+    const flag = manifest ? ` --manifest-path ${manifest}` : "";
+    cmds.push(`cargo check${flag}`, `cargo test${flag}`, `cargo clippy${flag} -- -D warnings`);
+  }
+
+  return cmds.length > 0 ? cmds : null;
+}
+
+/**
+ * Runs the green check for a worktree, stopping at the first failing command.
+ *
+ * @param cwd - Worktree root to check; every command runs in this directory.
+ * @returns Ok result when every command passed, otherwise the first failure.
+ */
+export function isGreen(cwd: string): Result {
+  const plan = buildCheckPlan(cwd);
+  if (!plan) {
+    return {
+      ok: false,
+      out: `No green-check defined. Drop a './.swt-check' executable at the repo root.\n`,
+    };
+  }
+  process.stderr.write(`Running green check in ${cwd}…`);
+  for (const cmd of plan) {
+    if (!streamCheck(cmd, cwd)) return { ok: false, out: `failed: ${cmd}\n` };
+  }
+  return { ok: true, out: "" };
+}

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -13,9 +13,10 @@
 //   Otherwise, detected from `target` and run there, whichever apply, additively
 //   (Tauri repos have both):
 //   - package.json declaring at least one of typecheck/tsc/lint/test:
-//     `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then those checks.
-//     A package.json with none of those scripts contributes nothing — the install
-//     alone verifies nothing and must never stand in for a check.
+//     `pnpm install --frozen-lockfile` (only if pnpm-lock.yaml exists *and*
+//     node_modules does not — see below), then those checks. A package.json with
+//     none of those scripts contributes nothing — the install alone verifies
+//     nothing and must never stand in for a check.
 //   - Cargo.toml at repo root and/or src-tauri/Cargo.toml: cargo check + test + clippy per manifest
 //   If nothing applies: error (drop a .swt-check).
 
@@ -104,10 +105,17 @@ export function buildCheckPlan(target: string, configRoot: string = target): str
     // can run in a fresh worktree, which has no node_modules. A plan of just an
     // install would report green having checked nothing, so it rides along with
     // the js checks or not at all.
+    //
+    // And it only rides along into a tree that is actually fresh. `isGreen` also
+    // runs against the parent worktree the user is living in, where an install is
+    // not a read-only step: `--frozen-lockfile` prunes extraneous packages and
+    // undoes local `pnpm link`s. An existing node_modules is the tell that the
+    // dependencies are already there — nothing to set up, and something to lose —
+    // so verification inspects that tree without touching it.
     if (jsChecks.length > 0) {
-      if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
-        cmds.push("pnpm install --frozen-lockfile");
-      }
+      const needsInstall =
+        existsSync(join(cwd, "pnpm-lock.yaml")) && !existsSync(join(cwd, "node_modules"));
+      if (needsInstall) cmds.push("pnpm install --frozen-lockfile");
       cmds.push(...jsChecks);
     }
   }

--- a/swt/green-check.ts
+++ b/swt/green-check.ts
@@ -50,10 +50,13 @@ const streamCheck = (cmd: string, cwd: string): boolean => {
  * expand. Single quotes suppress every expansion; the embedded-quote case is
  * handled by closing, escaping, and reopening (`'` → `'\''`).
  *
+ * The same applies to a command line swt *prints* for a human to paste back into
+ * their shell, which is why this is exported.
+ *
  * @param s - Raw string to embed in a shell command.
  * @returns The single-quoted form, safe to concatenate into a command line.
  */
-const shellQuote = (s: string): string => `'${s.replaceAll("'", `'\\''`)}'`;
+export const shellQuote = (s: string): string => `'${s.replaceAll("'", `'\\''`)}'`;
 
 /**
  * Reads the script names declared in a directory's package.json.

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -5,12 +5,13 @@
 // each other's directories.
 
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 
-import { git, gitMust, validateWorktreeName } from "./git.ts";
+import { git, gitMust, validateWorktreeName, worktreeDirt } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
 
 /** Process-unique root for this suite's fixtures; removed in the `after` hook. */
@@ -22,10 +23,12 @@ let fixtureCounter = 0;
  * Materializes a fixture directory containing the given files.
  *
  * @param files - Map of repo-relative path to file contents; parent directories are created.
+ * @param label - Prefix for the directory name; a counter is always appended so two
+ *   fixtures with the same label never share a path.
  * @returns Absolute path to the fixture directory.
  */
-function makeFixture(files: Record<string, string>): string {
-  const dir = join(FIXTURE_ROOT, `case-${fixtureCounter++}`);
+function makeFixture(files: Record<string, string>, label = "case"): string {
+  const dir = join(FIXTURE_ROOT, `${label}-${fixtureCounter++}`);
   mkdirSync(dir, { recursive: true });
   for (const [relPath, contents] of Object.entries(files)) {
     const full = join(dir, relPath);
@@ -52,21 +55,6 @@ describe("buildCheckPlan", () => {
       name: "empty directory has no plan",
       files: {},
       expected: null,
-    },
-    {
-      name: ".swt-check escape hatch is the whole plan",
-      files: { ".swt-check": "#!/bin/sh\nexit 0\n" },
-      expected: ["./.swt-check"],
-    },
-    {
-      name: ".swt-check wins alone over package.json and Cargo.toml",
-      files: {
-        ".swt-check": "#!/bin/sh\nexit 0\n",
-        "package.json": pkgJson("typecheck", "lint", "test"),
-        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
-        "Cargo.toml": "[package]\nname = \"fixture\"\n",
-      },
-      expected: ["./.swt-check"],
     },
     {
       name: "root Cargo.toml only uses no --manifest-path",
@@ -217,6 +205,76 @@ describe("buildCheckPlan", () => {
   });
 });
 
+// The `.swt-check` escape hatch is documented as a file you *drop* at the repo
+// root — i.e. uncommitted, and therefore absent from the fresh checkout of HEAD
+// the green check now runs in. So the override has to be resolved against the
+// parent repo root while the commands still run in the worktree being checked.
+describe("buildCheckPlan config root", () => {
+  /** Trivial always-green override script. */
+  const SWT_CHECK = "#!/bin/sh\nexit 0\n";
+  /** Minimal manifest that makes a directory auto-detect as a cargo repo. */
+  const CARGO_TOML = '[package]\nname = "fixture"\n';
+  /** The plan `CARGO_TOML` alone produces — what must NOT win over an override. */
+  const CARGO_PLAN = ["cargo check", "cargo test", "cargo clippy -- -D warnings"];
+
+  test(".swt-check in the target is the whole plan, as an absolute quoted path", () => {
+    const dir = makeFixture({ ".swt-check": SWT_CHECK });
+    assert.deepEqual(buildCheckPlan(dir), [`'${join(dir, ".swt-check")}'`]);
+  });
+
+  test(".swt-check wins alone over package.json and Cargo.toml", () => {
+    const dir = makeFixture({
+      ".swt-check": SWT_CHECK,
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      "Cargo.toml": CARGO_TOML,
+    });
+    assert.deepEqual(buildCheckPlan(dir), [`'${join(dir, ".swt-check")}'`]);
+  });
+
+  test(".swt-check at the config root is used when the target has none", () => {
+    const configRoot = makeFixture({ ".swt-check": SWT_CHECK });
+    const target = makeFixture({ "Cargo.toml": CARGO_TOML });
+    assert.deepEqual(buildCheckPlan(target, configRoot), [`'${join(configRoot, ".swt-check")}'`]);
+  });
+
+  test(".swt-check at the config root beats auto-detection in the target", () => {
+    const configRoot = makeFixture({ ".swt-check": SWT_CHECK });
+    const target = makeFixture({
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      "Cargo.toml": CARGO_TOML,
+    });
+    assert.deepEqual(buildCheckPlan(target, configRoot), [`'${join(configRoot, ".swt-check")}'`]);
+  });
+
+  test("no .swt-check at the config root leaves the target's auto-detected plan alone", () => {
+    const configRoot = makeFixture({});
+    const target = makeFixture({ "Cargo.toml": CARGO_TOML });
+    assert.deepEqual(buildCheckPlan(target, configRoot), CARGO_PLAN);
+  });
+
+  test("no .swt-check anywhere still yields no plan", () => {
+    assert.equal(buildCheckPlan(makeFixture({}), makeFixture({})), null);
+  });
+
+  // The emitted command is handed to `sh -c`, so a repo root containing a space,
+  // a quote or a `$` has to survive that round trip intact.
+  test("a config root path with a space and a quote is shell-quoted for sh -c", () => {
+    const configRoot = makeFixture({ ".swt-check": "#!/bin/sh\nexit 7\n" }, "wei'rd $config root");
+    chmodSync(join(configRoot, ".swt-check"), 0o755);
+    const target = makeFixture({ "Cargo.toml": CARGO_TOML });
+
+    const plan = buildCheckPlan(target, configRoot);
+    const quoted = `'${join(configRoot, ".swt-check").replaceAll("'", "'\\''")}'`;
+    assert.deepEqual(plan, [quoted]);
+
+    // Not tautological: this actually runs the emitted string the way swt does.
+    const r = spawnSync("sh", ["-c", plan![0]], { cwd: target, encoding: "utf8" });
+    assert.equal(r.status, 7, `sh could not run the quoted override: ${r.stderr}`);
+  });
+});
+
 describe("pkgScripts", () => {
   test("returns an empty set when there is no package.json", () => {
     assert.deepEqual(pkgScripts(makeFixture({})), new Set());
@@ -249,6 +307,82 @@ function makeGitRepo(): string {
   assert.ok(init.ok, `git init failed: ${init.out}`);
   return dir;
 }
+
+/** Path of the one tracked file `makeCommittedGitRepo` leaves behind. */
+const TRACKED_FILE = "tracked.txt";
+
+/**
+ * Creates a git repository with a single committed file under the process-unique
+ * fixture root. Identity and excludes are pinned locally so the fixture behaves
+ * the same regardless of the developer's global git config.
+ *
+ * @returns Absolute path to the initialized repository.
+ */
+function makeCommittedGitRepo(): string {
+  const dir = makeFixture({ [TRACKED_FILE]: "original\n" });
+  const init = git(["init", "-b", "main", "--quiet"], dir);
+  assert.ok(init.ok, `git init failed: ${init.out}`);
+  for (const [key, value] of [
+    ["user.email", "swt-test@example.com"],
+    ["user.name", "swt test"],
+    ["commit.gpgsign", "false"],
+    ["core.excludesFile", "/dev/null"],
+  ]) {
+    const set = git(["config", "--local", key, value], dir);
+    assert.ok(set.ok, `git config ${key} failed: ${set.out}`);
+  }
+  const add = git(["add", "--", TRACKED_FILE], dir);
+  assert.ok(add.ok, `git add failed: ${add.out}`);
+  const commit = git(["commit", "--quiet", "-m", "fixture"], dir);
+  assert.ok(commit.ok, `git commit failed: ${commit.out}`);
+  return dir;
+}
+
+// The parent guard and the subagent guard need different scopes, so dirt
+// detection is a parameter rather than a fixed `git status --porcelain`.
+describe("worktreeDirt", () => {
+  test("a freshly committed repo is clean under either scope", () => {
+    const dir = makeCommittedGitRepo();
+    assert.equal(worktreeDirt(dir, { includeUntracked: false }), "");
+    assert.equal(worktreeDirt(dir, { includeUntracked: true }), "");
+  });
+
+  test("an untracked file is dirt only when untracked files are included", () => {
+    const dir = makeCommittedGitRepo();
+    writeFileSync(join(dir, "scratch.txt"), "scratch\n");
+    assert.equal(worktreeDirt(dir, { includeUntracked: false }), "");
+    assert.match(worktreeDirt(dir, { includeUntracked: true }), /scratch\.txt/);
+  });
+
+  // Finding A in one test: the documented escape hatch is an uncommitted file at
+  // the repo root, so an untracked-sensitive parent guard hard-blocks every merge
+  // for anyone following the documented workflow.
+  test("an uncommitted .swt-check escape hatch is not parent dirt", () => {
+    const dir = makeCommittedGitRepo();
+    writeFileSync(join(dir, ".swt-check"), "#!/bin/sh\nexit 0\n");
+    assert.equal(worktreeDirt(dir, { includeUntracked: false }), "");
+  });
+
+  test("a modified tracked file is dirt even when untracked files are excluded", () => {
+    const dir = makeCommittedGitRepo();
+    writeFileSync(join(dir, TRACKED_FILE), "changed\n");
+    assert.match(worktreeDirt(dir, { includeUntracked: false }), /tracked\.txt/);
+  });
+
+  test("a staged addition is dirt even when untracked files are excluded", () => {
+    const dir = makeCommittedGitRepo();
+    writeFileSync(join(dir, "added.txt"), "added\n");
+    const add = git(["add", "--", "added.txt"], dir);
+    assert.ok(add.ok, `git add failed: ${add.out}`);
+    assert.match(worktreeDirt(dir, { includeUntracked: false }), /added\.txt/);
+  });
+
+  test("a deleted tracked file is dirt even when untracked files are excluded", () => {
+    const dir = makeCommittedGitRepo();
+    rmSync(join(dir, TRACKED_FILE));
+    assert.match(worktreeDirt(dir, { includeUntracked: false }), /tracked\.txt/);
+  });
+});
 
 // These tests exist to prove there is no shell between swt and git. Each one
 // feeds git an argument that a shell would mangle — a space (word splitting),

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -125,6 +125,39 @@ describe("buildCheckPlan", () => {
       expected: ["pnpm typecheck", "pnpm lint", "pnpm test --run"],
     },
     {
+      name: "a package.json with no check scripts yields no plan, install alone is not green",
+      files: {
+        "package.json": pkgJson("build"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      },
+      expected: null,
+    },
+    {
+      name: "a package.json with no scripts block at all yields no plan",
+      files: {
+        "package.json": JSON.stringify({ name: "fixture" }),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      },
+      expected: null,
+    },
+    {
+      name: "a checkless package.json adds no install to an otherwise cargo-only plan",
+      files: {
+        "package.json": pkgJson("build"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+        "Cargo.toml": "[package]\nname = \"fixture\"\n",
+      },
+      expected: ["cargo check", "cargo test", "cargo clippy -- -D warnings"],
+    },
+    {
+      name: "a lone test script still gets its install",
+      files: {
+        "package.json": pkgJson("build", "test"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      },
+      expected: ["pnpm install --frozen-lockfile", "pnpm test --run"],
+    },
+    {
       name: "tauri-shaped repo runs js checks then both cargo manifests",
       files: {
         "package.json": pkgJson("typecheck", "lint", "test"),
@@ -152,6 +185,36 @@ describe("buildCheckPlan", () => {
       assert.deepEqual(buildCheckPlan(makeFixture(files)), expected);
     });
   }
+
+  // `pnpm install --frozen-lockfile` verifies nothing on its own — it exists only
+  // to make the js checks runnable in a fresh worktree. A plan that is just an
+  // install would report green having checked nothing, so the install rides along
+  // with the js checks or not at all.
+  test("no js check means no install, even when the plan is non-empty", () => {
+    const dir = makeFixture({
+      "package.json": pkgJson("build", "dev", "start"),
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      "Cargo.toml": "[package]\nname = \"fixture\"\n",
+    });
+    const plan = buildCheckPlan(dir) ?? [];
+    assert.ok(
+      !plan.some((cmd) => cmd.includes("pnpm install")),
+      `plan must not install without a js check to run: ${JSON.stringify(plan)}`,
+    );
+  });
+
+  test("the install is first when js checks do exist", () => {
+    const dir = makeFixture({
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+    });
+    assert.deepEqual(buildCheckPlan(dir), [
+      "pnpm install --frozen-lockfile",
+      "pnpm typecheck",
+      "pnpm lint",
+      "pnpm test --run",
+    ]);
+  });
 });
 
 describe("pkgScripts", () => {

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -1,0 +1,175 @@
+// Baseline tests for the swt green-check plan builder.
+//
+// Every fixture lives under a process-unique temp root so two concurrent copies
+// of this suite (parallel agents, a manual run racing ./test.sh) never clobber
+// each other's directories.
+
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, test } from "node:test";
+
+import { buildCheckPlan, pkgScripts } from "./green-check.ts";
+
+/** Process-unique root for this suite's fixtures; removed in the `after` hook. */
+const FIXTURE_ROOT = join(tmpdir(), `swt-test-${process.pid}-${process.hrtime.bigint()}`);
+
+let fixtureCounter = 0;
+
+/**
+ * Materializes a fixture directory containing the given files.
+ *
+ * @param files - Map of repo-relative path to file contents; parent directories are created.
+ * @returns Absolute path to the fixture directory.
+ */
+function makeFixture(files: Record<string, string>): string {
+  const dir = join(FIXTURE_ROOT, `case-${fixtureCounter++}`);
+  mkdirSync(dir, { recursive: true });
+  for (const [relPath, contents] of Object.entries(files)) {
+    const full = join(dir, relPath);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return dir;
+}
+
+/** Serializes a package.json with the given script names (bodies are irrelevant to the plan). */
+const pkgJson = (...scripts: string[]): string =>
+  JSON.stringify({
+    name: "fixture",
+    scripts: Object.fromEntries(scripts.map((s) => [s, "true"])),
+  });
+
+after(() => {
+  rmSync(FIXTURE_ROOT, { recursive: true, force: true });
+});
+
+describe("buildCheckPlan", () => {
+  const cases: { name: string; files: Record<string, string>; expected: string[] | null }[] = [
+    {
+      name: "empty directory has no plan",
+      files: {},
+      expected: null,
+    },
+    {
+      name: ".swt-check escape hatch is the whole plan",
+      files: { ".swt-check": "#!/bin/sh\nexit 0\n" },
+      expected: ["./.swt-check"],
+    },
+    {
+      name: ".swt-check wins alone over package.json and Cargo.toml",
+      files: {
+        ".swt-check": "#!/bin/sh\nexit 0\n",
+        "package.json": pkgJson("typecheck", "lint", "test"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+        "Cargo.toml": "[package]\nname = \"fixture\"\n",
+      },
+      expected: ["./.swt-check"],
+    },
+    {
+      name: "root Cargo.toml only uses no --manifest-path",
+      files: { "Cargo.toml": "[package]\nname = \"fixture\"\n" },
+      expected: ["cargo check", "cargo test", "cargo clippy -- -D warnings"],
+    },
+    {
+      name: "root plus src-tauri manifests check root first",
+      files: {
+        "Cargo.toml": "[package]\nname = \"fixture\"\n",
+        "src-tauri/Cargo.toml": "[package]\nname = \"fixture-tauri\"\n",
+      },
+      expected: [
+        "cargo check",
+        "cargo test",
+        "cargo clippy -- -D warnings",
+        "cargo check --manifest-path src-tauri/Cargo.toml",
+        "cargo test --manifest-path src-tauri/Cargo.toml",
+        "cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+      ],
+    },
+    {
+      name: "pnpm lockfile adds a frozen install before the js checks",
+      files: {
+        "package.json": pkgJson("typecheck", "lint", "test"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      },
+      expected: [
+        "pnpm install --frozen-lockfile",
+        "pnpm typecheck",
+        "pnpm lint",
+        "pnpm test --run",
+      ],
+    },
+    {
+      name: "a tsc script substitutes for a missing typecheck script",
+      files: {
+        "package.json": pkgJson("tsc", "lint", "test"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      },
+      expected: [
+        "pnpm install --frozen-lockfile",
+        "pnpm exec tsc --noEmit",
+        "pnpm lint",
+        "pnpm test --run",
+      ],
+    },
+    {
+      name: "typecheck wins over tsc when both scripts exist",
+      files: { "package.json": pkgJson("typecheck", "tsc") },
+      expected: ["pnpm typecheck"],
+    },
+    {
+      name: "no pnpm lockfile means no install command",
+      files: { "package.json": pkgJson("typecheck", "lint", "test") },
+      expected: ["pnpm typecheck", "pnpm lint", "pnpm test --run"],
+    },
+    {
+      name: "tauri-shaped repo runs js checks then both cargo manifests",
+      files: {
+        "package.json": pkgJson("typecheck", "lint", "test"),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+        "Cargo.toml": "[package]\nname = \"fixture\"\n",
+        "src-tauri/Cargo.toml": "[package]\nname = \"fixture-tauri\"\n",
+      },
+      expected: [
+        "pnpm install --frozen-lockfile",
+        "pnpm typecheck",
+        "pnpm lint",
+        "pnpm test --run",
+        "cargo check",
+        "cargo test",
+        "cargo clippy -- -D warnings",
+        "cargo check --manifest-path src-tauri/Cargo.toml",
+        "cargo test --manifest-path src-tauri/Cargo.toml",
+        "cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+      ],
+    },
+  ];
+
+  for (const { name, files, expected } of cases) {
+    test(name, () => {
+      assert.deepEqual(buildCheckPlan(makeFixture(files)), expected);
+    });
+  }
+});
+
+describe("pkgScripts", () => {
+  test("returns an empty set when there is no package.json", () => {
+    assert.deepEqual(pkgScripts(makeFixture({})), new Set());
+  });
+
+  test("returns the declared script names", () => {
+    const dir = makeFixture({ "package.json": pkgJson("typecheck", "lint") });
+    assert.deepEqual(pkgScripts(dir), new Set(["typecheck", "lint"]));
+  });
+
+  test("returns an empty set for a package.json with no scripts block", () => {
+    const dir = makeFixture({ "package.json": JSON.stringify({ name: "fixture" }) });
+    assert.deepEqual(pkgScripts(dir), new Set());
+  });
+
+  test("returns an empty set for a malformed package.json instead of throwing", () => {
+    const dir = makeFixture({ "package.json": "{ this is not json" });
+    assert.deepEqual(pkgScripts(dir), new Set());
+  });
+});

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -22,7 +22,7 @@ import { delimiter, dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { git, gitMust, removeWorktree, validateWorktreeName, worktreeDirt } from "./git.ts";
+import { git, gitMust, removeWorktree, runGit, validateWorktreeName, worktreeDirt } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
 import { withParentLock } from "./swt.ts";
 
@@ -559,6 +559,79 @@ describe("git argv boundary", () => {
     const out = gitMust(["config", "--local", "swt.testvalue", "trimmed"], dir);
     assert.equal(out, "");
     assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), "trimmed");
+  });
+});
+
+// The shield that keeps interrupt teardown alive is a single undocumented
+// option: `detached` on `spawnSync`. Node honors it, but documents it only for
+// the asynchronous `spawn`, so a release that dropped the pass-through would
+// turn it into a silent no-op — teardown's git would slide back into swt's
+// process group, and the second-Ctrl-C orphan bug would return without one
+// assertion anywhere going red. These two tests are that alarm, and they call
+// `runGit` itself: a hand-rolled `spawnSync` here would only prove that Node
+// still honors an option the production code might have stopped passing.
+describe("runGit process-group shielding", () => {
+  /**
+   * A git alias that reports the process group git itself is running in.
+   *
+   * A `!`-prefixed alias body is handed to a shell that git forks, so `$$` is
+   * that shell's pid and the group it reports is the one it inherited from git.
+   * Supplying the alias with `-c` leaves the fixture repository's own config
+   * untouched, and beats any `alias.pg` in the developer's global config.
+   */
+  const PGID_ALIAS = "!ps -o pgid= -p $$";
+
+  /**
+   * Reports the process group a git launched through the production `runGit`
+   * ran in.
+   *
+   * @param cwd - Repository to run git in.
+   * @param shielded - Passed straight through to `runGit`.
+   * @returns Git's process group id, as decimal digits.
+   */
+  function gitProcessGroup(cwd: string, shielded: boolean): string {
+    const r = runGit(["-c", `alias.pg=${PGID_ALIAS}`, "pg"], cwd, shielded);
+    assert.ok(r.ok, `the pgid alias failed to run: ${r.out}`);
+    const pgid = r.out.trim();
+    assert.match(pgid, /^\d+$/, `expected a process group id, got ${JSON.stringify(r.out)}`);
+    return pgid;
+  }
+
+  /**
+   * Reports this process's own process group — the one a terminal Ctrl-C aims
+   * at, and therefore the group teardown has to stay out of.
+   *
+   * @returns This process's process group id, as decimal digits.
+   */
+  function ownProcessGroup(): string {
+    const r = spawnSync("ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" });
+    assert.equal(r.status, 0, `ps failed: ${r.stderr ?? ""}`);
+    return (r.stdout ?? "").trim();
+  }
+
+  /** Process groups are a POSIX notion; there is nothing to assert on Windows. */
+  const posixOnly = { skip: process.platform === "win32" ? "POSIX process groups only" : false };
+
+  test("a shielded git runs outside swt's process group", posixOnly, () => {
+    const dir = makeGitRepo();
+    const own = ownProcessGroup();
+    assert.notEqual(
+      gitProcessGroup(dir, true),
+      own,
+      "shielded git shared swt's process group, so a Ctrl-C aimed at swt would " +
+        "kill teardown mid-flight — `detached` is no longer being honored by spawnSync",
+    );
+  });
+
+  test("an unshielded git runs inside swt's process group", posixOnly, () => {
+    const dir = makeGitRepo();
+    const own = ownProcessGroup();
+    assert.equal(
+      gitProcessGroup(dir, false),
+      own,
+      "unshielded git escaped swt's process group; work the user is waiting on " +
+        "must stay interruptible by the Ctrl-C that abandons it",
+    );
   });
 });
 

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 
-import { git, gitMust } from "./git.ts";
+import { git, gitMust, validateWorktreeName } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
 
 /** Process-unique root for this suite's fixtures; removed in the `after` hook. */
@@ -250,4 +250,35 @@ describe("git argv boundary", () => {
     assert.equal(out, "");
     assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), "trimmed");
   });
+});
+
+describe("validateWorktreeName", () => {
+  const rejected: { name: string; why: string }[] = [
+    { name: "fix parser", why: "a space splits the branch name from the path" },
+    { name: "a;rm -rf /", why: "a semicolon is a command separator" },
+    { name: "$(touch pwned)", why: "command substitution" },
+    { name: "feat/foo", why: "a slash silently nests the branch and the path" },
+    { name: "..", why: "escapes the worktree parent directory" },
+    { name: ".", why: "resolves to the parent directory itself" },
+    { name: "../escape", why: "path traversal" },
+    { name: "-b", why: "a leading dash is read as a git option" },
+    { name: "-force", why: "a leading dash is read as a git option" },
+    { name: "", why: "an empty name yields an empty path component" },
+    { name: "café", why: "non-ASCII is outside the allowed set" },
+    { name: "with\nnewline", why: "a newline breaks ref parsing" },
+  ];
+
+  for (const { name, why } of rejected) {
+    test(`rejects ${JSON.stringify(name)} — ${why}`, () => {
+      assert.equal(validateWorktreeName(name), null);
+    });
+  }
+
+  const accepted = ["fix-parser", "fix_parser", "issue42", "v1.2.3", "A-Z_a-z.0-9", "x"];
+
+  for (const name of accepted) {
+    test(`accepts ${JSON.stringify(name)}`, () => {
+      assert.equal(validateWorktreeName(name), name);
+    });
+  }
 });

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -216,6 +216,104 @@ describe("buildCheckPlan", () => {
   });
 });
 
+// The install is a *setup* step smuggled into a *verification* step, and it is
+// not inert: `pnpm install --frozen-lockfile` prunes extraneous packages and
+// undoes local `pnpm link`s. That is acceptable in a fresh worktree, which has
+// no dependencies and nothing to lose, and unacceptable in the parent worktree
+// the user is living in — which `isGreen` also checks. An already-populated
+// node_modules is the tell: the target is not fresh, so the check must inspect
+// it without touching it.
+describe("buildCheckPlan install gating on node_modules", () => {
+  /** Lockfile contents; only its existence matters to the plan. */
+  const LOCKFILE = "lockfileVersion: '9.0'\n";
+  /** Minimal manifest that makes a directory auto-detect as a cargo repo. */
+  const CARGO_TOML = '[package]\nname = "fixture"\n';
+  /** A file inside node_modules, so `makeFixture` materializes the directory. */
+  const NODE_MODULES_MARKER = "node_modules/.modules.yaml";
+  /** The js checks a full package.json produces, in order, without any install. */
+  const JS_CHECKS = ["pnpm typecheck", "pnpm lint", "pnpm test --run"];
+
+  /** Every command in a plan that is a pnpm install, for pinpointing failures. */
+  const installsIn = (plan: string[] | null): string[] =>
+    (plan ?? []).filter((cmd) => cmd.includes("pnpm install"));
+
+  test("an existing node_modules suppresses the install entirely", () => {
+    const dir = makeFixture({
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": LOCKFILE,
+      [NODE_MODULES_MARKER]: "hoistPattern:\n  - '*'\n",
+    });
+    const plan = buildCheckPlan(dir);
+    assert.deepEqual(
+      installsIn(plan),
+      [],
+      `verification must not install into a populated tree: ${JSON.stringify(plan)}`,
+    );
+    assert.deepEqual(plan, JS_CHECKS);
+  });
+
+  test("a fresh worktree with no node_modules still gets the install first", () => {
+    const dir = makeFixture({
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": LOCKFILE,
+    });
+    assert.deepEqual(buildCheckPlan(dir), ["pnpm install --frozen-lockfile", ...JS_CHECKS]);
+  });
+
+  test("a populated tauri-shaped repo runs js then both cargo manifests, no install", () => {
+    const dir = makeFixture({
+      "package.json": pkgJson("typecheck", "lint", "test"),
+      "pnpm-lock.yaml": LOCKFILE,
+      [NODE_MODULES_MARKER]: "hoistPattern:\n  - '*'\n",
+      "Cargo.toml": CARGO_TOML,
+      "src-tauri/Cargo.toml": '[package]\nname = "fixture-tauri"\n',
+    });
+    assert.deepEqual(buildCheckPlan(dir), [
+      ...JS_CHECKS,
+      "cargo check",
+      "cargo test",
+      "cargo clippy -- -D warnings",
+      "cargo check --manifest-path src-tauri/Cargo.toml",
+      "cargo test --manifest-path src-tauri/Cargo.toml",
+      "cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+    ]);
+  });
+
+  // Dropping the install is the *only* thing node_modules may change: the checks
+  // themselves, their order, and the cargo commands after them stay identical.
+  test("node_modules removes the install and nothing else", () => {
+    const files = {
+      "package.json": pkgJson("tsc", "lint", "test"),
+      "pnpm-lock.yaml": LOCKFILE,
+      "Cargo.toml": CARGO_TOML,
+    };
+    const fresh = buildCheckPlan(makeFixture(files)) ?? [];
+    const populated = buildCheckPlan(
+      makeFixture({ ...files, [NODE_MODULES_MARKER]: "hoistPattern:\n  - '*'\n" }),
+    );
+    assert.deepEqual(installsIn(fresh), ["pnpm install --frozen-lockfile"]);
+    assert.deepEqual(
+      populated,
+      fresh.filter((cmd) => !cmd.includes("pnpm install")),
+    );
+  });
+
+  // A tree with no js checks never had an install to drop, so node_modules is a
+  // no-op there — it must not add, remove, or reorder anything.
+  test("node_modules alone changes nothing when there are no js checks", () => {
+    const files = {
+      "package.json": pkgJson("build"),
+      "pnpm-lock.yaml": LOCKFILE,
+      "Cargo.toml": CARGO_TOML,
+    };
+    const populated = buildCheckPlan(
+      makeFixture({ ...files, [NODE_MODULES_MARKER]: "hoistPattern:\n  - '*'\n" }),
+    );
+    assert.deepEqual(populated, buildCheckPlan(makeFixture(files)));
+    assert.deepEqual(populated, ["cargo check", "cargo test", "cargo clippy -- -D warnings"]);
+  });
+});
+
 // The `.swt-check` escape hatch is documented as a file you *drop* at the repo
 // root — i.e. uncommitted, and therefore absent from the fresh checkout of HEAD
 // the green check now runs in. So the override has to be resolved against the

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -775,6 +775,27 @@ function swtBranches(repo: string, name: string): string[] {
 const CHILD_DEADLINE_MS = 60_000;
 
 /**
+ * Reports whether any process remains in a process group.
+ *
+ * `npx tsx` is a small tree, not a single process: the wrapper exits the instant
+ * it is signalled while the node process actually running swt is still tearing
+ * its worktree down. Waiting on the tracked child alone would therefore sample
+ * the filesystem mid-cleanup; the group is empty only once every one of them has
+ * gone. Signal 0 performs the existence check without delivering anything.
+ *
+ * @param pid - Pid of the group leader, as spawned with `detached: true`.
+ * @returns True while at least one member of the group is alive.
+ */
+function groupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Polls until a condition holds, failing the test rather than hanging forever.
  *
  * @param ready - Condition to poll; must be cheap and side-effect free.
@@ -936,6 +957,7 @@ describe("swt create cleanup", () => {
       assert.ok(existsSync(wt), `precondition: create must have built ${wt} before checking it`);
       process.kill(-pid, "SIGINT");
       await withDeadline(exited, "swt to exit after SIGINT");
+      await waitUntil(() => !groupAlive(pid), "the interrupted swt to finish exiting");
     } finally {
       // Never leave a 30-second sleep running, whatever went wrong above.
       try {

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -6,7 +6,7 @@
 // each other's directories.
 
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -18,7 +18,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -756,6 +756,54 @@ function writeSwtCheck(repo: string, body: string): void {
 }
 
 /**
+ * How long the shimmed teardown command stalls before handing over to real git.
+ * Only a floor matters: it has to outlast the poll interval the test notices the
+ * shim's sentinel on, so the interrupt cannot arrive after teardown is over.
+ */
+const TEARDOWN_HOLD_SECONDS = 1;
+
+/**
+ * Materializes a PATH-shadowing `git` that announces swt's teardown and holds
+ * its first command open.
+ *
+ * The interrupt under test has to land *inside* teardown, and teardown is two
+ * back-to-back git commands that together take a few tens of milliseconds — so
+ * timing a signal into that window with a sleep is a coin flip, and a flaky test
+ * for a flaky bug proves nothing. Making the first teardown command its own
+ * synchronization point removes the guesswork: it touches a sentinel the test
+ * waits on, then stalls before handing over to the real git. Every other git
+ * invocation is passed straight through, so nothing else about the run changes.
+ *
+ * @param label - Distinguishes this shim's directory from every other fixture's.
+ * @returns The directory to prepend to PATH, and the sentinel it touches.
+ */
+function makeTeardownShim(label: string): { dir: string; sentinel: string } {
+  // Resolved here, before the shim can shadow it, so the shim can hand over.
+  const resolved = spawnSync("sh", ["-c", "command -v git"], { encoding: "utf8" });
+  assert.equal(resolved.status, 0, `could not resolve the real git: ${resolved.stderr}`);
+  const realGit = resolved.stdout.trim();
+
+  const dir = join(FIXTURE_ROOT, `git-shim-${label}`);
+  mkdirSync(dir, { recursive: true });
+  const sentinel = join(dir, "teardown-started");
+  const shim = join(dir, "git");
+  writeFileSync(
+    shim,
+    [
+      "#!/bin/sh",
+      `if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then`,
+      `  : > ${JSON.stringify(sentinel)}`,
+      `  sleep ${TEARDOWN_HOLD_SECONDS}`,
+      "fi",
+      `exec ${JSON.stringify(realGit)} "$@"`,
+      "",
+    ].join("\n"),
+  );
+  chmodSync(shim, 0o755);
+  return { dir, sentinel };
+}
+
+/**
  * Lists the branches `swt create <name>` could have left behind in a repository.
  *
  * @param repo - Repository to inspect.
@@ -775,13 +823,44 @@ function swtBranches(repo: string, name: string): string[] {
 const CHILD_DEADLINE_MS = 60_000;
 
 /**
+ * Spawns swt as a child in its own process group, with no launcher in between.
+ *
+ * The launcher is not incidental to any test that signals swt. `npx tsx` is a
+ * parent *process*: on SIGINT it relays the signal to the node process actually
+ * running swt, waits 30ms for an IPC acknowledgement that swt — blocked in the
+ * synchronous `spawnSync` of a green check — can never send, re-sends, and
+ * SIGKILLs at ~60ms. A test launched that way measures tsx's kill deadline
+ * against swt's teardown rather than swt's own guarantee, and fails whenever a
+ * loaded machine pushes teardown past 60ms. Re-using this process's own node
+ * binary and `execArgv` runs swt under exactly the same TypeScript loader (tsx's
+ * `--import` when the suite itself is run under tsx) with the launcher removed,
+ * so the signal lands on swt and nothing else can kill it.
+ *
+ * `detached` puts swt in its own process group, so a signal sent to `-pid`
+ * reaches the children swt spawned too — which is what a terminal Ctrl-C does.
+ *
+ * @param args - Arguments following the program name, e.g. `["create", name]`.
+ * @param cwd - Directory to run swt in.
+ * @param env - Environment entries merged over this process's own.
+ * @returns The spawned child; stdout is discarded and stderr is piped.
+ */
+function spawnSwt(args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): ChildProcess {
+  return spawn(process.execPath, [...process.execArgv, SWT_MODULE, ...args], {
+    cwd,
+    detached: true,
+    stdio: ["ignore", "ignore", "pipe"],
+    env: { ...process.env, ...env },
+  });
+}
+
+/**
  * Reports whether any process remains in a process group.
  *
- * `npx tsx` is a small tree, not a single process: the wrapper exits the instant
- * it is signalled while the node process actually running swt is still tearing
- * its worktree down. Waiting on the tracked child alone would therefore sample
- * the filesystem mid-cleanup; the group is empty only once every one of them has
- * gone. Signal 0 performs the existence check without delivering anything.
+ * A signalled swt is not necessarily the last process standing: the green check
+ * it spawned, and the git commands it runs while tearing down, are children too.
+ * Waiting on the tracked child alone would therefore sample the filesystem
+ * mid-cleanup; the group is empty only once every one of them has gone. Signal 0
+ * performs the existence check without delivering anything.
  *
  * @param pid - Pid of the group leader, as spawned with `detached: true`.
  * @returns True while at least one member of the group is alive.
@@ -937,13 +1016,7 @@ describe("swt create cleanup", () => {
     // lands mid-check rather than after it.
     writeSwtCheck(repo, `#!/bin/sh\n: > ${JSON.stringify(started)}\nsleep 30\n`);
 
-    // `detached` puts swt in its own process group, so the signal below reaches
-    // the check swt spawned too — which is what a terminal Ctrl-C does.
-    const child = spawn("npx", ["tsx", SWT_MODULE, "create", name], {
-      cwd: repo,
-      detached: true,
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+    const child = spawnSwt(["create", name], repo);
     let stderr = "";
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
@@ -970,5 +1043,63 @@ describe("swt create cleanup", () => {
 
     assert.ok(!existsSync(wt), `SIGINT left an orphaned worktree at ${wt}:\n${stderr}`);
     assert.deepEqual(swtBranches(repo, name), [], `SIGINT left an orphaned branch:\n${stderr}`);
+  });
+
+  // One Ctrl-C asks swt to stop; a second one, while it is still stopping, must
+  // not undo the stopping. Teardown is two git commands run as children of swt,
+  // in swt's process group — which is exactly where a terminal sends Ctrl-C — so
+  // an impatient second interrupt kills the teardown command mid-flight. The
+  // worktree removal never completes, the branch the surviving worktree still
+  // claims cannot be deleted, and both are orphaned by the very interrupt that
+  // asked for them to go away.
+  test("a second interrupt during teardown still leaves no worktree and no branch", async () => {
+    const repo = makeCommittedGitRepo();
+    const name = `reinterrupted${fixtureCounter++}`;
+    const wt = fixturePath(`${name}.swt`);
+    const started = fixturePath(`check-started-${fixtureCounter++}`);
+    writeSwtCheck(repo, `#!/bin/sh\n: > ${JSON.stringify(started)}\nsleep 30\n`);
+    const shim = makeTeardownShim(`${name}-${fixtureCounter++}`);
+
+    const child = spawnSwt(["create", name], repo, {
+      PATH: `${shim.dir}${delimiter}${process.env.PATH ?? ""}`,
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const exited = new Promise<void>((resolve) => child.on("exit", () => resolve()));
+    const pid = child.pid;
+    assert.ok(pid !== undefined, "child process never started");
+
+    try {
+      await waitUntil(() => existsSync(started), "the green check to start");
+      assert.ok(existsSync(wt), `precondition: create must have built ${wt} before checking it`);
+      process.kill(-pid, "SIGINT");
+      // Both sentinels are the synchronization: the first proved the check was
+      // running, this one proves teardown is. Only then is the second interrupt
+      // sent, so "it arrived mid-teardown" is a fact rather than a hope.
+      await waitUntil(() => existsSync(shim.sentinel), "teardown to start");
+      process.kill(-pid, "SIGINT");
+      await withDeadline(exited, "swt to exit after a second SIGINT");
+      await waitUntil(() => !groupAlive(pid), "the interrupted swt to finish exiting");
+    } finally {
+      // Never leave the 30-second sleep — or a stalled shim — running.
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        /* the process group is already gone */
+      }
+      await exited;
+    }
+
+    assert.ok(
+      !existsSync(wt),
+      `a second SIGINT truncated teardown, orphaning the worktree at ${wt}:\n${stderr}`,
+    );
+    assert.deepEqual(
+      swtBranches(repo, name),
+      [],
+      `a second SIGINT truncated teardown, orphaning the branch:\n${stderr}`,
+    );
   });
 });

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -1,4 +1,5 @@
-// Baseline tests for the swt green-check plan builder and the git argv boundary.
+// Baseline tests for the swt green-check plan builder, the git argv boundary,
+// and the parent merge lock.
 //
 // Every fixture lives under a process-unique temp root so two concurrent copies
 // of this suite (parallel agents, a manual run racing ./test.sh) never clobber
@@ -6,13 +7,23 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { git, gitMust, validateWorktreeName, worktreeDirt } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
+import { withParentLock } from "./swt.ts";
 
 /** Process-unique root for this suite's fixtures; removed in the `after` hook. */
 const FIXTURE_ROOT = join(tmpdir(), `swt-test-${process.pid}-${process.hrtime.bigint()}`);
@@ -478,4 +489,141 @@ describe("validateWorktreeName", () => {
       assert.equal(validateWorktreeName(name), name);
     });
   }
+});
+
+/**
+ * Adds a linked worktree to a fixture repository. A linked worktree's `.git` is
+ * a regular *file* holding `gitdir: …`, which is the whole point of these
+ * fixtures: it is the shape `swt merge` actually runs in, since the workflow
+ * this tool serves never works in the main repo.
+ *
+ * @param repo - Repository to add the worktree to; must already have a commit.
+ * @returns Absolute path to the new linked worktree.
+ */
+function addLinkedWorktree(repo: string): string {
+  const id = fixtureCounter++;
+  const path = join(FIXTURE_ROOT, `linked-worktree-${id}`);
+  const add = git(["worktree", "add", "--quiet", "-b", `linked-${id}`, path, "HEAD"], repo);
+  assert.ok(add.ok, `git worktree add failed: ${add.out}`);
+  return path;
+}
+
+// The lock that serializes concurrent `swt merge` runs against one parent repo.
+// Two things are being pinned here: *where* the lock file lives (the git dir
+// shared by every worktree of the repo — not `<worktree>/.git`, which is a file
+// in a linked worktree), and that it is always released, including on the exit
+// paths that skip `finally` entirely.
+describe("withParentLock", () => {
+  /** Basename of the lock file, relative to the repo's shared git dir. */
+  const LOCK_NAME = "swt.lock";
+
+  /** This module's sibling: the entry point child-process fixtures import. */
+  const SWT_MODULE = fileURLToPath(new URL("./swt.ts", import.meta.url));
+
+  /** Child fixture exit status meaning "exited from inside the locked region". */
+  const EXIT_INSIDE_LOCK = 17;
+
+  /** Child fixture exit status meaning "the lock file was never created". */
+  const EXIT_NO_LOCK = 18;
+
+  test("creates the lock while fn runs, removes it after, and returns fn's value", () => {
+    const repo = makeCommittedGitRepo();
+    const lock = join(repo, ".git", LOCK_NAME);
+
+    const returned = withParentLock(repo, () => {
+      assert.ok(existsSync(lock), `expected a lock at ${lock} while fn runs`);
+      return "fn result";
+    });
+
+    assert.equal(returned, "fn result");
+    assert.ok(!existsSync(lock), `lock at ${lock} outlived the locked region`);
+  });
+
+  // Bug A: `.git` is only a directory in the main worktree. In a linked worktree
+  // it is a regular file, so `join(repoRoot, ".git", "swt.lock")` is an ENOTDIR.
+  test("locks from a linked worktree, whose .git is a file rather than a directory", () => {
+    const repo = makeCommittedGitRepo();
+    const wt = addLinkedWorktree(repo);
+    assert.ok(
+      statSync(join(wt, ".git")).isFile(),
+      "fixture precondition: a linked worktree's .git must be a file",
+    );
+    const lock = join(repo, ".git", LOCK_NAME);
+
+    let ran = false;
+    withParentLock(wt, () => {
+      ran = true;
+      assert.ok(existsSync(lock), `expected the lock in the shared git dir at ${lock}`);
+    });
+
+    assert.ok(ran, "fn never ran");
+    assert.ok(!existsSync(lock), `lock at ${lock} outlived the locked region`);
+  });
+
+  // Serialization scope: a merge launched from any worktree of a repo must
+  // contend for the *same* file, so a lock written by one is seen by the other.
+  // Aging it past the staleness horizon keeps the assertion instant instead of
+  // parking the test on the retry backoff.
+  test("sees a stale lock left in the shared git dir by another worktree, and reaps it", () => {
+    const repo = makeCommittedGitRepo();
+    const wt = addLinkedWorktree(repo);
+    const lock = join(repo, ".git", LOCK_NAME);
+    writeFileSync(lock, "");
+    const longAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(lock, longAgo, longAgo);
+
+    let ran = false;
+    withParentLock(wt, () => {
+      ran = true;
+    });
+
+    assert.ok(ran, `a stale lock at ${lock} was never reaped from the linked worktree`);
+    assert.ok(!existsSync(lock), `lock at ${lock} outlived the locked region`);
+  });
+
+  test("releases the lock when fn throws", () => {
+    const repo = makeCommittedGitRepo();
+    const lock = join(repo, ".git", LOCK_NAME);
+
+    assert.throws(
+      () =>
+        withParentLock(repo, () => {
+          throw new Error("boom");
+        }),
+      /boom/,
+    );
+
+    assert.ok(!existsSync(lock), `a throwing fn left ${lock} behind`);
+  });
+
+  // Bug B, and the only assertion that can actually observe it: `process.exit`
+  // skips `finally`, so this has to be watched from outside the process. The
+  // rebase-conflict path inside the locked region is exactly this shape, and a
+  // leaked lock blocks every later merge until the one-hour stale reap.
+  test("releases the lock when fn exits the process outright", () => {
+    const repo = makeCommittedGitRepo();
+    const lock = join(repo, ".git", LOCK_NAME);
+    const script = join(FIXTURE_ROOT, `exit-inside-lock-${fixtureCounter++}.ts`);
+    writeFileSync(
+      script,
+      [
+        `import { existsSync } from "node:fs";`,
+        `import { withParentLock } from ${JSON.stringify(pathToFileURL(SWT_MODULE).href)};`,
+        ``,
+        `withParentLock(${JSON.stringify(repo)}, () => {`,
+        `  if (!existsSync(${JSON.stringify(lock)})) process.exit(${EXIT_NO_LOCK});`,
+        `  process.exit(${EXIT_INSIDE_LOCK});`,
+        `});`,
+        ``,
+      ].join("\n"),
+    );
+
+    const r = spawnSync("npx", ["tsx", script], { cwd: dirname(SWT_MODULE), encoding: "utf8" });
+    assert.equal(
+      r.status,
+      EXIT_INSIDE_LOCK,
+      `child did not exit from inside the locked region: ${r.stdout}${r.stderr}`,
+    );
+    assert.ok(!existsSync(lock), `process.exit inside the locked region left ${lock} behind`);
+  });
 });

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -1,15 +1,16 @@
-// Baseline tests for the swt green-check plan builder.
+// Baseline tests for the swt green-check plan builder and the git argv boundary.
 //
 // Every fixture lives under a process-unique temp root so two concurrent copies
 // of this suite (parallel agents, a manual run racing ./test.sh) never clobber
 // each other's directories.
 
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 
+import { git, gitMust } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
 
 /** Process-unique root for this suite's fixtures; removed in the `after` hook. */
@@ -171,5 +172,82 @@ describe("pkgScripts", () => {
   test("returns an empty set for a malformed package.json instead of throwing", () => {
     const dir = makeFixture({ "package.json": "{ this is not json" });
     assert.deepEqual(pkgScripts(dir), new Set());
+  });
+});
+
+/**
+ * Creates an empty git repository under the process-unique fixture root.
+ *
+ * @returns Absolute path to the initialized repository.
+ */
+function makeGitRepo(): string {
+  const dir = makeFixture({});
+  const init = git(["init", "--quiet"], dir);
+  assert.ok(init.ok, `git init failed: ${init.out}`);
+  return dir;
+}
+
+// These tests exist to prove there is no shell between swt and git. Each one
+// feeds git an argument that a shell would mangle — a space (word splitting),
+// a `;` (command separator), a `$(…)` (command substitution) — and asserts git
+// saw one literal argument and that nothing was executed.
+describe("git argv boundary", () => {
+  /** Argument that only survives intact if no shell ever parses it. */
+  const HOSTILE = "weird ; $(touch pwned) && echo no | tee bad.txt";
+
+  test("an argument containing spaces is one argument, not several", () => {
+    const dir = makeGitRepo();
+    const set = git(["config", "--local", "swt.testvalue", "one two three"], dir);
+    assert.ok(set.ok, `git config failed: ${set.out}`);
+    // Under `sh -c`, this would have reached git as four argv entries and failed.
+    assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), "one two three");
+  });
+
+  test("shell metacharacters are stored verbatim, never interpreted", () => {
+    const dir = makeGitRepo();
+    const set = git(["config", "--local", "swt.testvalue", HOSTILE], dir);
+    assert.ok(set.ok, `git config failed: ${set.out}`);
+    assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), HOSTILE);
+    assert.ok(!existsSync(join(dir, "pwned")), "command substitution was executed");
+    assert.ok(!existsSync(join(dir, "bad.txt")), "pipeline was executed");
+  });
+
+  test("a path argument full of metacharacters round-trips through the index", () => {
+    const dir = makeGitRepo();
+    const evil = `${HOSTILE}.txt`;
+    writeFileSync(join(dir, evil), "contents\n");
+
+    const add = git(["add", "--", evil], dir);
+    assert.ok(add.ok, `git add failed: ${add.out}`);
+
+    // ls-files -z emits raw, unquoted paths — an exact-match assertion.
+    const listed = git(["ls-files", "-z"], dir);
+    assert.ok(listed.ok, `git ls-files failed: ${listed.out}`);
+    assert.deepEqual(
+      listed.out.split("\0").filter((p) => p.length > 0),
+      [evil],
+    );
+    assert.ok(!existsSync(join(dir, "pwned")), "command substitution was executed");
+  });
+
+  test("a leading-dash argument is not swallowed as an option by a shell", () => {
+    const dir = makeGitRepo();
+    const set = git(["config", "--local", "swt.testvalue", "--not-an-option"], dir);
+    assert.ok(set.ok, `git config failed: ${set.out}`);
+    assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), "--not-an-option");
+  });
+
+  test("a failing git command reports ok=false with git's own output", () => {
+    const dir = makeGitRepo();
+    const r = git(["rev-parse", "--verify", "definitely-not-a-ref"], dir);
+    assert.equal(r.ok, false);
+    assert.ok(r.out.length > 0, "expected git's stderr to be captured");
+  });
+
+  test("gitMust returns trimmed combined output on success", () => {
+    const dir = makeGitRepo();
+    const out = gitMust(["config", "--local", "swt.testvalue", "trimmed"], dir);
+    assert.equal(out, "");
+    assert.equal(gitMust(["config", "--local", "--get", "swt.testvalue"], dir), "trimmed");
   });
 });

--- a/swt/swt.test.ts
+++ b/swt/swt.test.ts
@@ -6,11 +6,12 @@
 // each other's directories.
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
   mkdirSync,
+  realpathSync,
   rmSync,
   statSync,
   utimesSync,
@@ -21,12 +22,15 @@ import { dirname, join } from "node:path";
 import { after, describe, test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { git, gitMust, validateWorktreeName, worktreeDirt } from "./git.ts";
+import { git, gitMust, removeWorktree, validateWorktreeName, worktreeDirt } from "./git.ts";
 import { buildCheckPlan, pkgScripts } from "./green-check.ts";
 import { withParentLock } from "./swt.ts";
 
 /** Process-unique root for this suite's fixtures; removed in the `after` hook. */
 const FIXTURE_ROOT = join(tmpdir(), `swt-test-${process.pid}-${process.hrtime.bigint()}`);
+
+/** This module's sibling: the entry point child-process fixtures run and import. */
+const SWT_MODULE = fileURLToPath(new URL("./swt.ts", import.meta.url));
 
 let fixtureCounter = 0;
 
@@ -615,9 +619,6 @@ describe("withParentLock", () => {
   /** Basename of the lock file, relative to the repo's shared git dir. */
   const LOCK_NAME = "swt.lock";
 
-  /** This module's sibling: the entry point child-process fixtures import. */
-  const SWT_MODULE = fileURLToPath(new URL("./swt.ts", import.meta.url));
-
   /** Child fixture exit status meaning "exited from inside the locked region". */
   const EXIT_INSIDE_LOCK = 17;
 
@@ -723,5 +724,229 @@ describe("withParentLock", () => {
       `child did not exit from inside the locked region: ${r.stdout}${r.stderr}`,
     );
     assert.ok(!existsSync(lock), `process.exit inside the locked region left ${lock} behind`);
+  });
+});
+
+/**
+ * Names a path directly under the fixture root, spelled the way git spells it back.
+ *
+ * `getcwd(2)` always answers with the physical path and on macOS `$TMPDIR` is a
+ * symlink, so every path git and swt print is already symlink-resolved — string
+ * comparisons against a `FIXTURE_ROOT`-derived path would otherwise miss.
+ *
+ * @param name - Basename to place under the fixture root; nothing is created.
+ * @returns The absolute, symlink-resolved path.
+ */
+function fixturePath(name: string): string {
+  mkdirSync(FIXTURE_ROOT, { recursive: true });
+  return join(realpathSync(FIXTURE_ROOT), name);
+}
+
+/**
+ * Drops an executable `.swt-check` override at a repository root.
+ *
+ * @param repo - Repository root the override belongs to. It is deliberately left
+ *   untracked, which is exactly how the escape hatch is documented.
+ * @param body - Shell script contents, shebang included.
+ */
+function writeSwtCheck(repo: string, body: string): void {
+  const path = join(repo, ".swt-check");
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+/**
+ * Lists the branches `swt create <name>` could have left behind in a repository.
+ *
+ * @param repo - Repository to inspect.
+ * @param name - Worktree base name that was passed to `swt create`.
+ * @returns Matching branch names; empty when the branch was cleaned up.
+ */
+function swtBranches(repo: string, name: string): string[] {
+  const r = git(["branch", "--list", "--format=%(refname:short)", `swt/${name}-*`], repo);
+  assert.ok(r.ok, `git branch --list failed: ${r.out}`);
+  return r.out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Ceiling on every wait for a child `swt`, so a hang fails instead of parking the suite. */
+const CHILD_DEADLINE_MS = 60_000;
+
+/**
+ * Polls until a condition holds, failing the test rather than hanging forever.
+ *
+ * @param ready - Condition to poll; must be cheap and side-effect free.
+ * @param what - Phrase describing what is awaited, used in the failure message.
+ */
+async function waitUntil(ready: () => boolean, what: string): Promise<void> {
+  const deadline = Date.now() + CHILD_DEADLINE_MS;
+  while (!ready()) {
+    if (Date.now() > deadline) {
+      assert.fail(`timed out after ${CHILD_DEADLINE_MS}ms waiting for ${what}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
+ * Awaits a promise under the same deadline, so a wedged child cannot park the suite.
+ *
+ * @param promise - Promise to await.
+ * @param what - Phrase describing what is awaited, used in the failure message.
+ * @returns Whatever `promise` resolves to.
+ */
+async function withDeadline<T>(promise: Promise<T>, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`timed out after ${CHILD_DEADLINE_MS}ms waiting for ${what}`)),
+          CHILD_DEADLINE_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+// Finding #4: tearing an unverified worktree down takes two git commands, and
+// both used to have their results dropped on the floor. Teardown is genuinely
+// best-effort — a worktree whose `.git` link is gone cannot be removed, and a
+// branch cannot be deleted while a registered worktree still claims it — so the
+// outcome has to travel back to the caller instead of being assumed.
+describe("removeWorktree", () => {
+  test("removes the worktree and its branch, and reports success", () => {
+    const repo = makeCommittedGitRepo();
+    const branch = `swt/teardown-${fixtureCounter++}`;
+    const path = fixturePath(`teardown-${fixtureCounter++}.swt`);
+    const add = git(["worktree", "add", "--quiet", "-b", branch, path, "HEAD"], repo);
+    assert.ok(add.ok, `git worktree add failed: ${add.out}`);
+    assert.ok(existsSync(path), "fixture precondition: the worktree must exist first");
+
+    const torn = removeWorktree(repo, path, branch);
+
+    assert.equal(torn.ok, true, `teardown reported failure: ${torn.out}`);
+    assert.ok(!existsSync(path), `${path} survived a teardown that reported success`);
+    assert.ok(
+      !gitMust(["worktree", "list"], repo).includes(path),
+      `${path} is still a registered worktree`,
+    );
+    assert.equal(gitMust(["branch", "--list", "--format=%(refname:short)", branch], repo), "");
+  });
+
+  test("reports failure, and git's own output, when neither command can succeed", () => {
+    const repo = makeCommittedGitRepo();
+    const stranger = fixturePath(`not-a-worktree-${fixtureCounter++}`);
+    mkdirSync(stranger, { recursive: true });
+    const branch = "swt/never-existed";
+
+    const torn = removeWorktree(repo, stranger, branch);
+
+    assert.equal(
+      torn.ok,
+      false,
+      `teardown claimed success for ${stranger}: ${JSON.stringify(torn)}`,
+    );
+    // Both commands are attempted and both are reported. A caller shown only the
+    // first failure would still not know whether the branch is lying around.
+    assert.ok(torn.out.includes(stranger), `git's worktree complaint is missing:\n${torn.out}`);
+    assert.ok(torn.out.includes(branch), `git's branch complaint is missing:\n${torn.out}`);
+  });
+});
+
+// The user-facing half of finding #4, plus nit N1. Both are only observable from
+// outside the process: what `swt create` prints when its teardown fails, and what
+// it leaves behind when the user gives up on a long green check.
+describe("swt create cleanup", () => {
+  /**
+   * A `.swt-check` that deletes the worktree's own `.git` link and then fails.
+   * Teardown afterwards fails for two independent reasons: git refuses to remove
+   * a working tree whose `.git` has vanished, and refuses to delete a branch a
+   * registered worktree still claims. No permission games, so it behaves the
+   * same for an unprivileged user and for root.
+   */
+  const SABOTAGE_CHECK = '#!/bin/sh\nrm -f "$PWD/.git"\nexit 1\n';
+
+  test("never reports a cleanup that did not happen", () => {
+    const repo = makeCommittedGitRepo();
+    const name = `sabotaged${fixtureCounter++}`;
+    const wt = fixturePath(`${name}.swt`);
+    writeSwtCheck(repo, SABOTAGE_CHECK);
+
+    const r = spawnSync("npx", ["tsx", SWT_MODULE, "create", name], { cwd: repo, encoding: "utf8" });
+    const stderr = r.stderr ?? "";
+
+    assert.equal(r.status, 1, `expected a failed create: ${stderr}`);
+    // The claim is only a lie if the orphans really are orphans.
+    assert.ok(existsSync(wt), `fixture precondition: ${wt} should have survived teardown`);
+    const branches = swtBranches(repo, name);
+    assert.equal(
+      branches.length,
+      1,
+      `expected one leftover branch, got ${JSON.stringify(branches)}`,
+    );
+    const branch = branches[0] ?? "";
+
+    assert.ok(
+      !stderr.includes("Cleaned up"),
+      `claimed cleanup while ${wt} and ${branch} both survived:\n${stderr}`,
+    );
+    assert.match(stderr, /fatal:/, `git's own teardown output was swallowed:\n${stderr}`);
+    assert.ok(
+      stderr.includes(`git worktree remove --force '${wt}' && git branch -D ${branch}`),
+      `no copy-pasteable recovery command naming ${wt} and ${branch}:\n${stderr}`,
+    );
+  });
+
+  // Nit N1: the green check now runs *after* the worktree exists, so a user who
+  // Ctrl-Cs a long check is the one paying for the new ordering unless swt tears
+  // its own half-built state down on the way out.
+  test("interrupting the green check leaves no worktree and no branch behind", async () => {
+    const repo = makeCommittedGitRepo();
+    const name = `interrupted${fixtureCounter++}`;
+    const wt = fixturePath(`${name}.swt`);
+    const started = fixturePath(`check-started-${fixtureCounter++}`);
+    // The sentinel is the synchronization point — it proves the check is running,
+    // and therefore that the worktree exists. The sleep only guarantees the signal
+    // lands mid-check rather than after it.
+    writeSwtCheck(repo, `#!/bin/sh\n: > ${JSON.stringify(started)}\nsleep 30\n`);
+
+    // `detached` puts swt in its own process group, so the signal below reaches
+    // the check swt spawned too — which is what a terminal Ctrl-C does.
+    const child = spawn("npx", ["tsx", SWT_MODULE, "create", name], {
+      cwd: repo,
+      detached: true,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const exited = new Promise<void>((resolve) => child.on("exit", () => resolve()));
+    const pid = child.pid;
+    assert.ok(pid !== undefined, "child process never started");
+
+    try {
+      await waitUntil(() => existsSync(started), "the green check to start");
+      assert.ok(existsSync(wt), `precondition: create must have built ${wt} before checking it`);
+      process.kill(-pid, "SIGINT");
+      await withDeadline(exited, "swt to exit after SIGINT");
+    } finally {
+      // Never leave a 30-second sleep running, whatever went wrong above.
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        /* the process group is already gone */
+      }
+      await exited;
+    }
+
+    assert.ok(!existsSync(wt), `SIGINT left an orphaned worktree at ${wt}:\n${stderr}`);
+    assert.deepEqual(swtBranches(repo, name), [], `SIGINT left an orphaned branch:\n${stderr}`);
   });
 });

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -16,39 +16,14 @@
 //
 // The green check itself lives in ./green-check.ts — see that module for what
 // counts as green and how pnpm/cargo/Tauri repos are detected.
+//
+// Every git command runs through ./git.ts as an argv array, never a shell
+// string, so caller-supplied names cannot word-split or inject.
 
-import { spawnSync } from "node:child_process";
 import { closeSync, existsSync, openSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { git, gitMust } from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
-
-/**
- * Runs a shell command and captures its combined output.
- *
- * @param cmd - Shell command to run.
- * @param cwd - Directory to run it in; defaults to the current working directory.
- * @returns The command's success flag and combined stdout/stderr.
- */
-const sh = (cmd: string, cwd?: string): Result => {
-  const r = spawnSync("sh", ["-c", cmd], { cwd, encoding: "utf8" });
-  return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
-};
-
-/**
- * Runs a shell command, aborting the process with its output on failure.
- *
- * @param cmd - Shell command to run.
- * @param cwd - Directory to run it in; defaults to the current working directory.
- * @returns The command's trimmed combined output.
- */
-const must = (cmd: string, cwd?: string): string => {
-  const r = sh(cmd, cwd);
-  if (!r.ok) {
-    process.stderr.write(r.out);
-    process.exit(1);
-  }
-  return r.out.trim();
-};
 
 /**
  * Runs `fn` while holding the parent repo's merge lock, so concurrent
@@ -89,7 +64,8 @@ function withParentLock<T>(repoRoot: string, fn: () => T): T {
         process.stderr.write("Timed out waiting for parent repo lock.\n");
         process.exit(1);
       }
-      spawnSync("sh", ["-c", "sleep 1"]);
+      // Synchronous 1s backoff without spawning a shell to sleep.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
     }
   }
 }
@@ -102,18 +78,18 @@ function withParentLock<T>(repoRoot: string, fn: () => T): T {
  * @param name - Base name for the worktree directory and branch.
  */
 function create(name: string): void {
-  const root = must("git rev-parse --show-toplevel");
+  const root = gitMust(["rev-parse", "--show-toplevel"]);
   const branch = `swt/${name}-${Date.now().toString(36)}`;
   const path = resolve(root, "..", `${name}.swt`);
 
   // Create the worktree first, then run the green check INSIDE it. A fresh
   // worktree is a clean checkout of HEAD with no parent dirty state — so
   // uncommitted changes in the parent can't trick the check.
-  must(`git worktree add -b ${branch} ${path} HEAD`, root);
+  gitMust(["worktree", "add", "-b", branch, path, "HEAD"], root);
 
   const cleanup = (): void => {
-    sh(`git worktree remove --force ${path}`, root);
-    sh(`git branch -D ${branch}`, root);
+    git(["worktree", "remove", "--force", path], root);
+    git(["branch", "-D", branch], root);
   };
 
   let green: Result;
@@ -144,7 +120,7 @@ function create(name: string): void {
  */
 function merge(wtPath: string): void {
   const wt = resolve(wtPath);
-  const root = must("git rev-parse --show-toplevel");
+  const root = gitMust(["rev-parse", "--show-toplevel"]);
   if (resolve(root) === wt) {
     process.stderr.write("Refusing: that's the parent worktree.\n");
     process.exit(1);
@@ -159,7 +135,7 @@ function merge(wtPath: string): void {
   // that would vanish when the worktree is removed. `git status --porcelain`
   // catches both modified-tracked and untracked files.
   const checkClean = (cwd: string, label: string): void => {
-    const r = sh("git status --porcelain", cwd);
+    const r = git(["status", "--porcelain"], cwd);
     if (!r.ok) {
       process.stderr.write(r.out);
       process.exit(1);
@@ -190,14 +166,14 @@ function merge(wtPath: string): void {
     process.exit(1);
   }
 
-  const branch = must("git rev-parse --abbrev-ref HEAD", wt);
-  const parentBranch = must("git rev-parse --abbrev-ref HEAD", root);
+  const branch = gitMust(["rev-parse", "--abbrev-ref", "HEAD"], wt);
+  const parentBranch = gitMust(["rev-parse", "--abbrev-ref", "HEAD"], root);
 
   withParentLock(root, () => {
-    const ff = sh(`git merge --ff-only ${branch}`, root);
+    const ff = git(["merge", "--ff-only", branch], root);
     if (!ff.ok) {
       process.stderr.write("Parent advanced; rebasing subagent onto parent…\n");
-      const rebase = sh(`git rebase ${parentBranch}`, wt);
+      const rebase = git(["rebase", parentBranch], wt);
       if (!rebase.ok) {
         process.stderr.write(rebase.out);
         process.stderr.write(`\nResolve conflicts in ${wt}, then re-run: swt merge ${wt}\n`);
@@ -208,10 +184,10 @@ function merge(wtPath: string): void {
         process.stderr.write(`Not green after rebase: ${reGreen.out}`);
         process.exit(1);
       }
-      must(`git merge --ff-only ${branch}`, root);
+      gitMust(["merge", "--ff-only", branch], root);
     }
-    must(`git worktree remove ${wt}`, root);
-    must(`git branch -d ${branch}`, root);
+    gitMust(["worktree", "remove", wt], root);
+    gitMust(["branch", "-d", branch], root);
     process.stdout.write(`merged ${branch}, removed ${wt}\n`);
   });
 }

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -14,25 +14,33 @@
 //   3. If parent advanced during the subagent's work, rebase + re-verify green before ff-merging.
 //   4. Concurrent `swt merge` runs against the same parent are serialized via .git/swt.lock.
 //
-// Green check (always runs inside the worktree being checked, never the parent):
-//   - ./.swt-check at repo root (escape hatch — used alone if present)
-//   Otherwise, runs whichever apply, additively (Tauri repos have both):
-//   - package.json present: `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then
-//     typecheck/lint/test (whichever scripts exist)
-//   - Cargo.toml at repo root and/or src-tauri/Cargo.toml: cargo check + test + clippy per manifest
-//   If nothing applies: error (drop a .swt-check).
+// The green check itself lives in ./green-check.ts — see that module for what
+// counts as green and how pnpm/cargo/Tauri repos are detected.
 
 import { spawnSync } from "node:child_process";
-import { closeSync, existsSync, openSync, readFileSync, rmSync } from "node:fs";
+import { closeSync, existsSync, openSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { isGreen, type Result } from "./green-check.ts";
 
-type Result = { ok: boolean; out: string };
-
+/**
+ * Runs a shell command and captures its combined output.
+ *
+ * @param cmd - Shell command to run.
+ * @param cwd - Directory to run it in; defaults to the current working directory.
+ * @returns The command's success flag and combined stdout/stderr.
+ */
 const sh = (cmd: string, cwd?: string): Result => {
   const r = spawnSync("sh", ["-c", cmd], { cwd, encoding: "utf8" });
   return { ok: r.status === 0, out: (r.stdout ?? "") + (r.stderr ?? "") };
 };
 
+/**
+ * Runs a shell command, aborting the process with its output on failure.
+ *
+ * @param cmd - Shell command to run.
+ * @param cwd - Directory to run it in; defaults to the current working directory.
+ * @returns The command's trimmed combined output.
+ */
 const must = (cmd: string, cwd?: string): string => {
   const r = sh(cmd, cwd);
   if (!r.ok) {
@@ -42,70 +50,15 @@ const must = (cmd: string, cwd?: string): string => {
   return r.out.trim();
 };
 
-// Stream stdout/stderr live so the user sees progress on long checks.
-const streamCheck = (cmd: string, cwd: string): boolean => {
-  process.stderr.write(`\n  $ ${cmd}\n`);
-  const r = spawnSync("sh", ["-c", cmd], { cwd, stdio: "inherit" });
-  return r.status === 0;
-};
-
-function pkgScripts(cwd: string): Set<string> {
-  const p = join(cwd, "package.json");
-  if (!existsSync(p)) return new Set();
-  try {
-    const json = JSON.parse(readFileSync(p, "utf8"));
-    return new Set(Object.keys(json.scripts ?? {}));
-  } catch {
-    return new Set();
-  }
-}
-
-function buildCheckPlan(cwd: string): string[] | null {
-  if (existsSync(join(cwd, ".swt-check"))) return ["./.swt-check"];
-
-  const cmds: string[] = [];
-
-  if (existsSync(join(cwd, "package.json"))) {
-    // Fresh worktrees have no node_modules; install before checking.
-    if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
-      cmds.push("pnpm install --frozen-lockfile");
-    }
-    const scripts = pkgScripts(cwd);
-    if (scripts.has("typecheck")) cmds.push("pnpm typecheck");
-    else if (scripts.has("tsc")) cmds.push("pnpm exec tsc --noEmit");
-    if (scripts.has("lint")) cmds.push("pnpm lint");
-    if (scripts.has("test")) cmds.push("pnpm test --run");
-  }
-
-  // Rust checks run alongside package.json checks — Tauri repos have both.
-  // "" = root Cargo.toml (no --manifest-path needed); otherwise point at the manifest.
-  const cargoManifests: string[] = [];
-  if (existsSync(join(cwd, "Cargo.toml"))) cargoManifests.push("");
-  if (existsSync(join(cwd, "src-tauri", "Cargo.toml"))) cargoManifests.push("src-tauri/Cargo.toml");
-  for (const manifest of cargoManifests) {
-    const flag = manifest ? ` --manifest-path ${manifest}` : "";
-    cmds.push(`cargo check${flag}`, `cargo test${flag}`, `cargo clippy${flag} -- -D warnings`);
-  }
-
-  return cmds.length > 0 ? cmds : null;
-}
-
-function isGreen(cwd: string): Result {
-  const plan = buildCheckPlan(cwd);
-  if (!plan) {
-    return {
-      ok: false,
-      out: `No green-check defined. Drop a './.swt-check' executable at the repo root.\n`,
-    };
-  }
-  process.stderr.write(`Running green check in ${cwd}…`);
-  for (const cmd of plan) {
-    if (!streamCheck(cmd, cwd)) return { ok: false, out: `failed: ${cmd}\n` };
-  }
-  return { ok: true, out: "" };
-}
-
-// O_EXCL-based lock with bounded retry. Stale locks > 1h are reaped.
+/**
+ * Runs `fn` while holding the parent repo's merge lock, so concurrent
+ * `swt merge` runs are serialized. O_EXCL-based lock with bounded retry;
+ * stale locks older than 1h are reaped.
+ *
+ * @param repoRoot - Parent repository root containing the .git directory.
+ * @param fn - Work to perform under the lock.
+ * @returns Whatever `fn` returns.
+ */
 function withParentLock<T>(repoRoot: string, fn: () => T): T {
   const lockPath = join(repoRoot, ".git", "swt.lock");
   const STALE_MS = 60 * 60 * 1000;
@@ -141,6 +94,13 @@ function withParentLock<T>(repoRoot: string, fn: () => T): T {
   }
 }
 
+/**
+ * Creates a subagent worktree on a fresh branch, verifying HEAD is green inside
+ * it first. Prints the worktree path on stdout. Tears the worktree and branch
+ * down and exits non-zero if the check fails.
+ *
+ * @param name - Base name for the worktree directory and branch.
+ */
 function create(name: string): void {
   const root = must("git rev-parse --show-toplevel");
   const branch = `swt/${name}-${Date.now().toString(36)}`;
@@ -175,6 +135,13 @@ function create(name: string): void {
   process.stdout.write(path + "\n");
 }
 
+/**
+ * Merges a subagent worktree back into the parent: both worktrees must be clean
+ * and green, the subagent is rebased if the parent advanced, then fast-forwarded
+ * in and torn down. Exits non-zero on any violated invariant.
+ *
+ * @param wtPath - Path to the subagent worktree to merge.
+ */
 function merge(wtPath: string): void {
   const wt = resolve(wtPath);
   const root = must("git rev-parse --show-toplevel");

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -5,16 +5,20 @@
 //   swt merge <worktree-path>  → verify subagent green, ff-merge (rebase if parent advanced), cleanup
 //
 // Invariants enforced:
-//   1. Worktrees are only created from a green commit (parent HEAD green at create time).
-//   2. Merges are only accepted from a green subagent commit AND a green parent HEAD —
-//      so a `swt merge` mid-TDD-cycle in the parent is refused, not silently fast-forwarded past.
+//   1. The green check runs INSIDE the new worktree (a clean checkout of HEAD), not the
+//      parent — so uncommitted changes in the parent can't trick the check. The worktree
+//      and branch are torn down on failure.
+//   2. At merge time, BOTH worktrees must be clean (no uncommitted/untracked changes)
+//      AND both must pass the green check — so no in-progress red is silently advanced
+//      past, and no uncommitted subagent work is lost when the worktree is removed.
 //   3. If parent advanced during the subagent's work, rebase + re-verify green before ff-merging.
 //   4. Concurrent `swt merge` runs against the same parent are serialized via .git/swt.lock.
 //
-// Green check:
+// Green check (always runs inside the worktree being checked, never the parent):
 //   - ./.swt-check at repo root (escape hatch — used alone if present)
 //   Otherwise, runs whichever apply, additively (Tauri repos have both):
-//   - package.json scripts: typecheck/lint/test (only the ones that exist)
+//   - package.json present: `pnpm install --frozen-lockfile` (if pnpm-lock.yaml), then
+//     typecheck/lint/test (whichever scripts exist)
 //   - Cargo.toml at repo root and/or src-tauri/Cargo.toml: cargo check + test + clippy per manifest
 //   If nothing applies: error (drop a .swt-check).
 
@@ -61,11 +65,17 @@ function buildCheckPlan(cwd: string): string[] | null {
 
   const cmds: string[] = [];
 
-  const scripts = pkgScripts(cwd);
-  if (scripts.has("typecheck")) cmds.push("pnpm typecheck");
-  else if (scripts.has("tsc")) cmds.push("pnpm exec tsc --noEmit");
-  if (scripts.has("lint")) cmds.push("pnpm lint");
-  if (scripts.has("test")) cmds.push("pnpm test --run");
+  if (existsSync(join(cwd, "package.json"))) {
+    // Fresh worktrees have no node_modules; install before checking.
+    if (existsSync(join(cwd, "pnpm-lock.yaml"))) {
+      cmds.push("pnpm install --frozen-lockfile");
+    }
+    const scripts = pkgScripts(cwd);
+    if (scripts.has("typecheck")) cmds.push("pnpm typecheck");
+    else if (scripts.has("tsc")) cmds.push("pnpm exec tsc --noEmit");
+    if (scripts.has("lint")) cmds.push("pnpm lint");
+    if (scripts.has("test")) cmds.push("pnpm test --run");
+  }
 
   // Rust checks run alongside package.json checks — Tauri repos have both.
   // "" = root Cargo.toml (no --manifest-path needed); otherwise point at the manifest.
@@ -133,14 +143,34 @@ function withParentLock<T>(repoRoot: string, fn: () => T): T {
 
 function create(name: string): void {
   const root = must("git rev-parse --show-toplevel");
-  const green = isGreen(root);
-  if (!green.ok) {
-    process.stderr.write(`HEAD not green: ${green.out}`);
-    process.exit(1);
-  }
   const branch = `swt/${name}-${Date.now().toString(36)}`;
   const path = resolve(root, "..", `${name}.swt`);
+
+  // Create the worktree first, then run the green check INSIDE it. A fresh
+  // worktree is a clean checkout of HEAD with no parent dirty state — so
+  // uncommitted changes in the parent can't trick the check.
   must(`git worktree add -b ${branch} ${path} HEAD`, root);
+
+  const cleanup = (): void => {
+    sh(`git worktree remove --force ${path}`, root);
+    sh(`git branch -D ${branch}`, root);
+  };
+
+  let green: Result;
+  try {
+    green = isGreen(path);
+  } catch (e) {
+    cleanup();
+    throw e;
+  }
+
+  if (!green.ok) {
+    cleanup();
+    process.stderr.write(`HEAD not green: ${green.out}`);
+    process.stderr.write(`Cleaned up worktree ${path} and branch ${branch}.\n`);
+    process.exit(1);
+  }
+
   // Print only the path on stdout — callers can capture cleanly.
   process.stdout.write(path + "\n");
 }
@@ -156,6 +186,25 @@ function merge(wtPath: string): void {
     process.stderr.write(`No such worktree: ${wt}\n`);
     process.exit(1);
   }
+
+  // Refuse if either worktree is dirty. Parent dirt = in-progress work that
+  // shouldn't be silently fast-forwarded over. Subagent dirt = uncommitted work
+  // that would vanish when the worktree is removed. `git status --porcelain`
+  // catches both modified-tracked and untracked files.
+  const checkClean = (cwd: string, label: string): void => {
+    const r = sh("git status --porcelain", cwd);
+    if (!r.ok) {
+      process.stderr.write(r.out);
+      process.exit(1);
+    }
+    if (r.out.trim().length > 0) {
+      process.stderr.write(`${label} has uncommitted/untracked changes:\n${r.out}`);
+      process.stderr.write("Commit or stash before merging.\n");
+      process.exit(1);
+    }
+  };
+  checkClean(root, "Parent worktree");
+  checkClean(wt, "Subagent worktree");
 
   // Parent HEAD must be green: refusing to silently advance past an in-progress
   // red commit in the parent worktree (mirrors the create-time invariant).

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -4,23 +4,31 @@
 //   swt create <name>          → verify HEAD green, create worktree on a new branch, print path
 //   swt merge <worktree-path>  → verify subagent green, ff-merge (rebase if parent advanced), cleanup
 //
-// Invariants enforced:
-//   1. The green check runs INSIDE the new worktree (a clean checkout of HEAD), not the
-//      parent — so uncommitted changes in the parent can't trick the check. The worktree
-//      and branch are torn down on failure.
-//   2. At merge time, BOTH worktrees must be clean AND both must pass the green check —
-//      so no in-progress red is silently advanced past, and no uncommitted subagent work
-//      is lost when the worktree is removed. "Clean" is scoped per side: tracked changes
-//      only in the parent (a ff-merge cannot discard untracked files, and the `.swt-check`
-//      escape hatch is untracked by design), untracked included in the subagent (whose
-//      whole directory is deleted).
-//   3. If parent advanced during the subagent's work, rebase + re-verify green before ff-merging.
-//   4. Concurrent `swt merge` runs against the same parent are serialized via a
-//      swt.lock in the repo's *shared* git dir, so runs launched from two
-//      different worktrees of one repo still block each other.
+// Invariants enforced — each states the guarantee first, then the mechanism:
+//   1. Worktrees are only ever created from a green commit. The check runs INSIDE the
+//      new worktree — a clean checkout of HEAD, so uncommitted changes in the parent
+//      cannot trick it — and both the worktree and its branch are torn down again if the
+//      check fails or the run is interrupted. A failed check reports what that teardown
+//      actually did, plus the command to finish it by hand, rather than assuming it worked.
+//   2. A name from the command line can only ever name the thing it spells. It becomes
+//      both a branch and a filesystem path, so it is validated against a restricted
+//      character set (see WORKTREE_NAME_RULE) before anything at all is created.
+//   3. A merge neither loses work nor advances the parent past an in-progress red. BOTH
+//      worktrees must be clean AND both must pass the green check before anything moves.
+//      "Clean" is scoped per side: tracked changes only in the parent (a ff-merge cannot
+//      discard untracked files, and the `.swt-check` escape hatch is untracked by design),
+//      untracked included in the subagent (whose whole directory is deleted).
+//   4. What lands in the parent is green as merged, not merely green in isolation. If the
+//      parent advanced during the subagent's work, the subagent is rebased onto it and
+//      re-verified green before the fast-forward.
+//   5. Merges into one repository never interleave. They serialize on a swt.lock in the
+//      repo's *shared* git dir, so runs launched from two different worktrees of one repo
+//      still block each other, and that lock is released when the merge returns, when it
+//      throws, and when the process exits from inside the locked region.
 //
 // The green check itself lives in ./green-check.ts — see that module for what
-// counts as green and how pnpm/cargo/Tauri repos are detected.
+// counts as green, how pnpm/cargo/Tauri repos are detected, and where the
+// `.swt-check` override is looked up versus where it runs.
 //
 // Every git command runs through ./git.ts as an argv array, never a shell
 // string, so caller-supplied names cannot word-split or inject.

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -8,9 +8,12 @@
 //   1. The green check runs INSIDE the new worktree (a clean checkout of HEAD), not the
 //      parent — so uncommitted changes in the parent can't trick the check. The worktree
 //      and branch are torn down on failure.
-//   2. At merge time, BOTH worktrees must be clean (no uncommitted/untracked changes)
-//      AND both must pass the green check — so no in-progress red is silently advanced
-//      past, and no uncommitted subagent work is lost when the worktree is removed.
+//   2. At merge time, BOTH worktrees must be clean AND both must pass the green check —
+//      so no in-progress red is silently advanced past, and no uncommitted subagent work
+//      is lost when the worktree is removed. "Clean" is scoped per side: tracked changes
+//      only in the parent (a ff-merge cannot discard untracked files, and the `.swt-check`
+//      escape hatch is untracked by design), untracked included in the subagent (whose
+//      whole directory is deleted).
 //   3. If parent advanced during the subagent's work, rebase + re-verify green before ff-merging.
 //   4. Concurrent `swt merge` runs against the same parent are serialized via .git/swt.lock.
 //
@@ -105,7 +108,9 @@ function create(rawName: string): void {
 
   let green: Result;
   try {
-    green = isGreen(path);
+    // Checked in the new worktree, but configured from the parent: the
+    // `.swt-check` override is uncommitted, so it only exists in `root`.
+    green = isGreen(path, root);
   } catch (e) {
     cleanup();
     throw e;
@@ -141,10 +146,20 @@ function merge(wtPath: string): void {
     process.exit(1);
   }
 
-  // Refuse if either worktree is dirty. Parent dirt = in-progress work that
-  // shouldn't be silently fast-forwarded over. Subagent dirt = uncommitted work
-  // that would vanish when the worktree is removed. `git status --porcelain`
-  // catches both modified-tracked and untracked files.
+  // Refuse if either worktree is dirty — but the two guards need different scopes.
+  //
+  // Parent: tracked changes only. What matters there is in-progress work a
+  // fast-forward would silently advance past, and a ff-merge can only ever touch
+  // tracked files — git itself refuses to overwrite modified tracked ones, and it
+  // never discards untracked ones. Including untracked files here would instead
+  // hard-block every merge for anyone using the documented `./.swt-check` escape
+  // hatch, which is by definition an uncommitted file at the parent repo root.
+  //
+  // Subagent: untracked included. Uncommitted *or* untracked work there is
+  // genuinely destroyed, because `git worktree remove` deletes the whole
+  // directory. This is the early, clearer guard; the `git worktree remove` below
+  // is invoked without `--force`, so git's own dirty-worktree refusal is the
+  // backstop — but it fires after the merge and reports far less usefully.
   const checkClean = (cwd: string, label: string, includeUntracked: boolean): void => {
     let dirt: string;
     try {
@@ -154,12 +169,13 @@ function merge(wtPath: string): void {
       process.exit(1);
     }
     if (dirt.length > 0) {
-      process.stderr.write(`${label} has uncommitted/untracked changes:\n${dirt}\n`);
+      const kind = includeUntracked ? "uncommitted/untracked" : "uncommitted";
+      process.stderr.write(`${label} has ${kind} changes:\n${dirt}\n`);
       process.stderr.write("Commit or stash before merging.\n");
       process.exit(1);
     }
   };
-  checkClean(root, "Parent worktree", true);
+  checkClean(root, "Parent worktree", false);
   checkClean(wt, "Subagent worktree", true);
 
   // Parent HEAD must be green: refusing to silently advance past an in-progress
@@ -173,7 +189,7 @@ function merge(wtPath: string): void {
     process.exit(1);
   }
 
-  const green = isGreen(wt);
+  const green = isGreen(wt, root);
   if (!green.ok) {
     process.stderr.write(`Subagent worktree not green: ${green.out}`);
     process.exit(1);
@@ -192,7 +208,7 @@ function merge(wtPath: string): void {
         process.stderr.write(`\nResolve conflicts in ${wt}, then re-run: swt merge ${wt}\n`);
         process.exit(1);
       }
-      const reGreen = isGreen(wt);
+      const reGreen = isGreen(wt, root);
       if (!reGreen.ok) {
         process.stderr.write(`Not green after rebase: ${reGreen.out}`);
         process.exit(1);

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -15,7 +15,9 @@
 //      escape hatch is untracked by design), untracked included in the subagent (whose
 //      whole directory is deleted).
 //   3. If parent advanced during the subagent's work, rebase + re-verify green before ff-merging.
-//   4. Concurrent `swt merge` runs against the same parent are serialized via .git/swt.lock.
+//   4. Concurrent `swt merge` runs against the same parent are serialized via a
+//      swt.lock in the repo's *shared* git dir, so runs launched from two
+//      different worktrees of one repo still block each other.
 //
 // The green check itself lives in ./green-check.ts — see that module for what
 // counts as green and how pnpm/cargo/Tauri repos are detected.
@@ -23,40 +25,143 @@
 // Every git command runs through ./git.ts as an argv array, never a shell
 // string, so caller-supplied names cannot word-split or inject.
 
-import { closeSync, existsSync, openSync, realpathSync, rmSync } from "node:fs";
+import { closeSync, existsSync, openSync, realpathSync, rmSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { git, gitMust, validateWorktreeName, worktreeDirt, WORKTREE_NAME_RULE } from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
+
+/** Basename of the lock file, inside the repository's shared git directory. */
+const LOCK_FILE = "swt.lock";
+
+/** Locks this process created and is still responsible for removing. */
+const heldLocks = new Set<string>();
+
+/** Signals turned into an ordinary exit so held locks are still released. */
+const LOCK_RELEASE_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+
+/** Conventional shell exit status for a death by signal: 128 + signal number. */
+const SIGNAL_EXIT_STATUS: Record<(typeof LOCK_RELEASE_SIGNALS)[number], number> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+/**
+ * Removes every lock this process is holding. Registered as the `exit` hook, so
+ * it also covers `process.exit` calls that unwind no `finally` at all — never
+ * touching a lock file this process did not create.
+ */
+function releaseHeldLocks(): void {
+  for (const path of heldLocks) {
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* best effort: nothing useful to do while the process is going down */
+    }
+  }
+  heldLocks.clear();
+}
+
+/**
+ * Releases held locks and exits on a terminating signal. Without a listener the
+ * signal's default disposition kills the process outright and no `exit` hook
+ * ever runs, which is precisely how a lock would survive its owner.
+ *
+ * @param signal - Signal that arrived.
+ */
+function releaseLocksAndExit(signal: (typeof LOCK_RELEASE_SIGNALS)[number]): void {
+  releaseHeldLocks();
+  process.exit(SIGNAL_EXIT_STATUS[signal]);
+}
+
+let exitHookInstalled = false;
+
+/**
+ * Records a freshly created lock as this process's responsibility and arms the
+ * teardown hooks. The signal listeners exist only while a lock is actually held,
+ * so swt never changes the process's signal behaviour outside that window.
+ *
+ * @param path - Lock file this process just created with O_EXCL.
+ */
+function holdLock(path: string): void {
+  if (heldLocks.size === 0) {
+    if (!exitHookInstalled) {
+      process.on("exit", releaseHeldLocks);
+      exitHookInstalled = true;
+    }
+    for (const signal of LOCK_RELEASE_SIGNALS) process.on(signal, releaseLocksAndExit);
+  }
+  heldLocks.add(path);
+}
+
+/**
+ * Removes a lock this process holds and disarms the signal listeners once the
+ * last one is gone.
+ *
+ * @param path - Lock file previously passed to {@link holdLock}.
+ */
+function releaseLock(path: string): void {
+  heldLocks.delete(path);
+  rmSync(path, { force: true });
+  if (heldLocks.size === 0) {
+    for (const signal of LOCK_RELEASE_SIGNALS) {
+      process.removeListener(signal, releaseLocksAndExit);
+    }
+  }
+}
+
+/**
+ * Resolves the lock file that serializes merges for a repository.
+ *
+ * `.git` is a directory only in the main worktree; in a linked worktree it is a
+ * regular *file* holding `gitdir: …`, so joining `.git/swt.lock` onto a worktree
+ * root is an ENOTDIR — and the workflow swt serves never merges from the main
+ * repo. `--git-common-dir` names the git directory shared by every worktree of
+ * the repository, which is also exactly the serialization scope wanted: two
+ * `swt merge` runs launched from two different worktrees of one repo must
+ * contend for the same lock.
+ *
+ * @param repoRoot - Any worktree root of the repository.
+ * @returns Absolute path of that repository's merge lock file.
+ */
+function parentLockPath(repoRoot: string): string {
+  // Run in the main worktree, git answers with a path relative to its cwd ('.git').
+  const commonDir = gitMust(["rev-parse", "--git-common-dir"], repoRoot);
+  return join(resolve(repoRoot, commonDir), LOCK_FILE);
+}
 
 /**
  * Runs `fn` while holding the parent repo's merge lock, so concurrent
  * `swt merge` runs are serialized. O_EXCL-based lock with bounded retry;
  * stale locks older than 1h are reaped.
  *
- * @param repoRoot - Parent repository root containing the .git directory.
+ * The lock is released when `fn` returns, when it throws, and when it — or
+ * anything it calls — exits the process outright.
+ *
+ * @param repoRoot - Root of any worktree of the parent repository.
  * @param fn - Work to perform under the lock.
  * @returns Whatever `fn` returns.
  */
 export function withParentLock<T>(repoRoot: string, fn: () => T): T {
-  const lockPath = join(repoRoot, ".git", "swt.lock");
+  const lockPath = parentLockPath(repoRoot);
   const STALE_MS = 60 * 60 * 1000;
   const start = Date.now();
   while (true) {
     try {
       const fd = openSync(lockPath, "wx");
+      holdLock(lockPath);
       try {
         return fn();
       } finally {
         closeSync(fd);
-        rmSync(lockPath, { force: true });
+        releaseLock(lockPath);
       }
     } catch (e) {
       const err = e as NodeJS.ErrnoException;
       if (err.code !== "EEXIST") throw err;
       // Reap stale locks.
       try {
-        const stat = require("node:fs").statSync(lockPath);
+        const stat = statSync(lockPath);
         if (Date.now() - stat.mtimeMs > STALE_MS) {
           rmSync(lockPath, { force: true });
           continue;
@@ -199,27 +304,40 @@ function merge(wtPath: string): void {
   const branch = gitMust(["rev-parse", "--abbrev-ref", "HEAD"], wt);
   const parentBranch = gitMust(["rev-parse", "--abbrev-ref", "HEAD"], root);
 
-  withParentLock(root, () => {
+  // Nothing inside the locked region may exit the process: `process.exit` skips
+  // the `finally` that releases the lock, and a rebase conflict — the very case
+  // this path exists to handle — would then block every later merge until the
+  // stale reap. So the region *returns* its outcome and the exit happens out
+  // here, after the lock is released. `gitMust` is banned in there for the same
+  // reason: it exits on failure.
+  const outcome = withParentLock(root, (): Result => {
     const ff = git(["merge", "--ff-only", branch], root);
     if (!ff.ok) {
       process.stderr.write("Parent advanced; rebasing subagent onto parent…\n");
       const rebase = git(["rebase", parentBranch], wt);
       if (!rebase.ok) {
-        process.stderr.write(rebase.out);
-        process.stderr.write(`\nResolve conflicts in ${wt}, then re-run: swt merge ${wt}\n`);
-        process.exit(1);
+        return {
+          ok: false,
+          out: `${rebase.out}\nResolve conflicts in ${wt}, then re-run: swt merge ${wt}\n`,
+        };
       }
       const reGreen = isGreen(wt, root);
-      if (!reGreen.ok) {
-        process.stderr.write(`Not green after rebase: ${reGreen.out}`);
-        process.exit(1);
-      }
-      gitMust(["merge", "--ff-only", branch], root);
+      if (!reGreen.ok) return { ok: false, out: `Not green after rebase: ${reGreen.out}` };
+      const ffAfterRebase = git(["merge", "--ff-only", branch], root);
+      if (!ffAfterRebase.ok) return { ok: false, out: ffAfterRebase.out };
     }
-    gitMust(["worktree", "remove", wt], root);
-    gitMust(["branch", "-d", branch], root);
-    process.stdout.write(`merged ${branch}, removed ${wt}\n`);
+    const removed = git(["worktree", "remove", wt], root);
+    if (!removed.ok) return { ok: false, out: removed.out };
+    const deleted = git(["branch", "-d", branch], root);
+    if (!deleted.ok) return { ok: false, out: deleted.out };
+    return { ok: true, out: `merged ${branch}, removed ${wt}\n` };
   });
+
+  if (!outcome.ok) {
+    process.stderr.write(outcome.out);
+    process.exit(1);
+  }
+  process.stdout.write(outcome.out);
 }
 
 /**

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -28,7 +28,14 @@
 import { closeSync, existsSync, openSync, realpathSync, rmSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { git, gitMust, validateWorktreeName, worktreeDirt, WORKTREE_NAME_RULE } from "./git.ts";
+import {
+  git,
+  gitMust,
+  removeWorktree,
+  validateWorktreeName,
+  worktreeDirt,
+  WORKTREE_NAME_RULE,
+} from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
 
 /** Basename of the lock file, inside the repository's shared git directory. */
@@ -208,8 +215,7 @@ function create(rawName: string): void {
   gitMust(["worktree", "add", "-b", branch, path, "HEAD"], root);
 
   const cleanup = (): void => {
-    git(["worktree", "remove", "--force", path], root);
-    git(["branch", "-D", branch], root);
+    removeWorktree(root, path, branch);
   };
 
   let green: Result;

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -36,22 +36,58 @@ import {
   worktreeDirt,
   WORKTREE_NAME_RULE,
 } from "./git.ts";
-import { isGreen, type Result } from "./green-check.ts";
+import { isGreen, shellQuote, type Result } from "./green-check.ts";
 
 /** Basename of the lock file, inside the repository's shared git directory. */
 const LOCK_FILE = "swt.lock";
 
-/** Locks this process created and is still responsible for removing. */
-const heldLocks = new Set<string>();
-
-/** Signals turned into an ordinary exit so held locks are still released. */
-const LOCK_RELEASE_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+/** Signals swt turns into an ordinary exit so its `exit` hooks still run. */
+const TERMINATION_SIGNALS = ["SIGINT", "SIGTERM"] as const;
 
 /** Conventional shell exit status for a death by signal: 128 + signal number. */
-const SIGNAL_EXIT_STATUS: Record<(typeof LOCK_RELEASE_SIGNALS)[number], number> = {
+const SIGNAL_EXIT_STATUS: Record<(typeof TERMINATION_SIGNALS)[number], number> = {
   SIGINT: 130,
   SIGTERM: 143,
 };
+
+/**
+ * Turns a terminating signal into a normal exit. Without a listener the signal's
+ * default disposition kills the process outright — no `exit` hook runs — which
+ * is precisely how a lock, or a worktree that never passed its check, outlives
+ * its owner. This listener deliberately does no cleanup of its own: every
+ * teardown decision lives in an `exit` hook, so two responsibilities armed at
+ * the same time cannot fight over ordering.
+ *
+ * @param signal - Signal that arrived.
+ */
+function exitOnSignal(signal: (typeof TERMINATION_SIGNALS)[number]): void {
+  process.exit(SIGNAL_EXIT_STATUS[signal]);
+}
+
+/** How many teardown responsibilities currently need signals to reach `exit`. */
+let signalGuards = 0;
+
+/**
+ * Arms signal-to-exit conversion on behalf of one teardown responsibility, so
+ * swt only alters the process's signal behaviour while it actually owns
+ * something that would otherwise be orphaned.
+ */
+function armSignalExit(): void {
+  if (signalGuards++ === 0) {
+    for (const signal of TERMINATION_SIGNALS) process.on(signal, exitOnSignal);
+  }
+}
+
+/** Drops one responsibility's claim, restoring default signal handling at zero. */
+function disarmSignalExit(): void {
+  if (signalGuards === 0) return;
+  if (--signalGuards === 0) {
+    for (const signal of TERMINATION_SIGNALS) process.removeListener(signal, exitOnSignal);
+  }
+}
+
+/** Locks this process created and is still responsible for removing. */
+const heldLocks = new Set<string>();
 
 /**
  * Removes every lock this process is holding. Registered as the `exit` hook, so
@@ -69,51 +105,92 @@ function releaseHeldLocks(): void {
   heldLocks.clear();
 }
 
-/**
- * Releases held locks and exits on a terminating signal. Without a listener the
- * signal's default disposition kills the process outright and no `exit` hook
- * ever runs, which is precisely how a lock would survive its owner.
- *
- * @param signal - Signal that arrived.
- */
-function releaseLocksAndExit(signal: (typeof LOCK_RELEASE_SIGNALS)[number]): void {
-  releaseHeldLocks();
-  process.exit(SIGNAL_EXIT_STATUS[signal]);
-}
-
-let exitHookInstalled = false;
+let lockExitHookInstalled = false;
 
 /**
  * Records a freshly created lock as this process's responsibility and arms the
- * teardown hooks. The signal listeners exist only while a lock is actually held,
- * so swt never changes the process's signal behaviour outside that window.
+ * teardown hooks.
  *
  * @param path - Lock file this process just created with O_EXCL.
  */
 function holdLock(path: string): void {
   if (heldLocks.size === 0) {
-    if (!exitHookInstalled) {
+    if (!lockExitHookInstalled) {
       process.on("exit", releaseHeldLocks);
-      exitHookInstalled = true;
+      lockExitHookInstalled = true;
     }
-    for (const signal of LOCK_RELEASE_SIGNALS) process.on(signal, releaseLocksAndExit);
+    armSignalExit();
   }
   heldLocks.add(path);
 }
 
 /**
- * Removes a lock this process holds and disarms the signal listeners once the
- * last one is gone.
+ * Removes a lock this process holds and disarms its signal claim once the last
+ * one is gone.
  *
  * @param path - Lock file previously passed to {@link holdLock}.
  */
 function releaseLock(path: string): void {
   heldLocks.delete(path);
   rmSync(path, { force: true });
-  if (heldLocks.size === 0) {
-    for (const signal of LOCK_RELEASE_SIGNALS) {
-      process.removeListener(signal, releaseLocksAndExit);
-    }
+  if (heldLocks.size === 0) disarmSignalExit();
+}
+
+/** A worktree that exists but has not passed its green check yet. */
+type UnverifiedWorktree = { root: string; path: string; branch: string };
+
+/** The unverified worktree this process is on the hook for, if any. */
+let unverifiedWorktree: UnverifiedWorktree | null = null;
+
+let worktreeExitHookInstalled = false;
+
+/**
+ * Takes responsibility for a worktree that exists but is not verified yet, so a
+ * Ctrl-C during a long green check does not leave the user with a half-built
+ * worktree and branch they never asked to keep. Mirrors {@link holdLock}: the
+ * hooks are armed only for the window where something would actually be
+ * orphaned, and dropped by {@link keepUnverifiedWorktree} or
+ * {@link removeUnverifiedWorktree}.
+ *
+ * @param worktree - Worktree just created by `git worktree add`.
+ */
+function holdUnverifiedWorktree(worktree: UnverifiedWorktree): void {
+  if (!worktreeExitHookInstalled) {
+    process.on("exit", () => {
+      removeUnverifiedWorktree();
+    });
+    worktreeExitHookInstalled = true;
+  }
+  unverifiedWorktree = worktree;
+  armSignalExit();
+}
+
+/** Releases the hold without removing anything: the check passed, so it stays. */
+function keepUnverifiedWorktree(): void {
+  if (unverifiedWorktree === null) return;
+  unverifiedWorktree = null;
+  disarmSignalExit();
+}
+
+/**
+ * Tears down the held worktree, if one is still held. Idempotent, because it is
+ * both the `exit` hook and what `create` calls explicitly when the check fails.
+ *
+ * @returns The teardown outcome, or null when there was nothing left to remove.
+ */
+function removeUnverifiedWorktree(): Result | null {
+  const worktree = unverifiedWorktree;
+  if (worktree === null) return null;
+  // Clearing the hold first makes a second call a no-op; disarming waits until
+  // the git commands are done. An interrupted run is often *still* being
+  // signalled while it cleans up — the `npx tsx` launcher relays SIGINT again
+  // 30ms later — and dropping the listener mid-teardown would restore the
+  // default disposition and kill swt between the two commands.
+  unverifiedWorktree = null;
+  try {
+    return removeWorktree(worktree.root, worktree.path, worktree.branch);
+  } finally {
+    disarmSignalExit();
   }
 }
 
@@ -189,7 +266,8 @@ export function withParentLock<T>(repoRoot: string, fn: () => T): T {
 /**
  * Creates a subagent worktree on a fresh branch, verifying HEAD is green inside
  * it first. Prints the worktree path on stdout. Tears the worktree and branch
- * down and exits non-zero if the check fails.
+ * down and exits non-zero if the check fails — or if the run is interrupted
+ * before it passes — reporting honestly when that teardown does not work.
  *
  * @param rawName - Base name for the worktree directory and branch; rejected up
  *   front unless it satisfies {@link WORKTREE_NAME_RULE}.
@@ -213,9 +291,26 @@ function create(rawName: string): void {
   // worktree is a clean checkout of HEAD with no parent dirty state — so
   // uncommitted changes in the parent can't trick the check.
   gitMust(["worktree", "add", "-b", branch, path, "HEAD"], root);
+  // Nothing has verified this worktree yet, and the check about to run can take
+  // minutes. Until it passes, swt owns removing it — including when the user
+  // gives up and hits Ctrl-C.
+  holdUnverifiedWorktree({ root, path, branch });
 
+  /** Tears the unverified worktree down and says what actually happened to it. */
   const cleanup = (): void => {
-    removeWorktree(root, path, branch);
+    const torn = removeUnverifiedWorktree();
+    if (torn === null || torn.ok) {
+      process.stderr.write(`Cleaned up worktree ${path} and branch ${branch}.\n`);
+      return;
+    }
+    // Teardown is best-effort, so claiming it worked would strand the user with
+    // an orphaned worktree *and* branch they were told did not exist. Report
+    // git's own account, then the command that finishes the job by hand.
+    process.stderr.write(torn.out);
+    process.stderr.write(
+      `Could not clean up ${path}. Remove it by hand:\n` +
+        `  git worktree remove --force ${shellQuote(path)} && git branch -D ${branch}\n`,
+    );
   };
 
   let green: Result;
@@ -229,11 +324,13 @@ function create(rawName: string): void {
   }
 
   if (!green.ok) {
-    cleanup();
     process.stderr.write(`HEAD not green: ${green.out}`);
-    process.stderr.write(`Cleaned up worktree ${path} and branch ${branch}.\n`);
+    cleanup();
     process.exit(1);
   }
+
+  // Verified: it is the caller's worktree now, not swt's to tear down.
+  keepUnverifiedWorktree();
 
   // Print only the path on stdout — callers can capture cleanly.
   process.stdout.write(path + "\n");

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -22,7 +22,7 @@
 
 import { closeSync, existsSync, openSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { git, gitMust } from "./git.ts";
+import { git, gitMust, validateWorktreeName, WORKTREE_NAME_RULE } from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
 
 /**
@@ -75,9 +75,20 @@ function withParentLock<T>(repoRoot: string, fn: () => T): T {
  * it first. Prints the worktree path on stdout. Tears the worktree and branch
  * down and exits non-zero if the check fails.
  *
- * @param name - Base name for the worktree directory and branch.
+ * @param rawName - Base name for the worktree directory and branch; rejected up
+ *   front unless it satisfies {@link WORKTREE_NAME_RULE}.
  */
-function create(name: string): void {
+function create(rawName: string): void {
+  // Validate before touching git: the name becomes both a branch and a path, so
+  // `..` or a leading `-` would otherwise create the wrong thing somewhere else.
+  const name = validateWorktreeName(rawName);
+  if (name === null) {
+    process.stderr.write(
+      `Invalid worktree name ${JSON.stringify(rawName)} — ${WORKTREE_NAME_RULE}.\n`,
+    );
+    process.exit(1);
+  }
+
   const root = gitMust(["rev-parse", "--show-toplevel"]);
   const branch = `swt/${name}-${Date.now().toString(36)}`;
   const path = resolve(root, "..", `${name}.swt`);

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -23,8 +23,9 @@
 // Every git command runs through ./git.ts as an argv array, never a shell
 // string, so caller-supplied names cannot word-split or inject.
 
-import { closeSync, existsSync, openSync, rmSync } from "node:fs";
+import { closeSync, existsSync, openSync, realpathSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { git, gitMust, validateWorktreeName, worktreeDirt, WORKTREE_NAME_RULE } from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
 
@@ -37,7 +38,7 @@ import { isGreen, type Result } from "./green-check.ts";
  * @param fn - Work to perform under the lock.
  * @returns Whatever `fn` returns.
  */
-function withParentLock<T>(repoRoot: string, fn: () => T): T {
+export function withParentLock<T>(repoRoot: string, fn: () => T): T {
   const lockPath = join(repoRoot, ".git", "swt.lock");
   const STALE_MS = 60 * 60 * 1000;
   const start = Date.now();
@@ -221,10 +222,32 @@ function merge(wtPath: string): void {
   });
 }
 
-const [cmd, ...args] = process.argv.slice(2);
-if (cmd === "create" && args[0]) create(args[0]);
-else if (cmd === "merge" && args[0]) merge(args[0]);
-else {
-  process.stderr.write("usage: swt {create <name>|merge <worktree-path>}\n");
-  process.exit(2);
+/**
+ * Reports whether this module is the program being run rather than a module
+ * someone imported. Symlinked installs (`~/.local/bin/swt` → `swt/swt.ts`) mean
+ * argv[1] and this module's own URL can name the same file by different paths,
+ * so both sides are resolved through the filesystem before comparing.
+ *
+ * @returns True when swt was invoked as a command line program.
+ */
+function isProgramEntry(): boolean {
+  const entry = process.argv[1];
+  if (entry === undefined) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+// Guarded so importing this module — which the tests do, for `withParentLock` —
+// neither parses argv nor exits the importing process.
+if (isProgramEntry()) {
+  const [cmd, ...args] = process.argv.slice(2);
+  if (cmd === "create" && args[0]) create(args[0]);
+  else if (cmd === "merge" && args[0]) merge(args[0]);
+  else {
+    process.stderr.write("usage: swt {create <name>|merge <worktree-path>}\n");
+    process.exit(2);
+  }
 }

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -8,8 +8,12 @@
 //   1. Worktrees are only ever created from a green commit. The check runs INSIDE the
 //      new worktree — a clean checkout of HEAD, so uncommitted changes in the parent
 //      cannot trick it — and both the worktree and its branch are torn down again if the
-//      check fails or the run is interrupted. A failed check reports what that teardown
-//      actually did, plus the command to finish it by hand, rather than assuming it worked.
+//      check fails, or if the run is interrupted by any signal swt is allowed to handle:
+//      teardown ignores further signals and runs its git commands outside swt's process
+//      group, so the second Ctrl-C cannot undo what the first one asked for. SIGKILL is
+//      the exception no program can cover, and swt does not pretend otherwise. A failed
+//      check reports what that teardown actually did, plus the command to finish it by
+//      hand, rather than assuming it worked.
 //   2. A name from the command line can only ever name the thing it spells. It becomes
 //      both a branch and a filesystem path, so it is validated against a restricted
 //      character set (see WORKTREE_NAME_RULE) before anything at all is created.
@@ -58,6 +62,9 @@ const SIGNAL_EXIT_STATUS: Record<(typeof TERMINATION_SIGNALS)[number], number> =
   SIGTERM: 143,
 };
 
+/** Whether a teardown step is running right now; see {@link uninterrupted}. */
+let tearingDown = false;
+
 /**
  * Turns a terminating signal into a normal exit. Without a listener the signal's
  * default disposition kills the process outright — no `exit` hook runs — which
@@ -66,10 +73,49 @@ const SIGNAL_EXIT_STATUS: Record<(typeof TERMINATION_SIGNALS)[number], number> =
  * teardown decision lives in an `exit` hook, so two responsibilities armed at
  * the same time cannot fight over ordering.
  *
+ * Once teardown has started it does nothing at all — see {@link uninterrupted}.
+ *
  * @param signal - Signal that arrived.
  */
 function exitOnSignal(signal: (typeof TERMINATION_SIGNALS)[number]): void {
+  if (tearingDown) return;
   process.exit(SIGNAL_EXIT_STATUS[signal]);
+}
+
+/**
+ * Runs one teardown step, with interruption neutralized for its duration.
+ *
+ * The hazard is that teardown is usually what a signal *asked for*, and the
+ * signals keep coming: a terminal repeats Ctrl-C for as long as the user holds
+ * it, and the `npx tsx` launcher swt is installed behind relays SIGINT again
+ * 30ms after the first. Arriving mid-teardown, a second one must not be allowed
+ * to undo the first. So for the duration of a step the listener stays installed
+ * but stops acting: {@link exitOnSignal} would otherwise call `process.exit`,
+ * and `process.exit` from inside an `exit` hook does not re-emit `exit` — it
+ * goes straight to the real exit, dropping whatever teardown had not finished.
+ * Staying installed is the other half: removing the listener instead would
+ * restore the signal's default disposition, which kills swt outright and is
+ * strictly worse. Latching each step (below) then keeps the work itself to one
+ * run, however many callers reach it.
+ *
+ * What this cannot do is survive SIGKILL, which no process is allowed to handle.
+ * Teardown runs to completion against every signal swt is permitted to see; the
+ * only defence against the one it is not is that teardown's git commands run
+ * outside swt's process group (see `removeWorktree`), so whatever has already
+ * started still finishes.
+ *
+ * @param step - The teardown work. Must be synchronous: this runs inside `exit`
+ *   hooks, where the event loop is over and a promise would never be resumed.
+ * @returns Whatever `step` returns.
+ */
+function uninterrupted<T>(step: () => T): T {
+  const wasTearingDown = tearingDown;
+  tearingDown = true;
+  try {
+    return step();
+  } finally {
+    tearingDown = wasTearingDown;
+  }
 }
 
 /** How many teardown responsibilities currently need signals to reach `exit`. */
@@ -103,14 +149,20 @@ const heldLocks = new Set<string>();
  * touching a lock file this process did not create.
  */
 function releaseHeldLocks(): void {
-  for (const path of heldLocks) {
-    try {
-      rmSync(path, { force: true });
-    } catch {
-      /* best effort: nothing useful to do while the process is going down */
+  uninterrupted(() => {
+    // Latched by taking the paths out of the set up front, so a second call —
+    // the hook firing after an explicit release, or a signal on the way out —
+    // finds nothing left to do rather than repeating the work.
+    const paths = [...heldLocks];
+    heldLocks.clear();
+    for (const path of paths) {
+      try {
+        rmSync(path, { force: true });
+      } catch {
+        /* best effort: nothing useful to do while the process is going down */
+      }
     }
-  }
-  heldLocks.clear();
+  });
 }
 
 let lockExitHookInstalled = false;
@@ -189,17 +241,20 @@ function keepUnverifiedWorktree(): void {
 function removeUnverifiedWorktree(): Result | null {
   const worktree = unverifiedWorktree;
   if (worktree === null) return null;
-  // Clearing the hold first makes a second call a no-op; disarming waits until
-  // the git commands are done. An interrupted run is often *still* being
-  // signalled while it cleans up — the `npx tsx` launcher relays SIGINT again
-  // 30ms later — and dropping the listener mid-teardown would restore the
-  // default disposition and kill swt between the two commands.
+  // Latch: clearing the hold first makes a second call — `create`'s explicit one
+  // and the `exit` hook both reach here — a no-op rather than a repeat. Whoever
+  // gets here first runs the teardown to completion; disarming waits until the
+  // git commands are done, because dropping the listener mid-teardown would
+  // restore the default disposition and let the next signal kill swt between
+  // them.
   unverifiedWorktree = null;
-  try {
-    return removeWorktree(worktree.root, worktree.path, worktree.branch);
-  } finally {
-    disarmSignalExit();
-  }
+  return uninterrupted(() => {
+    try {
+      return removeWorktree(worktree.root, worktree.path, worktree.branch);
+    } finally {
+      disarmSignalExit();
+    }
+  });
 }
 
 /**
@@ -274,8 +329,9 @@ export function withParentLock<T>(repoRoot: string, fn: () => T): T {
 /**
  * Creates a subagent worktree on a fresh branch, verifying HEAD is green inside
  * it first. Prints the worktree path on stdout. Tears the worktree and branch
- * down and exits non-zero if the check fails — or if the run is interrupted
- * before it passes — reporting honestly when that teardown does not work.
+ * down and exits non-zero if the check fails — or if the run is interrupted by a
+ * catchable signal before it passes — reporting honestly when that teardown does
+ * not work.
  *
  * @param rawName - Base name for the worktree directory and branch; rejected up
  *   front unless it satisfies {@link WORKTREE_NAME_RULE}.

--- a/swt/swt.ts
+++ b/swt/swt.ts
@@ -22,7 +22,7 @@
 
 import { closeSync, existsSync, openSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { git, gitMust, validateWorktreeName, WORKTREE_NAME_RULE } from "./git.ts";
+import { git, gitMust, validateWorktreeName, worktreeDirt, WORKTREE_NAME_RULE } from "./git.ts";
 import { isGreen, type Result } from "./green-check.ts";
 
 /**
@@ -145,20 +145,22 @@ function merge(wtPath: string): void {
   // shouldn't be silently fast-forwarded over. Subagent dirt = uncommitted work
   // that would vanish when the worktree is removed. `git status --porcelain`
   // catches both modified-tracked and untracked files.
-  const checkClean = (cwd: string, label: string): void => {
-    const r = git(["status", "--porcelain"], cwd);
-    if (!r.ok) {
-      process.stderr.write(r.out);
+  const checkClean = (cwd: string, label: string, includeUntracked: boolean): void => {
+    let dirt: string;
+    try {
+      dirt = worktreeDirt(cwd, { includeUntracked });
+    } catch (e) {
+      process.stderr.write((e as Error).message);
       process.exit(1);
     }
-    if (r.out.trim().length > 0) {
-      process.stderr.write(`${label} has uncommitted/untracked changes:\n${r.out}`);
+    if (dirt.length > 0) {
+      process.stderr.write(`${label} has uncommitted/untracked changes:\n${dirt}\n`);
       process.stderr.write("Commit or stash before merging.\n");
       process.exit(1);
     }
   };
-  checkClean(root, "Parent worktree");
-  checkClean(wt, "Subagent worktree");
+  checkClean(root, "Parent worktree", true);
+  checkClean(wt, "Subagent worktree", true);
 
   // Parent HEAD must be green: refusing to silently advance past an in-progress
   // red commit in the parent worktree (mirrors the create-time invariant).

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Run all tests for Go and Rust programs in this repository
+# Run all tests for Go, Rust, and TypeScript programs in this repository
 #
 # Usage:
 #   ./test.sh           # Run all tests
 #   ./test.sh --go      # Run only Go tests
 #   ./test.sh --rust    # Run only Rust tests
+#   ./test.sh --ts      # Run only TypeScript tests
 
 set -e
 
@@ -12,24 +13,33 @@ cd "$(dirname "$0")"
 
 run_go=true
 run_rust=true
+run_ts=true
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --go)
             run_rust=false
+            run_ts=false
             shift
             ;;
         --rust)
             run_go=false
+            run_ts=false
+            shift
+            ;;
+        --ts)
+            run_go=false
+            run_rust=false
             shift
             ;;
         --help|-h)
-            echo "Usage: $0 [--go] [--rust]"
+            echo "Usage: $0 [--go] [--rust] [--ts]"
             echo ""
             echo "Options:"
             echo "  --go    Run only Go tests"
             echo "  --rust  Run only Rust tests"
+            echo "  --ts    Run only TypeScript tests"
             echo ""
             echo "If no options are specified, all tests are run."
             exit 0
@@ -69,6 +79,21 @@ if [ "$run_rust" = true ]; then
     else
         echo ""
         echo "[FAIL] Rust tests failed"
+        exit_code=1
+    fi
+    echo ""
+fi
+
+if [ "$run_ts" = true ]; then
+    echo "========================================="
+    echo "Running TypeScript tests..."
+    echo "========================================="
+    if npx tsx --test 'swt/*.test.ts'; then
+        echo ""
+        echo "[PASS] TypeScript tests passed"
+    else
+        echo ""
+        echo "[FAIL] TypeScript tests failed"
         exit_code=1
     fi
     echo ""


### PR DESCRIPTION
Addresses the review of `b3c45c8` ("fix swt to run checks in the right tree"), which is included here since it had not been pushed. That commit's core idea was right — running the green check inside a fresh worktree closes a real hole where uncommitted parent state could fake a pass — but it introduced a fail-open guard and broke the documented `.swt-check` escape hatch. Chasing those turned up two further bugs that made `swt` unusable in the workflow it exists to serve.

## The two that mattered most

**`swt merge` could never complete.** `join(repoRoot, ".git", "swt.lock")` assumes `.git` is a directory. In a linked worktree it is a *file* (`gitdir: …`), so the lock threw `ENOTDIR` — and the parent of an `swt` run is normally itself a worktree. Now resolved via `git rev-parse --git-common-dir`, which also gives the lock the right scope: it serializes across every worktree of the repo, not just one.

**A green check that verified nothing.** `pnpm install --frozen-lockfile` was pushed into the command list before any check script was found, so a repo with a lockfile but no `typecheck`/`lint`/`test` script produced a plan of exactly `["pnpm install --frozen-lockfile"]` — which succeeds, reporting green. The install is now gated on there actually being a JS check to run, so it can never stand in for one.

## Also fixed

- `.swt-check` is resolved from the **parent repo root** and run with the checked worktree as cwd, so an uncommitted per-developer override works for both `create` and `merge`; it is now gitignored, and the parent cleanliness guard is scoped to tracked changes so it no longer blocks every merge.
- Green checks no longer `pnpm install` into an already-populated tree — verification stopped mutating the environment it was only meant to inspect.
- Teardown reports honestly instead of always printing "Cleaned up", and emits a copy-pasteable recovery command when it fails.
- Ctrl-C during the check no longer orphans the worktree. Teardown's own `git` children now run outside swt's process group, so an impatient second Ctrl-C cannot kill `git worktree remove` mid-flight and strand a branch the surviving worktree still claims.
- `swt create <name>` validates `<name>` before creating anything.

## Guardrails

- **Test harness.** The tool had no tests; it now has 72, plus a `--ts` mode in `test.sh`. This is what made most of the above catchable.
- **`swt/git.ts` is the only git entrance.** Every git call is an argv array handed straight to `spawnSync`, and there is deliberately no string-command variant to reach for — `sh`/`must` are gone from the CLI, so shell injection is structurally unavailable rather than merely avoided.
- **A guard on undocumented behavior.** The process-group shield relies on `detached`, which Node honors for `spawnSync` but does not document. A test asserts the child really does land in its own process group, so a future Node dropping it fails loudly instead of silently restoring the orphaned-branch bug.

Each guardrail was mutation-tested — deliberately broken, confirmed red, restored — so none can pass green forever.

## Verification

```
npx tsx --test 'swt/*.test.ts'    72 pass / 0 fail
./test.sh --ts                    exit 0
./test.sh --rust                  [PASS]
shellcheck test.sh                clean
tsc --strict --noEmit (swt/*.ts)  0 errors
20 repeat runs (8 serial + 12 concurrent)   0 failures
```

`./test.sh` as a whole still exits 1 on the Go half (`missing go.sum entry`). That is pre-existing and environmental — `go.sum` is gitignored, so no checkout runs Go tests without `go mod tidy`; the identical failure reproduces at the pre-branch baseline, and this branch touches no Go files.

## Known limitation

`swt` ships as `#!/usr/bin/env -S npx tsx`, and tsx's launcher SIGKILLs its child ~60 ms after a signal — which swt cannot answer while blocked in the synchronous green check. So a Ctrl-C can still truncate teardown despite the process-group shield. The clean fix is dropping tsx from the shebang (Node 26 runs `swt.ts` natively), but that raises the minimum Node version and changes the documented install requirement, so it is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)