### PR TITLE
fix(nwt): sandbox test fixtures from the inherited git environment

### DIFF
--- a/src/nwt/tests/builder-guard.rs
+++ b/src/nwt/tests/builder-guard.rs
@@ -1,44 +1,70 @@
 //! Pins the contract of the shared `nwt_command` builder (issue #283): every
 //! integration test that spawns the real `nwt` binary does so through this
-//! builder, and the builder must scrub the terminal-multiplexer environment
-//! from the child so a suite launched from inside zellij/tmux can never hijack
-//! the user's real tab.
+//! builder, and the builder must scrub the environment that would otherwise let
+//! the spawned `nwt` reach out of its fixture and act on the developer's real
+//! session — the terminal multiplexer (whose tab it would rename) and the git
+//! location vars (whose repo it would create worktrees in).
 //!
 //! This inspects the builder's configured environment directly via
 //! `Command::get_envs`, so it is deterministic and cross-platform — no process
 //! is spawned and it does not depend on whether the test runner itself happens
-//! to be inside a multiplexer.
+//! to be inside a multiplexer or a git hook.
 
 mod support;
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
+use std::process::Command;
 
 use support::nwt_command;
 
-#[test]
-fn nwt_command_scrubs_multiplexer_env() {
-    let cmd = nwt_command(&std::env::temp_dir());
+/// Keys the builder must schedule for removal, each paired with the consequence
+/// of leaving it in place — quoted back in the failure message so a regression
+/// explains itself rather than just naming a missing key.
+const REQUIRED_REMOVALS: &[(&str, &str)] = &[
+    (
+        "ZELLIJ",
+        "the spawned nwt would believe it is inside zellij and rename the user's real tab",
+    ),
+    (
+        "TMUX",
+        "the spawned nwt would believe it is inside tmux and rename the user's real window",
+    ),
+    (
+        "GIT_DIR",
+        "git exports this into hooks and it overrides cwd-based discovery, so the spawned \
+         nwt would create worktrees in the real repo instead of the fixture",
+    ),
+    (
+        "GIT_WORK_TREE",
+        "the spawned nwt's git would resolve paths against the real working tree",
+    ),
+    (
+        "GIT_INDEX_FILE",
+        "the spawned nwt's git would stage into the real repo's index",
+    ),
+];
 
-    // `get_envs` yields `(key, Option<value>)`; a `None` value means the key is
-    // scheduled for *removal* from the child's inherited environment.
-    let scheduled_for_removal: Vec<_> = cmd
-        .get_envs()
+/// The keys a [`Command`] will delete from the child's inherited environment.
+///
+/// `get_envs` yields `(key, Option<value>)`; a `None` value means the key is
+/// scheduled for *removal* rather than being set to some value.
+fn scheduled_removals(cmd: &Command) -> Vec<OsString> {
+    cmd.get_envs()
         .filter(|(_, value)| value.is_none())
         .map(|(key, _)| key.to_owned())
-        .collect();
+        .collect()
+}
 
-    assert!(
-        scheduled_for_removal
-            .iter()
-            .any(|k| k == OsStr::new("ZELLIJ")),
-        "nwt_command must remove ZELLIJ from the child env so the spawned nwt \
-         never believes it is inside zellij.\nscheduled removals: {scheduled_for_removal:?}"
-    );
-    assert!(
-        scheduled_for_removal
-            .iter()
-            .any(|k| k == OsStr::new("TMUX")),
-        "nwt_command must remove TMUX from the child env so the spawned nwt \
-         never believes it is inside tmux.\nscheduled removals: {scheduled_for_removal:?}"
-    );
+#[test]
+fn nwt_command_scrubs_the_environment_that_would_escape_the_fixture() {
+    let cmd = nwt_command(&std::env::temp_dir());
+    let removals = scheduled_removals(&cmd);
+
+    for (key, consequence) in REQUIRED_REMOVALS {
+        assert!(
+            removals.iter().any(|k| k == OsStr::new(key)),
+            "nwt_command must remove {key} from the child env; otherwise {consequence}.\n\
+             scheduled removals: {removals:?}"
+        );
+    }
 }

--- a/src/nwt/tests/git-env-isolation.rs
+++ b/src/nwt/tests/git-env-isolation.rs
@@ -1,0 +1,108 @@
+//! Pins that `nwt`'s shared test fixtures stay sandboxed from the ambient git
+//! environment.
+//!
+//! When git invokes a hook it exports `GIT_DIR`/`GIT_WORK_TREE`/
+//! `GIT_INDEX_FILE` into the hook's environment, and anything that hook
+//! launches — `cargo test` included — inherits them. `GIT_DIR` overrides
+//! cwd-based repo discovery, so a fixture helper that only sets
+//! `current_dir(tempdir)` still has its `git` child operate on the *real* repo.
+//!
+//! That is not hypothetical. It is how `user.email = t@example.com` /
+//! `user.name = Test` (this suite's sibling fixture values over in `gsw`) came
+//! to be written into this repo's own `.git/config`, which then silently
+//! authored every subsequent commit as `Test <t@example.com>` until it was
+//! noticed. A config write is sticky: one leak outlives the run that caused it.
+//!
+//! `.husky/pre-commit` already scrubs these vars before `cargo test`, but that
+//! is a single caller. This pins the guarantee at the fixture itself — matching
+//! what `gsw`'s suite already does — so the sandbox holds for any other runner
+//! (`bacon`, an IDE, a future hook or CI job) that forgets the scrub.
+//!
+//! This file deliberately holds a SINGLE `#[test]`: it mutates the process-wide
+//! environment, and cargo runs the tests within one test binary on parallel
+//! threads. One test per binary means there is no sibling thread to race with,
+//! while every other test file is a separate process with its own environment.
+
+mod support;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+use support::run_git;
+
+/// The email the probe asks `run_git` to write.
+///
+/// Deliberately unique to this test and under the reserved `.invalid` TLD
+/// (RFC 2606), so finding it in any config file is unambiguous evidence of a
+/// leak rather than a pre-existing value someone legitimately configured.
+const LEAK_MARKER: &str = "nwt-git-env-isolation-probe@example.invalid";
+
+/// Runs `git init` in `dir` with the git-location environment scrubbed.
+///
+/// The test's own setup must not be redirected by the very leak it is probing
+/// for, so this does not go through [`run_git`] — that is the helper under
+/// test, and before the fix it is exactly what fails to scrub.
+fn init_sandboxed_repo(dir: &Path) {
+    let status = Command::new("git")
+        .arg("init")
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .status()
+        .expect("invoke git init");
+    assert!(status.success(), "git init failed in {}", dir.display());
+}
+
+/// Creates `<temp>/<name>` as a freshly initialised git repo, returning its path.
+fn sandboxed_repo(temp: &TempDir, name: &str) -> PathBuf {
+    let repo = temp.path().join(name);
+    fs::create_dir(&repo).expect("create repo dir");
+    init_sandboxed_repo(&repo);
+    repo
+}
+
+/// Reads a repo's local git config file as a string.
+fn read_local_config(repo: &Path) -> String {
+    fs::read_to_string(repo.join(".git").join("config")).expect("read local git config")
+}
+
+#[test]
+fn run_git_ignores_an_ambient_git_dir() {
+    let temp = TempDir::new().expect("create temp dir");
+    // Stands in for the developer's real repo — the one an inherited `GIT_DIR`
+    // points at when the suite runs from inside a git hook.
+    let sentinel = sandboxed_repo(&temp, "sentinel");
+    // The repo `run_git` is explicitly pointed at, and the only one it may touch.
+    let fixture = sandboxed_repo(&temp, "fixture");
+
+    // Reproduce the hook environment: `GIT_DIR` naming the sentinel repo, while
+    // the helper is handed an entirely different directory.
+    std::env::set_var("GIT_DIR", sentinel.join(".git"));
+    let ok = run_git(&fixture, &["config", "user.email", LEAK_MARKER]);
+    std::env::remove_var("GIT_DIR");
+
+    assert!(ok, "the probe's `git config` invocation should succeed");
+
+    let sentinel_config = read_local_config(&sentinel);
+    assert!(
+        !sentinel_config.contains(LEAK_MARKER),
+        "run_git wrote to the repo named by the ambient GIT_DIR instead of the \
+         directory it was given, so a fixture running under a git hook would \
+         corrupt the real repo's config.\nsentinel config:\n{sentinel_config}"
+    );
+
+    let fixture_config = read_local_config(&fixture);
+    assert!(
+        fixture_config.contains(LEAK_MARKER),
+        "run_git must still write to the directory it was given — otherwise \
+         this test could pass merely because the write went nowhere.\nfixture \
+         config:\n{fixture_config}"
+    );
+}

--- a/src/nwt/tests/support/mod.rs
+++ b/src/nwt/tests/support/mod.rs
@@ -27,6 +27,21 @@ use tempfile::TempDir;
 /// Runs a git command in `dir` with stdin/stdout/stderr nulled, returning
 /// whether it succeeded. Output is nulled so concurrent test runs (a background
 /// `bacon` loop alongside the pre-commit hook's own run) don't interleave noise.
+///
+/// Scrubs the inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` so that `dir`
+/// is the repo git operates on. Without this, `current_dir(dir)` is not enough:
+/// when the suite runs from inside a git hook, git exports those vars into the
+/// hook's environment, `cargo test` inherits them, and `GIT_DIR` overrides
+/// cwd-based discovery — so a fixture's `git config`/`commit` lands in the
+/// *real* repo. That is how `Test <t@example.com>` got written into this repo's
+/// own `.git/config` and then authored every later commit until it was noticed.
+/// Pinned by `tests/git-env-isolation.rs`.
+///
+/// Only the three location vars are scrubbed. `GIT_CONFIG_GLOBAL`/
+/// `GIT_CONFIG_SYSTEM` are deliberately left alone: they are not part of this
+/// leak (a bare `git config` writes to the *local* file named by `GIT_DIR`), and
+/// pinning them to `/dev/null` would also drop the host's `init.defaultBranch`,
+/// silently changing the branch fixtures are created on.
 pub fn run_git(dir: &Path, args: &[&str]) -> bool {
     Command::new("git")
         .args(args)
@@ -34,6 +49,9 @@ pub fn run_git(dir: &Path, args: &[&str]) -> bool {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
         .status()
         .map(|s| s.success())
         .unwrap_or(false)

--- a/src/nwt/tests/support/mod.rs
+++ b/src/nwt/tests/support/mod.rs
@@ -112,6 +112,11 @@ pub fn init_repo() -> (TempDir, PathBuf) {
 /// scrubs the terminal-multiplexer environment from the child so a suite
 /// launched from inside zellij/tmux can never hijack the user's real tab.
 ///
+/// It likewise scrubs the git location environment, so the spawned `nwt` — which
+/// shells out to `git worktree add` — operates on `repo` and not on whatever
+/// repo an inherited `GIT_DIR` names. Both scrubs guard the same class of bug:
+/// a fixture reaching out and acting on the developer's real session.
+///
 /// Tests that deliberately *exercise* the multiplexer behaviour (see
 /// [`FakeMultiplexer`]) re-add `ZELLIJ`/`TMUX` on the returned command; because
 /// those `.env(...)` calls run after the scrub here, they win for that child.
@@ -124,7 +129,13 @@ pub fn nwt_command(repo: &Path) -> Command {
         // real tab. Tests that deliberately exercise the multiplexer behavior
         // re-add ZELLIJ/TMUX after calling this (a later `.env(..)` wins).
         .env_remove("ZELLIJ")
-        .env_remove("TMUX");
+        .env_remove("TMUX")
+        // Same idea for git: a hook exports these, `cargo test` inherits them,
+        // and GIT_DIR beats `current_dir`. Left in place, the spawned nwt would
+        // add its worktree to the real repo. See `run_git` above.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE");
     cmd
 }
 


### PR DESCRIPTION
## Why

`nwt`'s test fixtures pointed `git` at a tempdir with `current_dir()` alone. That is not sufficient: when git invokes a hook it exports `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` into the hook's environment, `cargo test` inherits them, and `GIT_DIR` overrides cwd-based repo discovery. The fixture's `git` then operates on the **real** repo.

This is not hypothetical. The identical pattern in `gsw`'s fixture wrote `user.email = t@example.com` / `user.name = Test` into this repo's own `.git/config`. A config write is sticky, so every subsequent commit — tests running or not — was silently authored `Test <t@example.com>` until it was noticed. 14 such commits are on `main`.

`.husky/pre-commit` already scrubs these vars before `cargo test` (b9bfabf), and `gsw`'s fixture scrubs them again at the fixture itself (42ac7e6). `nwt` only had the first layer. This adds the second, bringing it to parity, so the sandbox holds for any runner that isn't that one hook line — `bacon`, an IDE, a future hook or CI job.

## What

Two red/green cycles.

**`run_git`** now scrubs the three location vars. It is the only git spawn in the entire `nwt` test tree, so this also covers `run-install-dedup.rs`, which imports it rather than rolling its own. Pinned by the new `tests/git-env-isolation.rs`: a sentinel repo plus an ambient `GIT_DIR`, asserting the write lands in the directory the helper was *given* — and, so the test cannot pass merely because the write went nowhere, that it lands there at all.

**`nwt_command`** gets the same scrub. This is the larger exposure: the spawned `nwt` shells out to `git worktree add`, so an inherited `GIT_DIR` would have added the worktree to the real repo. `builder-guard.rs` now drives a table of required removals through `Command::get_envs()`, extending the pattern already used there for `ZELLIJ`/`TMUX`.

`tests/git-env-isolation.rs` deliberately holds a single `#[test]` — it mutates process-wide environment, and cargo runs a binary's tests on parallel threads. One test per binary means no sibling thread to race with, while other test files are separate processes with their own environments.

### Deliberately not done

`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are **not** pinned to `/dev/null`, though `gsw` does pin them. They are not part of this leak — a bare `git config` writes to the *local* file named by `GIT_DIR` — and nulling them would also drop the host's `init.defaultBranch`, silently changing which branch fixtures are created on.

## Verification

- Full workspace: **1560 passed, 0 failed** across 111 targets. `cargo fmt --check`, `cargo machete`, and `cargo clippy --all-targets --workspace -- -D warnings` all clean.
- **End to end**: ran the whole `nwt` suite with all three vars pointed at a sentinel repo. Sentinel config SHA and HEAD byte-identical afterward.
- **Mutation-tested that harness**, since a green result proves nothing if the check cannot fail. The first attempt was misleading — `cargo test` halts at the first failing target, so the fixtures never ran. With `--no-fail-fast`, the pre-fix helper wrote `user.email=test@example.com` / `user.name=Test User` straight into the sentinel's config, reproducing the original mechanism exactly.

Note that the closing `--allow-empty` commit skipped every Rust gate: this repo's hook triggers on staged `.rs` files and an empty commit stages none. The four gates above were run explicitly rather than relying on it.

## Out of scope

`src/nwt/src/main.rs` spawns git in four places; two scrub `GIT_DIR` (lines 996, 1855) and two do not (886, 1953). That is `nwt`'s runtime behavior rather than the fixture leak, and whether `nwt` should ignore an ambient `GIT_DIR` when a user runs it from inside a hook is a genuine design question. Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
