### PR TITLE
gitnuke: a real tool that can nuke worktrees with submodules (behind --force)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitnuke"
+version = "0.1.0"
+dependencies = [
+ "buildinfo",
+ "clap",
+ "colored",
+ "repowalker",
+ "tempfile",
+]
+
+[[package]]
 name = "gitrdun"
 version = "0.1.0"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -1372,8 +1372,9 @@ in the worktree itself.
   standing in (or any parent of it) and names somewhere else to `cd` to first. It is a
   binary, not a shell function, so it cannot move your shell out of a directory it deletes.
 - **Never the main worktree**, and never a branch whose removal git refused.
-- **`--dry-run` is a real preflight.** It runs every check and exits with the same status a
-  real run would, so `gitnuke -n x` failing means `gitnuke x` would fail too.
+- **`--dry-run` is a real preflight.** It runs every check a real run runs — submodules,
+  uncommitted changes, and under `--safe` whether the branch is merged — and exits with the
+  same status that run would, so `gitnuke -n x` failing means `gitnuke x` would fail too.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,14 @@ out when the lock has none. This is exit code `8`, and `--dry-run` reports it to
 - **Never your own directory.** gitnuke refuses to remove the worktree your shell is
   standing in (or any parent of it) and names somewhere else to `cd` to first. It is a
   binary, not a shell function, so it cannot move your shell out of a directory it deletes.
-- **Never the main worktree**, and never a branch whose removal git refused.
+- **Never the main worktree.** It is the worktree the repository itself lives in, and git
+  declines to remove it with or without `--force`. gitnuke refuses it up front and says what
+  to do instead, rather than letting git's `fatal: '…' is a main working tree` be the answer —
+  a `--dry-run` never runs that command, so leaving the rule to git meant the dry run cleared
+  the one worktree nothing can ever remove. Both runs report exit `2`, the code git's own
+  refusal produces.
+- **Never a branch whose removal git refused.** The branch is deleted only once the worktree
+  is actually gone.
 - **A lock is honoured, not overridden.** A worktree locked with `git worktree lock` is
   refused even with `--force`, quoting the lock reason if git recorded one and handing back
   the `git worktree unlock` command to run.

--- a/README.md
+++ b/README.md
@@ -1360,8 +1360,24 @@ worktree with submodules checked out.
 
 `--force` is required because that warning is literal: a submodule checkout can hold commits
 and untracked files that exist nowhere else, and removing the worktree deletes them silently.
-One `--force` covers both of git's refusals — submodules checked out and uncommitted changes
-in the worktree itself.
+One `--force` covers both of the refusals gitnuke overrides — submodules checked out and
+uncommitted changes in the worktree itself.
+
+### Locked worktrees
+
+git has a third refusal, and `--force` is not the answer to it. A worktree you locked with
+`git worktree lock` is declined even by `git worktree remove --force`, which asks for
+`remove -f -f` instead. A lock is a deliberate "leave this alone" marker you set by hand, so
+gitnuke honours it rather than escalating, and says so before it touches anything:
+
+```text
+gitnuke: /code/repo-worktrees/issue-42 is locked (mid-bisect, do not touch) — git refuses to
+remove a locked worktree even with --force.
+  Unlock it first: git worktree unlock /code/repo-worktrees/issue-42
+```
+
+The reason in parentheses is whatever you passed to `git worktree lock --reason`; it is left
+out when the lock has none. This is exit code `8`, and `--dry-run` reports it too.
 
 ### Safety rails
 
@@ -1372,14 +1388,18 @@ in the worktree itself.
   standing in (or any parent of it) and names somewhere else to `cd` to first. It is a
   binary, not a shell function, so it cannot move your shell out of a directory it deletes.
 - **Never the main worktree**, and never a branch whose removal git refused.
+- **A lock is honoured, not overridden.** A worktree locked with `git worktree lock` is
+  refused even with `--force`, quoting the lock reason if git recorded one and handing back
+  the `git worktree unlock` command to run.
 - **`--dry-run` is a real preflight.** It runs every check a real run runs — submodules,
   uncommitted changes, and under `--safe` whether the branch is merged — and exits with the
   same status that run would, so `gitnuke -n x` failing means `gitnuke x` would fail too.
 
 ### Options
 
-- `-f, --force`: Nuke the worktree even if git would refuse — submodules checked out, or
-  uncommitted changes
+- `-f, --force`: Nuke the worktree despite the two refusals it overrides — submodules checked
+  out, or uncommitted changes. It does not override a locked worktree; that is refused
+  separately, with instructions to unlock it
 - `-s, --safe`: Keep the branch unless it is fully merged (`git branch -d` semantics instead
   of the default force-delete). Only affects the branch; the worktree is still removed
 - `-n, --dry-run`: Report what would happen without removing or deleting anything
@@ -1395,6 +1415,7 @@ in the worktree itself.
 - `5`: The worktree contains submodules and `--force` was not given
 - `6`: The shell is standing inside the target worktree
 - `7`: The worktree was removed but its branch could not be deleted
+- `8`: The worktree is locked, which `--force` does not override
 
 ### Replacing the shell functions
 

--- a/README.md
+++ b/README.md
@@ -1363,6 +1363,23 @@ and untracked files that exist nowhere else, and removing the worktree deletes t
 One `--force` covers both of the refusals gitnuke overrides — submodules checked out and
 uncommitted changes in the worktree itself.
 
+### Worktrees with uncommitted changes
+
+git's other refusal, and gitnuke raises it the same way it raises the submodule one — on its
+own terms, before `git worktree remove` is ever reached:
+
+```text
+gitnuke: /code/repo-worktrees/issue-42 contains modified or untracked files — nuking it
+discards work that exists nowhere else.
+  Re-run with --force to nuke it anyway.
+```
+
+Untracked files count, ignored files do not — the same question `git worktree remove` asks.
+This is exit code `9`, and `--dry-run` reports it with the identical message: one gate serves
+both runs, so they cannot drift. A worktree that has *both* submodules and uncommitted
+changes reports the submodule refusal (`5`), because a submodule checkout is the more
+consequential thing `--force` would take with it.
+
 ### Locked worktrees
 
 git has a third refusal, and `--force` is not the answer to it. A worktree you locked with
@@ -1395,6 +1412,10 @@ out when the lock has none. This is exit code `8`, and `--dry-run` reports it to
   refusal produces.
 - **Never a branch whose removal git refused.** The branch is deleted only once the worktree
   is actually gone.
+- **Uncommitted work is gitnuke's own refusal.** Submodules and uncommitted changes are both
+  diagnosed by gitnuke before `git worktree remove` is invoked, so each gets a message that
+  names what is in the way and an exit code of its own (`5` and `9`) rather than git's
+  locale-dependent `fatal:` under the generic `2`.
 - **A lock is honoured, not overridden.** A worktree locked with `git worktree lock` is
   refused even with `--force`, quoting the lock reason if git recorded one and handing back
   the `git worktree unlock` command to run.
@@ -1423,6 +1444,7 @@ out when the lock has none. This is exit code `8`, and `--dry-run` reports it to
 - `6`: The shell is standing inside the target worktree
 - `7`: The worktree was removed but its branch could not be deleted
 - `8`: The worktree is locked, which `--force` does not override
+- `9`: The worktree contains modified or untracked files and `--force` was not given
 
 ### Replacing the shell functions
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ containers/CI).
     `-p` (previous). Can also jump directly to a worktree by directory name or branch name.
     Use `--shell-setup` to automatically add shell integration to your config.
   - To install: `cargo install --git https://github.com/timmattison/tools cwt`
+- gitnuke
+  - Removes a git worktree and deletes the branch it had checked out, resolved as one
+    operation so the branch is never deleted while the worktree is left standing. Takes a
+    path, a directory name, or a branch name (exact matches only). A worktree with
+    submodules checked out - which plain `git worktree remove` refuses outright - or with
+    uncommitted changes needs `--force`. `--dry-run` reports the plan as a preflight, and
+    `--safe` keeps the branch unless it is fully merged.
+  - To install: `cargo install --git https://github.com/timmattison/tools gitnuke`
 - crap (Claude, Resume Anywhere Please)
   - Resume a Claude Code session from wherever you are. Given a session id, `crap` looks the
     session up under `~/.claude/projects`, recovers the directory it originally ran in, `cd`s
@@ -1313,6 +1321,97 @@ wtm               # Quick alias for main worktree
 - `3`: Worktree not found
 - `4`: Could not determine current worktree (for -f/-p)
 - `5`: Shell setup failed
+
+## gitnuke (nuke a worktree)
+
+Removes a git worktree and deletes the branch it had checked out. The two halves are one
+operation: the target is resolved against `git worktree list`, so the branch gitnuke deletes
+is whatever that worktree actually had checked out, and it is only deleted once the removal
+has succeeded. A refused removal never leaves the branch destroyed and the worktree standing.
+
+### Basic Usage
+
+```bash
+gitnuke ../issue-42-wt        # by path
+gitnuke issue-42-wt           # by directory name
+gitnuke issue-42              # by branch name
+gitnuke --force issue-42      # worktree has submodules or uncommitted changes
+gitnuke --dry-run issue-42    # report the plan, change nothing
+gitnuke --safe issue-42       # keep the branch unless it is fully merged
+gitnuke wt-a wt-b wt-c        # nuke several; each is reported independently
+```
+
+### Worktrees with submodules
+
+Plain `git worktree remove` refuses a worktree that has submodules checked out:
+
+```text
+fatal: working trees containing submodules cannot be moved or removed
+```
+
+gitnuke refuses too, but tells you what is in the way and how to override it:
+
+```text
+gitnuke: /code/repo-worktrees/issue-42 contains submodules (sub) — git refuses to remove a
+worktree with submodules checked out.
+  Nuking it deletes those checkouts along with any uncommitted or unpushed work inside them.
+  Re-run with --force to nuke it anyway.
+```
+
+`--force` is required because that warning is literal: a submodule checkout can hold commits
+and untracked files that exist nowhere else, and removing the worktree deletes them silently.
+One `--force` covers both of git's refusals — submodules checked out and uncommitted changes
+in the worktree itself.
+
+### Safety rails
+
+- **Exact matches only.** Unlike `cwt`, gitnuke never substring-matches: asking for
+  `issue-42` will not resolve `issue-421`. A target that matches both one worktree's
+  directory name and another's branch name is reported as ambiguous rather than guessed at.
+- **Never your own directory.** gitnuke refuses to remove the worktree your shell is
+  standing in (or any parent of it) and names somewhere else to `cd` to first. It is a
+  binary, not a shell function, so it cannot move your shell out of a directory it deletes.
+- **Never the main worktree**, and never a branch whose removal git refused.
+- **`--dry-run` is a real preflight.** It runs every check and exits with the same status a
+  real run would, so `gitnuke -n x` failing means `gitnuke x` would fail too.
+
+### Options
+
+- `-f, --force`: Nuke the worktree even if git would refuse — submodules checked out, or
+  uncommitted changes
+- `-s, --safe`: Keep the branch unless it is fully merged (`git branch -d` semantics instead
+  of the default force-delete). Only affects the branch; the worktree is still removed
+- `-n, --dry-run`: Report what would happen without removing or deleting anything
+- `[TARGETS]...`: One or more worktrees, each given as a path, directory name, or branch name
+
+### Exit Codes
+
+- `0`: Success
+- `1`: Not in a git repository
+- `2`: A git command failed
+- `3`: No worktree matched the target
+- `4`: The target matched more than one worktree
+- `5`: The worktree contains submodules and `--force` was not given
+- `6`: The shell is standing inside the target worktree
+- `7`: The worktree was removed but its branch could not be deleted
+
+### Replacing the shell functions
+
+gitnuke supersedes the hand-rolled `gitnuke`/`gitclean` shell functions this pattern usually
+starts as:
+
+```bash
+# Before: deletes the branch even when the worktree removal failed, and only
+# works when the worktree's directory name happens to equal its branch name.
+gitnuke() { git worktree remove "$@"; git branch -D "$@"; }
+```
+
+If you keep a `gitclean` alias for the safe variant, point it at the binary so it inherits
+the same submodule handling and ordering guarantees:
+
+```bash
+gitclean() { gitnuke --safe "$@"; }
+```
 
 ## crap (Claude, Resume Anywhere Please)
 

--- a/TLDR.md
+++ b/TLDR.md
@@ -19,6 +19,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `diskhog` | Live terminal UI of per-process disk I/O on macOS (IOPS with sudo). |
 | `freeport` | Finds a free TCP port on localhost, cross-platform. |
 | `gitdiggin` | Recursively searches git repos for commits containing a string (messages and diffs). |
+| `gitnuke` | Removes a git worktree and deletes its branch; `--force` is required for worktrees with submodules checked out (which `git worktree remove` refuses outright) or uncommitted changes. |
 | `gitrdun` | Shows your recent git commits across multiple repositories. |
 | `glo` | Finds and displays large objects in git repositories. |
 | `goup` | Updates Go dependencies across all `go.mod` files in a repo. |

--- a/src/gitnuke/Cargo.toml
+++ b/src/gitnuke/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gitnuke"
+version = "0.1.0"
+edition.workspace = true
+
+[[bin]]
+name = "gitnuke"
+path = "src/main.rs"
+
+[dependencies]
+buildinfo.workspace = true
+clap.workspace = true
+colored.workspace = true
+repowalker.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -1,7 +1,45 @@
+use std::path::{Path, PathBuf};
+use std::process::{exit, Command};
+
 use buildinfo::version_string;
 use clap::Parser;
+use colored::Colorize;
+use repowalker::find_git_repo;
 
-/// Remove a git worktree and delete its branch.
+/// Exit codes for different error conditions.
+mod exit_codes {
+    /// Not in a git repository.
+    pub const NOT_IN_REPO: i32 = 1;
+    /// A git command failed to execute or returned an error.
+    pub const GIT_COMMAND_ERROR: i32 = 2;
+    /// No worktree matched the target.
+    pub const WORKTREE_NOT_FOUND: i32 = 3;
+    /// The target matched more than one worktree.
+    pub const MULTIPLE_MATCHES: i32 = 4;
+}
+
+/// Remove a git worktree and force-delete its branch.
+///
+/// The target names a worktree, not a branch to delete in isolation: gitnuke
+/// resolves it against `git worktree list`, so the branch it deletes is
+/// whatever that worktree had checked out. A detached-HEAD worktree is removed
+/// with no branch deletion.
+///
+/// # Usage
+///
+/// ```sh
+/// gitnuke ../feature-wt        # by path
+/// gitnuke feature-wt           # by directory name
+/// gitnuke issue-42             # by branch name
+/// ```
+///
+/// # Exit Codes
+///
+/// - 0: Success
+/// - 1: Not in a git repository
+/// - 2: A git command failed
+/// - 3: No worktree matched the target
+/// - 4: The target matched more than one worktree
 #[derive(Parser)]
 #[command(name = "gitnuke")]
 #[command(about = "Remove a git worktree and force-delete its branch")]
@@ -12,11 +50,440 @@ struct Cli {
     targets: Vec<String>,
 }
 
+/// Represents a single git worktree.
+#[derive(Debug, Clone)]
+struct Worktree {
+    /// The filesystem path to this worktree.
+    path: PathBuf,
+    /// The branch name (without `refs/heads/` prefix), or None for detached HEAD.
+    branch: Option<String>,
+}
+
+impl Worktree {
+    /// The final path component (e.g. `absurd-rock` from a full path).
+    fn dir_name(&self) -> Option<&str> {
+        self.path.file_name()?.to_str()
+    }
+}
+
+/// Parses the output of `git worktree list --porcelain`.
+///
+/// The porcelain format looks like:
+/// ```text
+/// worktree /path/to/repo
+/// HEAD abc123...
+/// branch refs/heads/main
+///
+/// worktree /path/to/worktree
+/// HEAD def456...
+/// detached
+/// ```
+///
+/// For a detached HEAD the `branch` line is absent. The main worktree is always
+/// the first block, and the order here is preserved so callers can rely on it.
+fn parse_worktree_list(output: &str) -> Vec<Worktree> {
+    let mut worktrees = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            // A new block starts: flush the previous one.
+            if let Some(path) = current_path.take() {
+                worktrees.push(Worktree {
+                    path,
+                    branch: current_branch.take(),
+                });
+            }
+            current_path = Some(PathBuf::from(path));
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            current_branch = Some(
+                branch
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(branch)
+                    .to_string(),
+            );
+        }
+        // Ignore HEAD/bare/detached/locked/prunable lines.
+    }
+
+    if let Some(path) = current_path {
+        worktrees.push(Worktree {
+            path,
+            branch: current_branch,
+        });
+    }
+
+    worktrees
+}
+
+/// Lists the worktrees of the repository containing `repo_root`.
+fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| format!("failed to execute git: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree list failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    Ok(parse_worktree_list(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+/// Result of resolving a target string against the worktree list.
+#[derive(Debug, PartialEq, Eq)]
+enum Resolution {
+    /// Exactly one worktree matched (index into the list).
+    Single(usize),
+    /// Several worktrees matched (indices into the list).
+    Multiple(Vec<usize>),
+    /// Nothing matched.
+    NotFound,
+}
+
+/// Resolves a target to exactly one worktree.
+///
+/// Matching is deliberately **exact only** — path, then directory name, then
+/// branch name. gitnuke destroys whatever it resolves, so it must never guess:
+/// a substring match like cwt's would happily nuke `issue-421` when asked for
+/// `issue-42`.
+///
+/// `cwd` is the directory relative paths are resolved against.
+fn resolve_target(worktrees: &[Worktree], target: &str, cwd: Option<&Path>) -> Resolution {
+    if target.is_empty() {
+        return Resolution::NotFound;
+    }
+
+    // First: a path that points at one of the worktrees. Canonicalizing both
+    // sides makes `.`, `..`, trailing slashes, and symlinked temp dirs all
+    // resolve to the same thing.
+    if let Some(canonical) = canonicalize_target(target, cwd) {
+        if let Some(idx) = worktrees.iter().position(|wt| {
+            wt.path
+                .canonicalize()
+                .is_ok_and(|p| paths_equal(&p, &canonical))
+        }) {
+            return Resolution::Single(idx);
+        }
+    }
+
+    // Then: an exact directory name or branch name. Both passes are folded
+    // together so a name that hits one worktree's directory and another's
+    // branch is reported as ambiguous instead of silently preferring one.
+    let hits: Vec<usize> = worktrees
+        .iter()
+        .enumerate()
+        .filter(|(_, wt)| wt.dir_name() == Some(target) || wt.branch.as_deref() == Some(target))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    match hits.len() {
+        0 => Resolution::NotFound,
+        1 => Resolution::Single(hits[0]),
+        _ => Resolution::Multiple(hits),
+    }
+}
+
+/// Canonicalizes a possibly-relative target path, or None if it doesn't exist.
+fn canonicalize_target(target: &str, cwd: Option<&Path>) -> Option<PathBuf> {
+    let as_path = Path::new(target);
+    let absolute = if as_path.is_absolute() {
+        as_path.to_path_buf()
+    } else {
+        cwd?.join(as_path)
+    };
+    absolute.canonicalize().ok()
+}
+
+/// Compares two paths, handling case-insensitivity on macOS.
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        // The default macOS filesystem is case-insensitive.
+        a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        a == b
+    }
+}
+
+/// A failure to nuke one target: the message to print and the exit code to use.
+struct NukeError {
+    code: i32,
+    message: String,
+}
+
+impl NukeError {
+    fn new(code: i32, message: impl Into<String>) -> Self {
+        NukeError {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Removes a worktree, then deletes the branch it had checked out.
+///
+/// The branch is only deleted once the removal has actually succeeded, so a
+/// refused removal never leaves the branch destroyed and the worktree standing.
+fn nuke(repo_root: &Path, worktree: &Worktree) -> Result<(), NukeError> {
+    let output = Command::new("git")
+        .args(["worktree", "remove"])
+        .arg(&worktree.path)
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| {
+            NukeError::new(
+                exit_codes::GIT_COMMAND_ERROR,
+                format!("failed to execute git: {e}"),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(NukeError::new(
+            exit_codes::GIT_COMMAND_ERROR,
+            format!(
+                "could not remove worktree {}: {}",
+                worktree.path.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ));
+    }
+
+    println!(
+        "{} removed worktree {}",
+        "gitnuke:".green().bold(),
+        worktree.path.display()
+    );
+
+    let Some(branch) = &worktree.branch else {
+        println!(
+            "{} {} had a detached HEAD, so there is no branch to delete",
+            "gitnuke:".green().bold(),
+            worktree.path.display()
+        );
+        return Ok(());
+    };
+
+    delete_branch(repo_root, branch)
+}
+
+/// Force-deletes a branch (`git branch -D`), echoing git's own report.
+fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), NukeError> {
+    let output = Command::new("git")
+        .args(["branch", "-D", branch])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| {
+            NukeError::new(
+                exit_codes::GIT_COMMAND_ERROR,
+                format!("failed to execute git: {e}"),
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(NukeError::new(
+            exit_codes::GIT_COMMAND_ERROR,
+            format!(
+                "worktree removed, but branch '{branch}' could not be deleted: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ));
+    }
+
+    println!(
+        "{} {}",
+        "gitnuke:".green().bold(),
+        String::from_utf8_lossy(&output.stdout).trim()
+    );
+    Ok(())
+}
+
+/// Renders the "no worktree matched" message, listing what is available.
+fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
+    let mut message = format!("no worktree matches '{target}'. Known worktrees:");
+    for wt in worktrees {
+        let branch = wt.branch.as_deref().unwrap_or("detached HEAD");
+        message.push_str(&format!("\n  {} [{branch}]", wt.path.display()));
+    }
+    message
+}
+
+/// Nukes one target, resolving it against a freshly listed set of worktrees.
+fn nuke_target(repo_root: &Path, target: &str, cwd: Option<&Path>) -> Result<(), NukeError> {
+    let worktrees =
+        get_worktrees(repo_root).map_err(|e| NukeError::new(exit_codes::GIT_COMMAND_ERROR, e))?;
+
+    match resolve_target(&worktrees, target, cwd) {
+        Resolution::Single(idx) => nuke(repo_root, &worktrees[idx]),
+        Resolution::Multiple(indices) => {
+            let mut message =
+                format!("'{target}' matches more than one worktree; use a path instead:");
+            for idx in indices {
+                message.push_str(&format!("\n  {}", worktrees[idx].path.display()));
+            }
+            Err(NukeError::new(exit_codes::MULTIPLE_MATCHES, message))
+        }
+        Resolution::NotFound => Err(NukeError::new(
+            exit_codes::WORKTREE_NOT_FOUND,
+            not_found_message(&worktrees, target),
+        )),
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
-    eprintln!(
-        "gitnuke: not implemented ({} target(s) requested)",
-        cli.targets.len()
-    );
-    std::process::exit(1);
+
+    let Some(repo_root) = find_git_repo() else {
+        eprintln!("{} not in a git repository", "gitnuke:".red().bold());
+        exit(exit_codes::NOT_IN_REPO);
+    };
+
+    let cwd = std::env::current_dir().ok();
+
+    // The worktree list is re-read per target because nuking one invalidates it.
+    let mut first_error: Option<i32> = None;
+    for target in &cli.targets {
+        if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref()) {
+            eprintln!("{} {}", "gitnuke:".red().bold(), error.message);
+            first_error.get_or_insert(error.code);
+        }
+    }
+
+    if let Some(code) = first_error {
+        exit(code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wt(path: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            path: PathBuf::from(path),
+            branch: branch.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn parses_porcelain_worktree_list() {
+        let output = "\
+worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-worktrees/feature
+HEAD def456
+branch refs/heads/feature/login
+
+worktree /repo-worktrees/detached
+HEAD 789abc
+detached
+";
+        let worktrees = parse_worktree_list(output);
+
+        assert_eq!(worktrees.len(), 3);
+        assert_eq!(worktrees[0].path, PathBuf::from("/repo"));
+        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+        assert_eq!(worktrees[1].branch.as_deref(), Some("feature/login"));
+        assert_eq!(worktrees[2].branch, None);
+    }
+
+    #[test]
+    fn parses_final_block_without_trailing_blank_line() {
+        let worktrees = parse_worktree_list("worktree /repo\nHEAD abc\nbranch refs/heads/main");
+
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn resolves_exact_directory_and_branch_names() {
+        let worktrees = vec![
+            wt("/repo", Some("main")),
+            wt("/wt/absurd-rock", Some("issue-42")),
+        ];
+
+        assert_eq!(
+            resolve_target(&worktrees, "absurd-rock", None),
+            Resolution::Single(1)
+        );
+        assert_eq!(
+            resolve_target(&worktrees, "issue-42", None),
+            Resolution::Single(1)
+        );
+    }
+
+    #[test]
+    fn never_resolves_a_substring_of_a_branch_name() {
+        // A near-miss must be a miss: gitnuke destroys what it resolves.
+        let worktrees = vec![wt("/repo", Some("main")), wt("/wt/x", Some("issue-421"))];
+
+        assert_eq!(
+            resolve_target(&worktrees, "issue-42", None),
+            Resolution::NotFound
+        );
+        assert_eq!(resolve_target(&worktrees, "", None), Resolution::NotFound);
+    }
+
+    #[test]
+    fn reports_ambiguity_between_a_directory_name_and_a_branch_name() {
+        let worktrees = vec![
+            wt("/repo", Some("main")),
+            wt("/wt/shared", Some("branch-a")),
+            wt("/wt/other", Some("shared")),
+        ];
+
+        assert_eq!(
+            resolve_target(&worktrees, "shared", None),
+            Resolution::Multiple(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn resolves_multibyte_directory_and_branch_names() {
+        let worktrees = vec![
+            wt("/repo", Some("main")),
+            wt("/wt/日本語テスト", Some("機能/ログイン")),
+            wt("/wt/café", Some("🎉-party")),
+        ];
+
+        assert_eq!(
+            resolve_target(&worktrees, "日本語テスト", None),
+            Resolution::Single(1)
+        );
+        assert_eq!(
+            resolve_target(&worktrees, "機能/ログイン", None),
+            Resolution::Single(1)
+        );
+        assert_eq!(
+            resolve_target(&worktrees, "café", None),
+            Resolution::Single(2)
+        );
+        assert_eq!(
+            resolve_target(&worktrees, "🎉-party", None),
+            Resolution::Single(2)
+        );
+    }
+
+    #[test]
+    fn not_found_message_lists_known_worktrees() {
+        let worktrees = vec![wt("/repo", Some("main")), wt("/wt/x", None)];
+
+        let message = not_found_message(&worktrees, "nope");
+
+        assert!(message.contains("no worktree matches 'nope'"));
+        assert!(message.contains("/repo [main]"));
+        assert!(message.contains("/wt/x [detached HEAD]"));
+    }
 }

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -594,8 +594,13 @@ fn worktree_git_dir(worktree: &WorktreePath) -> Option<PathBuf> {
 /// without a repository on disk: everything downstream compares this path
 /// against the filesystem (`git_dir.join("modules").is_dir()`), where one stray
 /// terminator character silently turns a hit into a miss.
+///
+/// Only the line terminator is trimmed, not trailing whitespace at large: a
+/// path component may legitimately end in a space, and `trim_end` would quietly
+/// hand back a *different* path than git named — trading a rare bug for a rarer
+/// and worse one. `\r` and `\n` are the only characters git can add here.
 fn parse_absolute_git_dir(stdout: &str) -> PathBuf {
-    PathBuf::from(stdout.trim_end_matches('\n'))
+    PathBuf::from(stdout.trim_end_matches(['\r', '\n']))
 }
 
 /// A failure to nuke one target: the message to print and the exit code to use.

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -455,7 +455,24 @@ fn canonicalize_target(target: &str, cwd: Option<&Path>) -> Option<PathBuf> {
 fn paths_equal(a: &Path, b: &Path) -> bool {
     #[cfg(target_os = "macos")]
     {
-        // The default macOS filesystem is case-insensitive.
+        // Folding case assumes a difference of case cannot be a difference of
+        // directory. That holds on a case-insensitive volume, which is the macOS
+        // default, but APFS can be formatted case-sensitive, and there `/x/Foo`
+        // and `/x/foo` are two genuinely different directories this would call
+        // one — an alarming thing in a tool that destroys what it resolves.
+        //
+        // What makes it safe is *when* it is called: every caller canonicalizes
+        // both sides first, and macOS `realpath(3)` — which `Path::canonicalize`
+        // uses — rewrites each component to its true on-disk spelling. On either
+        // kind of volume the two sides therefore arrive already agreeing on case
+        // and the fold has nothing left to do; it is belt and braces. A runtime
+        // case-sensitivity probe was considered and rejected: more I/O and more
+        // moving parts for a misresolution no caller can currently reach.
+        //
+        // The residual limitation is that precondition. Hand this function two
+        // paths that have *not* been through `canonicalize` and on a
+        // case-sensitive volume it will report two different directories equal,
+        // so canonicalize first — every caller here does.
         a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
     }
 

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -18,6 +18,10 @@ mod exit_codes {
     pub const MULTIPLE_MATCHES: i32 = 4;
     /// The worktree contains submodules and `--force` was not given.
     pub const SUBMODULES_PRESENT: i32 = 5;
+    /// The shell is standing inside the worktree it was asked to nuke.
+    pub const INSIDE_TARGET: i32 = 6;
+    /// The worktree was removed but its branch could not be deleted.
+    pub const BRANCH_NOT_DELETED: i32 = 7;
 }
 
 /// The index mode git records for a submodule (gitlink) entry.
@@ -46,6 +50,8 @@ const GITLINK_MODE_PREFIX: &str = "160000 ";
 /// - 3: No worktree matched the target
 /// - 4: The target matched more than one worktree
 /// - 5: The worktree contains submodules and `--force` was not given
+/// - 6: The shell is standing inside the target worktree
+/// - 7: The worktree was removed but its branch could not be deleted
 #[derive(Parser)]
 #[command(name = "gitnuke")]
 #[command(about = "Remove a git worktree and force-delete its branch")]
@@ -63,6 +69,42 @@ struct Cli {
     /// or unpushed inside the submodule checkouts.
     #[arg(short = 'f', long, verbatim_doc_comment)]
     force: bool,
+
+    /// Keep the branch unless it is fully merged (`git branch -d`).
+    ///
+    /// Only affects the branch: the worktree is still removed. Without this,
+    /// gitnuke force-deletes the branch (`git branch -D`) whether or not its
+    /// commits landed anywhere.
+    #[arg(short = 's', long, verbatim_doc_comment)]
+    safe: bool,
+
+    /// Report what would happen without removing or deleting anything.
+    ///
+    /// Runs the same checks as a real run, so a target that would be refused is
+    /// still reported as a failure.
+    #[arg(short = 'n', long, verbatim_doc_comment)]
+    dry_run: bool,
+}
+
+/// How a nuke should behave, independent of which worktree it is aimed at.
+#[derive(Debug, Clone, Copy)]
+struct NukeOptions {
+    /// Override git's refusal to remove worktrees with submodules or changes.
+    force: bool,
+    /// Delete the branch only if it is fully merged.
+    safe: bool,
+    /// Check everything, change nothing.
+    dry_run: bool,
+}
+
+impl From<&Cli> for NukeOptions {
+    fn from(cli: &Cli) -> Self {
+        NukeOptions {
+            force: cli.force,
+            safe: cli.safe,
+            dry_run: cli.dry_run,
+        }
+    }
 }
 
 /// Represents a single git worktree.
@@ -346,9 +388,9 @@ impl NukeError {
 ///
 /// The branch is only deleted once the removal has actually succeeded, so a
 /// refused removal never leaves the branch destroyed and the worktree standing.
-fn nuke(repo_root: &Path, worktree: &Worktree, force: bool) -> Result<(), NukeError> {
+fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(), NukeError> {
     let submodules = find_submodules(&worktree.path);
-    if submodules.blocks_removal() && !force {
+    if submodules.blocks_removal() && !options.force {
         return Err(NukeError::new(
             exit_codes::SUBMODULES_PRESENT,
             format!(
@@ -362,8 +404,12 @@ fn nuke(repo_root: &Path, worktree: &Worktree, force: bool) -> Result<(), NukeEr
         ));
     }
 
+    if options.dry_run {
+        return report_plan(worktree, &submodules, options);
+    }
+
     let mut args = vec!["worktree", "remove"];
-    if force {
+    if options.force {
         // One --force is enough for both of git's refusals: submodules present
         // and uncommitted changes. (Verified against git 2.55.)
         args.push("--force");
@@ -407,13 +453,52 @@ fn nuke(repo_root: &Path, worktree: &Worktree, force: bool) -> Result<(), NukeEr
         return Ok(());
     };
 
-    delete_branch(repo_root, branch)
+    delete_branch(repo_root, branch, options.safe)
 }
 
-/// Force-deletes a branch (`git branch -D`), echoing git's own report.
-fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), NukeError> {
+/// Prints what a real run would do, and returns Ok since nothing was touched.
+///
+/// Reached only after every gate has passed, so a refused target reports its
+/// refusal instead: a dry run is a preflight, not a description.
+fn report_plan(
+    worktree: &Worktree,
+    submodules: &SubmoduleReport,
+    options: NukeOptions,
+) -> Result<(), NukeError> {
+    let extra = if submodules.blocks_removal() {
+        format!(" (discarding its {})", submodules.describe())
+    } else {
+        String::new()
+    };
+    println!(
+        "{} would remove worktree {}{extra}",
+        "gitnuke:".yellow().bold(),
+        worktree.path.display()
+    );
+
+    match &worktree.branch {
+        Some(branch) => println!(
+            "{} would delete branch {branch} (git branch {})",
+            "gitnuke:".yellow().bold(),
+            if options.safe { "-d" } else { "-D" }
+        ),
+        None => println!(
+            "{} {} has a detached HEAD, so no branch would be deleted",
+            "gitnuke:".yellow().bold(),
+            worktree.path.display()
+        ),
+    }
+
+    Ok(())
+}
+
+/// Deletes a branch, echoing git's own report.
+///
+/// `safe` picks `git branch -d` (refuses an unmerged branch) over `-D`.
+fn delete_branch(repo_root: &Path, branch: &str, safe: bool) -> Result<(), NukeError> {
+    let delete_flag = if safe { "-d" } else { "-D" };
     let output = Command::new("git")
-        .args(["branch", "-D", branch])
+        .args(["branch", delete_flag, branch])
         .current_dir(repo_root)
         .output()
         .map_err(|e| {
@@ -425,9 +510,10 @@ fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), NukeError> {
 
     if !output.status.success() {
         return Err(NukeError::new(
-            exit_codes::GIT_COMMAND_ERROR,
+            exit_codes::BRANCH_NOT_DELETED,
             format!(
-                "worktree removed, but branch '{branch}' could not be deleted: {}",
+                "worktree removed, but branch '{branch}' was kept: {}\n  \
+                 Delete it anyway with: git branch -D {branch}",
                 String::from_utf8_lossy(&output.stderr).trim()
             ),
         ));
@@ -451,18 +537,58 @@ fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
     message
 }
 
+/// Whether `cwd` is the worktree at `worktree`, or somewhere beneath it.
+///
+/// Both sides are canonicalized so `..` segments, trailing slashes, and
+/// symlinked parents (macOS `/var` → `/private/var`) cannot hide the overlap.
+fn cwd_is_inside(cwd: Option<&Path>, worktree: &Path) -> bool {
+    let Some(Ok(cwd)) = cwd.map(Path::canonicalize) else {
+        return false;
+    };
+    let Ok(worktree) = worktree.canonicalize() else {
+        return false;
+    };
+
+    paths_equal(&cwd, &worktree) || cwd.starts_with(&worktree)
+}
+
 /// Nukes one target, resolving it against a freshly listed set of worktrees.
 fn nuke_target(
     repo_root: &Path,
     target: &str,
     cwd: Option<&Path>,
-    force: bool,
+    options: NukeOptions,
 ) -> Result<(), NukeError> {
     let worktrees =
         get_worktrees(repo_root).map_err(|e| NukeError::new(exit_codes::GIT_COMMAND_ERROR, e))?;
 
     match resolve_target(&worktrees, target, cwd) {
-        Resolution::Single(idx) => nuke(repo_root, &worktrees[idx], force),
+        Resolution::Single(idx) => {
+            let worktree = &worktrees[idx];
+
+            // Removing the directory the shell is sitting in leaves that shell
+            // in a deleted cwd, where every later git command fails
+            // confusingly. gitnuke is a binary, not a shell function, so it
+            // cannot cd the caller out — refusing is the only safe answer, and
+            // --force does not change that: it overrides git's refusals, not
+            // the caller's shell.
+            if cwd_is_inside(cwd, &worktree.path) {
+                // worktrees[0] is always the main worktree in git's listing.
+                let elsewhere = worktrees.first().map_or_else(String::new, |main| {
+                    format!(" (for example {})", main.path.display())
+                });
+                return Err(NukeError::new(
+                    exit_codes::INSIDE_TARGET,
+                    format!(
+                        "you are inside {} — cd somewhere else first{elsewhere}, \
+                         otherwise your shell is left in a deleted directory",
+                        worktree.path.display()
+                    ),
+                ));
+            }
+
+            nuke(repo_root, worktree, options)
+        }
         Resolution::Multiple(indices) => {
             let mut message =
                 format!("'{target}' matches more than one worktree; use a path instead:");
@@ -487,11 +613,12 @@ fn main() {
     };
 
     let cwd = std::env::current_dir().ok();
+    let options = NukeOptions::from(&cli);
 
     // The worktree list is re-read per target because nuking one invalidates it.
     let mut first_error: Option<i32> = None;
     for target in &cli.targets {
-        if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref(), cli.force) {
+        if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref(), options) {
             eprintln!("{} {}", "gitnuke:".red().bold(), error.message);
             first_error.get_or_insert(error.code);
         }
@@ -617,8 +744,8 @@ detached
     #[test]
     fn extracts_only_gitlink_entries_from_ls_files_output() {
         // `<mode> <object> <stage>\t<path>`, NUL-separated.
-        let stdout = "100644 aaa 0\tREADME.md\0160000 bbb 0\tsub\0\
-                      100755 ccc 0\tscript.sh\0160000 ddd 0\tvendor/lib\0";
+        let stdout = "100644 aaa 0\tREADME.md\x00160000 bbb 0\tsub\x00\
+                      100755 ccc 0\tscript.sh\x00160000 ddd 0\tvendor/lib\x00";
 
         assert_eq!(
             parse_gitlink_paths(stdout),
@@ -629,7 +756,7 @@ detached
     #[test]
     fn extracts_gitlink_paths_with_multibyte_and_space_characters() {
         // `-z` output is unquoted, so these arrive verbatim.
-        let stdout = "160000 aaa 0\t日本語/サブ\0160000 bbb 0\tmy submodule\0";
+        let stdout = "160000 aaa 0\t日本語/サブ\x00160000 bbb 0\tmy submodule\x00";
 
         assert_eq!(
             parse_gitlink_paths(stdout),
@@ -641,7 +768,7 @@ detached
     fn ignores_entries_that_only_look_like_gitlinks() {
         // A path *named* like a mode, and a regular file whose mode merely
         // starts with the same digits, must not be mistaken for submodules.
-        let stdout = "100644 aaa 0\t160000 notes.txt\01600000 bbb 0\tweird\0";
+        let stdout = "100644 aaa 0\t160000 notes.txt\x001600000 bbb 0\tweird\x00";
 
         assert!(parse_gitlink_paths(stdout).is_empty());
     }

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -33,6 +33,8 @@ enum ExitCode {
     BranchNotDeleted = 7,
     /// The worktree is locked, which `--force` deliberately does not override.
     LockedWorktree = 8,
+    /// The worktree holds modified or untracked files and `--force` was absent.
+    DirtyWorktree = 9,
 }
 
 impl ExitCode {
@@ -79,6 +81,7 @@ const MAIN_WORKTREE_INDEX: usize = 0;
 /// - 6: The shell is standing inside the target worktree
 /// - 7: The worktree was removed but its branch could not be deleted
 /// - 8: The worktree is locked, which `--force` does not override
+/// - 9: The worktree contains modified or untracked files and `--force` was not given
 #[derive(Parser)]
 #[command(verbatim_doc_comment)]
 #[command(name = "gitnuke")]
@@ -685,6 +688,25 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
         ));
     }
 
+    // Below the submodule gate on purpose: a worktree that trips both is told
+    // about the submodules, because a submodule checkout can hold commits and
+    // untracked files that exist nowhere else and `--force` would take them all.
+    // Above the dry-run branch, like every gate before it, because the two paths
+    // owe the same verdict — and stated here rather than left to `git worktree
+    // remove` for the same reason the submodule gate is: gitnuke already knows
+    // the answer, so relaying git's locale-dependent `fatal:` under the generic
+    // "a git command failed" code would only make its two runs disagree.
+    if !options.force && has_uncommitted_changes(&worktree.path) {
+        return Err(NukeError::new(
+            ExitCode::DirtyWorktree,
+            format!(
+                "{} contains modified or untracked files — nuking it discards work \
+                 that exists nowhere else.\n  Re-run with --force to nuke it anyway.",
+                worktree.path
+            ),
+        ));
+    }
+
     if options.dry_run {
         preflight(repo_root, worktree, options)?;
         return report_plan(worktree, &submodules, options);
@@ -747,24 +769,16 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 /// the authority on whether they will refuse, and letting them answer is what
 /// keeps their own wording and their own edge cases. A dry run invokes neither,
 /// so without a stand-in it reports "would remove" for targets git is going to
-/// turn away — a false all-clear on a tool whose whole job is destruction. The
-/// main-worktree, lock, and submodule gates are the caller's, since they refuse
-/// both paths before either reaches this point.
+/// turn away — a false all-clear on a tool whose whole job is destruction.
+///
+/// Only the branch is left to stand in for. The main-worktree, lock, submodule
+/// and dirty-worktree gates are the caller's, since gitnuke raises those itself
+/// on both paths before either reaches this point — which is what leaves one
+/// message and one exit code per refusal instead of a dry-run copy to drift.
 ///
 /// The exit codes match the real refusals deliberately: `gitnuke -n x` failing
 /// has to mean `gitnuke x` fails the same way, or the preflight is decoration.
 fn preflight(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(), NukeError> {
-    if !options.force && has_uncommitted_changes(&worktree.path) {
-        return Err(NukeError::new(
-            ExitCode::GitCommandError,
-            format!(
-                "could not remove worktree {}: it contains modified or untracked \
-                 files.\n  Re-run with --force to discard them.",
-                worktree.path
-            ),
-        ));
-    }
-
     // A detached worktree has no branch, so there is nothing to be unmerged.
     if options.safe {
         if let Some(branch) = &worktree.branch {

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
@@ -910,6 +911,25 @@ fn nuke_target(
     }
 }
 
+/// The targets of a run, in the order first given, with repeats collapsed.
+///
+/// Naming a target twice is one instruction: without this, `gitnuke dup dup`
+/// nukes the worktree on the first pass and then reports `no worktree matches
+/// 'dup'` on the second, failing the whole run over its own success.
+///
+/// The comparison is on the literal strings the caller typed. Two *different*
+/// spellings of the same worktree — a path and the branch it has checked out —
+/// are still two targets here, and the second one still reports a miss once the
+/// first has removed it.
+fn distinct_targets(targets: &[String]) -> Vec<&str> {
+    let mut seen = HashSet::new();
+    targets
+        .iter()
+        .map(String::as_str)
+        .filter(|target| seen.insert(*target))
+        .collect()
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -923,7 +943,7 @@ fn main() {
 
     // The worktree list is re-read per target because nuking one invalidates it.
     let mut first_error: Option<i32> = None;
-    for target in &cli.targets {
+    for target in distinct_targets(&cli.targets) {
         if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref(), options) {
             eprintln!("{} {}", "gitnuke:".red().bold(), error.message);
             first_error.get_or_insert(error.code);
@@ -1243,6 +1263,19 @@ branch refs/heads/loud
         };
         assert!(metadata_only.blocks_removal());
         assert_eq!(metadata_only.describe(), "submodule metadata");
+    }
+
+    #[test]
+    fn collapses_repeats_and_keeps_the_order_they_were_first_given() {
+        let targets: Vec<String> = ["second", "first", "second", "third", "first"]
+            .iter()
+            .map(|target| (*target).to_string())
+            .collect();
+
+        // Order is the contract, not just the set: the run reports each target
+        // as it goes and exits with the *first* failure's code.
+        assert_eq!(distinct_targets(&targets), vec!["second", "first", "third"]);
+        assert_eq!(distinct_targets(&[]), Vec::<&str>::new());
     }
 
     #[test]

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -709,7 +709,8 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 
     if options.dry_run {
         preflight(repo_root, worktree, options)?;
-        return report_plan(worktree, &submodules, options);
+        report_plan(worktree, &submodules, options);
+        return Ok(());
     }
 
     let mut args = vec!["worktree", "remove"];
@@ -799,15 +800,11 @@ fn preflight(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Res
     Ok(())
 }
 
-/// Prints what a real run would do, and returns Ok since nothing was touched.
+/// Prints what a real run would do, touching nothing, so it cannot fail.
 ///
 /// Reached only after every gate has passed, so a refused target reports its
 /// refusal instead: a dry run is a preflight, not a description.
-fn report_plan(
-    worktree: &Worktree,
-    submodules: &SubmoduleReport,
-    options: NukeOptions,
-) -> Result<(), NukeError> {
+fn report_plan(worktree: &Worktree, submodules: &SubmoduleReport, options: NukeOptions) {
     let extra = if submodules.blocks_removal() {
         format!(" (discarding its {})", submodules.describe())
     } else {
@@ -831,8 +828,6 @@ fn report_plan(
             worktree.path
         ),
     }
-
-    Ok(())
 }
 
 /// Deletes a branch, echoing git's own report.

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -16,7 +16,12 @@ mod exit_codes {
     pub const WORKTREE_NOT_FOUND: i32 = 3;
     /// The target matched more than one worktree.
     pub const MULTIPLE_MATCHES: i32 = 4;
+    /// The worktree contains submodules and `--force` was not given.
+    pub const SUBMODULES_PRESENT: i32 = 5;
 }
+
+/// The index mode git records for a submodule (gitlink) entry.
+const GITLINK_MODE_PREFIX: &str = "160000 ";
 
 /// Remove a git worktree and force-delete its branch.
 ///
@@ -40,6 +45,7 @@ mod exit_codes {
 /// - 2: A git command failed
 /// - 3: No worktree matched the target
 /// - 4: The target matched more than one worktree
+/// - 5: The worktree contains submodules and `--force` was not given
 #[derive(Parser)]
 #[command(name = "gitnuke")]
 #[command(about = "Remove a git worktree and force-delete its branch")]
@@ -48,6 +54,15 @@ struct Cli {
     /// Worktree to nuke: its path, its directory name, or its branch name.
     #[arg(required = true)]
     targets: Vec<String>,
+
+    /// Nuke the worktree even if git would refuse to remove it.
+    ///
+    /// Required for a worktree containing submodules, which git otherwise
+    /// refuses outright, and for one holding uncommitted changes. Both cases
+    /// discard work that exists nowhere else — including anything uncommitted
+    /// or unpushed inside the submodule checkouts.
+    #[arg(short = 'f', long, verbatim_doc_comment)]
+    force: bool,
 }
 
 /// Represents a single git worktree.
@@ -216,6 +231,102 @@ fn paths_equal(a: &Path, b: &Path) -> bool {
     }
 }
 
+/// What is standing between a worktree and its removal, submodule-wise.
+///
+/// This mirrors git's own `validate_no_submodules` check, which is what produces
+/// "working trees containing submodules cannot be moved or removed": a worktree
+/// blocks removal if its index holds a gitlink whose directory exists on disk,
+/// or if its private git dir has a `modules/` directory. Reproducing the check
+/// rather than parsing git's refusal keeps the diagnosis locale-independent and
+/// lets gitnuke name the submodules that are in the way.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SubmoduleReport {
+    /// Submodule paths, relative to the worktree, that are checked out.
+    paths: Vec<String>,
+    /// Whether the worktree's private git dir contains submodule metadata.
+    has_module_metadata: bool,
+}
+
+impl SubmoduleReport {
+    /// Whether git will refuse a plain `git worktree remove` because of this.
+    fn blocks_removal(&self) -> bool {
+        !self.paths.is_empty() || self.has_module_metadata
+    }
+
+    /// Human-readable description of what is in the way.
+    fn describe(&self) -> String {
+        if self.paths.is_empty() {
+            "submodule metadata".to_string()
+        } else {
+            format!("submodules ({})", self.paths.join(", "))
+        }
+    }
+}
+
+/// Extracts the submodule (gitlink) paths from `git ls-files --stage -z` output.
+///
+/// Each NUL-separated entry looks like `<mode> <object> <stage>\t<path>`. `-z`
+/// is what makes this safe for non-ASCII and whitespace-bearing paths: without
+/// it git would quote and escape them according to `core.quotePath`.
+fn parse_gitlink_paths(stdout: &str) -> Vec<String> {
+    stdout
+        .split('\0')
+        .filter_map(|entry| {
+            let (metadata, path) = entry.split_once('\t')?;
+            metadata
+                .starts_with(GITLINK_MODE_PREFIX)
+                .then(|| path.to_string())
+        })
+        .collect()
+}
+
+/// Inspects `worktree` for submodules that would block its removal.
+///
+/// A worktree git can no longer inspect (already deleted, corrupt) yields an
+/// empty report: there is nothing to protect, and `git worktree remove` will
+/// give the authoritative answer either way.
+fn find_submodules(worktree: &Path) -> SubmoduleReport {
+    let mut paths = Vec::new();
+    if let Ok(output) = Command::new("git")
+        .args(["ls-files", "--stage", "-z"])
+        .current_dir(worktree)
+        .output()
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // git only refuses when the submodule is actually checked out; a
+            // gitlink with no directory on disk is inert.
+            paths = parse_gitlink_paths(&stdout)
+                .into_iter()
+                .filter(|path| worktree.join(path).exists())
+                .collect();
+        }
+    }
+
+    SubmoduleReport {
+        has_module_metadata: worktree_git_dir(worktree)
+            .is_some_and(|git_dir| git_dir.join("modules").is_dir()),
+        paths,
+    }
+}
+
+/// The worktree's private git dir (`.../.git/worktrees/<name>` for a linked one).
+fn worktree_git_dir(worktree: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--absolute-git-dir"])
+        .current_dir(worktree)
+        .output()
+        .ok()?;
+
+    output.status.success().then(|| {
+        PathBuf::from(
+            String::from_utf8_lossy(&output.stdout)
+                .trim_end_matches('\n')
+                .to_string(),
+        )
+    })
+}
+
 /// A failure to nuke one target: the message to print and the exit code to use.
 struct NukeError {
     code: i32,
@@ -235,9 +346,31 @@ impl NukeError {
 ///
 /// The branch is only deleted once the removal has actually succeeded, so a
 /// refused removal never leaves the branch destroyed and the worktree standing.
-fn nuke(repo_root: &Path, worktree: &Worktree) -> Result<(), NukeError> {
+fn nuke(repo_root: &Path, worktree: &Worktree, force: bool) -> Result<(), NukeError> {
+    let submodules = find_submodules(&worktree.path);
+    if submodules.blocks_removal() && !force {
+        return Err(NukeError::new(
+            exit_codes::SUBMODULES_PRESENT,
+            format!(
+                "{} contains {} — git refuses to remove a worktree with submodules \
+                 checked out.\n  Nuking it deletes those checkouts along with any \
+                 uncommitted or unpushed work inside them.\n  Re-run with --force to \
+                 nuke it anyway.",
+                worktree.path.display(),
+                submodules.describe(),
+            ),
+        ));
+    }
+
+    let mut args = vec!["worktree", "remove"];
+    if force {
+        // One --force is enough for both of git's refusals: submodules present
+        // and uncommitted changes. (Verified against git 2.55.)
+        args.push("--force");
+    }
+
     let output = Command::new("git")
-        .args(["worktree", "remove"])
+        .args(args)
         .arg(&worktree.path)
         .current_dir(repo_root)
         .output()
@@ -319,12 +452,17 @@ fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
 }
 
 /// Nukes one target, resolving it against a freshly listed set of worktrees.
-fn nuke_target(repo_root: &Path, target: &str, cwd: Option<&Path>) -> Result<(), NukeError> {
+fn nuke_target(
+    repo_root: &Path,
+    target: &str,
+    cwd: Option<&Path>,
+    force: bool,
+) -> Result<(), NukeError> {
     let worktrees =
         get_worktrees(repo_root).map_err(|e| NukeError::new(exit_codes::GIT_COMMAND_ERROR, e))?;
 
     match resolve_target(&worktrees, target, cwd) {
-        Resolution::Single(idx) => nuke(repo_root, &worktrees[idx]),
+        Resolution::Single(idx) => nuke(repo_root, &worktrees[idx], force),
         Resolution::Multiple(indices) => {
             let mut message =
                 format!("'{target}' matches more than one worktree; use a path instead:");
@@ -353,7 +491,7 @@ fn main() {
     // The worktree list is re-read per target because nuking one invalidates it.
     let mut first_error: Option<i32> = None;
     for target in &cli.targets {
-        if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref()) {
+        if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref(), cli.force) {
             eprintln!("{} {}", "gitnuke:".red().bold(), error.message);
             first_error.get_or_insert(error.code);
         }
@@ -474,6 +612,65 @@ detached
             resolve_target(&worktrees, "🎉-party", None),
             Resolution::Single(2)
         );
+    }
+
+    #[test]
+    fn extracts_only_gitlink_entries_from_ls_files_output() {
+        // `<mode> <object> <stage>\t<path>`, NUL-separated.
+        let stdout = "100644 aaa 0\tREADME.md\0160000 bbb 0\tsub\0\
+                      100755 ccc 0\tscript.sh\0160000 ddd 0\tvendor/lib\0";
+
+        assert_eq!(
+            parse_gitlink_paths(stdout),
+            vec!["sub".to_string(), "vendor/lib".to_string()]
+        );
+    }
+
+    #[test]
+    fn extracts_gitlink_paths_with_multibyte_and_space_characters() {
+        // `-z` output is unquoted, so these arrive verbatim.
+        let stdout = "160000 aaa 0\t日本語/サブ\0160000 bbb 0\tmy submodule\0";
+
+        assert_eq!(
+            parse_gitlink_paths(stdout),
+            vec!["日本語/サブ".to_string(), "my submodule".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_entries_that_only_look_like_gitlinks() {
+        // A path *named* like a mode, and a regular file whose mode merely
+        // starts with the same digits, must not be mistaken for submodules.
+        let stdout = "100644 aaa 0\t160000 notes.txt\01600000 bbb 0\tweird\0";
+
+        assert!(parse_gitlink_paths(stdout).is_empty());
+    }
+
+    #[test]
+    fn empty_gitlink_output_yields_nothing() {
+        assert!(parse_gitlink_paths("").is_empty());
+    }
+
+    #[test]
+    fn report_blocks_removal_for_checked_out_submodules_or_metadata() {
+        let clean = SubmoduleReport::default();
+        assert!(!clean.blocks_removal());
+
+        let with_paths = SubmoduleReport {
+            paths: vec!["sub".to_string(), "vendor/lib".to_string()],
+            has_module_metadata: false,
+        };
+        assert!(with_paths.blocks_removal());
+        assert_eq!(with_paths.describe(), "submodules (sub, vendor/lib)");
+
+        // git refuses on leftover metadata even with nothing checked out, so
+        // gitnuke has to gate on it too or it would gate then fail anyway.
+        let metadata_only = SubmoduleReport {
+            paths: Vec::new(),
+            has_module_metadata: true,
+        };
+        assert!(metadata_only.blocks_removal());
+        assert_eq!(metadata_only.describe(), "submodule metadata");
     }
 
     #[test]

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -582,13 +582,20 @@ fn worktree_git_dir(worktree: &WorktreePath) -> Option<PathBuf> {
         .output()
         .ok()?;
 
-    output.status.success().then(|| {
-        PathBuf::from(
-            String::from_utf8_lossy(&output.stdout)
-                .trim_end_matches('\n')
-                .to_string(),
-        )
-    })
+    output
+        .status
+        .success()
+        .then(|| parse_absolute_git_dir(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Reads the path out of `git rev-parse --absolute-git-dir` stdout.
+///
+/// Split out from the command that produces it so the trimming is testable
+/// without a repository on disk: everything downstream compares this path
+/// against the filesystem (`git_dir.join("modules").is_dir()`), where one stray
+/// terminator character silently turns a hit into a miss.
+fn parse_absolute_git_dir(stdout: &str) -> PathBuf {
+    PathBuf::from(stdout.trim_end_matches('\n'))
 }
 
 /// A failure to nuke one target: the message to print and the exit code to use.
@@ -1176,6 +1183,39 @@ branch refs/heads/loud
     #[test]
     fn empty_gitlink_output_yields_nothing() {
         assert!(parse_gitlink_paths("").is_empty());
+    }
+
+    #[test]
+    fn reads_the_git_dir_path_whatever_terminates_the_line() {
+        // git's own output ends in LF, but a CRLF one has to yield the same
+        // path: the result is joined with "modules" and asked whether that is a
+        // directory, and a path ending in a stray \r answers no to everything.
+        assert_eq!(
+            parse_absolute_git_dir("/repo/.git/worktrees/feature\n"),
+            PathBuf::from("/repo/.git/worktrees/feature")
+        );
+        assert_eq!(
+            parse_absolute_git_dir("/repo/.git/worktrees/feature\r\n"),
+            PathBuf::from("/repo/.git/worktrees/feature")
+        );
+        assert_eq!(
+            parse_absolute_git_dir("/repo/.git/worktrees/feature"),
+            PathBuf::from("/repo/.git/worktrees/feature")
+        );
+    }
+
+    #[test]
+    fn keeps_every_character_a_git_dir_path_is_entitled_to() {
+        // Spaces and multi-byte characters are legal in a path, including at the
+        // very end, so only the line terminator may be trimmed.
+        assert_eq!(
+            parse_absolute_git_dir("/repo dir/.git/worktrees/日本語 テスト\n"),
+            PathBuf::from("/repo dir/.git/worktrees/日本語 テスト")
+        );
+        assert_eq!(
+            parse_absolute_git_dir("/repo/.git/worktrees/trailing space \n"),
+            PathBuf::from("/repo/.git/worktrees/trailing space ")
+        );
     }
 
     #[test]

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -1,0 +1,22 @@
+use buildinfo::version_string;
+use clap::Parser;
+
+/// Remove a git worktree and delete its branch.
+#[derive(Parser)]
+#[command(name = "gitnuke")]
+#[command(about = "Remove a git worktree and force-delete its branch")]
+#[command(version = version_string!())]
+struct Cli {
+    /// Worktree to nuke: its path, its directory name, or its branch name.
+    #[arg(required = true)]
+    targets: Vec<String>,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    eprintln!(
+        "gitnuke: not implemented ({} target(s) requested)",
+        cli.targets.len()
+    );
+    std::process::exit(1);
+}

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -451,35 +451,19 @@ fn canonicalize_target(target: &str, cwd: Option<&Path>) -> Option<PathBuf> {
     absolute.canonicalize().ok()
 }
 
-/// Compares two paths, handling case-insensitivity on macOS.
+/// Compares two canonical paths for exact equality.
+///
+/// Exact is the only comparison that is correct on both kinds of volume, and
+/// every caller canonicalizes both sides first, which is what makes it
+/// sufficient. On a case-insensitive volume (the macOS default) `realpath(3)`
+/// — which `Path::canonicalize` uses — rewrites each component to its true
+/// on-disk spelling, so `FEATURE-WT/nested` arrives as `feature-wt/nested` and
+/// the two sides already agree on case. On a case-sensitive volume `/x/Foo` and
+/// `/x/foo` are two genuinely different directories, each canonicalizing to
+/// itself; case-folding would call them one and hand this destructive tool the
+/// wrong worktree.
 fn paths_equal(a: &Path, b: &Path) -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        // Folding case assumes a difference of case cannot be a difference of
-        // directory. That holds on a case-insensitive volume, which is the macOS
-        // default, but APFS can be formatted case-sensitive, and there `/x/Foo`
-        // and `/x/foo` are two genuinely different directories this would call
-        // one — an alarming thing in a tool that destroys what it resolves.
-        //
-        // What makes it safe is *when* it is called: every caller canonicalizes
-        // both sides first, and macOS `realpath(3)` — which `Path::canonicalize`
-        // uses — rewrites each component to its true on-disk spelling. On either
-        // kind of volume the two sides therefore arrive already agreeing on case
-        // and the fold has nothing left to do; it is belt and braces. A runtime
-        // case-sensitivity probe was considered and rejected: more I/O and more
-        // moving parts for a misresolution no caller can currently reach.
-        //
-        // The residual limitation is that precondition. Hand this function two
-        // paths that have *not* been through `canonicalize` and on a
-        // case-sensitive volume it will report two different directories equal,
-        // so canonicalize first — every caller here does.
-        a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        a == b
-    }
+    a == b
 }
 
 /// What is standing between a worktree and its removal, submodule-wise.

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -23,6 +23,8 @@ mod exit_codes {
     pub const INSIDE_TARGET: i32 = 6;
     /// The worktree was removed but its branch could not be deleted.
     pub const BRANCH_NOT_DELETED: i32 = 7;
+    /// The worktree is locked, which `--force` deliberately does not override.
+    pub const LOCKED_WORKTREE: i32 = 8;
 }
 
 /// The index mode git records for a submodule (gitlink) entry.
@@ -51,6 +53,7 @@ const GITLINK_MODE_PREFIX: &str = "160000 ";
 /// - 5: The worktree contains submodules and `--force` was not given
 /// - 6: The shell is standing inside the target worktree
 /// - 7: The worktree was removed but its branch could not be deleted
+/// - 8: The worktree is locked, which `--force` does not override
 #[derive(Parser)]
 #[command(verbatim_doc_comment)]
 #[command(name = "gitnuke")]
@@ -61,12 +64,16 @@ struct Cli {
     #[arg(required = true)]
     targets: Vec<String>,
 
-    /// Nuke the worktree even if git would refuse to remove it.
+    /// Nuke the worktree despite submodules or uncommitted changes.
     ///
-    /// Required for a worktree containing submodules, which git otherwise
-    /// refuses outright, and for one holding uncommitted changes. Both cases
+    /// Those are the two refusals it covers: a worktree containing submodules,
+    /// which git refuses outright, and one holding uncommitted changes. Both
     /// discard work that exists nowhere else — including anything uncommitted
     /// or unpushed inside the submodule checkouts.
+    ///
+    /// It does not cover a *locked* worktree. A lock is a deliberate "leave
+    /// this alone" marker, so gitnuke refuses one on its own terms and tells
+    /// you how to unlock it.
     #[arg(short = 'f', long, verbatim_doc_comment)]
     force: bool,
 
@@ -174,6 +181,40 @@ impl fmt::Display for WorktreePath {
     }
 }
 
+/// Whether git has a worktree locked, and why.
+///
+/// A lock is git's third refusal, alongside submodules and uncommitted changes,
+/// and the only one a single `--force` does not buy through: `git worktree
+/// remove --force` on a locked worktree still fails and asks for `remove -f -f`.
+/// gitnuke does not escalate — a lock is set by hand and means "leave this
+/// alone" — so this type exists to let it say so before it touches anything.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+enum LockState {
+    /// Nothing lock-related stands between this worktree and its removal.
+    #[default]
+    Unlocked,
+    /// git will refuse to remove this worktree, for `reason` if it recorded one.
+    Locked {
+        /// The text passed to `git worktree lock --reason`, if any.
+        reason: Option<String>,
+    },
+}
+
+impl LockState {
+    /// The lock's recorded reason, or None when locked without one.
+    fn reason(&self) -> Option<&str> {
+        match self {
+            LockState::Unlocked => None,
+            LockState::Locked { reason } => reason.as_deref(),
+        }
+    }
+
+    /// Whether git would refuse to remove the worktree over this lock.
+    fn blocks_removal(&self) -> bool {
+        matches!(self, LockState::Locked { .. })
+    }
+}
+
 /// Represents a single git worktree.
 #[derive(Debug, Clone)]
 struct Worktree {
@@ -181,6 +222,8 @@ struct Worktree {
     path: WorktreePath,
     /// The branch checked out here, or None for detached HEAD.
     branch: Option<BranchName>,
+    /// Whether git has this worktree locked.
+    lock: LockState,
 }
 
 /// Parses the output of `git worktree list --porcelain`.
@@ -194,14 +237,19 @@ struct Worktree {
 /// worktree /path/to/worktree
 /// HEAD def456...
 /// detached
+/// locked waiting on review
 /// ```
 ///
-/// For a detached HEAD the `branch` line is absent. The main worktree is always
-/// the first block, and the order here is preserved so callers can rely on it.
+/// For a detached HEAD the `branch` line is absent. The `locked` line is absent
+/// unless the worktree is locked, and carries a reason only when one was
+/// recorded. Attribute lines may appear in any order within a block. The main
+/// worktree is always the first block, and the order here is preserved so
+/// callers can rely on it.
 fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut current_path: Option<WorktreePath> = None;
     let mut current_branch: Option<BranchName> = None;
+    let mut current_lock = LockState::Unlocked;
 
     for line in output.lines() {
         if let Some(path) = line.strip_prefix("worktree ") {
@@ -210,24 +258,97 @@ fn parse_worktree_list(output: &str) -> Vec<Worktree> {
                 worktrees.push(Worktree {
                     path,
                     branch: current_branch.take(),
+                    lock: std::mem::take(&mut current_lock),
                 });
             }
             current_path = Some(WorktreePath::new(path));
         } else if let Some(branch) = line.strip_prefix("branch ") {
             // BranchName::from_ref owns the `refs/heads/` stripping.
             current_branch = Some(BranchName::from_ref(branch));
+        } else if let Some(lock) = parse_locked_line(line) {
+            current_lock = lock;
         }
-        // Ignore HEAD/bare/detached/locked/prunable lines.
+        // Ignore HEAD/bare/detached/prunable lines.
     }
 
     if let Some(path) = current_path {
         worktrees.push(Worktree {
             path,
             branch: current_branch,
+            lock: current_lock,
         });
     }
 
     worktrees
+}
+
+/// Reads a porcelain `locked` line, or None if this line is not one.
+///
+/// The grammar has two forms: a bare `locked`, meaning locked with no reason
+/// recorded, and `locked <reason>`. Requiring the separating space keeps any
+/// future attribute that merely starts with those letters from being read as a
+/// lock, and an all-whitespace reason is treated as none at all — which is what
+/// `git worktree lock --reason ""` records.
+fn parse_locked_line(line: &str) -> Option<LockState> {
+    let rest = line.strip_prefix("locked")?;
+    if !rest.is_empty() && !rest.starts_with(' ') {
+        return None;
+    }
+
+    let reason = rest.trim();
+    Some(LockState::Locked {
+        reason: (!reason.is_empty())
+            .then(|| unquote_c_style(reason).unwrap_or_else(|| reason.to_string())),
+    })
+}
+
+/// Decodes the C-style quoted form git uses for values it cannot print raw.
+///
+/// A lock reason is printed verbatim while it is plain ASCII, and wrapped in
+/// double quotes with backslash escapes — octal for every non-ASCII byte — as
+/// soon as it is not. Leaving that encoded would report
+/// `"\343\203\254\343\203\223..."` back to the person who typed
+/// `レビュー待ち`. Anything that is not a well-formed quoted string yields None,
+/// so the caller can fall back to the text as git printed it.
+///
+/// Bytes are collected and decoded as UTF-8 only at the end: one multi-byte
+/// character arrives as several separate octal escapes, so decoding per escape
+/// would mangle it.
+fn unquote_c_style(value: &str) -> Option<String> {
+    let inner = value.strip_prefix('"')?.strip_suffix('"')?;
+    let mut bytes: Vec<u8> = Vec::with_capacity(inner.len());
+    let mut chars = inner.chars();
+
+    while let Some(character) = chars.next() {
+        if character != '\\' {
+            let mut buffer = [0_u8; 4];
+            bytes.extend_from_slice(character.encode_utf8(&mut buffer).as_bytes());
+            continue;
+        }
+
+        match chars.next()? {
+            'a' => bytes.push(0x07),
+            'b' => bytes.push(0x08),
+            'f' => bytes.push(0x0c),
+            'n' => bytes.push(b'\n'),
+            'r' => bytes.push(b'\r'),
+            't' => bytes.push(b'\t'),
+            'v' => bytes.push(0x0b),
+            '"' => bytes.push(b'"'),
+            '\\' => bytes.push(b'\\'),
+            // Octal escapes are always exactly three digits.
+            first @ '0'..='7' => {
+                let mut value = first.to_digit(8)?;
+                for _ in 0..2 {
+                    value = value * 8 + chars.next()?.to_digit(8)?;
+                }
+                bytes.push(u8::try_from(value).ok()?);
+            }
+            _ => return None,
+        }
+    }
+
+    Some(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 /// Lists the worktrees of the repository containing `repo_root`.
@@ -490,6 +611,27 @@ impl NukeError {
 /// The branch is only deleted once the removal has actually succeeded, so a
 /// refused removal never leaves the branch destroyed and the worktree standing.
 fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(), NukeError> {
+    // Before the submodule gate, because a lock is the refusal --force cannot
+    // clear: reporting the overridable problem first would send the caller off
+    // to re-run with a flag that then hits this anyway. Ahead of the dry-run
+    // branch for the same reason the submodule gate is — both paths owe the
+    // same verdict.
+    if worktree.lock.blocks_removal() {
+        let reason = worktree
+            .lock
+            .reason()
+            .map_or_else(String::new, |reason| format!(" ({reason})"));
+        return Err(NukeError::new(
+            exit_codes::LOCKED_WORKTREE,
+            format!(
+                "{path} is locked{reason} — git refuses to remove a locked \
+                 worktree even with --force.\n  Unlock it first: git worktree \
+                 unlock {path}",
+                path = worktree.path,
+            ),
+        ));
+    }
+
     let submodules = find_submodules(&worktree.path);
     if submodules.blocks_removal() && !options.force {
         return Err(NukeError::new(
@@ -512,8 +654,10 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 
     let mut args = vec!["worktree", "remove"];
     if options.force {
-        // One --force is enough for both of git's refusals: submodules present
-        // and uncommitted changes. (Verified against git 2.55.)
+        // One --force is enough for the two of git's refusals gitnuke overrides:
+        // submodules present and uncommitted changes. (Verified against git
+        // 2.55.) The third — a locked worktree, which would need `-f -f` — was
+        // refused above rather than escalated to.
         args.push("--force");
     }
 
@@ -566,7 +710,8 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 /// keeps their own wording and their own edge cases. A dry run invokes neither,
 /// so without a stand-in it reports "would remove" for targets git is going to
 /// turn away — a false all-clear on a tool whose whole job is destruction. The
-/// submodule gate is the caller's, since it applies to both paths.
+/// lock and submodule gates are the caller's, since they refuse both paths
+/// before either reaches this point.
 ///
 /// The exit codes match the real refusals deliberately: `gitnuke -n x` failing
 /// has to mean `gitnuke x` fails the same way, or the preflight is decoration.
@@ -786,6 +931,7 @@ mod tests {
         Worktree {
             path: WorktreePath::new(path),
             branch: branch.map(BranchName::from_ref),
+            lock: LockState::Unlocked,
         }
     }
 
@@ -824,6 +970,106 @@ detached
 
         assert_eq!(worktrees.len(), 1);
         assert_eq!(branch_of(&worktrees[0]), Some("main"));
+    }
+
+    #[test]
+    fn records_the_lock_state_of_each_block() {
+        // A bare `locked` line, a `locked <reason>` line, and no line at all —
+        // the three states a block can be in. The lock is deliberately not the
+        // last line of its block: it may appear in any position.
+        let output = "\
+worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /wt/no-reason
+locked
+HEAD def456
+branch refs/heads/quiet
+
+worktree /wt/with-reason
+HEAD 789abc
+locked waiting on review
+branch refs/heads/loud
+";
+        let worktrees = parse_worktree_list(output);
+
+        assert_eq!(worktrees.len(), 3);
+        assert_eq!(worktrees[0].lock, LockState::Unlocked);
+        assert!(!worktrees[0].lock.blocks_removal());
+        assert_eq!(worktrees[1].lock, LockState::Locked { reason: None });
+        assert!(worktrees[1].lock.blocks_removal());
+        assert_eq!(worktrees[1].lock.reason(), None);
+        assert_eq!(worktrees[2].lock.reason(), Some("waiting on review"));
+        // The lock must not swallow the rest of its block.
+        assert_eq!(branch_of(&worktrees[1]), Some("quiet"));
+        assert_eq!(branch_of(&worktrees[2]), Some("loud"));
+    }
+
+    #[test]
+    fn records_a_lock_in_the_final_block_without_a_trailing_blank_line() {
+        let worktrees = parse_worktree_list("worktree /wt/x\nHEAD abc\nlocked");
+
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].lock, LockState::Locked { reason: None });
+    }
+
+    #[test]
+    fn reads_the_two_forms_of_the_porcelain_locked_line() {
+        assert_eq!(
+            parse_locked_line("locked"),
+            Some(LockState::Locked { reason: None })
+        );
+        assert_eq!(
+            parse_locked_line("locked mid-bisect, do not touch"),
+            Some(LockState::Locked {
+                reason: Some("mid-bisect, do not touch".to_string()),
+            })
+        );
+        // `git worktree lock --reason ""` records an empty reason, which is no
+        // reason at all rather than a reason that renders as "()".
+        assert_eq!(
+            parse_locked_line("locked   "),
+            Some(LockState::Locked { reason: None })
+        );
+
+        // Lines that merely start with the same letters are not locks.
+        assert_eq!(parse_locked_line("lockedby someone"), None);
+        assert_eq!(parse_locked_line("detached"), None);
+        assert_eq!(parse_locked_line(""), None);
+    }
+
+    #[test]
+    fn decodes_the_c_quoted_form_git_uses_for_awkward_lock_reasons() {
+        // Non-ASCII arrives as one octal escape per *byte*, so the decode has to
+        // reassemble the character rather than decode escape by escape.
+        assert_eq!(
+            parse_locked_line(
+                r#"locked "\343\203\254\343\203\223\343\203\245\343\203\274\345\276\205\343\201\241 \360\237\216\211""#
+            ),
+            Some(LockState::Locked {
+                reason: Some("レビュー待ち 🎉".to_string()),
+            })
+        );
+        assert_eq!(
+            unquote_c_style(r#""line one\nline two""#),
+            Some("line one\nline two".to_string())
+        );
+        assert_eq!(
+            unquote_c_style(r#""a \"quoted\" \\ backslash""#),
+            Some("a \"quoted\" \\ backslash".to_string())
+        );
+
+        // Not a quoted string, or a malformed one: the caller keeps git's text.
+        assert_eq!(unquote_c_style("plain reason"), None);
+        assert_eq!(unquote_c_style(r#""unterminated escape \"#), None);
+        assert_eq!(unquote_c_style(r#""short octal \34""#), None);
+        assert_eq!(
+            parse_locked_line(r#"locked "unterminated"#),
+            Some(LockState::Locked {
+                reason: Some(r#""unterminated"#.to_string()),
+            })
+        );
     }
 
     #[test]

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -1205,6 +1205,21 @@ branch refs/heads/loud
     }
 
     #[test]
+    fn never_equates_two_paths_that_differ_only_in_case() {
+        // A difference of case can be a difference of directory: APFS can be
+        // formatted case-sensitive, and on such a volume `/x/Foo` and `/x/foo`
+        // are two unrelated directories. gitnuke destroys what it resolves, so
+        // calling them equal means removing a worktree nobody named and
+        // deleting its branch. Only exact comparison is safe here.
+        assert!(!paths_equal(Path::new("/x/Foo"), Path::new("/x/foo")));
+        assert!(!paths_equal(
+            Path::new("/wt/FEATURE-WT/nested"),
+            Path::new("/wt/feature-wt/nested")
+        ));
+        assert!(paths_equal(Path::new("/x/foo"), Path::new("/x/foo")));
+    }
+
+    #[test]
     fn reports_ambiguity_between_a_directory_name_and_a_branch_name() {
         let worktrees = vec![
             wt("/repo", Some("main")),

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -31,6 +31,14 @@ mod exit_codes {
 /// The index mode git records for a submodule (gitlink) entry.
 const GITLINK_MODE_PREFIX: &str = "160000 ";
 
+/// Where the main worktree sits in `git worktree list`: always first.
+///
+/// That position is the *only* thing distinguishing the main worktree from the
+/// linked ones in the porcelain output — there is no `main` attribute line — so
+/// both rules that need to know about it read it from here rather than
+/// re-deriving it: the "cd somewhere else" hint, and the refusal to nuke it.
+const MAIN_WORKTREE_INDEX: usize = 0;
+
 /// Remove a git worktree and force-delete its branch.
 ///
 /// The target names a worktree, not a branch to delete in isolation: gitnuke
@@ -245,7 +253,7 @@ struct Worktree {
 /// unless the worktree is locked, and carries a reason only when one was
 /// recorded. Attribute lines may appear in any order within a block. The main
 /// worktree is always the first block, and the order here is preserved so
-/// callers can rely on it.
+/// callers can rely on it — see [`MAIN_WORKTREE_INDEX`].
 fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut current_path: Option<WorktreePath> = None;
@@ -723,8 +731,8 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 /// keeps their own wording and their own edge cases. A dry run invokes neither,
 /// so without a stand-in it reports "would remove" for targets git is going to
 /// turn away — a false all-clear on a tool whose whole job is destruction. The
-/// lock and submodule gates are the caller's, since they refuse both paths
-/// before either reaches this point.
+/// main-worktree, lock, and submodule gates are the caller's, since they refuse
+/// both paths before either reaches this point.
 ///
 /// The exit codes match the real refusals deliberately: `gitnuke -n x` failing
 /// has to mean `gitnuke x` fails the same way, or the preflight is decoration.
@@ -880,15 +888,41 @@ fn nuke_target(
             // --force does not change that: it overrides git's refusals, not
             // the caller's shell.
             if cwd_is_inside(cwd, &worktree.path) {
-                // worktrees[0] is always the main worktree in git's listing.
                 let elsewhere = worktrees
-                    .first()
+                    .get(MAIN_WORKTREE_INDEX)
                     .map_or_else(String::new, |main| format!(" (for example {})", main.path));
                 return Err(NukeError::new(
                     exit_codes::INSIDE_TARGET,
                     format!(
                         "you are inside {} — cd somewhere else first{elsewhere}, \
                          otherwise your shell is left in a deleted directory",
+                        worktree.path
+                    ),
+                ));
+            }
+
+            // git will not remove the worktree the repository itself lives in —
+            // `fatal: '<path>' is a main working tree`, with or without --force
+            // — so this refusal only decides *who says so*, never the outcome.
+            // Saying it here rather than leaving it to `git worktree remove` is
+            // what makes --dry-run tell the truth: a dry run never issues that
+            // command, so with the rule living in git it cleared the one
+            // worktree nothing can ever remove. Deferring also cost the caller
+            // the answer to "then what?", which git's fatal does not give.
+            //
+            // Below the cwd guard on purpose: standing inside the main worktree
+            // trips both, and a shell about to be stranded in a deleted
+            // directory is the more urgent thing to be told about.
+            if idx == MAIN_WORKTREE_INDEX {
+                return Err(NukeError::new(
+                    // git's own code for this refusal, so `gitnuke -n main` and
+                    // `gitnuke main` still agree the way the preflight promises.
+                    exit_codes::GIT_COMMAND_ERROR,
+                    format!(
+                        "{} is the main worktree — git refuses to remove the worktree \
+                         the repository itself lives in, with or without --force.\n  \
+                         Nuke one of its linked worktrees instead, or delete the \
+                         repository directory by hand.",
                         worktree.path
                     ),
                 ));

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
@@ -107,20 +108,78 @@ impl From<&Cli> for NukeOptions {
     }
 }
 
+/// The name of a git branch, always with any `refs/heads/` prefix stripped.
+///
+/// gitnuke's most destructive call — `git branch -D` — takes one of these, and
+/// it sits right next to a worktree path in that signature. Keeping the two as
+/// distinct types makes swapping them a compile error rather than a deleted
+/// branch. Construction goes through [`BranchName::from_ref`], so no caller can
+/// forget to strip the prefix and end up asking git to delete `refs/heads/x`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BranchName(String);
+
+impl BranchName {
+    /// Builds a branch name from a git ref, stripping a leading `refs/heads/`.
+    ///
+    /// A ref that carries no such prefix (already a short name) is taken as-is.
+    fn from_ref(reference: &str) -> Self {
+        BranchName(
+            reference
+                .strip_prefix("refs/heads/")
+                .unwrap_or(reference)
+                .to_string(),
+        )
+    }
+
+    /// The short branch name, as git's own `branch` subcommand wants it.
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The filesystem path of a git worktree.
+///
+/// Distinct from a plain `PathBuf` so it cannot be confused with the repository
+/// root (which every git invocation here also takes) or with a [`BranchName`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorktreePath(PathBuf);
+
+impl WorktreePath {
+    /// Wraps a path reported by git as a worktree location.
+    fn new(path: impl Into<PathBuf>) -> Self {
+        WorktreePath(path.into())
+    }
+
+    /// The path itself, for handing to `git` or the filesystem.
+    fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// The final path component (e.g. `absurd-rock` from a full path).
+    fn dir_name(&self) -> Option<&str> {
+        self.0.file_name()?.to_str()
+    }
+}
+
+impl fmt::Display for WorktreePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
 /// Represents a single git worktree.
 #[derive(Debug, Clone)]
 struct Worktree {
     /// The filesystem path to this worktree.
-    path: PathBuf,
-    /// The branch name (without `refs/heads/` prefix), or None for detached HEAD.
-    branch: Option<String>,
-}
-
-impl Worktree {
-    /// The final path component (e.g. `absurd-rock` from a full path).
-    fn dir_name(&self) -> Option<&str> {
-        self.path.file_name()?.to_str()
-    }
+    path: WorktreePath,
+    /// The branch checked out here, or None for detached HEAD.
+    branch: Option<BranchName>,
 }
 
 /// Parses the output of `git worktree list --porcelain`.
@@ -140,8 +199,8 @@ impl Worktree {
 /// the first block, and the order here is preserved so callers can rely on it.
 fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
-    let mut current_path: Option<PathBuf> = None;
-    let mut current_branch: Option<String> = None;
+    let mut current_path: Option<WorktreePath> = None;
+    let mut current_branch: Option<BranchName> = None;
 
     for line in output.lines() {
         if let Some(path) = line.strip_prefix("worktree ") {
@@ -152,14 +211,10 @@ fn parse_worktree_list(output: &str) -> Vec<Worktree> {
                     branch: current_branch.take(),
                 });
             }
-            current_path = Some(PathBuf::from(path));
+            current_path = Some(WorktreePath::new(path));
         } else if let Some(branch) = line.strip_prefix("branch ") {
-            current_branch = Some(
-                branch
-                    .strip_prefix("refs/heads/")
-                    .unwrap_or(branch)
-                    .to_string(),
-            );
+            // BranchName::from_ref owns the `refs/heads/` stripping.
+            current_branch = Some(BranchName::from_ref(branch));
         }
         // Ignore HEAD/bare/detached/locked/prunable lines.
     }
@@ -224,6 +279,7 @@ fn resolve_target(worktrees: &[Worktree], target: &str, cwd: Option<&Path>) -> R
     if let Some(canonical) = canonicalize_target(target, cwd) {
         if let Some(idx) = worktrees.iter().position(|wt| {
             wt.path
+                .as_path()
                 .canonicalize()
                 .is_ok_and(|p| paths_equal(&p, &canonical))
         }) {
@@ -237,7 +293,10 @@ fn resolve_target(worktrees: &[Worktree], target: &str, cwd: Option<&Path>) -> R
     let hits: Vec<usize> = worktrees
         .iter()
         .enumerate()
-        .filter(|(_, wt)| wt.dir_name() == Some(target) || wt.branch.as_deref() == Some(target))
+        .filter(|(_, wt)| {
+            wt.path.dir_name() == Some(target)
+                || wt.branch.as_ref().map(BranchName::as_str) == Some(target)
+        })
         .map(|(idx, _)| idx)
         .collect();
 
@@ -327,11 +386,11 @@ fn parse_gitlink_paths(stdout: &str) -> Vec<String> {
 /// A worktree git can no longer inspect (already deleted, corrupt) yields an
 /// empty report: there is nothing to protect, and `git worktree remove` will
 /// give the authoritative answer either way.
-fn find_submodules(worktree: &Path) -> SubmoduleReport {
+fn find_submodules(worktree: &WorktreePath) -> SubmoduleReport {
     let mut paths = Vec::new();
     if let Ok(output) = Command::new("git")
         .args(["ls-files", "--stage", "-z"])
-        .current_dir(worktree)
+        .current_dir(worktree.as_path())
         .output()
     {
         if output.status.success() {
@@ -340,7 +399,7 @@ fn find_submodules(worktree: &Path) -> SubmoduleReport {
             // gitlink with no directory on disk is inert.
             paths = parse_gitlink_paths(&stdout)
                 .into_iter()
-                .filter(|path| worktree.join(path).exists())
+                .filter(|path| worktree.as_path().join(path).exists())
                 .collect();
         }
     }
@@ -353,10 +412,10 @@ fn find_submodules(worktree: &Path) -> SubmoduleReport {
 }
 
 /// The worktree's private git dir (`.../.git/worktrees/<name>` for a linked one).
-fn worktree_git_dir(worktree: &Path) -> Option<PathBuf> {
+fn worktree_git_dir(worktree: &WorktreePath) -> Option<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--absolute-git-dir"])
-        .current_dir(worktree)
+        .current_dir(worktree.as_path())
         .output()
         .ok()?;
 
@@ -398,7 +457,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
                  checked out.\n  Nuking it deletes those checkouts along with any \
                  uncommitted or unpushed work inside them.\n  Re-run with --force to \
                  nuke it anyway.",
-                worktree.path.display(),
+                worktree.path,
                 submodules.describe(),
             ),
         ));
@@ -417,7 +476,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 
     let output = Command::new("git")
         .args(args)
-        .arg(&worktree.path)
+        .arg(worktree.path.as_path())
         .current_dir(repo_root)
         .output()
         .map_err(|e| {
@@ -432,7 +491,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
             exit_codes::GIT_COMMAND_ERROR,
             format!(
                 "could not remove worktree {}: {}",
-                worktree.path.display(),
+                worktree.path,
                 String::from_utf8_lossy(&output.stderr).trim()
             ),
         ));
@@ -441,14 +500,14 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
     println!(
         "{} removed worktree {}",
         "gitnuke:".green().bold(),
-        worktree.path.display()
+        worktree.path
     );
 
     let Some(branch) = &worktree.branch else {
         println!(
             "{} {} had a detached HEAD, so there is no branch to delete",
             "gitnuke:".green().bold(),
-            worktree.path.display()
+            worktree.path
         );
         return Ok(());
     };
@@ -473,7 +532,7 @@ fn report_plan(
     println!(
         "{} would remove worktree {}{extra}",
         "gitnuke:".yellow().bold(),
-        worktree.path.display()
+        worktree.path
     );
 
     match &worktree.branch {
@@ -485,7 +544,7 @@ fn report_plan(
         None => println!(
             "{} {} has a detached HEAD, so no branch would be deleted",
             "gitnuke:".yellow().bold(),
-            worktree.path.display()
+            worktree.path
         ),
     }
 
@@ -495,10 +554,10 @@ fn report_plan(
 /// Deletes a branch, echoing git's own report.
 ///
 /// `safe` picks `git branch -d` (refuses an unmerged branch) over `-D`.
-fn delete_branch(repo_root: &Path, branch: &str, safe: bool) -> Result<(), NukeError> {
+fn delete_branch(repo_root: &Path, branch: &BranchName, safe: bool) -> Result<(), NukeError> {
     let delete_flag = if safe { "-d" } else { "-D" };
     let output = Command::new("git")
-        .args(["branch", delete_flag, branch])
+        .args(["branch", delete_flag, branch.as_str()])
         .current_dir(repo_root)
         .output()
         .map_err(|e| {
@@ -531,8 +590,11 @@ fn delete_branch(repo_root: &Path, branch: &str, safe: bool) -> Result<(), NukeE
 fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
     let mut message = format!("no worktree matches '{target}'. Known worktrees:");
     for wt in worktrees {
-        let branch = wt.branch.as_deref().unwrap_or("detached HEAD");
-        message.push_str(&format!("\n  {} [{branch}]", wt.path.display()));
+        let branch = wt
+            .branch
+            .as_ref()
+            .map_or("detached HEAD", BranchName::as_str);
+        message.push_str(&format!("\n  {} [{branch}]", wt.path));
     }
     message
 }
@@ -541,11 +603,11 @@ fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
 ///
 /// Both sides are canonicalized so `..` segments, trailing slashes, and
 /// symlinked parents (macOS `/var` → `/private/var`) cannot hide the overlap.
-fn cwd_is_inside(cwd: Option<&Path>, worktree: &Path) -> bool {
+fn cwd_is_inside(cwd: Option<&Path>, worktree: &WorktreePath) -> bool {
     let Some(Ok(cwd)) = cwd.map(Path::canonicalize) else {
         return false;
     };
-    let Ok(worktree) = worktree.canonicalize() else {
+    let Ok(worktree) = worktree.as_path().canonicalize() else {
         return false;
     };
 
@@ -574,15 +636,15 @@ fn nuke_target(
             // the caller's shell.
             if cwd_is_inside(cwd, &worktree.path) {
                 // worktrees[0] is always the main worktree in git's listing.
-                let elsewhere = worktrees.first().map_or_else(String::new, |main| {
-                    format!(" (for example {})", main.path.display())
-                });
+                let elsewhere = worktrees
+                    .first()
+                    .map_or_else(String::new, |main| format!(" (for example {})", main.path));
                 return Err(NukeError::new(
                     exit_codes::INSIDE_TARGET,
                     format!(
                         "you are inside {} — cd somewhere else first{elsewhere}, \
                          otherwise your shell is left in a deleted directory",
-                        worktree.path.display()
+                        worktree.path
                     ),
                 ));
             }
@@ -593,7 +655,7 @@ fn nuke_target(
             let mut message =
                 format!("'{target}' matches more than one worktree; use a path instead:");
             for idx in indices {
-                message.push_str(&format!("\n  {}", worktrees[idx].path.display()));
+                message.push_str(&format!("\n  {}", worktrees[idx].path));
             }
             Err(NukeError::new(exit_codes::MULTIPLE_MATCHES, message))
         }
@@ -635,9 +697,14 @@ mod tests {
 
     fn wt(path: &str, branch: Option<&str>) -> Worktree {
         Worktree {
-            path: PathBuf::from(path),
-            branch: branch.map(str::to_string),
+            path: WorktreePath::new(path),
+            branch: branch.map(BranchName::from_ref),
         }
+    }
+
+    /// The short branch name a worktree carries, as a plain `&str`.
+    fn branch_of(worktree: &Worktree) -> Option<&str> {
+        worktree.branch.as_ref().map(BranchName::as_str)
     }
 
     #[test]
@@ -658,10 +725,10 @@ detached
         let worktrees = parse_worktree_list(output);
 
         assert_eq!(worktrees.len(), 3);
-        assert_eq!(worktrees[0].path, PathBuf::from("/repo"));
-        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
-        assert_eq!(worktrees[1].branch.as_deref(), Some("feature/login"));
-        assert_eq!(worktrees[2].branch, None);
+        assert_eq!(worktrees[0].path.as_path(), Path::new("/repo"));
+        assert_eq!(branch_of(&worktrees[0]), Some("main"));
+        assert_eq!(branch_of(&worktrees[1]), Some("feature/login"));
+        assert_eq!(branch_of(&worktrees[2]), None);
     }
 
     #[test]
@@ -669,7 +736,7 @@ detached
         let worktrees = parse_worktree_list("worktree /repo\nHEAD abc\nbranch refs/heads/main");
 
         assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+        assert_eq!(branch_of(&worktrees[0]), Some("main"));
     }
 
     #[test]

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -35,8 +35,10 @@ const GITLINK_MODE_PREFIX: &str = "160000 ";
 ///
 /// That position is the *only* thing distinguishing the main worktree from the
 /// linked ones in the porcelain output — there is no `main` attribute line — so
-/// both rules that need to know about it read it from here rather than
-/// re-deriving it: the "cd somewhere else" hint, and the refusal to nuke it.
+/// the refusal to nuke it reads the position from here rather than re-deriving
+/// it. The "cd somewhere else" hint leans on the same ordering without naming
+/// it: [`somewhere_else`] takes the first worktree that is *not* the target,
+/// which is this one in every case except the one where this one is the target.
 const MAIN_WORKTREE_INDEX: usize = 0;
 
 /// Remove a git worktree and force-delete its branch.
@@ -852,6 +854,25 @@ fn not_found_message(worktrees: &[Worktree], target: &str) -> String {
     message
 }
 
+/// A worktree to send a stranded caller to, given the one they are standing in.
+///
+/// The main worktree is the natural answer — it outlives every removal gitnuke
+/// can perform — and simply taking the first worktree git lists picks it. But
+/// the main worktree is also a legal target, and standing inside it while naming
+/// it is precisely when this hint fires, so "first entry" on its own answers
+/// "cd somewhere else, for example: here". Skipping the target is what keeps the
+/// advice advice; the main worktree still wins every other time, because it is
+/// still first.
+///
+/// A repo with nothing but its main worktree has nowhere to offer, and says so
+/// by offering nothing rather than by offering the target back.
+fn somewhere_else(worktrees: &[Worktree], target: usize) -> Option<&WorktreePath> {
+    worktrees
+        .iter()
+        .enumerate()
+        .find_map(|(index, worktree)| (index != target).then_some(&worktree.path))
+}
+
 /// Whether `cwd` is the worktree at `worktree`, or somewhere beneath it.
 ///
 /// Both sides are canonicalized so `..` segments, trailing slashes, and
@@ -888,9 +909,8 @@ fn nuke_target(
             // --force does not change that: it overrides git's refusals, not
             // the caller's shell.
             if cwd_is_inside(cwd, &worktree.path) {
-                let elsewhere = worktrees
-                    .get(MAIN_WORKTREE_INDEX)
-                    .map_or_else(String::new, |main| format!(" (for example {})", main.path));
+                let elsewhere = somewhere_else(&worktrees, idx)
+                    .map_or_else(String::new, |path| format!(" (for example {path})"));
                 return Err(NukeError::new(
                     exit_codes::INSIDE_TARGET,
                     format!(

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -8,24 +8,38 @@ use clap::Parser;
 use colored::Colorize;
 use repowalker::find_git_repo;
 
-/// Exit codes for different error conditions.
-mod exit_codes {
+/// The exit status gitnuke leaves behind, one variant per documented code.
+///
+/// A closed set rather than loose `i32` constants: these numbers are a published
+/// contract — they appear in `README.md` and in [`Cli`]'s own help — and the
+/// enum is what keeps an arbitrary integer from ever reaching [`NukeError`].
+/// The discriminants are the contract itself, so they must never be renumbered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+enum ExitCode {
     /// Not in a git repository.
-    pub const NOT_IN_REPO: i32 = 1;
+    NotInRepo = 1,
     /// A git command failed to execute or returned an error.
-    pub const GIT_COMMAND_ERROR: i32 = 2;
+    GitCommandError = 2,
     /// No worktree matched the target.
-    pub const WORKTREE_NOT_FOUND: i32 = 3;
+    WorktreeNotFound = 3,
     /// The target matched more than one worktree.
-    pub const MULTIPLE_MATCHES: i32 = 4;
+    MultipleMatches = 4,
     /// The worktree contains submodules and `--force` was not given.
-    pub const SUBMODULES_PRESENT: i32 = 5;
+    SubmodulesPresent = 5,
     /// The shell is standing inside the worktree it was asked to nuke.
-    pub const INSIDE_TARGET: i32 = 6;
+    InsideTarget = 6,
     /// The worktree was removed but its branch could not be deleted.
-    pub const BRANCH_NOT_DELETED: i32 = 7;
+    BranchNotDeleted = 7,
     /// The worktree is locked, which `--force` deliberately does not override.
-    pub const LOCKED_WORKTREE: i32 = 8;
+    LockedWorktree = 8,
+}
+
+impl ExitCode {
+    /// The number to hand [`exit`], which takes a plain `i32`.
+    fn as_i32(self) -> i32 {
+        self as i32
+    }
 }
 
 /// The index mode git records for a submodule (gitlink) entry.
@@ -617,12 +631,12 @@ fn parse_absolute_git_dir(stdout: &str) -> PathBuf {
 
 /// A failure to nuke one target: the message to print and the exit code to use.
 struct NukeError {
-    code: i32,
+    code: ExitCode,
     message: String,
 }
 
 impl NukeError {
-    fn new(code: i32, message: impl Into<String>) -> Self {
+    fn new(code: ExitCode, message: impl Into<String>) -> Self {
         NukeError {
             code,
             message: message.into(),
@@ -646,7 +660,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
             .reason()
             .map_or_else(String::new, |reason| format!(" ({reason})"));
         return Err(NukeError::new(
-            exit_codes::LOCKED_WORKTREE,
+            ExitCode::LockedWorktree,
             format!(
                 "{path} is locked{reason} — git refuses to remove a locked \
                  worktree even with --force.\n  Unlock it first: git worktree \
@@ -659,7 +673,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
     let submodules = find_submodules(&worktree.path);
     if submodules.blocks_removal() && !options.force {
         return Err(NukeError::new(
-            exit_codes::SUBMODULES_PRESENT,
+            ExitCode::SubmodulesPresent,
             format!(
                 "{} contains {} — git refuses to remove a worktree with submodules \
                  checked out.\n  Nuking it deletes those checkouts along with any \
@@ -692,14 +706,14 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
         .output()
         .map_err(|e| {
             NukeError::new(
-                exit_codes::GIT_COMMAND_ERROR,
+                ExitCode::GitCommandError,
                 format!("failed to execute git: {e}"),
             )
         })?;
 
     if !output.status.success() {
         return Err(NukeError::new(
-            exit_codes::GIT_COMMAND_ERROR,
+            ExitCode::GitCommandError,
             format!(
                 "could not remove worktree {}: {}",
                 worktree.path,
@@ -742,7 +756,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
 fn preflight(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(), NukeError> {
     if !options.force && has_uncommitted_changes(&worktree.path) {
         return Err(NukeError::new(
-            exit_codes::GIT_COMMAND_ERROR,
+            ExitCode::GitCommandError,
             format!(
                 "could not remove worktree {}: it contains modified or untracked \
                  files.\n  Re-run with --force to discard them.",
@@ -756,7 +770,7 @@ fn preflight(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Res
         if let Some(branch) = &worktree.branch {
             if !branch_is_merged(repo_root, branch) {
                 return Err(NukeError::new(
-                    exit_codes::BRANCH_NOT_DELETED,
+                    ExitCode::BranchNotDeleted,
                     format!(
                         "worktree {} would be removed, but branch '{branch}' is not \
                          fully merged, so --safe would keep it.\n  Delete it anyway \
@@ -818,14 +832,14 @@ fn delete_branch(repo_root: &Path, branch: &BranchName, safe: bool) -> Result<()
         .output()
         .map_err(|e| {
             NukeError::new(
-                exit_codes::GIT_COMMAND_ERROR,
+                ExitCode::GitCommandError,
                 format!("failed to execute git: {e}"),
             )
         })?;
 
     if !output.status.success() {
         return Err(NukeError::new(
-            exit_codes::BRANCH_NOT_DELETED,
+            ExitCode::BranchNotDeleted,
             format!(
                 "worktree removed, but branch '{branch}' was kept: {}\n  \
                  Delete it anyway with: git branch -D {branch}",
@@ -897,7 +911,7 @@ fn nuke_target(
     options: NukeOptions,
 ) -> Result<(), NukeError> {
     let worktrees =
-        get_worktrees(repo_root).map_err(|e| NukeError::new(exit_codes::GIT_COMMAND_ERROR, e))?;
+        get_worktrees(repo_root).map_err(|e| NukeError::new(ExitCode::GitCommandError, e))?;
 
     match resolve_target(&worktrees, target, cwd) {
         Resolution::Single(idx) => {
@@ -913,7 +927,7 @@ fn nuke_target(
                 let elsewhere = somewhere_else(&worktrees, idx)
                     .map_or_else(String::new, |path| format!(" (for example {path})"));
                 return Err(NukeError::new(
-                    exit_codes::INSIDE_TARGET,
+                    ExitCode::InsideTarget,
                     format!(
                         "you are inside {} — cd somewhere else first{elsewhere}, \
                          otherwise your shell is left in a deleted directory",
@@ -938,7 +952,7 @@ fn nuke_target(
                 return Err(NukeError::new(
                     // git's own code for this refusal, so `gitnuke -n main` and
                     // `gitnuke main` still agree the way the preflight promises.
-                    exit_codes::GIT_COMMAND_ERROR,
+                    ExitCode::GitCommandError,
                     format!(
                         "{} is the main worktree — git refuses to remove the worktree \
                          the repository itself lives in, with or without --force.\n  \
@@ -957,10 +971,10 @@ fn nuke_target(
             for idx in indices {
                 message.push_str(&format!("\n  {}", worktrees[idx].path));
             }
-            Err(NukeError::new(exit_codes::MULTIPLE_MATCHES, message))
+            Err(NukeError::new(ExitCode::MultipleMatches, message))
         }
         Resolution::NotFound => Err(NukeError::new(
-            exit_codes::WORKTREE_NOT_FOUND,
+            ExitCode::WorktreeNotFound,
             not_found_message(&worktrees, target),
         )),
     }
@@ -990,14 +1004,14 @@ fn main() {
 
     let Some(repo_root) = find_git_repo() else {
         eprintln!("{} not in a git repository", "gitnuke:".red().bold());
-        exit(exit_codes::NOT_IN_REPO);
+        exit(ExitCode::NotInRepo.as_i32());
     };
 
     let cwd = std::env::current_dir().ok();
     let options = NukeOptions::from(&cli);
 
     // The worktree list is re-read per target because nuking one invalidates it.
-    let mut first_error: Option<i32> = None;
+    let mut first_error: Option<ExitCode> = None;
     for target in distinct_targets(&cli.targets) {
         if let Err(error) = nuke_target(&repo_root, target, cwd.as_deref(), options) {
             eprintln!("{} {}", "gitnuke:".red().bold(), error.message);
@@ -1006,7 +1020,7 @@ fn main() {
     }
 
     if let Some(code) = first_error {
-        exit(code);
+        exit(code.as_i32());
     }
 }
 

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -81,8 +81,10 @@ struct Cli {
 
     /// Report what would happen without removing or deleting anything.
     ///
-    /// Runs the same checks as a real run, so a target that would be refused is
-    /// still reported as a failure.
+    /// A preflight, not a description: it runs every check a real run runs —
+    /// submodules, uncommitted changes, and under --safe whether the branch is
+    /// merged — and exits with the status that run would. A target that would
+    /// be refused is reported as a failure, with the same exit code.
     #[arg(short = 'n', long, verbatim_doc_comment)]
     dry_run: bool,
 }
@@ -411,6 +413,47 @@ fn find_submodules(worktree: &WorktreePath) -> SubmoduleReport {
     }
 }
 
+/// Whether `worktree` holds the modified or untracked files git refuses over.
+///
+/// This is the same question `git worktree remove` asks before it will delete
+/// anything, down to `--ignore-submodules=none`: ignored files do not count,
+/// untracked ones do. A worktree git can no longer inspect reports clean, the
+/// same way [`find_submodules`] reports nothing — the real removal is the
+/// authority, and it will say so in its own words.
+fn has_uncommitted_changes(worktree: &WorktreePath) -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain", "--ignore-submodules=none"])
+        .current_dir(worktree.as_path())
+        .output()
+        .is_ok_and(|output| output.status.success() && !output.stdout.is_empty())
+}
+
+/// Whether `branch` is merged into whatever `git branch -d` would compare it to.
+///
+/// git measures merged-ness against the branch's upstream when it has one and
+/// against HEAD otherwise, so gitnuke asks about the same ref. Assuming HEAD
+/// unconditionally would cry "not fully merged" over every branch whose commits
+/// are already safe on its remote but not yet back on the local mainline.
+fn branch_is_merged(repo_root: &Path, branch: &BranchName) -> bool {
+    let upstream = format!("{branch}@{{upstream}}");
+    let has_upstream = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", &upstream])
+        .current_dir(repo_root)
+        .output()
+        .is_ok_and(|output| output.status.success());
+
+    let reference = if has_upstream {
+        upstream.as_str()
+    } else {
+        "HEAD"
+    };
+    Command::new("git")
+        .args(["merge-base", "--is-ancestor", branch.as_str(), reference])
+        .current_dir(repo_root)
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
 /// The worktree's private git dir (`.../.git/worktrees/<name>` for a linked one).
 fn worktree_git_dir(worktree: &WorktreePath) -> Option<PathBuf> {
     let output = Command::new("git")
@@ -464,6 +507,7 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
     }
 
     if options.dry_run {
+        preflight(repo_root, worktree, options)?;
         return report_plan(worktree, &submodules, options);
     }
 
@@ -513,6 +557,50 @@ fn nuke(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(
     };
 
     delete_branch(repo_root, branch, options.safe)
+}
+
+/// Raises, ahead of time, the refusals a real run would only discover by asking
+/// git.
+///
+/// A real run never needs this: `git worktree remove` and `git branch -d` are
+/// the authority on whether they will refuse, and letting them answer is what
+/// keeps their own wording and their own edge cases. A dry run invokes neither,
+/// so without a stand-in it reports "would remove" for targets git is going to
+/// turn away — a false all-clear on a tool whose whole job is destruction. The
+/// submodule gate is the caller's, since it applies to both paths.
+///
+/// The exit codes match the real refusals deliberately: `gitnuke -n x` failing
+/// has to mean `gitnuke x` fails the same way, or the preflight is decoration.
+fn preflight(repo_root: &Path, worktree: &Worktree, options: NukeOptions) -> Result<(), NukeError> {
+    if !options.force && has_uncommitted_changes(&worktree.path) {
+        return Err(NukeError::new(
+            exit_codes::GIT_COMMAND_ERROR,
+            format!(
+                "could not remove worktree {}: it contains modified or untracked \
+                 files.\n  Re-run with --force to discard them.",
+                worktree.path
+            ),
+        ));
+    }
+
+    // A detached worktree has no branch, so there is nothing to be unmerged.
+    if options.safe {
+        if let Some(branch) = &worktree.branch {
+            if !branch_is_merged(repo_root, branch) {
+                return Err(NukeError::new(
+                    exit_codes::BRANCH_NOT_DELETED,
+                    format!(
+                        "worktree {} would be removed, but branch '{branch}' is not \
+                         fully merged, so --safe would keep it.\n  Delete it anyway \
+                         with: git branch -D {branch}",
+                        worktree.path
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Prints what a real run would do, and returns Ok since nothing was touched.

--- a/src/gitnuke/src/main.rs
+++ b/src/gitnuke/src/main.rs
@@ -35,15 +35,13 @@ const GITLINK_MODE_PREFIX: &str = "160000 ";
 /// whatever that worktree had checked out. A detached-HEAD worktree is removed
 /// with no branch deletion.
 ///
-/// # Usage
+/// Examples:
 ///
-/// ```sh
-/// gitnuke ../feature-wt        # by path
-/// gitnuke feature-wt           # by directory name
-/// gitnuke issue-42             # by branch name
-/// ```
+///     gitnuke ../feature-wt        # by path
+///     gitnuke feature-wt           # by directory name
+///     gitnuke issue-42             # by branch name
 ///
-/// # Exit Codes
+/// Exit codes:
 ///
 /// - 0: Success
 /// - 1: Not in a git repository
@@ -54,6 +52,7 @@ const GITLINK_MODE_PREFIX: &str = "160000 ";
 /// - 6: The shell is standing inside the target worktree
 /// - 7: The worktree was removed but its branch could not be deleted
 #[derive(Parser)]
+#[command(verbatim_doc_comment)]
 #[command(name = "gitnuke")]
 #[command(about = "Remove a git worktree and force-delete its branch")]
 #[command(version = version_string!())]

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -999,3 +999,66 @@ fn refuses_to_run_outside_a_git_repository() {
         combined(&output)
     );
 }
+
+/// The exit-code list `gitnuke --help` publishes, one entry per rendered line.
+///
+/// Stated here rather than derived from the binary for the same reason as
+/// `mod exit_codes` above: this is the contract users read, so the test has to
+/// spell it out independently.
+const HELP_EXIT_CODE_LINES: [&str; 8] = [
+    "- 0: Success",
+    "- 1: Not in a git repository",
+    "- 2: A git command failed",
+    "- 3: No worktree matched the target",
+    "- 4: The target matched more than one worktree",
+    "- 5: The worktree contains submodules and `--force` was not given",
+    "- 6: The shell is standing inside the target worktree",
+    "- 7: The worktree was removed but its branch could not be deleted",
+];
+
+/// The usage examples `gitnuke --help` publishes, as (command, trailing note).
+///
+/// Each pair has to land on a single rendered line of its own: the command at
+/// the start, its explanatory comment at the end.
+const HELP_USAGE_EXAMPLES: [(&str, &str); 3] = [
+    ("gitnuke ../feature-wt", "# by path"),
+    ("gitnuke feature-wt", "# by directory name"),
+    ("gitnuke issue-42", "# by branch name"),
+];
+
+/// `--help` has to render its long description with the newlines intact.
+///
+/// clap only keeps the line breaks of a doc comment when the *command* itself
+/// carries `verbatim_doc_comment`; the per-flag attributes do not cover the
+/// struct's own doc comment. Without it every usage example is jammed onto one
+/// line and all eight exit codes run together as a single paragraph.
+#[test]
+fn long_help_renders_one_line_per_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let output = gitnuke(tmp.path(), &["--help"]);
+
+    assert!(
+        output.status.success(),
+        "--help should succeed: {}",
+        combined(&output)
+    );
+    let help = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = help.lines().map(str::trim).collect();
+
+    for entry in HELP_EXIT_CODE_LINES {
+        assert!(
+            lines.contains(&entry),
+            "exit code entry {entry:?} should be a line of its own, got:\n{help}"
+        );
+    }
+
+    for (command, note) in HELP_USAGE_EXAMPLES {
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.starts_with(command) && line.ends_with(note)),
+            "usage example {command:?} should be a line of its own ending in {note:?}, got:\n{help}"
+        );
+    }
+}

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -104,6 +104,45 @@ impl Fixture {
         self.root.join("main")
     }
 
+    /// Create a `sub` repo and register it as a submodule at `sub/` in `main`.
+    ///
+    /// Must be called *before* `add_worktree` so the worktree's HEAD contains
+    /// the gitlink. `protocol.file.allow` is needed because git refuses
+    /// file-transport submodule clones by default (CVE-2022-39253).
+    fn add_submodule(&self) {
+        self.init_repo("sub");
+        let main = self.main_repo();
+        git(
+            &main,
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                "-q",
+                "../sub",
+                "sub",
+            ],
+        );
+        git(&main, &["commit", "-qm", "add submodule"]);
+    }
+
+    /// Check out the submodule contents inside a linked worktree, which is what
+    /// makes git refuse to remove that worktree.
+    fn populate_submodule(&self, worktree: &Path) {
+        git(
+            worktree,
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "update",
+                "--init",
+                "-q",
+            ],
+        );
+    }
+
     /// Add a linked worktree at `<root>/<dir>` checked out on a new `branch`.
     fn add_worktree(&self, dir: &str, branch: &str) -> PathBuf {
         let path = self.root.join(dir);
@@ -143,6 +182,130 @@ fn worktree_registered(repo: &Path, path: &Path) -> bool {
     String::from_utf8_lossy(&output.stdout)
         .lines()
         .any(|line| line.strip_prefix("worktree ") == Some(path.to_str().expect("utf-8 path")))
+}
+
+/// A worktree containing a populated submodule is the case plain
+/// `git worktree remove` refuses outright ("working trees containing submodules
+/// cannot be moved or removed"). gitnuke must refuse too — but say what is in
+/// the way and how to override it, and leave the branch alone.
+#[test]
+fn refuses_a_submodule_worktree_without_force() {
+    let fixture = Fixture::new();
+    fixture.add_submodule();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    fixture.populate_submodule(&worktree);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["feature"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke should refuse a submodule worktree without --force: {message}"
+    );
+    assert!(
+        worktree.exists(),
+        "the worktree must survive a refusal: {message}"
+    );
+    assert!(
+        worktree_registered(&main, &worktree),
+        "git must still track the worktree after a refusal: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "the branch must survive a refused removal: {message}"
+    );
+    assert!(
+        message.contains("submodule"),
+        "the message should say submodules are the problem: {message}"
+    );
+    assert!(
+        message.contains("sub"),
+        "the message should name the submodule in the way: {message}"
+    );
+    assert!(
+        message.contains("--force"),
+        "the message should point at --force: {message}"
+    );
+}
+
+#[test]
+fn nukes_a_submodule_worktree_with_force() {
+    let fixture = Fixture::new();
+    fixture.add_submodule();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    fixture.populate_submodule(&worktree);
+    assert!(
+        worktree.join("sub/README.md").exists(),
+        "fixture should have a populated submodule checkout"
+    );
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke --force should nuke a submodule worktree: {}",
+        combined(&output)
+    );
+    assert!(
+        !worktree.exists(),
+        "worktree directory should be gone, submodule and all"
+    );
+    assert!(
+        !worktree_registered(&main, &worktree),
+        "git should no longer track the worktree"
+    );
+    assert!(
+        !branch_exists(&main, "feature"),
+        "branch 'feature' should be deleted"
+    );
+}
+
+/// Uncommitted work is git's other reason to refuse a removal. gitnuke must not
+/// delete the branch when that happens — the whole point of the worktree being
+/// left standing is that the work inside it is still recoverable.
+#[test]
+fn keeps_the_branch_when_a_dirty_worktree_is_refused() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("README.md"), "uncommitted work\n").expect("dirty the worktree");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["feature"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke should refuse a dirty worktree without --force: {message}"
+    );
+    assert!(worktree.exists(), "the dirty worktree must survive");
+    assert!(
+        branch_exists(&main, "feature"),
+        "the branch must survive a refused removal: {message}"
+    );
+}
+
+#[test]
+fn force_nukes_a_dirty_worktree() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("README.md"), "uncommitted work\n").expect("dirty the worktree");
+    std::fs::write(worktree.join("scratch.txt"), "untracked\n").expect("add untracked file");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke --force should nuke a dirty worktree: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !branch_exists(&main, "feature"),
+        "branch 'feature' should be deleted"
+    );
 }
 
 #[test]

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -126,7 +126,12 @@ impl Fixture {
 fn branch_exists(repo: &Path, branch: &str) -> bool {
     git_allow_fail(
         repo,
-        &["rev-parse", "--verify", "--quiet", &format!("refs/heads/{branch}")],
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
     )
     .status
     .success()

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -294,6 +294,132 @@ fn dry_run_reports_the_plan_without_touching_anything() {
     );
 }
 
+/// Uncommitted changes are one of the two refusals git itself raises, and a dry
+/// run never invokes git to find out. The preflight promise is worthless if
+/// `gitnuke -n x` clears a target that `gitnuke x` turns away.
+#[test]
+fn dry_run_reports_a_dirty_worktree_refusal() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("README.md"), "uncommitted work\n").expect("dirty the worktree");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--dry-run", "feature"]);
+    let message = combined(&output);
+
+    // The same code the real run reports for this refusal, so the two agree.
+    assert_exit_code(
+        &output,
+        exit_codes::GIT_COMMAND_ERROR,
+        "a dry run must report the refusal a real run would hit",
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        worktree_registered(&main, &worktree),
+        "dry run must leave git still tracking the worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch: {message}"
+    );
+    assert!(
+        message.contains("--force"),
+        "should point at --force, like the real refusal does: {message}"
+    );
+}
+
+/// git refuses on untracked files too, not just modified ones — a preflight that
+/// only asked about tracked changes would clear half the targets git rejects.
+#[test]
+fn dry_run_reports_an_untracked_only_worktree_refusal() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("scratch.txt"), "untracked\n").expect("add untracked file");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::GIT_COMMAND_ERROR,
+        "untracked files alone are enough for git to refuse",
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch: {message}"
+    );
+}
+
+/// The other refusal a real run hits: `--safe` keeps an unmerged branch and
+/// exits 7. A dry run that reported "would delete branch feature" for it would
+/// be advertising a deletion git is going to refuse.
+#[test]
+fn dry_run_reports_an_unmerged_branch_refusal_under_safe() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("work.txt"), "unmerged work\n").expect("write work file");
+    git(&worktree, &["add", "work.txt"]);
+    git(&worktree, &["commit", "-qm", "unmerged commit"]);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--safe", "--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::BRANCH_NOT_DELETED,
+        "a dry run must report the branch --safe would refuse to delete",
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        worktree_registered(&main, &worktree),
+        "dry run must leave git still tracking the worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch: {message}"
+    );
+    assert!(
+        message.contains("feature"),
+        "the message should name the branch that would be kept: {message}"
+    );
+}
+
+/// A detached worktree has no branch, so `--safe` has nothing to ask about
+/// merged-ness. The preflight must clear it rather than invent a refusal.
+#[test]
+fn dry_run_of_a_detached_worktree_under_safe_still_succeeds() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let worktree = fixture.root.join("detached-wt");
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "--detach",
+            worktree.to_str().expect("utf-8 path"),
+        ],
+    );
+
+    let output = gitnuke(&main, &["--safe", "--dry-run", "detached-wt"]);
+    let message = combined(&output);
+
+    assert!(
+        output.status.success(),
+        "a clean detached worktree would be removed for real, so the dry run \
+         must succeed: {message}"
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        message.contains("detached"),
+        "should explain why no branch would be deleted: {message}"
+    );
+}
+
 /// A dry run is a preflight: it runs the same gates, so a submodule worktree
 /// reports the same refusal it would hit for real.
 #[test]

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -65,6 +65,42 @@ fn combined(output: &Output) -> String {
     )
 }
 
+/// The exit codes `gitnuke --help` and the README publish.
+///
+/// Spelled out here rather than imported from the binary on purpose: these are a
+/// contract callers script against, so the test has to state the numbers
+/// independently. A copy that followed `mod exit_codes` around would pin nothing.
+mod exit_codes {
+    pub const NOT_IN_REPO: i32 = 1;
+    pub const GIT_COMMAND_ERROR: i32 = 2;
+    pub const WORKTREE_NOT_FOUND: i32 = 3;
+    pub const MULTIPLE_MATCHES: i32 = 4;
+    pub const SUBMODULES_PRESENT: i32 = 5;
+    pub const INSIDE_TARGET: i32 = 6;
+    pub const BRANCH_NOT_DELETED: i32 = 7;
+}
+
+/// Assert the process exited with exactly `code`, showing gitnuke's output on
+/// failure.
+///
+/// `context` says what the run was supposed to be refusing (or doing), so a
+/// failure names the behaviour rather than just the number. A run killed by a
+/// signal has no exit code at all; that is reported as such instead of being
+/// silently compared against `None`.
+fn assert_exit_code(output: &Output, code: i32, context: &str) {
+    let actual = output.status.code();
+    assert_eq!(
+        actual,
+        Some(code),
+        "{context}: expected exit code {code}, got {}\n--- gitnuke output ---\n{}",
+        match actual {
+            Some(actual) => actual.to_string(),
+            None => format!("no exit code ({})", output.status),
+        },
+        combined(output),
+    );
+}
+
 /// A throwaway directory holding a `main` repo plus any worktrees a test adds.
 ///
 /// Every path lives under a fresh `TempDir`, so concurrent runs of the same
@@ -197,9 +233,10 @@ fn refuses_to_nuke_the_worktree_you_are_standing_in() {
     let output = gitnuke(&worktree, &["--force", "feature"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke should refuse to nuke its own cwd: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::INSIDE_TARGET,
+        "gitnuke should refuse to nuke its own cwd",
     );
     assert!(worktree.exists(), "the worktree must survive: {message}");
     assert!(
@@ -223,10 +260,10 @@ fn refuses_when_cwd_is_below_the_target_worktree() {
 
     let output = gitnuke(&nested, &["--force", "feature"]);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke should refuse from a subdirectory of the target: {}",
-        combined(&output)
+    assert_exit_code(
+        &output,
+        exit_codes::INSIDE_TARGET,
+        "gitnuke should refuse from a subdirectory of the target",
     );
     assert!(worktree.exists(), "the worktree must survive");
     assert!(branch_exists(&main, "feature"), "the branch must survive");
@@ -270,9 +307,10 @@ fn dry_run_reports_a_submodule_refusal() {
     let output = gitnuke(&main, &["--dry-run", "feature"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "a dry run that would be refused should exit non-zero: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::SUBMODULES_PRESENT,
+        "a dry run that would be refused should report the refusal's own code",
     );
     assert!(
         message.contains("--force"),
@@ -295,9 +333,10 @@ fn safe_mode_removes_the_worktree_but_keeps_an_unmerged_branch() {
     let output = gitnuke(&main, &["--safe", "feature"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "keeping an unmerged branch is a failure to report, not a silent skip: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::BRANCH_NOT_DELETED,
+        "keeping an unmerged branch is a failure to report, not a silent skip",
     );
     assert!(!worktree.exists(), "the worktree should still be removed");
     assert!(
@@ -368,9 +407,10 @@ fn refuses_a_submodule_worktree_without_force() {
     let output = gitnuke(&main, &["feature"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke should refuse a submodule worktree without --force: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::SUBMODULES_PRESENT,
+        "gitnuke should refuse a submodule worktree without --force",
     );
     assert!(
         worktree.exists(),
@@ -444,9 +484,12 @@ fn keeps_the_branch_when_a_dirty_worktree_is_refused() {
     let output = gitnuke(&main, &["feature"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke should refuse a dirty worktree without --force: {message}"
+    // git's own refusal, surfaced verbatim: gitnuke did not gate this itself, so
+    // it reports the failed git command rather than a gitnuke-specific code.
+    assert_exit_code(
+        &output,
+        exit_codes::GIT_COMMAND_ERROR,
+        "gitnuke should refuse a dirty worktree without --force",
     );
     assert!(worktree.exists(), "the dirty worktree must survive");
     assert!(
@@ -600,9 +643,10 @@ fn reports_an_unknown_target_and_lists_the_known_worktrees() {
     let output = gitnuke(&main, &["no-such-thing"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "an unknown target should fail: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::WORKTREE_NOT_FOUND,
+        "an unknown target should fail",
     );
     assert!(
         message.contains("no-such-thing"),
@@ -624,15 +668,55 @@ fn never_nukes_a_worktree_whose_branch_merely_contains_the_target() {
 
     let output = gitnuke(&main, &["issue-42"]);
 
-    assert!(
-        !output.status.success(),
-        "a substring must not resolve: {}",
-        combined(&output)
+    assert_exit_code(
+        &output,
+        exit_codes::WORKTREE_NOT_FOUND,
+        "a substring must not resolve",
     );
     assert!(worktree.exists(), "issue-421's worktree must survive");
     assert!(
         branch_exists(&main, "issue-421"),
         "issue-421 must survive a request to nuke issue-42"
+    );
+}
+
+/// A name that is one worktree's *directory* and another worktree's *branch* is
+/// genuinely ambiguous. gitnuke destroys whatever it resolves, so an ambiguous
+/// target has to destroy nothing at all and hand back both candidates.
+#[test]
+fn refuses_an_ambiguous_target_and_destroys_nothing() {
+    let fixture = Fixture::new();
+    // "shared" is the directory name of one worktree and the branch of another.
+    let by_directory = fixture.add_worktree("shared", "branch-a");
+    let by_branch = fixture.add_worktree("other", "shared");
+    let main = fixture.main_repo();
+
+    // Run from the main repo so "shared" cannot resolve as a relative path:
+    // `<main>/shared` does not exist, only `<root>/shared` does.
+    let output = gitnuke(&main, &["shared"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::MULTIPLE_MATCHES,
+        "an ambiguous target must be refused",
+    );
+    assert!(
+        by_directory.exists() && worktree_registered(&main, &by_directory),
+        "the directory-name match must survive: {message}"
+    );
+    assert!(
+        by_branch.exists() && worktree_registered(&main, &by_branch),
+        "the branch-name match must survive: {message}"
+    );
+    assert!(
+        branch_exists(&main, "branch-a") && branch_exists(&main, "shared"),
+        "neither branch may be deleted for an ambiguous target: {message}"
+    );
+    assert!(
+        message.contains(by_directory.to_str().expect("utf-8 path"))
+            && message.contains(by_branch.to_str().expect("utf-8 path")),
+        "both candidates should be listed so the caller can disambiguate: {message}"
     );
 }
 
@@ -646,9 +730,12 @@ fn nukes_every_target_it_can_and_reports_the_ones_it_cannot() {
     let output = gitnuke(&main, &["first", "no-such-thing", "second"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "a failed target should fail the run: {message}"
+    // The run exits with the *first* failure's code; the only failing target here
+    // is the unresolvable one.
+    assert_exit_code(
+        &output,
+        exit_codes::WORKTREE_NOT_FOUND,
+        "a failed target should fail the run",
     );
     assert!(!first.exists(), "'first' should have been nuked: {message}");
     assert!(
@@ -709,10 +796,10 @@ fn refuses_to_run_outside_a_git_repository() {
 
     let output = gitnuke(tmp.path(), &["anything"]);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke should fail outside a repo: {}",
-        combined(&output)
+    assert_exit_code(
+        &output,
+        exit_codes::NOT_IN_REPO,
+        "gitnuke should fail outside a repo",
     );
     assert!(
         combined(&output).contains("git repository"),

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -80,7 +80,16 @@ mod exit_codes {
     pub const INSIDE_TARGET: i32 = 6;
     pub const BRANCH_NOT_DELETED: i32 = 7;
     pub const LOCKED_WORKTREE: i32 = 8;
+    pub const DIRTY_WORKTREE: i32 = 9;
 }
+
+/// The text git prints when *it* is the one refusing something.
+///
+/// A refusal gitnuke gates itself must never contain this: reaching git at all
+/// for a condition gitnuke already knows about means the gate did not fire, and
+/// the caller gets git's locale-dependent wording under a generic exit code
+/// instead of gitnuke's own.
+const GIT_FATAL_PREFIX: &str = "fatal:";
 
 /// Assert the process exited with exactly `code`, showing gitnuke's output on
 /// failure.
@@ -410,7 +419,7 @@ fn dry_run_reports_a_dirty_worktree_refusal() {
     // The same code the real run reports for this refusal, so the two agree.
     assert_exit_code(
         &output,
-        exit_codes::GIT_COMMAND_ERROR,
+        exit_codes::DIRTY_WORKTREE,
         "a dry run must report the refusal a real run would hit",
     );
     assert!(worktree.exists(), "dry run must not remove the worktree");
@@ -428,6 +437,129 @@ fn dry_run_reports_a_dirty_worktree_refusal() {
     );
 }
 
+/// A dirty worktree is gitnuke's refusal to make, not git's to report.
+///
+/// gitnuke already knows the answer — the dry run has been asking `git status`
+/// for it all along — so handing the case to `git worktree remove` and relaying
+/// whatever it says buys nothing and costs everything the submodule gate was
+/// built to keep: a diagnosis that does not depend on git's locale, and an exit
+/// code that names *this* refusal rather than "some git command failed".
+#[test]
+fn refuses_a_dirty_worktree_on_gitnukes_own_terms() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("README.md"), "uncommitted work\n").expect("dirty the worktree");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::DIRTY_WORKTREE,
+        "a dirty worktree has its own exit code, not the generic git-failed one",
+    );
+    assert!(
+        !message.contains(GIT_FATAL_PREFIX),
+        "gitnuke must gate this itself rather than relaying git's refusal: {message}"
+    );
+    assert!(
+        message.contains("--force"),
+        "the refusal should point at the flag that overrides it: {message}"
+    );
+    assert!(
+        worktree.exists() && worktree_registered(&main, &worktree),
+        "the dirty worktree must survive: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "the branch must survive a refused removal: {message}"
+    );
+}
+
+/// The preflight's contract, stated at its strictest: for the same dirty
+/// worktree the two runs must be indistinguishable — same words, same code.
+/// Two gates written separately drift, which is how `gitnuke -n x` ends up
+/// promising a refusal `gitnuke x` words differently or numbers differently.
+#[test]
+fn a_dirty_worktree_reads_the_same_dry_or_not() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("scratch.txt"), "untracked\n").expect("add untracked file");
+    let main = fixture.main_repo();
+
+    let dry_run = gitnuke(&main, &["--dry-run", "feature"]);
+    // Order matters: the dry run must not have changed anything, so the real
+    // run that follows meets exactly the worktree the dry run reported on.
+    let real_run = gitnuke(&main, &["feature"]);
+
+    assert_eq!(
+        real_run.status.code(),
+        dry_run.status.code(),
+        "the two runs must agree on the code:\n--- dry ---\n{}\n--- real ---\n{}",
+        combined(&dry_run),
+        combined(&real_run),
+    );
+    assert_eq!(
+        combined(&real_run),
+        combined(&dry_run),
+        "the two runs must agree word for word, which one shared message is what \
+         guarantees"
+    );
+    assert_exit_code(
+        &real_run,
+        exit_codes::DIRTY_WORKTREE,
+        "both runs refuse a dirty worktree with its own code",
+    );
+    assert!(
+        worktree.exists() && branch_exists(&main, "feature"),
+        "neither run may destroy anything: {}",
+        combined(&real_run)
+    );
+}
+
+/// Two refusals at once, and the submodule one still answers.
+///
+/// A submodule checkout can hold commits and untracked files that exist nowhere
+/// else, so it is the more consequential thing to be told about — and the dirty
+/// gate arriving first would quietly demote it to a footnote of exit 9. The
+/// ordering is the contract; this pins it against the new gate.
+#[test]
+fn the_submodule_refusal_still_answers_before_the_dirty_one() {
+    let fixture = Fixture::new();
+    fixture.add_submodule();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    fixture.populate_submodule(&worktree);
+    std::fs::write(worktree.join("scratch.txt"), "untracked\n").expect("dirty the worktree");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::SUBMODULES_PRESENT,
+        "submodules outrank uncommitted changes when a worktree has both",
+    );
+    assert!(
+        message.contains("submodule"),
+        "the message should name the more consequential problem: {message}"
+    );
+    assert!(
+        worktree.exists() && branch_exists(&main, "feature"),
+        "nothing may be destroyed: {message}"
+    );
+
+    // And the dry run reaches the same verdict, as it does for every other gate.
+    let dry_run = gitnuke(&main, &["--dry-run", "feature"]);
+
+    assert_exit_code(
+        &dry_run,
+        exit_codes::SUBMODULES_PRESENT,
+        "the dry run must order the two gates the same way the real run does",
+    );
+}
+
 /// git refuses on untracked files too, not just modified ones — a preflight that
 /// only asked about tracked changes would clear half the targets git rejects.
 #[test]
@@ -442,7 +574,7 @@ fn dry_run_reports_an_untracked_only_worktree_refusal() {
 
     assert_exit_code(
         &output,
-        exit_codes::GIT_COMMAND_ERROR,
+        exit_codes::DIRTY_WORKTREE,
         "untracked files alone are enough for git to refuse",
     );
     assert!(worktree.exists(), "dry run must not remove the worktree");
@@ -933,11 +1065,11 @@ fn keeps_the_branch_when_a_dirty_worktree_is_refused() {
     let output = gitnuke(&main, &["feature"]);
     let message = combined(&output);
 
-    // git's own refusal, surfaced verbatim: gitnuke did not gate this itself, so
-    // it reports the failed git command rather than a gitnuke-specific code.
+    // gitnuke's own refusal, with its own code — the same shape the submodule
+    // gate has, so a caller scripting around exit codes can tell the two apart.
     assert_exit_code(
         &output,
-        exit_codes::GIT_COMMAND_ERROR,
+        exit_codes::DIRTY_WORKTREE,
         "gitnuke should refuse a dirty worktree without --force",
     );
     assert!(worktree.exists(), "the dirty worktree must survive");
@@ -1374,7 +1506,7 @@ fn refuses_to_run_outside_a_git_repository() {
 /// Stated here rather than derived from the binary for the same reason as
 /// `mod exit_codes` above: this is the contract users read, so the test has to
 /// spell it out independently.
-const HELP_EXIT_CODE_LINES: [&str; 9] = [
+const HELP_EXIT_CODE_LINES: [&str; 10] = [
     "- 0: Success",
     "- 1: Not in a git repository",
     "- 2: A git command failed",
@@ -1384,6 +1516,7 @@ const HELP_EXIT_CODE_LINES: [&str; 9] = [
     "- 6: The shell is standing inside the target worktree",
     "- 7: The worktree was removed but its branch could not be deleted",
     "- 8: The worktree is locked, which `--force` does not override",
+    "- 9: The worktree contains modified or untracked files and `--force` was not given",
 ];
 
 /// The usage examples `gitnuke --help` publishes, as (command, trailing note).
@@ -1401,7 +1534,7 @@ const HELP_USAGE_EXAMPLES: [(&str, &str); 3] = [
 /// clap only keeps the line breaks of a doc comment when the *command* itself
 /// carries `verbatim_doc_comment`; the per-flag attributes do not cover the
 /// struct's own doc comment. Without it every usage example is jammed onto one
-/// line and all eight exit codes run together as a single paragraph.
+/// line and every exit code runs together as a single paragraph.
 #[test]
 fn long_help_renders_one_line_per_entry() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -274,7 +274,10 @@ fn dry_run_reports_a_submodule_refusal() {
         !output.status.success(),
         "a dry run that would be refused should exit non-zero: {message}"
     );
-    assert!(message.contains("--force"), "should point at --force: {message}");
+    assert!(
+        message.contains("--force"),
+        "should point at --force: {message}"
+    );
     assert!(worktree.exists(), "dry run must not remove the worktree");
 }
 
@@ -648,7 +651,10 @@ fn nukes_every_target_it_can_and_reports_the_ones_it_cannot() {
         "a failed target should fail the run: {message}"
     );
     assert!(!first.exists(), "'first' should have been nuked: {message}");
-    assert!(!second.exists(), "'second' should have been nuked: {message}");
+    assert!(
+        !second.exists(),
+        "'second' should have been nuked: {message}"
+    );
     assert!(
         !branch_exists(&main, "first") && !branch_exists(&main, "second"),
         "both resolvable branches should be deleted: {message}"

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -387,6 +387,72 @@ fn dry_run_reports_an_unmerged_branch_refusal_under_safe() {
     );
 }
 
+/// The other half of the preflight's contract: it must not refuse what a real
+/// run would happily do. Without this, a merge check that always answered "not
+/// merged" would still satisfy the refusal tests above.
+#[test]
+fn dry_run_clears_a_merged_branch_under_safe() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--safe", "--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert!(
+        output.status.success(),
+        "a merged branch would be deleted for real, so the dry run must clear \
+         it: {message}"
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch: {message}"
+    );
+}
+
+/// `git branch -d` measures merged-ness against a branch's *upstream* when it
+/// has one, so a branch whose commits are only on its remote is still
+/// deletable. The dry run has to answer the same question against the same ref
+/// — and the real run immediately after it proves that is what git does.
+#[test]
+fn dry_run_clears_a_branch_merged_only_into_its_upstream_under_safe() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let remote = fixture.root.join("remote.git");
+    let remote_path = remote.to_str().expect("utf-8 path");
+    git(&main, &["init", "-q", "--bare", remote_path]);
+    git(&main, &["remote", "add", "origin", remote_path]);
+
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("work.txt"), "work only on the remote\n").expect("write file");
+    git(&worktree, &["add", "work.txt"]);
+    git(&worktree, &["commit", "-qm", "unmerged locally"]);
+    // Now 'feature' is ahead of HEAD but identical to its upstream.
+    git(&worktree, &["push", "-q", "-u", "origin", "feature"]);
+
+    let dry_run = gitnuke(&main, &["--safe", "--dry-run", "feature"]);
+
+    assert!(
+        dry_run.status.success(),
+        "a branch merged into its upstream is deletable, so the dry run must \
+         not refuse it: {}",
+        combined(&dry_run)
+    );
+
+    let real_run = gitnuke(&main, &["--safe", "feature"]);
+
+    assert!(
+        real_run.status.success(),
+        "the real run must reach the same verdict the dry run gave: {}",
+        combined(&real_run)
+    );
+    assert!(
+        !branch_exists(&main, "feature"),
+        "the branch should have been deleted for real"
+    );
+}
+
 /// A detached worktree has no branch, so `--safe` has nothing to ask about
 /// merged-ness. The preflight must clear it rather than invent a refusal.
 #[test]

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -184,6 +184,172 @@ fn worktree_registered(repo: &Path, path: &Path) -> bool {
         .any(|line| line.strip_prefix("worktree ") == Some(path.to_str().expect("utf-8 path")))
 }
 
+/// Nuking the worktree your shell is sitting in leaves that shell in a deleted
+/// directory, where every later git command fails confusingly. gitnuke is not a
+/// shell function and cannot cd you out, so it must refuse — even with --force,
+/// which is about git's refusals, not about breaking your shell.
+#[test]
+fn refuses_to_nuke_the_worktree_you_are_standing_in() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&worktree, &["--force", "feature"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke should refuse to nuke its own cwd: {message}"
+    );
+    assert!(worktree.exists(), "the worktree must survive: {message}");
+    assert!(
+        branch_exists(&main, "feature"),
+        "the branch must survive: {message}"
+    );
+    assert!(
+        message.contains(main.to_str().expect("utf-8 path")),
+        "the message should point at the main worktree to cd to: {message}"
+    );
+}
+
+/// A subdirectory of the target is just as fatal to the shell as its root.
+#[test]
+fn refuses_when_cwd_is_below_the_target_worktree() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let nested = worktree.join("nested/deeper");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&nested, &["--force", "feature"]);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke should refuse from a subdirectory of the target: {}",
+        combined(&output)
+    );
+    assert!(worktree.exists(), "the worktree must survive");
+    assert!(branch_exists(&main, "feature"), "the branch must survive");
+}
+
+#[test]
+fn dry_run_reports_the_plan_without_touching_anything() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert!(output.status.success(), "dry run should succeed: {message}");
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch"
+    );
+    assert!(
+        message.contains("would"),
+        "dry run should describe what it would do: {message}"
+    );
+    assert!(
+        message.contains("feature"),
+        "dry run should name the branch: {message}"
+    );
+}
+
+/// A dry run is a preflight: it runs the same gates, so a submodule worktree
+/// reports the same refusal it would hit for real.
+#[test]
+fn dry_run_reports_a_submodule_refusal() {
+    let fixture = Fixture::new();
+    fixture.add_submodule();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    fixture.populate_submodule(&worktree);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "a dry run that would be refused should exit non-zero: {message}"
+    );
+    assert!(message.contains("--force"), "should point at --force: {message}");
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+}
+
+/// `--safe` is the gitclean half of the tool: remove the worktree, but refuse to
+/// throw away a branch whose commits are not merged anywhere.
+#[test]
+fn safe_mode_removes_the_worktree_but_keeps_an_unmerged_branch() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("work.txt"), "unmerged work\n").expect("write work file");
+    git(&worktree, &["add", "work.txt"]);
+    git(&worktree, &["commit", "-qm", "unmerged commit"]);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--safe", "feature"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "keeping an unmerged branch is a failure to report, not a silent skip: {message}"
+    );
+    assert!(!worktree.exists(), "the worktree should still be removed");
+    assert!(
+        branch_exists(&main, "feature"),
+        "an unmerged branch must survive --safe: {message}"
+    );
+    assert!(
+        message.contains("feature"),
+        "the message should name the surviving branch: {message}"
+    );
+}
+
+#[test]
+fn safe_mode_deletes_a_merged_branch() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--safe", "feature"]);
+
+    assert!(
+        output.status.success(),
+        "a merged branch should be deleted under --safe: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !branch_exists(&main, "feature"),
+        "the merged branch should be deleted"
+    );
+}
+
+/// Default (non-`--safe`) behaviour is `git branch -D`: unmerged is no obstacle.
+#[test]
+fn deletes_an_unmerged_branch_by_default() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    std::fs::write(worktree.join("work.txt"), "unmerged work\n").expect("write work file");
+    git(&worktree, &["add", "work.txt"]);
+    git(&worktree, &["commit", "-qm", "unmerged commit"]);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["feature"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke should force-delete an unmerged branch: {}",
+        combined(&output)
+    );
+    assert!(
+        !branch_exists(&main, "feature"),
+        "branch 'feature' should be force-deleted"
+    );
+}
+
 /// A worktree containing a populated submodule is the case plain
 /// `git worktree remove` refuses outright ("working trees containing submodules
 /// cannot be moved or removed"). gitnuke must refuse too — but say what is in
@@ -369,5 +535,182 @@ fn nukes_a_worktree_given_its_directory_name() {
     assert!(
         !branch_exists(&main, "feature/login"),
         "branch 'feature/login' should be deleted"
+    );
+}
+
+#[test]
+fn refuses_the_main_worktree() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--force", "main"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke must never nuke the main worktree: {message}"
+    );
+    assert!(main.exists(), "the main worktree must survive");
+    assert!(
+        branch_exists(&main, "main"),
+        "branch 'main' must survive: {message}"
+    );
+}
+
+#[test]
+fn removes_a_detached_head_worktree_without_deleting_a_branch() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let worktree = fixture.root.join("detached-wt");
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "--detach",
+            worktree.to_str().expect("utf-8 path"),
+        ],
+    );
+
+    let output = gitnuke(&main, &["detached-wt"]);
+    let message = combined(&output);
+
+    assert!(output.status.success(), "gitnuke failed: {message}");
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        branch_exists(&main, "main"),
+        "no branch should have been deleted: {message}"
+    );
+    assert!(
+        message.contains("detached"),
+        "should explain why no branch was deleted: {message}"
+    );
+}
+
+#[test]
+fn reports_an_unknown_target_and_lists_the_known_worktrees() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["no-such-thing"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "an unknown target should fail: {message}"
+    );
+    assert!(
+        message.contains("no-such-thing"),
+        "should quote the target back: {message}"
+    );
+    assert!(
+        message.contains(worktree.to_str().expect("utf-8 path")),
+        "should list the worktrees that do exist: {message}"
+    );
+    assert!(worktree.exists(), "nothing should have been removed");
+}
+
+/// A near-miss must be a miss end to end, not just in the resolver unit tests.
+#[test]
+fn never_nukes_a_worktree_whose_branch_merely_contains_the_target() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("wt-421", "issue-421");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["issue-42"]);
+
+    assert!(
+        !output.status.success(),
+        "a substring must not resolve: {}",
+        combined(&output)
+    );
+    assert!(worktree.exists(), "issue-421's worktree must survive");
+    assert!(
+        branch_exists(&main, "issue-421"),
+        "issue-421 must survive a request to nuke issue-42"
+    );
+}
+
+#[test]
+fn nukes_every_target_it_can_and_reports_the_ones_it_cannot() {
+    let fixture = Fixture::new();
+    let first = fixture.add_worktree("first-wt", "first");
+    let second = fixture.add_worktree("second-wt", "second");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["first", "no-such-thing", "second"]);
+    let message = combined(&output);
+
+    assert!(
+        !output.status.success(),
+        "a failed target should fail the run: {message}"
+    );
+    assert!(!first.exists(), "'first' should have been nuked: {message}");
+    assert!(!second.exists(), "'second' should have been nuked: {message}");
+    assert!(
+        !branch_exists(&main, "first") && !branch_exists(&main, "second"),
+        "both resolvable branches should be deleted: {message}"
+    );
+    assert!(
+        message.contains("no-such-thing"),
+        "the unresolvable target should be reported: {message}"
+    );
+}
+
+/// Directory names, branch names and submodule paths can all be multi-byte;
+/// none of it may panic or mis-slice.
+#[test]
+fn nukes_a_worktree_with_multibyte_names_and_submodules() {
+    let fixture = Fixture::new();
+    fixture.add_submodule();
+    let worktree = fixture.add_worktree("日本語テスト", "機能/ログイン-🎉");
+    fixture.populate_submodule(&worktree);
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--force", "機能/ログイン-🎉"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke should handle multi-byte names: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !branch_exists(&main, "機能/ログイン-🎉"),
+        "the multi-byte branch should be deleted"
+    );
+}
+
+#[test]
+fn reports_its_version_with_git_metadata() {
+    let fixture = Fixture::new();
+
+    let output = gitnuke(&fixture.main_repo(), &["--version"]);
+    let version = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "--version should succeed");
+    assert!(
+        version.starts_with("gitnuke 0.1.0 ("),
+        "expected 'gitnuke <version> (<hash>, <status>)', got: {version}"
+    );
+}
+
+#[test]
+fn refuses_to_run_outside_a_git_repository() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let output = gitnuke(tmp.path(), &["anything"]);
+
+    assert!(
+        !output.status.success(),
+        "gitnuke should fail outside a repo: {}",
+        combined(&output)
+    );
+    assert!(
+        combined(&output).contains("git repository"),
+        "should say why: {}",
+        combined(&output)
     );
 }

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -71,6 +71,7 @@ fn combined(output: &Output) -> String {
 /// contract callers script against, so the test has to state the numbers
 /// independently. A copy that followed `mod exit_codes` around would pin nothing.
 mod exit_codes {
+    pub const SUCCESS: i32 = 0;
     pub const NOT_IN_REPO: i32 = 1;
     pub const GIT_COMMAND_ERROR: i32 = 2;
     pub const WORKTREE_NOT_FOUND: i32 = 3;
@@ -1116,6 +1117,39 @@ fn nukes_every_target_it_can_and_reports_the_ones_it_cannot() {
     assert!(
         message.contains("no-such-thing"),
         "the unresolvable target should be reported: {message}"
+    );
+}
+
+/// Naming the same target twice is one instruction, not two. The first pass
+/// nukes the worktree and the second finds nothing left to match, so a run that
+/// took the list verbatim would report "no worktree matches 'dup'" and exit 3 —
+/// an error about its own success, on a tool people script around exit codes.
+#[test]
+fn nukes_a_repeated_target_once_and_still_succeeds() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("dup-wt", "dup");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["dup", "dup"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::SUCCESS,
+        "a repeated target is one nuke, not a nuke followed by a failure",
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !worktree_registered(&main, &worktree),
+        "git should no longer track the worktree: {message}"
+    );
+    assert!(
+        !branch_exists(&main, "dup"),
+        "branch 'dup' should be deleted: {message}"
+    );
+    assert!(
+        !message.contains("no worktree matches"),
+        "the second mention must not be reported as a miss: {message}"
     );
 }
 

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -239,6 +239,19 @@ fn worktree_registered(repo: &Path, path: &Path) -> bool {
         .any(|line| line.strip_prefix("worktree ") == Some(path.to_str().expect("utf-8 path")))
 }
 
+/// The path the cwd-guard hint offers as somewhere to cd to, if it offered one.
+///
+/// Asserting on the whole message cannot tell a useful hint from a useless one:
+/// the target's path legitimately appears earlier in it ("you are inside
+/// <target>"), so a plain `contains` is satisfied by a hint that names the very
+/// directory being nuked. This pulls out just the parenthesised suggestion, and
+/// yields None when the message makes none at all.
+fn suggested_destination(message: &str) -> Option<&str> {
+    let (_, after_marker) = message.split_once("(for example ")?;
+    let (path, _) = after_marker.split_once(')')?;
+    Some(path)
+}
+
 /// Nuking the worktree your shell is sitting in leaves that shell in a deleted
 /// directory, where every later git command fails confusingly. gitnuke is not a
 /// shell function and cannot cd you out, so it must refuse — even with --force,
@@ -266,6 +279,74 @@ fn refuses_to_nuke_the_worktree_you_are_standing_in() {
         message.contains(main.to_str().expect("utf-8 path")),
         "the message should point at the main worktree to cd to: {message}"
     );
+    assert_eq!(
+        suggested_destination(&message),
+        Some(main.to_str().expect("utf-8 path")),
+        "the ordinary case should send the caller to the main worktree: {message}"
+    );
+}
+
+/// The hint has to name somewhere *else*. It is built from git's worktree list,
+/// where the main worktree comes first — which is the right answer for every
+/// target except the main worktree itself. Standing in it and naming it, taking
+/// the first entry regardless produces "cd somewhere else, for example: here",
+/// advice that is useless in exactly the case it fires.
+#[test]
+fn never_suggests_cd_ing_to_the_worktree_being_nuked() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let elsewhere = fixture.add_worktree("elsewhere-wt", "elsewhere");
+
+    let output = gitnuke(&main, &["--force", "main"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::INSIDE_TARGET,
+        "the cwd guard owns the case of standing in the main worktree",
+    );
+    let Some(suggestion) = suggested_destination(&message) else {
+        panic!("a worktree the caller could go to exists, so the hint should name it: {message}");
+    };
+    assert_ne!(
+        suggestion,
+        main.to_str().expect("utf-8 path"),
+        "the hint must not send the caller to the directory it is refusing over: {message}"
+    );
+    assert_eq!(
+        suggestion,
+        elsewhere.to_str().expect("utf-8 path"),
+        "the hint should name the worktree that is not the target: {message}"
+    );
+    assert!(main.exists(), "the main worktree must survive: {message}");
+}
+
+/// A repo with nothing but its main worktree has nowhere to send the caller.
+/// The refusal still stands — the shell would still be stranded — so the hint
+/// offers nothing rather than offering the target back.
+#[test]
+fn omits_the_suggestion_when_there_is_no_other_worktree_to_offer() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["--force", "main"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::INSIDE_TARGET,
+        "the cwd guard still refuses when it has no advice to give",
+    );
+    assert_eq!(
+        suggested_destination(&message),
+        None,
+        "with nowhere else to go the hint must stay silent, not name the target: {message}"
+    );
+    assert!(
+        message.contains("cd somewhere else"),
+        "the refusal should still say why it refused: {message}"
+    );
+    assert!(main.exists(), "the main worktree must survive: {message}");
 }
 
 /// A subdirectory of the target is just as fatal to the shell as its root.

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -1,0 +1,205 @@
+//! End-to-end: drive the real `gitnuke` binary against throwaway git repos.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+/// Scrub the git-location env vars that git exports when it invokes a hook.
+///
+/// In a *worktree*, git exports absolute `GIT_DIR`/`GIT_WORK_TREE`/
+/// `GIT_INDEX_FILE`/`GIT_PREFIX` to the pre-commit hook. Those leak into child
+/// `git` and `gitnuke` processes and pin them to the *real* repo regardless of
+/// `current_dir(tempdir)`, so fixture commits would land in the real repo and
+/// `gitnuke` would nuke real worktrees. Every git and gitnuke invocation here
+/// routes through this so the per-test tempdir is the only thing at risk.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are pinned to `/dev/null` so the
+/// developer's own git config (aliases, `init.defaultBranch`, hooks) cannot
+/// change what these tests observe.
+fn scrub_git_env(cmd: &mut Command) -> &mut Command {
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+}
+
+/// Run `git <args>` in `dir` and assert it succeeded.
+fn git(dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(dir);
+    let output = scrub_git_env(&mut cmd).output().expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} in {} failed: {}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+/// Run `git <args>` in `dir` without asserting success.
+fn git_allow_fail(dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(dir);
+    scrub_git_env(&mut cmd).output().expect("failed to run git")
+}
+
+/// Run the real `gitnuke` binary in `dir` and capture its result.
+fn gitnuke(dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_gitnuke"));
+    cmd.args(args).current_dir(dir);
+    scrub_git_env(&mut cmd)
+        .output()
+        .expect("failed to run gitnuke")
+}
+
+/// Combined stdout + stderr of a `gitnuke` run, for message assertions.
+fn combined(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// A throwaway directory holding a `main` repo plus any worktrees a test adds.
+///
+/// Every path lives under a fresh `TempDir`, so concurrent runs of the same
+/// test never collide.
+struct Fixture {
+    /// Held only to keep the temp directory alive for the test's lifetime.
+    _tmp: TempDir,
+    /// Canonicalized temp root (macOS `/var` is a symlink to `/private/var`,
+    /// and git records canonical worktree paths).
+    root: PathBuf,
+}
+
+impl Fixture {
+    /// Create a temp root containing a `main` repo with one commit on `main`.
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        let fixture = Fixture { _tmp: tmp, root };
+        fixture.init_repo("main");
+        fixture
+    }
+
+    /// `git init` a repo named `name` under the temp root, with one commit.
+    fn init_repo(&self, name: &str) -> PathBuf {
+        let path = self.root.join(name);
+        std::fs::create_dir_all(&path).expect("create repo dir");
+        git(&path, &["init", "-q", "-b", "main"]);
+        git(&path, &["config", "user.email", "test@example.com"]);
+        git(&path, &["config", "user.name", "Test"]);
+        std::fs::write(path.join("README.md"), "hello\n").expect("write README");
+        git(&path, &["add", "README.md"]);
+        git(&path, &["commit", "-qm", "initial"]);
+        path
+    }
+
+    fn main_repo(&self) -> PathBuf {
+        self.root.join("main")
+    }
+
+    /// Add a linked worktree at `<root>/<dir>` checked out on a new `branch`.
+    fn add_worktree(&self, dir: &str, branch: &str) -> PathBuf {
+        let path = self.root.join(dir);
+        git(
+            &self.main_repo(),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                branch,
+                path.to_str().expect("utf-8 path"),
+            ],
+        );
+        path
+    }
+}
+
+/// True if `refs/heads/<branch>` still exists in the repo.
+fn branch_exists(repo: &Path, branch: &str) -> bool {
+    git_allow_fail(
+        repo,
+        &["rev-parse", "--verify", "--quiet", &format!("refs/heads/{branch}")],
+    )
+    .status
+    .success()
+}
+
+/// True if git still tracks a worktree at `path`.
+fn worktree_registered(repo: &Path, path: &Path) -> bool {
+    let output = git(repo, &["worktree", "list", "--porcelain"]);
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|line| line.strip_prefix("worktree ") == Some(path.to_str().expect("utf-8 path")))
+}
+
+#[test]
+fn nukes_a_worktree_given_its_path() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &[worktree.to_str().expect("utf-8 path")]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke failed: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !worktree_registered(&main, &worktree),
+        "git should no longer track the worktree"
+    );
+    assert!(
+        !branch_exists(&main, "feature"),
+        "branch 'feature' should be deleted"
+    );
+}
+
+#[test]
+fn nukes_a_worktree_given_its_branch_name() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("some-directory", "issue-42");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["issue-42"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke failed: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !branch_exists(&main, "issue-42"),
+        "branch 'issue-42' should be deleted"
+    );
+}
+
+#[test]
+fn nukes_a_worktree_given_its_directory_name() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("absurd-rock", "feature/login");
+    let main = fixture.main_repo();
+
+    let output = gitnuke(&main, &["absurd-rock"]);
+
+    assert!(
+        output.status.success(),
+        "gitnuke failed: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !branch_exists(&main, "feature/login"),
+        "branch 'feature/login' should be deleted"
+    );
+}

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -952,19 +952,98 @@ fn nukes_a_worktree_given_its_directory_name() {
     );
 }
 
+/// git refuses to remove the main worktree at all — `fatal: '…' is a main
+/// working tree`, with or without `--force` — so gitnuke must fail too.
+///
+/// The run is deliberately made from a *second* worktree. From inside the main
+/// worktree the cwd guard answers first (see
+/// `cwd_guard_answers_before_the_main_worktree_refusal`), so a test standing
+/// there passes without this rule ever being reached.
 #[test]
 fn refuses_the_main_worktree() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let elsewhere = fixture.add_worktree("elsewhere-wt", "elsewhere");
+
+    let output = gitnuke(&elsewhere, &["--force", "main"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::GIT_COMMAND_ERROR,
+        "gitnuke must never nuke the main worktree",
+    );
+    assert!(main.exists(), "the main worktree must survive: {message}");
+    assert!(
+        worktree_registered(&main, &main),
+        "git must still track the main worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "main"),
+        "branch 'main' must survive: {message}"
+    );
+    assert!(
+        message.contains(main.to_str().expect("utf-8 path")),
+        "the refusal should name the worktree it is about: {message}"
+    );
+}
+
+/// The dry run's whole promise is that its verdict is the real run's verdict.
+/// The main worktree is the one target no check gitnuke performs can catch —
+/// it is neither locked, nor dirty, nor holding submodules — so a preflight
+/// that never consults the worktree's *position* in git's listing reports
+/// "would remove" for the one worktree that can never be removed.
+#[test]
+fn dry_run_refuses_the_main_worktree() {
+    let fixture = Fixture::new();
+    let main = fixture.main_repo();
+    let elsewhere = fixture.add_worktree("elsewhere-wt", "elsewhere");
+
+    let output = gitnuke(&elsewhere, &["--dry-run", "main"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::GIT_COMMAND_ERROR,
+        "a dry run must report the refusal a real run would hit",
+    );
+    assert!(
+        !message.contains("would remove"),
+        "a dry run must not advertise a removal git will never perform: {message}"
+    );
+    assert!(main.exists(), "dry run must not remove the main worktree");
+    assert!(
+        worktree_registered(&main, &main),
+        "dry run must leave git still tracking the main worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "main"),
+        "dry run must not delete branch 'main': {message}"
+    );
+}
+
+/// Standing in the main worktree and naming it trips two rules at once, and the
+/// cwd guard owns the case. Whichever way the removal would have ended, a shell
+/// left in a deleted directory is the caller's more immediate problem, and exit
+/// 6 — not the main-worktree refusal's exit 2 — is what says so.
+#[test]
+fn cwd_guard_answers_before_the_main_worktree_refusal() {
     let fixture = Fixture::new();
     let main = fixture.main_repo();
 
     let output = gitnuke(&main, &["--force", "main"]);
     let message = combined(&output);
 
-    assert!(
-        !output.status.success(),
-        "gitnuke must never nuke the main worktree: {message}"
+    assert_exit_code(
+        &output,
+        exit_codes::INSIDE_TARGET,
+        "the cwd guard, not the main-worktree rule, answers this case",
     );
-    assert!(main.exists(), "the main worktree must survive");
+    assert!(main.exists(), "the main worktree must survive: {message}");
+    assert!(
+        worktree_registered(&main, &main),
+        "git must still track the main worktree: {message}"
+    );
     assert!(
         branch_exists(&main, "main"),
         "branch 'main' must survive: {message}"

--- a/src/gitnuke/tests/integration.rs
+++ b/src/gitnuke/tests/integration.rs
@@ -78,6 +78,7 @@ mod exit_codes {
     pub const SUBMODULES_PRESENT: i32 = 5;
     pub const INSIDE_TARGET: i32 = 6;
     pub const BRANCH_NOT_DELETED: i32 = 7;
+    pub const LOCKED_WORKTREE: i32 = 8;
 }
 
 /// Assert the process exited with exactly `code`, showing gitnuke's output on
@@ -177,6 +178,23 @@ impl Fixture {
                 "-q",
             ],
         );
+    }
+
+    /// Lock `worktree` the way `git worktree lock` does, with or without a
+    /// reason.
+    ///
+    /// A lock is a deliberate "leave this alone" marker, and git treats it as a
+    /// refusal of its own: `git worktree remove --force` still declines and asks
+    /// for `remove -f -f`.
+    fn lock_worktree(&self, worktree: &Path, reason: Option<&str>) {
+        let path = worktree.to_str().expect("utf-8 path");
+        match reason {
+            Some(reason) => git(
+                &self.main_repo(),
+                &["worktree", "lock", "--reason", reason, path],
+            ),
+            None => git(&self.main_repo(), &["worktree", "lock", path]),
+        };
     }
 
     /// Add a linked worktree at `<root>/<dir>` checked out on a new `branch`.
@@ -663,6 +681,163 @@ fn nukes_a_submodule_worktree_with_force() {
     );
 }
 
+/// A lock is git's *third* refusal, and the one `--force` deliberately does not
+/// buy through: `git worktree remove --force` on a locked worktree still fails,
+/// asking for `remove -f -f`. A lock is a deliberate "leave this alone" marker
+/// set by hand, so gitnuke honours it rather than escalating — and diagnoses it
+/// itself instead of letting git's raw `fatal:` leak out.
+#[test]
+fn refuses_a_locked_worktree_even_with_force() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+    fixture.lock_worktree(&worktree, None);
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::LOCKED_WORKTREE,
+        "a locked worktree must get its own refusal, not git's raw failure",
+    );
+    assert!(
+        worktree.exists(),
+        "the locked worktree must survive: {message}"
+    );
+    assert!(
+        worktree_registered(&main, &worktree),
+        "git must still track the locked worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "the branch must survive a refused removal: {message}"
+    );
+    assert!(
+        message.contains("locked"),
+        "the message should say the lock is what is in the way: {message}"
+    );
+    assert!(
+        message.contains(&format!(
+            "git worktree unlock {}",
+            worktree.to_str().expect("utf-8 path")
+        )),
+        "the message should hand back the exact unlock command: {message}"
+    );
+}
+
+/// `git worktree lock --reason` records *why* the worktree was locked. That
+/// reason is the whole reason the lock is respectable, so the refusal has to
+/// quote it back rather than making the caller go look it up.
+#[test]
+fn locked_worktree_refusal_quotes_the_lock_reason() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+    fixture.lock_worktree(&worktree, Some("mid-bisect, do not touch"));
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::LOCKED_WORKTREE,
+        "a reason does not change the refusal, only what it says",
+    );
+    assert!(
+        message.contains("mid-bisect, do not touch"),
+        "the message should quote git's recorded lock reason: {message}"
+    );
+    assert!(worktree.exists(), "the locked worktree must survive");
+    assert!(branch_exists(&main, "feature"), "the branch must survive");
+}
+
+/// git prints a non-ASCII lock reason C-quoted and octal-escaped in its
+/// porcelain output (`locked "\343\203\254..."`). Echoing that back at the
+/// person who typed the reason is not surfacing it.
+#[test]
+fn locked_worktree_refusal_quotes_a_multibyte_lock_reason() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+    fixture.lock_worktree(&worktree, Some("レビュー待ち 🎉"));
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::LOCKED_WORKTREE,
+        "a multi-byte reason is still just a locked worktree",
+    );
+    assert!(
+        message.contains("レビュー待ち 🎉"),
+        "the reason should be readable, not octal-escaped: {message}"
+    );
+}
+
+/// A dry run is a preflight: `gitnuke -n x` failing has to mean `gitnuke x`
+/// fails the same way, so the lock must be reported with the same code there.
+#[test]
+fn dry_run_reports_a_locked_worktree_refusal() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+    fixture.lock_worktree(&worktree, Some("held for CI"));
+
+    let output = gitnuke(&main, &["--force", "--dry-run", "feature"]);
+    let message = combined(&output);
+
+    assert_exit_code(
+        &output,
+        exit_codes::LOCKED_WORKTREE,
+        "a dry run must report the refusal a real run would hit",
+    );
+    assert!(worktree.exists(), "dry run must not remove the worktree");
+    assert!(
+        worktree_registered(&main, &worktree),
+        "dry run must leave git still tracking the worktree: {message}"
+    );
+    assert!(
+        branch_exists(&main, "feature"),
+        "dry run must not delete the branch: {message}"
+    );
+    assert!(
+        message.contains("held for CI"),
+        "the dry run should quote the lock reason too: {message}"
+    );
+}
+
+/// The other half of the contract: the check must key on the lock being *there*,
+/// not on the worktree having once been locked. Unlocking puts it straight back
+/// in reach of `--force`.
+#[test]
+fn force_still_nukes_a_worktree_that_was_unlocked_again() {
+    let fixture = Fixture::new();
+    let worktree = fixture.add_worktree("feature-wt", "feature");
+    let main = fixture.main_repo();
+    let path = worktree.to_str().expect("utf-8 path");
+    fixture.lock_worktree(&worktree, Some("briefly"));
+    git(&main, &["worktree", "unlock", path]);
+
+    let output = gitnuke(&main, &["--force", "feature"]);
+
+    assert!(
+        output.status.success(),
+        "an unlocked worktree must still nuke: {}",
+        combined(&output)
+    );
+    assert!(!worktree.exists(), "worktree directory should be gone");
+    assert!(
+        !worktree_registered(&main, &worktree),
+        "git should no longer track the worktree"
+    );
+    assert!(
+        !branch_exists(&main, "feature"),
+        "branch 'feature' should be deleted"
+    );
+}
+
 /// Uncommitted work is git's other reason to refuse a removal. gitnuke must not
 /// delete the branch when that happens — the whole point of the worktree being
 /// left standing is that the work inside it is still recoverable.
@@ -1005,7 +1180,7 @@ fn refuses_to_run_outside_a_git_repository() {
 /// Stated here rather than derived from the binary for the same reason as
 /// `mod exit_codes` above: this is the contract users read, so the test has to
 /// spell it out independently.
-const HELP_EXIT_CODE_LINES: [&str; 8] = [
+const HELP_EXIT_CODE_LINES: [&str; 9] = [
     "- 0: Success",
     "- 1: Not in a git repository",
     "- 2: A git command failed",
@@ -1014,6 +1189,7 @@ const HELP_EXIT_CODE_LINES: [&str; 8] = [
     "- 5: The worktree contains submodules and `--force` was not given",
     "- 6: The shell is standing inside the target worktree",
     "- 7: The worktree was removed but its branch could not be deleted",
+    "- 8: The worktree is locked, which `--force` does not override",
 ];
 
 /// The usage examples `gitnuke --help` publishes, as (command, trailing note).


### PR DESCRIPTION
## Why

`gitnuke` was a shell function that could not remove a worktree containing submodules:

```
fatal: working trees containing submodules cannot be moved or removed
```

It had two further bugs. It passed the same argument to `git worktree remove` and to the branch force-delete, so it only worked when a worktree's directory name happened to equal its branch name. And the two commands were not chained, so a failed removal still force-deleted the branch — caught live during verification, where git's "cannot delete branch used by worktree" protection was the only thing preventing loss.

This replaces it with a real Rust tool in `src/gitnuke`.

## What it does

Resolves the target against `git worktree list --porcelain`, so the branch it deletes is the one that worktree actually had checked out, and deletes it only after the removal succeeds.

- **`--force`** — required for a worktree with submodules checked out or with uncommitted changes. One `--force` clears both of git's refusals (verified against git 2.55) and leaves nothing behind on disk. The refusal message names the submodules in the way instead of surfacing git's bare `fatal:`; detection mirrors git's own `validate_no_submodules` (a gitlink in the worktree index whose directory exists, or submodule metadata in the worktree's git dir), so it is locale-independent rather than parsing git's English error.
- **`--safe`** — keeps the branch unless fully merged. This is what a `gitclean` alias delegates to.
- **`--dry-run`** — a real preflight: runs every gate and exits with the status a real run would.
- **Exact matches only** — unlike `cwt`, asking for `issue-42` will not resolve `issue-421`; a name matching one worktree's directory and another's branch is reported as ambiguous rather than guessed.
- **Refuses your own cwd** — a binary cannot `cd` its caller out, so it names somewhere else to go instead of stranding the shell in a deleted directory. `--force` does not override this: it overrides git's refusals, not the caller's shell.
- **Never the main worktree**, and never a branch whose removal git refused.

## Tests

34 tests, built TDD across three red/green pairs (`test: red` → `feat: green`):

- 22 end-to-end against real submodule fixtures — including the reported failure, a dirty worktree with modified *and* untracked submodule content, multi-byte directory/branch/submodule names, detached HEAD, near-miss targets, multi-target runs, and running outside a repo.
- 12 unit tests over the porcelain parser, target resolution, and gitlink extraction (`ls-files --stage -z`, so quoting cannot corrupt non-ASCII paths).

Fixtures use per-test `TempDir`s and scrub `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_PREFIX`, so concurrent runs stay isolated and no test can reach the real repo.

## Verification note

The repo's pre-commit hook gates every check on staged file patterns, so the conventional closing `git commit --allow-empty` stages nothing and skips them all. The four gates were run directly over the workspace instead — `cargo fmt --all --check`, `cargo machete`, `cargo clippy --all-targets --workspace -- -D warnings`, `cargo test --workspace` — and all passed. That hook gap affects every TDD run in this repo and is worth fixing separately.

## Not in this PR

The shell side lives in yadm, not here: the `gitnuke()` function was removed from `~/.zshrc##template.default` (it would shadow the binary) and `gitclean()` now delegates to `gitnuke --safe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)