### PR TITLE
chore: bump pinned Rust toolchain to 1.97.1 and remove the false MSRV declarations

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,14 @@
-# Pin the toolchain so the formatting contract (and clippy gate) is
-# machine-independent: every contributor and CI run resolves the exact same
-# rustfmt/clippy behavior instead of whatever stable happens to be installed.
-# See issue #273. Bump deliberately; after bumping, re-run `cargo fmt --all`
-# in a dedicated style-only commit if the check no longer passes.
+# Pin the toolchain so the clippy gate is machine-independent: every
+# contributor resolves the exact same lint set instead of whatever stable
+# happens to be installed. Formatting is already insulated independently by
+# `style_edition` in rustfmt.toml, which holds rustfmt's output stable across
+# compiler versions (verified byte-identical from 1.88 through 1.97.1), so the
+# pin is carrying the clippy contract, not the formatting one. See issue #273.
+#
+# Bump deliberately, and only once `cargo clippy --all-targets --workspace --
+# -D warnings` passes on the new toolchain: `-D warnings` turns any new or
+# renamed lint into a repo-wide commit blocker. Editing this file re-triggers
+# the full Rust gate in .husky/pre-commit, which re-proves that on commit.
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/src/bm/Cargo.toml
+++ b/src/bm/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bm"
 version = "0.1.0"
 edition.workspace = true
-rust-version = "1.80"
 
 [dependencies]
 anyhow.workspace = true

--- a/src/prcp/Cargo.toml
+++ b/src/prcp/Cargo.toml
@@ -2,7 +2,6 @@
 name = "prcp"
 version = "0.1.0"
 edition.workspace = true
-rust-version = "1.80"
 
 [dependencies]
 anyhow.workspace = true

--- a/src/prcp/src/main.rs
+++ b/src/prcp/src/main.rs
@@ -41,7 +41,7 @@ fn create_uninit_buffer(size: usize) -> Vec<u8> {
     // but callers will only access bytes that File::read has written to.
     // File::read returns the number of bytes actually read, so we never
     // access uninitialized memory as long as we respect that count.
-    #[allow(clippy::uninit_vec)]
+    #[allow(clippy::uninit_vec, reason = "see the SAFETY note above")]
     unsafe {
         buffer.set_len(size);
     }
@@ -126,7 +126,10 @@ impl<'a> PartialFileGuard<'a> {
     ///
     /// # Panics
     /// Panics if called after `defuse()` - this is a programming error.
-    #[allow(clippy::expect_used)] // Invariant: file is always Some until defuse()
+    #[allow(
+        clippy::expect_used,
+        reason = "invariant: file is always Some until defuse()"
+    )]
     fn file_mut(&mut self) -> &mut File {
         self.file
             .as_mut()
@@ -139,7 +142,10 @@ impl<'a> PartialFileGuard<'a> {
     ///
     /// # Panics
     /// Panics if called more than once - this is a programming error.
-    #[allow(clippy::expect_used)] // Invariant: file is always Some until defuse()
+    #[allow(
+        clippy::expect_used,
+        reason = "invariant: file is always Some until defuse()"
+    )]
     fn defuse(mut self) -> File {
         self.defused = true;
         self.file
@@ -300,11 +306,11 @@ fn format_buffer_size(size: usize) -> String {
     const MB: usize = 1024 * 1024;
     const GB: usize = 1024 * 1024 * 1024;
 
-    if size >= GB && size % GB == 0 {
+    if size >= GB && size.is_multiple_of(GB) {
         format!("{}GB", size / GB)
-    } else if size >= MB && size % MB == 0 {
+    } else if size >= MB && size.is_multiple_of(MB) {
         format!("{}MB", size / MB)
-    } else if size >= KB && size % KB == 0 {
+    } else if size >= KB && size.is_multiple_of(KB) {
         format!("{}KB", size / KB)
     } else {
         format!("{} bytes", size)
@@ -1243,7 +1249,7 @@ fn calculate_file_hash(
         iteration_count = iteration_count.wrapping_add(1);
 
         // Throttle UI updates - only check time every N iterations to reduce overhead
-        if iteration_count % TIME_CHECK_INTERVAL == 0 {
+        if iteration_count.is_multiple_of(TIME_CHECK_INTERVAL) {
             let now = Instant::now();
             if now.duration_since(last_update) >= UPDATE_INTERVAL {
                 last_update = now;
@@ -1311,7 +1317,10 @@ fn format_duration(duration: Duration) -> String {
 ///
 /// Handles edge cases including zero duration and potential overflow
 /// when converting from f64 to u64.
-#[allow(clippy::cast_precision_loss)] // Precision loss is acceptable for human-readable display
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "precision loss is acceptable for human-readable display"
+)]
 fn format_speed(bytes: u64, duration: Duration) -> String {
     // Use Duration's is_zero() instead of floating-point equality comparison
     if duration.is_zero() {
@@ -1320,7 +1329,11 @@ fn format_speed(bytes: u64, duration: Duration) -> String {
     let bytes_per_sec = bytes as f64 / duration.as_secs_f64();
     // Clamp to u64::MAX to prevent overflow when casting from f64.
     // We also handle negative values (which shouldn't occur) by treating them as 0.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the surrounding branches clamp the value to 0..=u64::MAX before this cast"
+    )]
     let bytes_per_sec_u64 = if bytes_per_sec <= 0.0 {
         0
     } else if bytes_per_sec >= u64::MAX as f64 {
@@ -1553,7 +1566,10 @@ fn try_preallocate(file: &File, size: u64) {
         fst_bytesalloc: libc::off_t,
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "a preallocation size never approaches off_t's signed range"
+    )]
     let mut fstore = FStore {
         fst_flags: libc::F_ALLOCATECONTIG | libc::F_ALLOCATEALL,
         fst_posmode: libc::F_PEOFPOSMODE,
@@ -1654,7 +1670,10 @@ fn same_device(_source: &Path, _destination: &Path) -> bool {
 /// - If `force_sequential` is true: always use sequential copy
 /// - If source and destination are on the same device: use sequential copy (avoids HDD head thrashing)
 /// - Otherwise: use parallel copy for better throughput on cross-device transfers
-#[allow(clippy::too_many_arguments)] // All parameters serve distinct purposes for progress/cancellation/resize
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all parameters serve distinct purposes for progress/cancellation/resize"
+)]
 async fn copy_with_progress(
     source: &Path,
     destination: &Path,
@@ -1705,7 +1724,10 @@ async fn copy_with_progress(
 ///
 /// Performs read→hash→write in sequence. This is optimal for spinning HDDs
 /// to avoid head thrashing, and is the fallback for non-Unix platforms.
-#[allow(clippy::too_many_arguments)] // All parameters serve distinct purposes for progress/cancellation/resize
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all parameters serve distinct purposes for progress/cancellation/resize"
+)]
 async fn copy_sequential(
     source: &Path,
     destination: &Path,
@@ -1828,7 +1850,7 @@ async fn copy_sequential(
         iteration_count = iteration_count.wrapping_add(1);
 
         // Throttle UI updates - only check time every N iterations to reduce overhead
-        if iteration_count % TIME_CHECK_INTERVAL == 0 {
+        if iteration_count.is_multiple_of(TIME_CHECK_INTERVAL) {
             let now = Instant::now();
             if now.duration_since(last_update) >= UPDATE_INTERVAL {
                 last_update = now;
@@ -1899,7 +1921,10 @@ const PARALLEL_CHANNEL_DEPTH: usize = 4;
 /// - Reader respects pause flag
 /// - When cancelling: set paused=false, drop receiver to disconnect channel
 /// - Reader exits naturally when its send() fails
-#[allow(clippy::too_many_arguments)] // All parameters serve distinct purposes for progress/cancellation/resize
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all parameters serve distinct purposes for progress/cancellation/resize"
+)]
 async fn copy_parallel(
     source: &Path,
     destination: &Path,
@@ -2087,7 +2112,7 @@ async fn copy_parallel(
                 iteration_count = iteration_count.wrapping_add(1);
 
                 // Throttle UI updates
-                if iteration_count % TIME_CHECK_INTERVAL == 0 {
+                if iteration_count.is_multiple_of(TIME_CHECK_INTERVAL) {
                     let now = Instant::now();
                     if now.duration_since(last_update) >= UPDATE_INTERVAL {
                         last_update = now;
@@ -2172,7 +2197,10 @@ async fn copy_parallel(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)] // Tests use unwrap for brevity and clear failure messages
+#[allow(
+    clippy::unwrap_used,
+    reason = "tests use unwrap for brevity and clear failure messages"
+)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
Bumps the pinned toolchain from 1.96.0 to 1.97.1 (current stable), and removes two `rust-version` declarations that were quietly suppressing lints.

## Why now

`rust-toolchain.toml` had drifted behind stable. Bumping while the gates are verifiably green keeps it a small diff instead of letting the gap accumulate until some future clippy turns it into a repo-wide lint cleanup. Nothing was broken on 1.96.0 — this is deliberate hygiene, per the file's own "bump deliberately" instruction.

## What's here

**1. `chore(toolchain)` — bump to 1.97.1.** One-line channel change, plus a rewrite of the file's header comment. The old comment credited the pin with making the *formatting* contract machine-independent, but `rustfmt.toml`'s `style_edition` already does that independently — formatting is byte-identical from 1.88 through 1.97.1 regardless of the pin (measured). What the pin actually freezes is the clippy lint set, so the comment now says so. It also dropped a reference to "CI run"; this repo has no CI.

**2. `chore` — drop `rust-version = "1.80"` from `bm` and `prcp`, and fix the lints it hid.**

That floor was false — the workspace uses `#[expect(...)]` (1.81+), `style_edition` needs a much newer rustfmt, and `gix`/`ratatui`/`aws-sdk-s3` all require well above 1.80. But it was *not* inert: clippy reads `rust-version` as an MSRV and suppresses lints whose suggested APIs postdate it. Declaring 1.80 was silently hiding two lints across `prcp`:

- `manual_is_multiple_of` — `is_multiple_of` stabilized in 1.87 (6 sites)
- `allow_attributes_without_reason` — `reason = ".."` stabilized in 1.81 (10 sites)

Both are fixed in the same commit, because splitting them would leave an intermediate commit that fails the clippy gate.

Worth noting: **no honest MSRV avoids these fixes.** Any accurate floor here is >= 1.87, where both APIs already exist. Only the false 1.80 suppressed them.

The `is_multiple_of` rewrites are all on unsigned types (`usize`, `u32`), so they're exactly equivalent. The `reason = "..."` additions carry over the trailing `//` comments that already justified each `allow`, moving them somewhere the lint and the reader can both see.

## Verification

Full `.husky/pre-commit` gate ran on 1.97.1 for both commits — it fires automatically here, since the trigger regex matches `rust-toolchain.toml` and `Cargo.toml` by name.

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | PASS |
| `cargo machete` | no unused dependencies |
| `cargo clippy --all-targets --workspace -- -D warnings` | PASS, 0 diagnostics |
| `cargo test --workspace` | 1622 passed, 0 failed, 8 ignored, 112 suites |

No TDD red/green cycle: a version string in a config file and a set of lint-attribute rewrites have no behavior a test can assert. The pre-commit gate is the verification, and `prcp`'s existing 40 tests cover the `is_multiple_of` rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)