### PR TITLE
chore(deps): bump golang.org/x/crypto and golang.org/x/net for security advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/timmattison/aws-iot-core-websockets-go v0.6.1
 	golang.design/x/clipboard v0.7.1
-	golang.org/x/text v0.37.0
+	golang.org/x/text v0.40.0
 )
 
 require (
@@ -66,13 +66,13 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/exp/shiny v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/mobile v0.0.0-20260520154334-0e4426e1883d // indirect
-	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )


### PR DESCRIPTION
Clears all 14 open Dependabot alerts on `main`. Both modules are indirect deps, reached through `go-git` (SSH) and the HTML parser.

| Module | From | To | Patched floor |
|---|---|---|---|
| `golang.org/x/crypto` | v0.51.0 | **v0.54.0** | 0.52.0 |
| `golang.org/x/net` | v0.54.0 | **v0.57.0** | 0.55.0 |
| `golang.org/x/text` | v0.37.0 | v0.40.0 | carried by `go mod tidy` |
| `golang.org/x/sync` | v0.20.0 | v0.22.0 | carried by `go mod tidy` |
| `golang.org/x/sys` | v0.45.0 | v0.47.0 | carried by `go mod tidy` |

The 13 `x/crypto` advisories are all SSH-path issues — agent key-constraint bypasses, `@revoked` auth bypass, FIDO/U2F presence-check bypass, and several DoS/panic paths. The `x/net` one is a denial of service in the HTML parser.

## Verification

All gates run and passing:

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `scripts/build-go.sh` — all six binaries build
- pre-commit hook on the commit itself
- `govulncheck ./...` — **0 vulnerabilities affecting this code**

## Notes

- **One vulnerability is not fixable by a bump.** `GO-2026-5932` flags `x/crypto/openpgp` as unmaintained and unsafe by design; govulncheck reports **"Fixed in: N/A"**. Nothing here calls it, and it was not among the Dependabot alerts (those all had patched versions).
- **`go.sum` is gitignored** (`.gitignore:7`), so it is untracked and absent from this diff. The `go.mod` floors are therefore the only thing enforcing these minimums — there is no checksum pinning in the repo. Pre-existing decision, left alone here, but it is why this diff is 5 lines instead of a few hundred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)