### PR TITLE
fix(gsw): harden the watch-refresh fix — survive failed walks, guard the linked-worktree re-open

### DIFF
--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -591,7 +591,9 @@ mod tests {
     use super::RepoHandle;
     use crate::git::FileStatus;
     use crate::render::Operation;
-    use crate::testrepo::{git, git_allowing_failure, init_repo, init_repo_with_upstream};
+    use crate::testrepo::{
+        git, git_allowing_failure, init_repo, init_repo_with_upstream, init_repo_with_worktree,
+    };
 
     /// Open a repo at an explicit path (tests can't rely on cwd under a
     /// parallel test runner).
@@ -1041,6 +1043,74 @@ mod tests {
             (up.ahead, up.behind),
             (0, 0),
             "the push left the branch level with its brand-new upstream",
+        );
+    }
+
+    /// Read the `gsw.probe` key out of the repository's config as it stands
+    /// *right now*, owned so the snapshot's borrow ends with the call.
+    ///
+    /// The key is one git itself never consults, so a non-`None` answer can only
+    /// have come from a fresh read of the config file the handle resolves to —
+    /// exactly the observation the re-open is supposed to make possible.
+    fn probe(repo: &gix::Repository) -> Option<String> {
+        repo.config_snapshot()
+            .string("gsw.probe")
+            .map(|value| value.to_string())
+    }
+
+    #[test]
+    fn reopened_handle_in_a_linked_worktree_sees_config_written_after_open() {
+        // Nearly all work on this repository happens in a linked worktree
+        // (`nwt`), so that is where gsw's watch mode actually runs, and it is
+        // the one layout whose work-tree root holds a `.git` *file* pointing at
+        // `<repo>/.git/worktrees/<name>` rather than a `.git` directory.
+        // `reopened()` re-opens with `gix::open` — chosen over `gix::discover`
+        // precisely because it resolves that pointer without walking up — so if
+        // resolution ever regressed, `open` would simply fail, the handle would
+        // fall back to the stale repository it already holds, and every config
+        // change made mid-watch (`git push -u origin <branch>` above all) would
+        // go unseen until restart, with nothing on screen to say so. The rest
+        // of the re-open tests run against a plain repo or a clone, where a
+        // broken pointer costs nothing.
+        //
+        // This guard is not red-first: the property already holds. It exists so
+        // a gix upgrade or a later refactor cannot turn the #334 fix into a
+        // no-op in the environment it is used in most while the suite stays
+        // green.
+        let (_repo, linked) = init_repo_with_worktree();
+
+        // The fixture only proves anything if it really is a linked worktree —
+        // a plain clone would exercise the `.git`-directory path and satisfy
+        // every assertion below while covering none of the pointer resolution.
+        assert!(
+            linked.join(".git").is_file(),
+            "a linked worktree's `.git` is a gitdir pointer file, not a directory",
+        );
+
+        // Opened BEFORE the config write and held across it, like watch mode.
+        let mut held = RepoHandle::discover(&linked).expect("linked worktree is a worktree repo");
+        assert_ne!(
+            held.repo().git_dir(),
+            held.repo().common_dir(),
+            "a linked worktree's per-worktree git dir lives under the main repo's common dir",
+        );
+        assert_eq!(probe(held.repo()), None, "nothing has written the key yet");
+
+        // What any `git config` run in another pane does mid-watch. From a
+        // linked worktree this lands in the *common* `.git/config`, which is
+        // reachable only by following the gitdir pointer.
+        git(&linked, &["config", "gsw.probe", "written-after-open"]);
+
+        assert_eq!(
+            probe(held.repo()),
+            None,
+            "the handle opened before the write still has the old config cached",
+        );
+        assert_eq!(
+            probe(held.reopened()).as_deref(),
+            Some("written-after-open"),
+            "re-opening from a work-tree root whose `.git` is a pointer file must \
+             still re-read the configuration it points at",
         );
     }
 

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -57,9 +57,17 @@ impl RepoHandle {
     /// Wrap an opened repository, rejecting one gsw can't render.
     ///
     /// Bare repos have no work tree; gsw renders a per-file working-tree view,
-    /// so there's nothing to show. Treat them like "not a repo". Shared by the
-    /// initial discovery and by [`reopened`](Self::reopened) so both apply the
-    /// same admission rule.
+    /// so there's nothing to show. Treat them like "not a repo".
+    ///
+    /// This is the discovery path only. [`reopened`](Self::reopened) admits a
+    /// repository by the same rule — the repository must have a work tree — but
+    /// states it inline instead of calling here, because a re-open keeps the
+    /// work-tree root captured at discovery and has no use for the `PathBuf`
+    /// this builds. That is a weaker guarantee than one shared code path: the
+    /// two could drift. What keeps them honest is that the rule is a single
+    /// `workdir()` call on each side, small enough to compare at a glance, and
+    /// that changing it here without changing it there would leave a handle
+    /// whose `workdir` field no longer describes what a re-open will accept.
     fn from_repo(repo: gix::Repository) -> Option<Self> {
         let workdir = repo.workdir()?.to_path_buf();
         Some(Self { repo, workdir })
@@ -90,7 +98,11 @@ impl RepoHandle {
     /// A failed re-open, or one that comes back without a work tree, keeps the
     /// handle already in hand: a monitor that blanks out for one tick because
     /// it caught git mid-write is worse than a monitor that repaints one
-    /// tick-old configuration and recovers on the next call.
+    /// tick-old configuration and recovers on the next call. The work-tree
+    /// check is written out here rather than borrowed from
+    /// [`from_repo`](Self::from_repo): only the repository is being replaced,
+    /// and building a second work-tree root just to drop it would suggest the
+    /// captured one gets refreshed, which is exactly what this must not do.
     ///
     /// That "never a blank screen" property is **not** delivered here alone —
     /// this fallback only guarantees a usable *handle*. Reading a repository
@@ -103,8 +115,11 @@ impl RepoHandle {
     /// ends watch mode outright, which is precisely the bug this pairing was
     /// written to close.
     pub fn reopened(&mut self) -> &gix::Repository {
-        if let Some(fresh) = gix::open(&self.workdir).ok().and_then(Self::from_repo) {
-            self.repo = fresh.repo;
+        if let Some(fresh) = gix::open(&self.workdir)
+            .ok()
+            .filter(|repo| repo.workdir().is_some())
+        {
+            self.repo = fresh;
         }
         &self.repo
     }

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -91,6 +91,17 @@ impl RepoHandle {
     /// handle already in hand: a monitor that blanks out for one tick because
     /// it caught git mid-write is worse than a monitor that repaints one
     /// tick-old configuration and recovers on the next call.
+    ///
+    /// That "never a blank screen" property is **not** delivered here alone —
+    /// this fallback only guarantees a usable *handle*. Reading a repository
+    /// that is mid-`gc`, mid-checkout, or renamed away can still fail on the
+    /// status walk performed against the handle it hands back, and watch mode's
+    /// `event_loop` is what absorbs *that* failure by re-rendering the last good
+    /// snapshot at its true age. Removing either half re-breaks the guarantee:
+    /// drop this fallback and a momentary re-open failure loses the
+    /// configuration; drop the loop's absorption and the same momentary failure
+    /// ends watch mode outright, which is precisely the bug this pairing was
+    /// written to close.
     pub fn reopened(&mut self) -> &gix::Repository {
         if let Some(fresh) = gix::open(&self.workdir).ok().and_then(Self::from_repo) {
             self.repo = fresh.repo;

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -59,15 +59,9 @@ impl RepoHandle {
     /// Bare repos have no work tree; gsw renders a per-file working-tree view,
     /// so there's nothing to show. Treat them like "not a repo".
     ///
-    /// This is the discovery path only. [`reopened`](Self::reopened) admits a
-    /// repository by the same rule — the repository must have a work tree — but
-    /// states it inline instead of calling here, because a re-open keeps the
-    /// work-tree root captured at discovery and has no use for the `PathBuf`
-    /// this builds. That is a weaker guarantee than one shared code path: the
-    /// two could drift. What keeps them honest is that the rule is a single
-    /// `workdir()` call on each side, small enough to compare at a glance, and
-    /// that changing it here without changing it there would leave a handle
-    /// whose `workdir` field no longer describes what a re-open will accept.
+    /// This is the discovery path only; [`reopened`](Self::reopened) admits a
+    /// repository by the same rule — it must have a work tree — but applies it
+    /// inline. See there for why the check is stated twice rather than shared.
     fn from_repo(repo: gix::Repository) -> Option<Self> {
         let workdir = repo.workdir()?.to_path_buf();
         Some(Self { repo, workdir })
@@ -103,6 +97,11 @@ impl RepoHandle {
     /// [`from_repo`](Self::from_repo): only the repository is being replaced,
     /// and building a second work-tree root just to drop it would suggest the
     /// captured one gets refreshed, which is exactly what this must not do.
+    /// That leaves one rule stated in two places, which could drift — an
+    /// accepted cost, because each side is a single `workdir()` call, small
+    /// enough to compare at a glance, and changing one without the other would
+    /// leave a handle whose `workdir` field no longer describes what a re-open
+    /// will accept.
     ///
     /// That "never a blank screen" property is **not** delivered here alone —
     /// this fallback only guarantees a usable *handle*. Reading a repository

--- a/src/gsw/src/testrepo.rs
+++ b/src/gsw/src/testrepo.rs
@@ -10,7 +10,7 @@
 //! Every fixture lives in its own [`tempfile::TempDir`], so the suite stays
 //! parallel-safe: two concurrent runs of the same test never share a path.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -101,6 +101,40 @@ pub(crate) fn init_repo_with_upstream() -> (TempDir, TempDir) {
     );
     identity(clone.path());
     (origin, clone)
+}
+
+/// An [`init_repo`] repo plus a linked worktree checked out on its own branch,
+/// returning `(repo, linked_worktree_path)`.
+///
+/// A linked worktree is the only layout where the work-tree root holds a `.git`
+/// *file* — a `gitdir:` pointer at `<repo>/.git/worktrees/<name>` — instead of a
+/// `.git` directory, and following that pointer to the shared config is a
+/// distinct code path from reading `<root>/.git/config` directly. It is also the
+/// layout this repository mandates all development happen in, so fixtures built
+/// only from [`init_repo`] and [`init_repo_with_upstream`] leave the path gsw
+/// runs against most as the one path nothing covers.
+///
+/// The worktree is deliberately nested *inside* the repo's tempdir so a single
+/// [`TempDir`] owns both halves: dropping it removes the checkout and the
+/// `.git/worktrees` administrative directory that describes it together, with no
+/// second directory to leak. That [`TempDir`] must therefore be held for as long
+/// as the caller reads *either* repository — the returned path points inside it,
+/// so dropping the [`TempDir`] invalidates the path as well.
+pub(crate) fn init_repo_with_worktree() -> (TempDir, PathBuf) {
+    let repo = init_repo();
+    let linked = repo.path().join("linked");
+    git(
+        repo.path(),
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "linked",
+            linked.to_str().expect("utf-8 tempdir path"),
+        ],
+    );
+    (repo, linked)
 }
 
 /// Give the repo at `dir` a committer identity and disable signing, so commits

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -143,7 +143,7 @@ impl LiveIgnore {
     /// Build the matcher from the repository's ignore sources as they are on
     /// disk right now. See [`build_ignore_matcher`] for which sources those are.
     pub(crate) fn new(repo: &gix::Repository) -> Self {
-        Self::from(build_ignore_matcher(repo))
+        Self(Arc::new(RwLock::new(build_ignore_matcher(repo))))
     }
 
     /// Re-read the repository's ignore sources so a rule added or removed since
@@ -200,11 +200,26 @@ impl LiveIgnore {
     }
 }
 
+#[cfg(test)]
 impl From<Gitignore> for LiveIgnore {
-    /// Share an already-built matcher. Production always goes through
-    /// [`LiveIgnore::new`]; this is the seam the [`should_react`] unit tests use
-    /// to hand in a matcher assembled from raw gitignore lines instead of from a
-    /// repository on disk.
+    /// Share an already-built matcher — **in test builds only**, and the
+    /// `#[cfg(test)]` above is load-bearing rather than tidiness.
+    ///
+    /// A [`LiveIgnore`] built from a bare [`Gitignore`] is one nobody refreshes.
+    /// It is assembled from a glob set the caller already had in hand, with no
+    /// repository behind it to re-read, so it is frozen at whatever those globs
+    /// said the moment it was handed over — the exact staleness this type was
+    /// introduced to prevent, wearing the type that promises the opposite. Left
+    /// ungated, that construction is reachable from anywhere in the crate, and
+    /// the liveness invariant degrades from something the compiler holds into
+    /// something a future caller is trusted to remember.
+    ///
+    /// Gating it leaves [`LiveIgnore::new`] as the only entrance that survives
+    /// into a production build, and `new` reads from a repository — so every
+    /// `LiveIgnore` that ships is one [`refresh`](LiveIgnore::refresh) can keep
+    /// current. Under `cfg(test)` the impl remains what it always was: the seam
+    /// the pure [`should_react`] tests use to hand in a matcher assembled from
+    /// raw gitignore lines instead of from a repository on disk.
     fn from(matcher: Gitignore) -> Self {
         Self(Arc::new(RwLock::new(matcher)))
     }

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -496,14 +496,24 @@ enum Event {
 /// walk, which only happens when the throttle admits a walk in the first place —
 /// and it rides along with a full status traversal that dwarfs both.
 /// [`RepoHandle::reopened`] keeps the previous handle if the re-open fails, so
-/// catching git mid-write costs a tick of stale configuration, never a blank
-/// screen.
+/// catching git mid-write costs a tick of stale configuration rather than a
+/// failed walk. That fallback is only half of "never a blank screen": it keeps
+/// the *handle*, while [`event_loop`] keeps the *frame* when the status walk on
+/// that handle fails anyway. Both halves are required — see the `# Errors`
+/// section.
 ///
 /// # Errors
 ///
 /// Propagates a [`collect_snapshot`] failure (the status walk). Neither a failed
 /// *re-open* nor an unreadable ignore file is an error: the first degrades to the
 /// handle already in hand, the second to a matcher without that source.
+///
+/// The one production caller, [`event_loop`], deliberately does **not** let that
+/// error out of watch mode: it keeps the last good snapshot, re-renders it at its
+/// true (still-advancing) age, arms the throttle from the failed walk's cost, and
+/// retries on the next event. So this signature says "this walk did not produce a
+/// snapshot", not "the monitor should stop" — a distinction worth preserving if a
+/// second caller ever appears.
 pub(crate) fn walk(
     handle: &mut RepoHandle,
     ignore: &LiveIgnore,
@@ -762,7 +772,24 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
 ///   collect;
 /// - a recompute whose output is byte-identical to what's displayed paints
 ///   nothing (suppression);
+/// - a walk that *fails* does not end the loop: the last good snapshot is
+///   re-rendered at its true age and the next event retries (see below);
 /// - [`Event::Quit`] ends the loop, as does every sender hanging up.
+///
+/// A failed collect is absorbed rather than propagated because the failures are
+/// overwhelmingly transient and none of the user's doing — `git gc` swapping the
+/// ref store out from under the walk, a worktree being pruned, `.git` renamed
+/// mid-operation. This is the other half of [`RepoHandle::reopened`]'s "never a
+/// blank screen" guarantee: that fallback keeps a *handle* when the re-open
+/// fails, and this keeps a *frame* when the status walk on it fails. Either half
+/// alone leaves the monitor dying on a repository that is momentarily
+/// unreadable. The failed walk still arms the throttle from its measured cost —
+/// so a repo that fails every walk backs off on the same duty cycle instead of
+/// hot-looping — and deliberately does *not* advance `collected_at`, so the
+/// stale frame goes on aging honestly rather than resetting every displayed age
+/// to zero. The accepted cost: a repository deleted for good leaves a frozen
+/// (but visibly aging) frame until the user quits. That is the right failure for
+/// a monitor — a wrong-but-labeled-old screen beats no screen.
 fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick>(
     rx: &Receiver<Event>,
     debounce: Duration,
@@ -888,15 +915,40 @@ where
 
         let render = if walk_now {
             cache.dims = (hooks.dimensions)();
-            // Re-seed the collection time to the walk's start so a later decay
-            // tick or resize advances ages from *this* walk, not the previous
-            // one. Measure the walk's wall-clock cost around collect and feed it
-            // to the throttle, which arms the next cooldown (= 100·cost) from it.
-            cache.collected_at = now;
-            cache.snapshot = (hooks.collect)()?;
+            let collected = (hooks.collect)();
+            // Measure the walk's wall-clock cost around collect and feed it to
+            // the throttle, which arms the next cooldown (= 100·cost) from it.
+            // Deliberately outside the match: a *failed* walk still paid for a
+            // status traversal, and a repo that is unreadable for a while fails
+            // every walk, so gating the retries on the same duty-cycle budget is
+            // what keeps a permanently-deleted repo from pinning a core.
             let cost = (hooks.clock)().saturating_duration_since(now);
             throttle.record(now, cost);
-            (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
+            match collected {
+                Ok(snapshot) => {
+                    // Re-seed the collection time to the walk's start so a later
+                    // decay tick or resize advances ages from *this* walk, not
+                    // the previous one.
+                    cache.collected_at = now;
+                    cache.snapshot = snapshot;
+                    (hooks.render)(&cache.snapshot, cache.dims, Duration::ZERO)
+                }
+                // A walk can fail for reasons that are none of the user's
+                // business and usually transient: `git gc` swapping the ref
+                // store, a worktree being pruned, `.git` renamed mid-operation.
+                // Ending watch mode over that would make the whole
+                // stale-configuration fallback in [`RepoHandle::reopened`]
+                // pointless, so absorb it: keep the last good snapshot and let
+                // the next event retry. `collected_at` is pointedly NOT advanced
+                // — a collection that never happened must not reset every
+                // displayed age to "just now", or the monitor would claim
+                // freshness exactly when it has none. The frame therefore keeps
+                // aging truthfully while the repository is unreadable.
+                Err(_) => {
+                    let age_offset = now.saturating_duration_since(cache.collected_at);
+                    (hooks.render)(&cache.snapshot, cache.dims, age_offset)
+                }
+            }
         } else if saw_resize {
             cache.dims = (hooks.dimensions)();
             let age_offset = now.saturating_duration_since(cache.collected_at);

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -2651,6 +2651,157 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_absorbs_a_failed_walk_and_keeps_the_last_good_frame() {
+        // A walk can fail for reasons that have nothing to do with the user:
+        // `git gc` swapping the ref store out from under us, a worktree being
+        // pruned, `.git` momentarily renamed by a tool. `RepoHandle::reopened`
+        // already degrades to the handle in hand rather than blanking the
+        // screen — but that fallback only matters if the loop survives the
+        // *status walk* failing too. So a failed collect must not end watch
+        // mode; it must re-render the LAST GOOD snapshot, and it must render it
+        // at its TRUE age: `collected_at` may not advance for a collection that
+        // never happened, or the monitor would show a stale repo with every
+        // file age reset to "just now" — lying about freshness precisely when
+        // it is least fresh. With the cache collected at `base` and the clock
+        // 50 s later, the render hook must see the cached snapshot and a 50 s
+        // offset, and the loop must return `Ok`.
+        let base = Instant::now();
+        let clock_at = base + Duration::from_secs(50);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue fs change");
+        drop(tx);
+
+        let mut cache = seeded_cache(base);
+        cache.snapshot.branch = "last-good".to_string();
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut rendered: Vec<(String, Duration)> = Vec::new();
+        let result = event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            cache,
+            None, // decay timer off: isolate the failed walk from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    // The exact shape `collect_snapshot` produces when the ref
+                    // store has gone missing mid-walk.
+                    Err(anyhow::anyhow!(
+                        "status iter: The reference 'HEAD' did not exist"
+                    ))
+                },
+                render: |snap: &Snapshot, _dims: Dimensions, offset: Duration| {
+                    rendered.push((snap.branch.clone(), offset));
+                    frame("last good frame")
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || clock_at,
+                next_tick: timer_off,
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "a failed walk must be absorbed, not propagated out of watch mode: {result:?}",
+        );
+        assert_eq!(collects, 1, "the failed walk still ran exactly once");
+        assert_eq!(
+            rendered.len(),
+            1,
+            "a failed walk must still produce a frame — the screen never blanks",
+        );
+        assert_eq!(
+            rendered[0].0, "last-good",
+            "the frame after a failed walk must come from the CACHED snapshot",
+        );
+        assert_eq!(
+            rendered[0].1,
+            Duration::from_secs(50),
+            "a failed walk must not advance collected_at: the cached snapshot has \
+             to keep aging truthfully (now - collected_at = 50s), not reset to 0",
+        );
+        assert_eq!(displayed, "last good frame");
+    }
+
+    #[test]
+    fn event_loop_keeps_throttling_when_every_walk_fails() {
+        // Absorbing a failed walk must not turn the loop into a hot spin. A
+        // repository that is unreadable for a while (mid-`gc`, mid-checkout)
+        // will fail *every* walk, and each failure still costs a real status
+        // traversal — so the failure path has to feed the throttle exactly like
+        // the success path does, or a deleted repo would burn a core retrying.
+        //
+        // Same shape as `event_loop_throttles_walks_after_an_idle_change`, but
+        // every collect fails: three FS changes across the cooldown boundary
+        // must still collapse to exactly TWO walks. The first walk costs
+        // D = 10 ms, arming a 100·D = 1 s cooldown; the change at base + 100 ms
+        // lands mid-cooldown and is deferred; the change at base + 2 s is past
+        // expiry and walks. The injected clock is a short clamped sequence, so
+        // the test never sleeps and stays deterministic.
+        let base = Instant::now();
+        let times = [
+            base,                              // first (failing) walk start
+            base + Duration::from_millis(10),  // first walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_millis(100), // second change: mid-cooldown → deferred
+            base + Duration::from_secs(2), // third change: past expiry → walks; trailing reads clamp here
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue first change");
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut changes_sent = 1_usize;
+        let result = event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            seeded_cache(base),
+            None, // decay timer off: isolate the throttle from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    Err(anyhow::anyhow!("status platform: repository is gone"))
+                },
+                render: |_snap: &Snapshot, _dims: Dimensions, _offset: Duration| {
+                    // Deliver the next change in its own iteration so the three
+                    // never coalesce; quit once all three have been processed.
+                    if changes_sent < 3 {
+                        changes_sent += 1;
+                        let _ = tx.send(Event::FsChanged);
+                    } else {
+                        let _ = tx.send(Event::Quit);
+                    }
+                    frame(&format!("frame {changes_sent}"))
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: timer_off,
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "failing walks must keep the loop alive: {result:?}",
+        );
+        assert_eq!(
+            collects, 2,
+            "a failing walk must arm the cooldown exactly like a successful one: \
+             three FS changes across the boundary walk twice, not three times",
+        );
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -2869,6 +2869,137 @@ mod tests {
     }
 
     #[test]
+    fn event_loop_recovers_and_reseeds_age_after_a_failed_walk() {
+        // Absorbing a failed walk is only half the promise; the other half is
+        // that "the next event retries" and the monitor visibly RECOVERS. The
+        // two failure tests above never let a walk succeed afterward, so
+        // neither can tell a loop that retries from one that has quietly
+        // wedged itself on the last good frame forever. This drives the whole
+        // arc: fail, then succeed.
+        //
+        // The recovery that matters is the age display. While the repo is
+        // unreadable the cached frame keeps aging truthfully (50 s here); the
+        // moment a walk succeeds, the fresh snapshot must render at age zero
+        // AND `collected_at` must be re-seeded to that walk's start, so every
+        // later re-render ages from the new walk rather than from the
+        // long-stale seed. The final resize is what makes the re-seed directly
+        // observable: it re-renders the cache with no walk, and its offset is
+        // `now - collected_at` — 3 s off the second walk, not 55 s off the
+        // original seed. Without that third frame a "do not re-seed after a
+        // failure" regression would leave the loop stuck reporting the stale
+        // seed's age while every assertion still passed.
+        //
+        // Clock reads, in order (a clamped sequence, so the test never sleeps
+        // on real time): iteration 1's `now` and the failed walk's cost end;
+        // iteration 2's `now` and the successful walk's cost end; iteration
+        // 3's `now`. No read for a deferred deadline — nothing lands
+        // mid-cooldown, so the throttle is never dirty.
+        let base = Instant::now();
+        let times = [
+            base + Duration::from_secs(50), // failed walk start (cache is 50 s stale)
+            base + Duration::from_millis(50_010), // failed walk end → D = 10 ms → 1 s cooldown
+            base + Duration::from_secs(52), // retry: past expiry → walks, and succeeds
+            base + Duration::from_millis(52_010), // successful walk end
+            base + Duration::from_secs(55), // resize re-render; trailing reads clamp here
+        ];
+        let clock_calls = std::cell::Cell::new(0_usize);
+
+        let (tx, rx) = mpsc::channel();
+        tx.send(Event::FsChanged).expect("queue first change");
+
+        let mut cache = seeded_cache(base);
+        cache.snapshot.branch = "last-good".to_string();
+
+        let mut displayed = String::new();
+        let mut collects = 0_usize;
+        let mut rendered: Vec<(String, Duration)> = Vec::new();
+        let result = event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            cache,
+            None, // decay timer off: isolate recovery from tick behavior
+            LoopHooks {
+                collect: || {
+                    collects += 1;
+                    if collects == 1 {
+                        // The repo is momentarily unreadable — mid-`gc`, say.
+                        Err(anyhow::anyhow!(
+                            "status iter: The reference 'HEAD' did not exist"
+                        ))
+                    } else {
+                        // ...and then it isn't. A distinguishable branch name
+                        // proves the frame came from THIS walk, not the cache.
+                        let mut fresh = empty_snapshot();
+                        fresh.branch = "recovered".to_string();
+                        Ok(fresh)
+                    }
+                },
+                render: |snap: &Snapshot, _dims: Dimensions, offset: Duration| {
+                    rendered.push((snap.branch.clone(), offset));
+                    match rendered.len() {
+                        // Deliver the retry in its own iteration so it lands in
+                        // a separate debounce window instead of coalescing.
+                        1 => {
+                            let _ = tx.send(Event::FsChanged);
+                            frame("stale")
+                        }
+                        // A resize forces one more cached re-render (no walk),
+                        // whose age offset is read straight off `collected_at`.
+                        // The quit rides the same debounce window, so the loop
+                        // renders that frame and then stops.
+                        2 => {
+                            let _ = tx.send(Event::Resize);
+                            let _ = tx.send(Event::Quit);
+                            frame("fresh")
+                        }
+                        _ => frame("aged"),
+                    }
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: || {
+                    let i = clock_calls.get();
+                    clock_calls.set(i + 1);
+                    times[i.min(times.len() - 1)]
+                },
+                next_tick: timer_off,
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "a failure followed by a success must run to a clean stop: {result:?}",
+        );
+        assert_eq!(collects, 2, "the failed walk must be retried exactly once");
+        assert_eq!(
+            rendered.len(),
+            3,
+            "expected three frames: the absorbed failure, the recovery, and the \
+             cached re-render that exposes the re-seeded age",
+        );
+        assert_eq!(
+            rendered[0],
+            ("last-good".to_string(), Duration::from_secs(50)),
+            "while the walk is failing the CACHED snapshot keeps aging truthfully",
+        );
+        assert_eq!(
+            rendered[1],
+            ("recovered".to_string(), Duration::ZERO),
+            "the walk that succeeds after a failure must render its FRESH snapshot \
+             at age zero — recovery, not a permanently frozen last-good frame",
+        );
+        assert_eq!(
+            rendered[2],
+            ("recovered".to_string(), Duration::from_secs(3)),
+            "the successful walk must re-seed collected_at to its own start: the \
+             re-render 3s later ages from that walk (55s - 52s), not from the \
+             50s-stale seed the failure left in place",
+        );
+        assert_eq!(displayed, "aged");
+    }
+
+    #[test]
     fn should_repaint_suppresses_byte_identical_output() {
         // The suppression backstop: an unchanged snapshot must not trigger a
         // repaint, no matter how many accepted events drove the recompute.


### PR DESCRIPTION
Follow-up to #338 (which closed #334). That PR was squash-merged before its code review landed, so these are the review's findings applied on top of the merged state. No behavior from #338 is reverted or reworked — this only closes the gaps the review found in it.

### What the review found, and what changed here

**1. Watch mode died on a failed status walk, despite documenting that it wouldn't.** (`test: red` / `fix: green`)

`RepoHandle::reopened` degrades to the handle already in hand when a re-open fails, and both its doc comment and `walk`'s claimed this bought "a tick of stale configuration, never a blank screen." It didn't: `walk` then ran `collect_snapshot` against that retained handle, and `event_loop`'s `(hooks.collect)()?` propagated the failure straight out of `run()`, ending watch mode. Verified against a fixture — with `.git` renamed away, `walk()` returns `Err("status iter: The reference 'HEAD' did not exist")` and recovers to `Ok` once it's back, so the fallback worked but never got the chance to matter.

`event_loop` now absorbs the failure and keeps the last good frame. Two details that are easy to get wrong and are covered by tests:

- `collected_at` advances **only** on success. A collection that never happened must not reset every displayed age to "just now" — that would claim freshness exactly when there is none. The frozen frame keeps aging honestly.
- The throttle is armed from the failed walk's measured cost on **both** arms, so a repository that fails every walk backs off on the same duty cycle instead of hot-looping.

Accepted trade-off, stated in the code: a repository deleted for good leaves a frozen but visibly aging frame until the user quits. For a monitor, a wrong-but-labeled-old screen beats no screen.

**2. The linked-worktree re-open path had no test.** (`test:`)

`reopened`'s doc justifies choosing `gix::open` over `gix::discover` *specifically* because `open` resolves the `.git` **file** a linked worktree uses — and nothing exercised that. Since this repo mandates working in worktrees, a gix upgrade breaking `.git`-file resolution would have turned the whole #334 fix into a silent no-op exactly where it's used most, with a green suite.

Adds `testrepo::init_repo_with_worktree()` and a guard that opens a handle on a linked worktree, writes config afterwards, and asserts `reopened()` observes it. Two structural assertions pin the fixture down (`linked/.git` is a file; `git_dir() != common_dir()`) so a future change that quietly downgraded it to a plain clone can't leave the test green over nothing.

**3. `LiveIgnore`'s liveness invariant was convention, not enforcement.** (`refactor:`)

`LiveIgnore` exists to guarantee the ignore matcher gets rebuilt every walk, but `impl From<Gitignore>` was reachable crate-wide and handed back a matcher nobody refreshes — the exact staleness the type was introduced to prevent, wearing the type that promises the opposite. `new` now constructs directly, freeing the `From` impl to be `#[cfg(test)]`-gated, so the only entrance surviving into a production build is the one that reads from a repository.

**4. `reopened()` allocated a `PathBuf` per walk and threw it away.** (`refactor:`)

It routed through `from_repo` purely for the bare-repo rejection, discarding the `workdir` that helper also builds — and it read as though the handle's workdir were being refreshed when it deliberately isn't. Now `.filter(|repo| repo.workdir().is_some())`, which states the admission rule directly. `from_repo` stays (`discover` still uses it), but its doc no longer claims to be shared with `reopened`.

### Verification

Every guard here was mutation-tested — a guard that can't fail is worthless:

- Moving `throttle.record` into the `Ok` arm → the throttle test reports 3 walks instead of 2.
- Advancing `collected_at` unconditionally → the age assertion reports 0ns instead of 50s.
- Stubbing `reopened()` to return `&self.repo` → the linked-worktree guard fails.
- Pointing that fixture at a plain repo instead of a linked worktree → the structural assertions fail.
- Inverting `reopened()`'s admission filter → 6 tests go red across `repo.rs` and `watch.rs`.

Gates on the final tree: `cargo fmt --all --check`, `cargo machete`, `cargo clippy --workspace --all-targets` (zero warnings), `cargo test -p gsw` (258 unit + 25 integration, up from 255).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
