### PR TITLE
fix(gitscratch): scrub the inherited git identity so the pinned one survives a hook

### DIFF
--- a/src/gitscratch/src/git.rs
+++ b/src/gitscratch/src/git.rs
@@ -193,7 +193,11 @@ mod tests {
     fn inherited_identity() -> String {
         let held: Vec<String> = INHERITED_IDENTITY_VARS
             .iter()
-            .filter_map(|name| std::env::var(name).ok().map(|value| format!("{name}={value}")))
+            .filter_map(|name| {
+                std::env::var(name)
+                    .ok()
+                    .map(|value| format!("{name}={value}"))
+            })
             .collect();
 
         if held.is_empty() {

--- a/src/gitscratch/src/git.rs
+++ b/src/gitscratch/src/git.rs
@@ -167,4 +167,66 @@ mod tests {
             "scratch commits should be authored by the crate, not a consumer: {ident}"
         );
     }
+
+    /// Marks the re-executed child half of
+    /// [`the_pinned_identity_survives_a_hook_environment`].
+    const CHILD_MARKER: &str = "GITSCRATCH_HOOK_ENVIRONMENT_CHILD";
+
+    /// libtest's exact filter for the one test the child half runs.
+    const HOOK_TEST_PATH: &str = "git::tests::the_pinned_identity_survives_a_hook_environment";
+
+    /// The identity variables git exports into every hook it runs, carrying
+    /// values that stand in for a developer's own git identity.
+    const HOOK_ENVIRONMENT: [(&str, &str); 4] = [
+        ("GIT_AUTHOR_NAME", "Consuming Tool"),
+        ("GIT_AUTHOR_EMAIL", "consumer@example.invalid"),
+        ("GIT_COMMITTER_NAME", "Consuming Tool"),
+        ("GIT_COMMITTER_EMAIL", "consumer@example.invalid"),
+    ];
+
+    /// A consumer invoked from a git hook inherits `GIT_AUTHOR_NAME` and its
+    /// siblings, and those variables outrank the `-c user.name` that
+    /// [`Git::safety_config`] pins. This test reproduces that environment, so
+    /// the suite catches the leak on its own instead of a developer's own
+    /// pre-commit run catching it on an unrelated commit.
+    ///
+    /// The environment belongs to a re-executed child of this test binary
+    /// rather than to this process. `std::env::set_var` would leak into every
+    /// other test in the binary, and a child process keeps concurrent runs of
+    /// this suite isolated from each other.
+    #[test]
+    fn the_pinned_identity_survives_a_hook_environment() {
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let git = Git::new(std::env::temp_dir(), "");
+
+            let ident = git
+                .run(&["var", "GIT_AUTHOR_IDENT"])
+                .expect("git var GIT_AUTHOR_IDENT");
+
+            assert!(
+                ident.starts_with("gitscratch <gitscratch@localhost>"),
+                "scratch commits should be authored by the crate, not a consumer: {ident}"
+            );
+            return;
+        }
+
+        let mut child = std::process::Command::new(
+            std::env::current_exe().expect("path of the running test binary"),
+        );
+        child
+            .args([HOOK_TEST_PATH, "--exact", "--nocapture"])
+            .env(CHILD_MARKER, "1");
+        for (name, value) in HOOK_ENVIRONMENT {
+            child.env(name, value);
+        }
+
+        let output = child.output().expect("re-run this test binary");
+
+        assert!(
+            output.status.success(),
+            "the pinned identity did not survive a hook environment:\n{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }

--- a/src/gitscratch/src/git.rs
+++ b/src/gitscratch/src/git.rs
@@ -11,6 +11,26 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 
+/// The name every scratch commit is authored and committed under.
+const SCRATCH_USER_NAME: &str = "gitscratch";
+
+/// The email every scratch commit is authored and committed under.
+const SCRATCH_USER_EMAIL: &str = "gitscratch@localhost";
+
+/// The identity git hands a child through the environment instead of through
+/// configuration. git sets all six for every hook it runs, and sets the author
+/// trio again for each commit that rebase, cherry-pick, or am replays. An
+/// environment variable outranks every config source, `-c` included, so
+/// [`Git::try_run`] removes them to keep the pinned identity in force.
+const INHERITED_IDENTITY_VARS: [&str; 6] = [
+    "GIT_AUTHOR_NAME",
+    "GIT_AUTHOR_EMAIL",
+    "GIT_AUTHOR_DATE",
+    "GIT_COMMITTER_NAME",
+    "GIT_COMMITTER_EMAIL",
+    "GIT_COMMITTER_DATE",
+];
+
 /// The outcome of one git invocation.
 pub struct GitOutput {
     pub success: bool,
@@ -46,7 +66,8 @@ impl Git {
     ///
     /// Returns an error only if git could not be spawned at all.
     pub fn try_run(&self, args: &[&str]) -> Result<GitOutput> {
-        let output = Command::new("git")
+        let mut command = Command::new("git");
+        command
             .args(self.safety_config())
             .args(args)
             .current_dir(&self.cwd)
@@ -54,7 +75,21 @@ impl Git {
             // hang forever on a commit message or a todo list.
             .env("GIT_EDITOR", "true")
             .env("GIT_SEQUENCE_EDITOR", "true")
-            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_TERMINAL_PROMPT", "0");
+
+        // Config alone does not settle the identity. Whichever tool drives this
+        // crate may itself be running under a git that exported the identity
+        // into the environment - every hook gets it, and so does every commit
+        // replayed by rebase, cherry-pick, or am - and those variables outrank
+        // the `user.name` pinned in safety_config. Left in place they put the
+        // developer's own name on scratch commits, which is the single thing
+        // the pin exists to prevent. Same leak class as the GIT_DIR scrub the
+        // repository's pre-commit hook performs before it runs the test suite.
+        for variable in INHERITED_IDENTITY_VARS {
+            command.env_remove(variable);
+        }
+
+        let output = command
             .output()
             .with_context(|| format!("failed to run git {}", args.join(" ")))?;
 
@@ -129,43 +164,86 @@ impl Git {
             "gc.auto=0",
             "commit.gpgsign=false",
             "gpg.format=openpgp",
+        ]
+        .into_iter()
+        .map(String::from)
+        .chain([
             // The identity belongs to this crate, not to whichever tool is
             // driving it, so every consumer's scratch commits are attributable
-            // to the harness that actually made them.
-            "user.name=gitscratch",
-            "user.email=gitscratch@localhost",
-        ]
-        .iter()
-        .flat_map(|setting| ["-c".to_string(), (*setting).to_string()])
-        .chain([
-            "-c".to_string(),
+            // to the harness that actually made them. These two settle it only
+            // in company with the environment scrub in `try_run`, which removes
+            // the identity variables that would otherwise outrank them.
+            format!("user.name={SCRATCH_USER_NAME}"),
+            format!("user.email={SCRATCH_USER_EMAIL}"),
             format!("core.hooksPath={}", self.hooks_path),
         ])
+        .flat_map(|setting| ["-c".to_string(), setting])
         .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Git;
+    use super::{Git, INHERITED_IDENTITY_VARS, SCRATCH_USER_EMAIL, SCRATCH_USER_NAME};
 
+    /// The identity variables this process holds, named and valued, for a
+    /// failure message. Reports their absence just as plainly: a mismatch with
+    /// nothing inherited means something other than the environment outranked
+    /// the pin, and that is a different bug worth saying out loud.
+    fn inherited_identity() -> String {
+        let held: Vec<String> = INHERITED_IDENTITY_VARS
+            .iter()
+            .filter_map(|name| std::env::var(name).ok().map(|value| format!("{name}={value}")))
+            .collect();
+
+        if held.is_empty() {
+            "nothing (so the pin lost to something other than the environment)".to_string()
+        } else {
+            held.join(", ")
+        }
+    }
+
+    /// Assert that git stamps this crate's own identity, and name the inherited
+    /// variables when it does not.
+    ///
+    /// The variables are the whole diagnosis. A bare identity mismatch reads
+    /// like a flake, and it surfaces at the worst possible moment - inside a
+    /// developer's pre-commit hook, on a commit that has nothing to do with
+    /// this crate - so the message has to carry the cause with it.
+    ///
     /// `git var GIT_AUTHOR_IDENT` reports exactly the identity git would stamp
-    /// on a commit, so it proves what [`Git::safety_config`] actually pins
-    /// without having to build a repository and commit into it. It resolves
-    /// outside a repository too, which is why `temp_dir` is only ever a cwd
-    /// here — nothing is created in it, so concurrent test runs cannot collide.
-    #[test]
-    fn commits_under_the_crate_s_own_identity_not_a_consuming_tool_s() {
+    /// on a commit, so it proves what [`Git::safety_config`] and
+    /// [`Git::try_run`] actually pin without having to build a repository and
+    /// commit into it. It resolves outside a repository too, which is why
+    /// `temp_dir` is only ever a cwd here — nothing is created in it, so
+    /// concurrent test runs cannot collide.
+    fn assert_scratch_identity() {
         let git = Git::new(std::env::temp_dir(), "");
 
         let ident = git
             .run(&["var", "GIT_AUTHOR_IDENT"])
             .expect("git var GIT_AUTHOR_IDENT");
 
+        let expected = format!("{SCRATCH_USER_NAME} <{SCRATCH_USER_EMAIL}>");
         assert!(
-            ident.starts_with("gitscratch <gitscratch@localhost>"),
-            "scratch commits should be authored by the crate, not a consumer: {ident}"
+            ident.starts_with(&expected),
+            "scratch commits must be authored by the crate, not by a consumer.\n  \
+             expected:    {expected}\n  \
+             got:         {ident}\n  \
+             inherited:   {}\n\
+             An identity variable outranks every config source, `-c` included, so \
+             Git::try_run removes the six of them before it spawns git. git exports \
+             them into every hook it runs, and into every commit that rebase, \
+             cherry-pick, or am replays.",
+            inherited_identity()
         );
+    }
+
+    /// The identity holds in an environment that carries nothing of its own,
+    /// which is how the suite runs from a shell.
+    #[test]
+    fn commits_under_the_crate_s_own_identity_not_a_consuming_tool_s() {
+        assert_scratch_identity();
     }
 
     /// Marks the re-executed child half of
@@ -197,16 +275,7 @@ mod tests {
     #[test]
     fn the_pinned_identity_survives_a_hook_environment() {
         if std::env::var_os(CHILD_MARKER).is_some() {
-            let git = Git::new(std::env::temp_dir(), "");
-
-            let ident = git
-                .run(&["var", "GIT_AUTHOR_IDENT"])
-                .expect("git var GIT_AUTHOR_IDENT");
-
-            assert!(
-                ident.starts_with("gitscratch <gitscratch@localhost>"),
-                "scratch commits should be authored by the crate, not a consumer: {ident}"
-            );
+            assert_scratch_identity();
             return;
         }
 


### PR DESCRIPTION
## The symptom

`git commit` fails in the pre-commit hook, on any commit that touches Rust files:

```
thread 'git::tests::commits_under_the_crate_s_own_identity_not_a_consuming_tool_s'
panicked at src/gitscratch/src/git.rs:165:9:
scratch commits should be authored by the crate, not a consumer:
Tim Mattison <tim@mattison.org> 1786113152 -0400
husky - pre-commit script failed (code 101)
```

The same test passes from a shell. It fails only inside a commit.

## The cause

`Git::safety_config` pins the scratch identity with `-c user.name=gitscratch` and
`-c user.email=gitscratch@localhost`. But `git commit` exports `GIT_AUTHOR_NAME`,
`GIT_AUTHOR_EMAIL`, and `GIT_AUTHOR_DATE` into every hook it runs, and an identity
variable outranks every config source, `-c` included. Inside the hook the pin loses.

I confirmed the export in a lab repository. All three commit forms behave the same,
so `-a` makes no difference:

| Commit form | Variables the hook inherits | `git var GIT_AUTHOR_IDENT` |
| --- | --- | --- |
| `git commit` (staged) | `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_AUTHOR_DATE` | the developer, not the pin |
| `git commit -a` | the same three | the developer, not the pin |

## This is a production bug, not a test artifact

The comment above the pin says the identity belongs to this crate, "not to whichever
tool is driving it". The environment defeats that claim wherever a consumer runs, not
only under a test. `grist` consumes `gitscratch`. Any consumer invoked from a git
hook — or from `git rebase`, `git cherry-pick`, or `git am`, which export the same
variables — writes its scratch commits under the developer's identity.

The test is correct. The code under it was wrong.

## The fix

`Git::try_run` now removes the six identity variables before it spawns git, so the
pinned config takes effect again. It is the same leak class as the `GIT_DIR` scrub
that `.husky/pre-commit` already performs before it runs the test suite.

## Why it surfaced now

The test landed on 2026-07-30 in 8574e53 (#339). GitHub squash-merged that PR, and a
squash merge on GitHub runs no local hook. Every commit after it was also a squash
merge. The first local commit to touch Rust files since then is the one that hit this.

## The failure now carries its own diagnosis

Two changes, because a bare identity mismatch reads like a flake and surfaces at the
worst possible moment — inside a pre-commit hook, on an unrelated commit.

1. **The suite reproduces the hook environment itself.**
   `the_pinned_identity_survives_a_hook_environment` sets the identity variables and
   asserts the pin still wins, so a plain `cargo test` catches a regression instead of
   a developer's own commit catching it. The variables belong to a re-executed child
   of the test binary, not to this process: `std::env::set_var` would leak into every
   other test in the binary, and a child process keeps concurrent runs isolated.

2. **The assertion names the inherited variables.** Under the reverted fix it prints:

```
scratch commits must be authored by the crate, not by a consumer.
  expected:    gitscratch <gitscratch@localhost>
  got:         Consuming Tool <consumer@example.invalid> 1786113689 -0400
  inherited:   GIT_AUTHOR_NAME=Consuming Tool, GIT_AUTHOR_EMAIL=consumer@example.invalid, ...
An identity variable outranks every config source, `-c` included, so Git::try_run
removes the six of them before it spawns git. git exports them into every hook it
runs, and into every commit that rebase, cherry-pick, or am replays.
```

## Verification

- **TDD** — red commit c4b6811 fails with `Consuming Tool <consumer@example.invalid>`;
  green commit 7b3dd26 passes.
- **Mutation test** — with `env_remove` replaced by a no-op, the test fails and the
  message names the leaked variables. Restored afterward.
- **Real hook environment** — `cargo test -p gitscratch` passes under
  `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/`GIT_AUTHOR_DATE`/`GIT_COMMITTER_*` set to the
  exact values from the reported failure.
- **Four gates by hand** — `cargo fmt --all -- --check`, `cargo machete`,
  `cargo clippy --all-targets --workspace -- -D warnings`, and `cargo test --workspace`
  (exit 0, 126 test binaries, no failures).
- **End to end** — commit 8fc2cd4 went through the real pre-commit hook and passed,
  which is the scenario that started this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
