### PR TITLE
fix(ic): scope the zellij transport decision to the current session

### DIFF
--- a/.review-decisions.md
+++ b/.review-decisions.md
@@ -1,0 +1,52 @@
+# Review decisions
+
+Findings that a review round found **accurate** and that were deliberately not
+fixed, because the fix costs more than the defect. `review-time` reads this file
+before it reports, so an entry here is out of scope for later reviews.
+
+Reopening is cheap: a real occurrence of the accepted risk reopens a decision. A
+new argument about the same hypothetical does not.
+
+## `src/ic` zellij client attribution — argv-scoped, and deliberately incomplete
+
+**Settled** 2026-08-12 (branch ic-mosh-session-scope, finding R-20260812T193340Z#I1)
+
+`zellij_client_pids` attributes a Zellij client to a session by looking for the
+session name as a complete argument in the argv of the client. `classify_transport`
+then reports Mosh only when *every* client of this session is a Mosh client.
+
+The finding is accurate. `zellij attach` takes an optional `[SESSION_NAME]` and
+also accepts `--index <INDEX>`, and a bare `zellij` creates and attaches to a
+session with a generated name. A client that starts in one of those forms names no
+session in its argv, so it is invisible to the scan. The `all()` rule then runs
+over a subset of the clients of this session. When the invisible client is the one
+that can show images and a visible client is a Mosh client, `ic` refuses an image
+that this session could have displayed.
+
+It is not fixed, because every fix available to us is worse than the defect:
+
+- **Falling back to `ZellijScan::EveryClient` when the list looks incomplete gives
+  the same refusal.** `EveryClient` scans every Zellij process on the machine, so
+  it finds the Mosh client and answers Mosh. The reasoning changes and the answer
+  does not.
+- **Counting a viewer that names no session as a client of this session replaces a
+  clear error with a silent one.** Such a viewer can belong to a different session.
+  When it does, `ic` writes escape sequences that no client of *this* session can
+  render, so the image goes nowhere and the user sees no message. Today the user
+  gets an error that names Mosh and says to reconnect with `ssh`.
+- **Attributing each client through its Zellij socket is correct and costs too
+  much.** It resolves every attach form, but it needs `lsof` on every `ic`
+  invocation inside Zellij, and `lsof` routinely takes hundreds of milliseconds.
+  Linux needs a separate `/proc` implementation. That is a permanent cost on every
+  image, paid to close a gap that needs three conditions at once.
+
+The error direction is the conservative one. `ic` refuses and says why, which is
+the same answer the code gave before this branch narrowed the scan, and the
+refusal is recoverable by naming the session on attach.
+
+**The boundary.** This decision settles the *completeness of argv-based client
+attribution*. A finding that proposes widening the argv matching, or that observes
+the client set can be partial, is settled here. A refusal observed in the wild
+reopens it, as does any finding that this scan is wrong on a client it *can* see.
+Findings about this code on a different axis — a bug in the walk, a panic, a
+performance problem — are not covered.

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -60,6 +60,23 @@ cat image.png | ./ic --stdin
 curl -s https://example.com/image.jpg | ./ic --stdin
 ```
 
+### Ask whether an image can be displayed here:
+```bash
+ic --will-display && ic image.png
+```
+
+`--will-display` exits with code 0 when this session can show an image, and prints nothing. It exits with code 1 and prints the reason to stderr when it cannot, for example:
+
+```
+$ TERM=linux ic --will-display
+Error: Image display is not supported in this terminal.
+...
+```
+
+The flag asks the same question the display path asks — the terminal, the multiplexer, and the remote transport — so a session that passes cannot be refused by the next `ic image.png`. The flag does not ask whether stdout is a terminal, thus a redirected stdout does not change the answer.
+
+`--will-display` is an input mode of its own. Do not combine it with a file, `--stdin`, or `--monitor`.
+
 ## Command Line Options
 
 - `FILE` - Image file to display (optional if using --stdin)
@@ -68,6 +85,7 @@ curl -s https://example.com/image.jpg | ./ic --stdin
 - `--preserve-aspect` - Preserve aspect ratio when resizing (default: true)
 - `--stdin` - Read from stdin instead of file
 - `-n, --no-newline` - Don't output newline after image
+- `--will-display` - Report whether this session can display an image, then exit (0 = yes, 1 = no with the reason on stderr)
 - `-h, --help` - Print help information
 - `-V, --version` - Print version information
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2132,6 +2132,11 @@ struct Pid(u32);
 /// 64 levels is generous; real-world process trees rarely exceed 20 levels.
 const MAX_ANCESTOR_DEPTH: usize = 64;
 
+/// The basename of the Zellij client program. The match must be exact, so
+/// that `zellij-server` and a wrapper script such as `my-zellij-wrapper` do
+/// not count as clients.
+const ZELLIJ_PROGRAM_NAME: &str = "zellij";
+
 /// Extracts the basename (filename) from a process comm string.
 ///
 /// On macOS, `ps -eo comm=` returns the full executable path (e.g.,
@@ -2162,8 +2167,32 @@ fn comm_basename(comm: &str) -> &str {
 /// process (`zellij --server /path/.../NAME`) does not match, because the
 /// session name is only a part of its socket path.
 fn zellij_client_pids(ps_args_output: &str, session: &str) -> Vec<Pid> {
-    let _ = (ps_args_output, session);
-    Vec::new()
+    if session.is_empty() {
+        return Vec::new();
+    }
+
+    let mut clients = Vec::new();
+
+    for line in ps_args_output.lines() {
+        let mut parts = line.split_whitespace();
+        let pid = match parts.next().and_then(|s| s.parse::<u32>().ok()) {
+            Some(p) => Pid(p),
+            None => continue,
+        };
+        let Some(program) = parts.next() else {
+            continue;
+        };
+        if comm_basename(program) != ZELLIJ_PROGRAM_NAME {
+            continue;
+        }
+        // The remaining tokens are the arguments of the client. The session
+        // name must be one complete argument.
+        if parts.any(|arg| arg == session) {
+            clients.push(pid);
+        }
+    }
+
+    clients
 }
 
 /// The type of remote transport detected in the process tree.
@@ -2312,7 +2341,7 @@ fn find_ancestor_process(
     // include the target process.
     if in_zellij {
         for (&zellij_pid, comm) in &comm_of {
-            if comm_basename(comm) != "zellij" {
+            if comm_basename(comm) != ZELLIJ_PROGRAM_NAME {
                 continue;
             }
             let mut ancestor = zellij_pid;

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2234,14 +2234,9 @@ fn detect_remote_transport() -> RemoteTransport {
 /// 3. **Mosh via Zellij heuristic only** (no ET) → Mosh
 /// 4. **Neither** → None
 fn detect_remote_transport_inner() -> RemoteTransport {
-    let output = match std::process::Command::new("ps")
-        .args(["-eo", "pid=,ppid=,comm="])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output()
-    {
-        Ok(o) => o,
-        Err(_) => {
+    let comm_output = match run_ps(&["-eo", "pid=,ppid=,comm="]) {
+        Some(o) => o,
+        None => {
             // Can't check process tree; fall back to env var for ET
             if std::env::var("ET_VERSION").is_ok() {
                 return RemoteTransport::EternalTerminal;
@@ -2250,13 +2245,57 @@ fn detect_remote_transport_inner() -> RemoteTransport {
         }
     };
 
-    let table = String::from_utf8_lossy(&output.stdout);
-    let current_pid = Pid(std::process::id());
-    let in_zellij = std::env::var("ZELLIJ").is_ok();
+    // The argument snapshot is a second `ps` call because the comm snapshot
+    // deliberately treats every token after the PPID as one executable path,
+    // so that a path that holds a space survives. Arguments cannot be read
+    // from that same line without making the path ambiguous.
+    let args_output = run_ps(&["-eo", "pid=,args="]).unwrap_or_default();
+
+    classify_transport(
+        &comm_output,
+        &args_output,
+        Pid(std::process::id()),
+        std::env::var("ZELLIJ")
+            .ok()
+            .map(|_| std::env::var("ZELLIJ_SESSION_NAME").unwrap_or_default()),
+        std::env::var("ET_VERSION").is_ok(),
+    )
+}
+
+/// Run `ps` with the given arguments and return its standard output.
+///
+/// Returns `None` when `ps` cannot be run at all.
+fn run_ps(args: &[&str]) -> Option<String> {
+    std::process::Command::new("ps")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+}
+
+/// Decide the remote transport from two process snapshots and the environment.
+///
+/// This function holds all of the policy and reads nothing from the outside,
+/// so every rule below is testable.
+///
+/// `zellij_session` is `None` when the `ZELLIJ` variable is unset. It is
+/// `Some(name)` inside Zellij, where `name` can be empty if
+/// `ZELLIJ_SESSION_NAME` is unset.
+fn classify_transport(
+    ps_comm_output: &str,
+    ps_args_output: &str,
+    current_pid: Pid,
+    zellij_session: Option<String>,
+    et_version_set: bool,
+) -> RemoteTransport {
+    let _ = ps_args_output;
+    let in_zellij = zellij_session.is_some();
 
     // Direct Mosh ancestry (Case 1 only, no Zellij heuristic) — the current
     // shell is definitely under Mosh, so images cannot work.
-    if find_ancestor_process(&table, current_pid, false, "mosh-server") {
+    if find_ancestor_process(ps_comm_output, current_pid, false, "mosh-server") {
         return RemoteTransport::Mosh;
     }
 
@@ -2264,14 +2303,13 @@ fn detect_remote_transport_inner() -> RemoteTransport {
     // This takes priority over Mosh-via-Zellij because in a multiplexed Zellij
     // session, Mosh and ET may both be attached — ET viewers can display images
     // while Mosh viewers silently strip the escape sequences.
-    if std::env::var("ET_VERSION").is_ok()
-        || find_ancestor_process(&table, current_pid, in_zellij, "etterminal")
+    if et_version_set || find_ancestor_process(ps_comm_output, current_pid, in_zellij, "etterminal")
     {
         return RemoteTransport::EternalTerminal;
     }
 
     // Mosh via Zellij heuristic (Case 2) — only reached when ET is not present.
-    if find_ancestor_process(&table, current_pid, in_zellij, "mosh-server") {
+    if find_ancestor_process(ps_comm_output, current_pid, in_zellij, "mosh-server") {
         return RemoteTransport::Mosh;
     }
 
@@ -3202,6 +3240,209 @@ not_a_number  1 /bin/bash
         // current PID 400 is not an ancestor of mosh-server via Case 1,
         // and in_zellij=false disables Case 2
         assert!(!has_mosh_in_process_tree(ps_output, Pid(400), false));
+    }
+
+    // =========================================================================
+    // Tests for classify_transport (the whole transport decision)
+    // =========================================================================
+
+    /// The PID of the process that asks for the transport. It sits under the
+    /// Zellij server of the session named `ic-test`.
+    const CURRENT: Pid = Pid(63481);
+
+    /// A process table that holds two Zellij sessions.
+    ///
+    /// `ic-test` is viewed over SSH. `meshtastic` is viewed over Mosh. The
+    /// Zellij server of each session is reparented to PID 1, which is why the
+    /// chain from `CURRENT` reaches no terminal.
+    ///
+    /// The basename of the server is `zellij`, not `zellij-server`. That is
+    /// what macOS reports, because the server is the same binary started with
+    /// `--server`.
+    const PS_COMM_TWO_SESSIONS: &str = "\
+    1     0 /sbin/launchd
+56659     1 sshd-session
+56665 56659 sshd-session
+56666 56665 -zsh
+57053 56666 /Users/t/.local/bin/zellij
+51648     1 /Users/t/.local/bin/zellij
+63481 51648 /bin/zsh
+31465     1 /usr/bin/mosh-server
+31466 31465 -zsh
+32269 31466 /Users/t/.local/bin/zellij";
+
+    const PS_ARGS_TWO_SESSIONS_FULL: &str = "\
+51648 /Users/t/.local/bin/zellij --server /tmp/zellij-501/contract_version_1/ic-test
+57053 zellij a ic-test
+32269 zellij a meshtastic";
+
+    #[test]
+    fn another_sessions_mosh_client_does_not_decide_this_session() {
+        // The client of `ic-test` runs under SSH. The Mosh client belongs to
+        // `meshtastic`, so it says nothing about this session.
+        assert_eq!(
+            classify_transport(
+                PS_COMM_TWO_SESSIONS,
+                PS_ARGS_TWO_SESSIONS_FULL,
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::None
+        );
+    }
+
+    #[test]
+    fn mosh_detected_when_the_only_client_of_this_session_is_mosh() {
+        let ps_comm = "\
+    1     0 /sbin/launchd
+51648     1 /Users/t/.local/bin/zellij
+63481 51648 /bin/zsh
+31465     1 /usr/bin/mosh-server
+31466 31465 -zsh
+57100 31466 /Users/t/.local/bin/zellij";
+        let ps_args = "\
+51648 /Users/t/.local/bin/zellij --server /tmp/zellij-501/contract_version_1/ic-test
+57100 zellij a ic-test";
+        assert_eq!(
+            classify_transport(
+                ps_comm,
+                ps_args,
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::Mosh
+        );
+    }
+
+    #[test]
+    fn one_capable_client_wins_over_a_mosh_client_of_the_same_session() {
+        // Zellij sends the output to every attached client. An SSH viewer can
+        // show the image. The Mosh viewer ignores the escape sequences.
+        let ps_comm = "\
+    1     0 /sbin/launchd
+51648     1 /Users/t/.local/bin/zellij
+63481 51648 /bin/zsh
+56665     1 sshd-session
+56666 56665 -zsh
+57053 56666 /Users/t/.local/bin/zellij
+31465     1 /usr/bin/mosh-server
+31466 31465 -zsh
+57100 31466 /Users/t/.local/bin/zellij";
+        let ps_args = "\
+57053 zellij a ic-test
+57100 zellij a ic-test";
+        assert_eq!(
+            classify_transport(
+                ps_comm,
+                ps_args,
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::None
+        );
+    }
+
+    #[test]
+    fn an_unnamed_zellij_session_keeps_the_careful_answer() {
+        // ZELLIJ_SESSION_NAME is unset, so no client can be tied to this
+        // session. Report Mosh rather than send escape sequences that Mosh
+        // strips.
+        assert_eq!(
+            classify_transport(
+                PS_COMM_TWO_SESSIONS,
+                PS_ARGS_TWO_SESSIONS_FULL,
+                CURRENT,
+                Some(String::new()),
+                false,
+            ),
+            RemoteTransport::Mosh
+        );
+    }
+
+    #[test]
+    fn a_session_with_no_named_client_keeps_the_careful_answer() {
+        // The session name is known, but no client argv carries it. This
+        // happens when Zellij starts with a generated session name.
+        assert_eq!(
+            classify_transport(
+                PS_COMM_TWO_SESSIONS,
+                "",
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::Mosh
+        );
+    }
+
+    #[test]
+    fn outside_zellij_a_mosh_client_of_a_session_is_ignored() {
+        assert_eq!(
+            classify_transport(
+                PS_COMM_TWO_SESSIONS,
+                PS_ARGS_TWO_SESSIONS_FULL,
+                CURRENT,
+                None,
+                false,
+            ),
+            RemoteTransport::None
+        );
+    }
+
+    #[test]
+    fn direct_mosh_ancestry_beats_every_client_rule() {
+        let ps_comm = "\
+31465     1 /usr/bin/mosh-server
+31466 31465 -zsh
+63481 31466 /bin/zsh";
+        assert_eq!(
+            classify_transport(
+                ps_comm,
+                "57053 zellij a ic-test",
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::Mosh
+        );
+    }
+
+    #[test]
+    fn eternal_terminal_env_var_beats_a_mosh_client() {
+        assert_eq!(
+            classify_transport(
+                PS_COMM_TWO_SESSIONS,
+                PS_ARGS_TWO_SESSIONS_FULL,
+                CURRENT,
+                Some("ic-test".to_string()),
+                true,
+            ),
+            RemoteTransport::EternalTerminal
+        );
+    }
+
+    #[test]
+    fn an_eternal_terminal_client_of_this_session_wins() {
+        let ps_comm = "\
+    1     0 /sbin/launchd
+51648     1 /Users/t/.local/bin/zellij
+63481 51648 /bin/zsh
+40000     1 /usr/local/bin/etterminal
+40001 40000 -zsh
+57053 40001 /Users/t/.local/bin/zellij";
+        assert_eq!(
+            classify_transport(
+                ps_comm,
+                "57053 zellij a ic-test",
+                CURRENT,
+                Some("ic-test".to_string()),
+                false,
+            ),
+            RemoteTransport::EternalTerminal
+        );
     }
 
     // =========================================================================

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2144,6 +2144,28 @@ fn comm_basename(comm: &str) -> &str {
         .unwrap_or(comm)
 }
 
+/// Finds the Zellij client processes that are attached to one Zellij session.
+///
+/// Zellij daemonizes its server, so the server reparents to PID 1 and the
+/// chain from the current process to the terminal is broken. The client
+/// process keeps that chain, so the client stands in for the current process
+/// when the transport is detected.
+///
+/// A client must belong to *this* session. A machine can run many Zellij
+/// sessions at the same time, and a client of some other session says nothing
+/// about how this session is viewed.
+///
+/// `ps_args_output` is the output of `ps -eo pid=,args=`. A client is a
+/// process whose argv[0] basename is exactly `zellij` and that has the session
+/// name as a complete argument. The forms `zellij a NAME`, `zellij attach
+/// NAME`, `zellij -s NAME`, and `zellij --session NAME` all match. The server
+/// process (`zellij --server /path/.../NAME`) does not match, because the
+/// session name is only a part of its socket path.
+fn zellij_client_pids(ps_args_output: &str, session: &str) -> Vec<Pid> {
+    let _ = (ps_args_output, session);
+    Vec::new()
+}
+
 /// The type of remote transport detected in the process tree.
 ///
 /// Used to adapt image display behavior for proxies that don't understand
@@ -3151,6 +3173,92 @@ not_a_number  1 /bin/bash
         // current PID 400 is not an ancestor of mosh-server via Case 1,
         // and in_zellij=false disables Case 2
         assert!(!has_mosh_in_process_tree(ps_output, Pid(400), false));
+    }
+
+    // =========================================================================
+    // Tests for zellij_client_pids (session-scoped client discovery)
+    // =========================================================================
+
+    /// A `ps -eo pid=,args=` table with two Zellij sessions and one server.
+    const PS_ARGS_TWO_SESSIONS: &str = "\
+  51648 /Users/t/.local/bin/zellij --server /tmp/zellij-501/contract_version_1/ic-test
+  57053 zellij a ic-test
+  32269 zellij a meshtastic
+  56666 -zsh";
+
+    #[test]
+    fn zellij_client_pids_finds_the_client_of_this_session() {
+        assert_eq!(
+            zellij_client_pids(PS_ARGS_TWO_SESSIONS, "ic-test"),
+            vec![Pid(57053)]
+        );
+    }
+
+    #[test]
+    fn zellij_client_pids_ignores_another_sessions_client() {
+        let found = zellij_client_pids(PS_ARGS_TWO_SESSIONS, "ic-test");
+        assert!(!found.contains(&Pid(32269)));
+    }
+
+    #[test]
+    fn zellij_client_pids_ignores_the_server_of_this_session() {
+        // The server has the session name in its socket path, not as an
+        // argument of its own. It is not a client.
+        let found = zellij_client_pids(PS_ARGS_TWO_SESSIONS, "ic-test");
+        assert!(!found.contains(&Pid(51648)));
+    }
+
+    #[test]
+    fn zellij_client_pids_accepts_every_attach_form() {
+        let ps_args = "\
+  100 zellij a work
+  200 zellij attach work
+  300 zellij -s work
+  400 zellij --session work";
+        assert_eq!(
+            zellij_client_pids(ps_args, "work"),
+            vec![Pid(100), Pid(200), Pid(300), Pid(400)]
+        );
+    }
+
+    #[test]
+    fn zellij_client_pids_requires_a_whole_argument_match() {
+        // "work" must not match the session named "work-tree".
+        let ps_args = "  100 zellij a work-tree";
+        assert!(zellij_client_pids(ps_args, "work").is_empty());
+    }
+
+    #[test]
+    fn zellij_client_pids_requires_an_exact_program_name() {
+        // A wrapper script named "my-zellij-wrapper" is not the Zellij CLI.
+        let ps_args = "\
+  100 /usr/local/bin/my-zellij-wrapper a work
+  200 /usr/local/bin/zellij-server a work";
+        assert!(zellij_client_pids(ps_args, "work").is_empty());
+    }
+
+    #[test]
+    fn zellij_client_pids_is_empty_for_an_unknown_session() {
+        assert!(zellij_client_pids(PS_ARGS_TWO_SESSIONS, "no-such-session").is_empty());
+    }
+
+    #[test]
+    fn zellij_client_pids_handles_empty_input() {
+        assert!(zellij_client_pids("", "ic-test").is_empty());
+    }
+
+    #[test]
+    fn zellij_client_pids_skips_malformed_lines() {
+        let ps_args = "\
+not_a_number zellij a work
+  100 zellij a work";
+        assert_eq!(zellij_client_pids(ps_args, "work"), vec![Pid(100)]);
+    }
+
+    #[test]
+    fn zellij_client_pids_ignores_an_empty_session_name() {
+        // ZELLIJ_SESSION_NAME is unset or empty. No client can be identified.
+        assert!(zellij_client_pids(PS_ARGS_TWO_SESSIONS, "").is_empty());
     }
 
     // =========================================================================

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -144,6 +144,11 @@ struct Args {
     /// Monitor directories for new images and display them automatically
     #[clap(long)]
     monitor: Vec<PathBuf>,
+
+    /// Report whether this session can display an image, then exit. Exit code 0
+    /// means yes. Exit code 1 means no, and the reason goes to stderr
+    #[clap(long)]
+    will_display: bool,
 }
 
 fn main() -> Result<()> {
@@ -151,7 +156,9 @@ fn main() -> Result<()> {
 
     validate_arguments(&args)?;
 
-    if args.stdin {
+    if args.will_display {
+        report_display_readiness()?;
+    } else if args.stdin {
         display_image_from_stdin(&args)?;
     } else if !args.files.is_empty() {
         for file_path in &args.files {
@@ -184,15 +191,22 @@ fn validate_arguments(args: &Args) -> Result<()> {
 }
 
 fn validate_input_modes(args: &Args) -> Result<()> {
-    let input_modes = [args.stdin, !args.files.is_empty(), !args.monitor.is_empty()];
+    let input_modes = [
+        args.stdin,
+        !args.files.is_empty(),
+        !args.monitor.is_empty(),
+        args.will_display,
+    ];
     let input_count = input_modes.iter().filter(|&&x| x).count();
 
     if input_count == 0 {
-        anyhow::bail!("Must specify a file, use --stdin, or use --monitor");
+        anyhow::bail!("Must specify a file, use --stdin, use --monitor, or use --will-display");
     }
 
     if input_count > 1 {
-        anyhow::bail!("Cannot specify multiple input modes (--stdin, file, --monitor)");
+        anyhow::bail!(
+            "Cannot specify multiple input modes (--stdin, file, --monitor, --will-display)"
+        );
     }
 
     Ok(())
@@ -501,6 +515,26 @@ fn validate_terminal_for_graphics(
         anyhow::bail!("{}", error_msg);
     }
     Ok(())
+}
+
+/// Answer `--will-display`: can this session show an image?
+///
+/// The answer is the process exit status. `Ok` exits 0 and prints nothing.
+/// An error exits 1 and prints the reason to stderr, so a script can write
+/// `ic --will-display && ic picture.png` and get a usable message when the
+/// answer is no.
+///
+/// The question goes to [`validate_terminal_for_graphics`], the same gate the
+/// image path runs. Both callers therefore give one answer, and a session that
+/// passes here cannot be refused by the next `ic picture.png`. The gate asks
+/// about the terminal, the multiplexer, and the remote transport. It does not
+/// ask whether stdout is a terminal, so a redirected stdout does not change
+/// the answer.
+fn report_display_readiness() -> Result<()> {
+    let terminal_caps = detect_terminal_capabilities();
+    let transport = detect_remote_transport();
+
+    validate_terminal_for_graphics(&terminal_caps, &transport, "Image")
 }
 
 fn display_video_from_file(file_path: &Path, args: &Args) -> Result<()> {

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2477,7 +2477,12 @@ fn has_mosh_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) 
 /// because `etterminal` is the direct ancestor of the user's shell.
 #[cfg(test)]
 fn has_et_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) -> bool {
-    find_ancestor_process(ps_output, current_pid, scan_for_flag(in_zellij), "etterminal")
+    find_ancestor_process(
+        ps_output,
+        current_pid,
+        scan_for_flag(in_zellij),
+        "etterminal",
+    )
 }
 
 fn print_kitty_image(

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2290,30 +2290,74 @@ fn classify_transport(
     zellij_session: Option<String>,
     et_version_set: bool,
 ) -> RemoteTransport {
-    let _ = ps_args_output;
-    let in_zellij = zellij_session.is_some();
-
     // Direct Mosh ancestry (Case 1 only, no Zellij heuristic) — the current
     // shell is definitely under Mosh, so images cannot work.
-    if find_ancestor_process(ps_comm_output, current_pid, false, "mosh-server") {
+    if find_ancestor_process(ps_comm_output, current_pid, ZellijScan::Off, "mosh-server") {
         return RemoteTransport::Mosh;
     }
+
+    let scan = match &zellij_session {
+        None => ZellijScan::Off,
+        Some(session) => {
+            let clients = zellij_client_pids(ps_args_output, session);
+            if clients.is_empty() {
+                // The session named no client, so the careful answer is the
+                // one that treats every Zellij client on the machine as a
+                // candidate. It can over-report Mosh, which hides an image
+                // that would have worked. The opposite mistake writes escape
+                // sequences that Mosh strips.
+                ZellijScan::EveryClient
+            } else {
+                ZellijScan::Clients(clients)
+            }
+        }
+    };
 
     // ET detected via env var or process tree (including Zellij heuristic).
     // This takes priority over Mosh-via-Zellij because in a multiplexed Zellij
     // session, Mosh and ET may both be attached — ET viewers can display images
     // while Mosh viewers silently strip the escape sequences.
-    if et_version_set || find_ancestor_process(ps_comm_output, current_pid, in_zellij, "etterminal")
+    if et_version_set
+        || find_ancestor_process(ps_comm_output, current_pid, scan.clone(), "etterminal")
     {
         return RemoteTransport::EternalTerminal;
     }
 
     // Mosh via Zellij heuristic (Case 2) — only reached when ET is not present.
-    if find_ancestor_process(ps_comm_output, current_pid, in_zellij, "mosh-server") {
+    let mosh = match &scan {
+        // Zellij sends the output of a pane to every attached client. One
+        // client that can show images is enough, so Mosh only blocks when
+        // every client of this session is a Mosh client.
+        ZellijScan::Clients(clients) => clients.iter().all(|&client| {
+            find_ancestor_process(ps_comm_output, client, ZellijScan::Off, "mosh-server")
+        }),
+        _ => find_ancestor_process(ps_comm_output, current_pid, scan.clone(), "mosh-server"),
+    };
+    if mosh {
         return RemoteTransport::Mosh;
     }
 
     RemoteTransport::None
+}
+
+/// Which Zellij clients stand in for the current process during the search.
+///
+/// Zellij daemonizes its server, so the chain from the current process stops
+/// at PID 1 and never reaches a terminal. The client keeps that chain, which
+/// is why the client is searched instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ZellijScan {
+    /// Do not stand in for the current process. Used outside Zellij, and for
+    /// the direct-ancestry question, which must not use the workaround.
+    Off,
+    /// Every process on the machine whose basename is exactly `zellij`.
+    ///
+    /// This is the careful answer for a session whose clients cannot be
+    /// named. It can report a transport that belongs to another session.
+    EveryClient,
+    /// The clients that are attached to this session, found by
+    /// [`zellij_client_pids`].
+    Clients(Vec<Pid>),
 }
 
 /// Determines whether a target process (identified by basename) is an ancestor
@@ -2322,13 +2366,12 @@ fn classify_transport(
 /// This handles two cases:
 /// 1. **Direct ancestry**: The target process is a direct ancestor of `current_pid`.
 /// 2. **Zellij workaround**: Zellij daemonizes (reparents to PID 1), breaking the
-///    direct ancestry. In this case, we check if any process whose basename is
-///    exactly `zellij` (the CLI, not `zellij-server` or other variants) has the
-///    target process as an ancestor.
+///    direct ancestry. In this case, `scan` names the client processes that stand
+///    in for the current process, and the target is searched above each of them.
 fn find_ancestor_process(
     ps_output: &str,
     current_pid: Pid,
-    in_zellij: bool,
+    scan: ZellijScan,
     target_name: &str,
 ) -> bool {
     let mut parent_of: HashMap<Pid, Pid> = HashMap::new();
@@ -2374,27 +2417,32 @@ fn find_ancestor_process(
     }
 
     // Case 2: Inside Zellij, which daemonized and broke the ancestry chain.
-    // Find any process whose basename is exactly "zellij" (the CLI binary,
-    // not "zellij-server" or other variants) and check if its ancestors
-    // include the target process.
-    if in_zellij {
-        for (&zellij_pid, comm) in &comm_of {
-            if comm_basename(comm) != ZELLIJ_PROGRAM_NAME {
-                continue;
-            }
-            let mut ancestor = zellij_pid;
-            for _ in 0..MAX_ANCESTOR_DEPTH {
-                match parent_of.get(&ancestor) {
-                    Some(&ppid) if ppid != Pid(0) && ppid != ancestor => {
-                        if let Some(pcomm) = comm_of.get(&ppid) {
-                            if comm_basename(pcomm) == target_name {
-                                return true;
-                            }
+    // Search above each client that stands in for the current process.
+    let clients: Vec<Pid> = match scan {
+        ZellijScan::Off => return false,
+        ZellijScan::Clients(clients) => clients,
+        // Any process whose basename is exactly "zellij" (the CLI binary, not
+        // "zellij-server" or other variants).
+        ZellijScan::EveryClient => comm_of
+            .iter()
+            .filter(|(_, comm)| comm_basename(comm) == ZELLIJ_PROGRAM_NAME)
+            .map(|(&pid, _)| pid)
+            .collect(),
+    };
+
+    for client in clients {
+        let mut ancestor = client;
+        for _ in 0..MAX_ANCESTOR_DEPTH {
+            match parent_of.get(&ancestor) {
+                Some(&ppid) if ppid != Pid(0) && ppid != ancestor => {
+                    if let Some(pcomm) = comm_of.get(&ppid) {
+                        if comm_basename(pcomm) == target_name {
+                            return true;
                         }
-                        ancestor = ppid;
                     }
-                    _ => break,
+                    ancestor = ppid;
                 }
+                _ => break,
             }
         }
     }
@@ -2402,10 +2450,26 @@ fn find_ancestor_process(
     false
 }
 
+/// Turn the older `in_zellij` flag into a scan. A session whose clients are
+/// not named uses [`ZellijScan::EveryClient`], which is what `in_zellij` meant.
+#[cfg(test)]
+fn scan_for_flag(in_zellij: bool) -> ZellijScan {
+    if in_zellij {
+        ZellijScan::EveryClient
+    } else {
+        ZellijScan::Off
+    }
+}
+
 /// Check if Mosh is in the process tree. Delegates to [`find_ancestor_process`].
 #[cfg(test)]
 fn has_mosh_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) -> bool {
-    find_ancestor_process(ps_output, current_pid, in_zellij, "mosh-server")
+    find_ancestor_process(
+        ps_output,
+        current_pid,
+        scan_for_flag(in_zellij),
+        "mosh-server",
+    )
 }
 
 /// Check if Eternal Terminal is in the process tree. Delegates to [`find_ancestor_process`].
@@ -2413,7 +2477,7 @@ fn has_mosh_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) 
 /// because `etterminal` is the direct ancestor of the user's shell.
 #[cfg(test)]
 fn has_et_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) -> bool {
-    find_ancestor_process(ps_output, current_pid, in_zellij, "etterminal")
+    find_ancestor_process(ps_output, current_pid, scan_for_flag(in_zellij), "etterminal")
 }
 
 fn print_kitty_image(

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2245,19 +2245,27 @@ fn detect_remote_transport_inner() -> RemoteTransport {
         }
     };
 
-    // The argument snapshot is a second `ps` call because the comm snapshot
+    let zellij_session = std::env::var("ZELLIJ")
+        .ok()
+        .map(|_| std::env::var("ZELLIJ_SESSION_NAME").unwrap_or_default());
+
+    // The argument snapshot is a second `ps` call, because the comm snapshot
     // deliberately treats every token after the PPID as one executable path,
     // so that a path that holds a space survives. Arguments cannot be read
-    // from that same line without making the path ambiguous.
-    let args_output = run_ps(&["-eo", "pid=,args="]).unwrap_or_default();
+    // from that same line without making the path ambiguous. Only a Zellij
+    // session needs the arguments, so a session outside Zellij does not pay
+    // for the second call.
+    let args_output = if zellij_session.is_some() {
+        run_ps(&["-eo", "pid=,args="]).unwrap_or_default()
+    } else {
+        String::new()
+    };
 
     classify_transport(
         &comm_output,
         &args_output,
         Pid(std::process::id()),
-        std::env::var("ZELLIJ")
-            .ok()
-            .map(|_| std::env::var("ZELLIJ_SESSION_NAME").unwrap_or_default()),
+        zellij_session,
         std::env::var("ET_VERSION").is_ok(),
     )
 }
@@ -2292,7 +2300,7 @@ fn classify_transport(
 ) -> RemoteTransport {
     // Direct Mosh ancestry (Case 1 only, no Zellij heuristic) — the current
     // shell is definitely under Mosh, so images cannot work.
-    if find_ancestor_process(ps_comm_output, current_pid, ZellijScan::Off, "mosh-server") {
+    if find_ancestor_process(ps_comm_output, current_pid, &ZellijScan::Off, "mosh-server") {
         return RemoteTransport::Mosh;
     }
 
@@ -2317,21 +2325,23 @@ fn classify_transport(
     // This takes priority over Mosh-via-Zellij because in a multiplexed Zellij
     // session, Mosh and ET may both be attached — ET viewers can display images
     // while Mosh viewers silently strip the escape sequences.
-    if et_version_set
-        || find_ancestor_process(ps_comm_output, current_pid, scan.clone(), "etterminal")
-    {
+    if et_version_set || find_ancestor_process(ps_comm_output, current_pid, &scan, "etterminal") {
         return RemoteTransport::EternalTerminal;
     }
 
     // Mosh via Zellij heuristic (Case 2) — only reached when ET is not present.
     let mosh = match &scan {
+        // The direct walk above already answered this question.
+        ZellijScan::Off => false,
         // Zellij sends the output of a pane to every attached client. One
         // client that can show images is enough, so Mosh only blocks when
         // every client of this session is a Mosh client.
         ZellijScan::Clients(clients) => clients.iter().all(|&client| {
-            find_ancestor_process(ps_comm_output, client, ZellijScan::Off, "mosh-server")
+            find_ancestor_process(ps_comm_output, client, &ZellijScan::Off, "mosh-server")
         }),
-        _ => find_ancestor_process(ps_comm_output, current_pid, scan.clone(), "mosh-server"),
+        ZellijScan::EveryClient => {
+            find_ancestor_process(ps_comm_output, current_pid, &scan, "mosh-server")
+        }
     };
     if mosh {
         return RemoteTransport::Mosh;
@@ -2357,6 +2367,10 @@ enum ZellijScan {
     EveryClient,
     /// The clients that are attached to this session, found by
     /// [`zellij_client_pids`].
+    ///
+    /// The list must not be empty. `classify_transport` asks whether *every*
+    /// client is a Mosh client, and an empty list answers yes for no reason.
+    /// A session with no named client uses [`ZellijScan::EveryClient`].
     Clients(Vec<Pid>),
 }
 
@@ -2371,7 +2385,7 @@ enum ZellijScan {
 fn find_ancestor_process(
     ps_output: &str,
     current_pid: Pid,
-    scan: ZellijScan,
+    scan: &ZellijScan,
     target_name: &str,
 ) -> bool {
     let mut parent_of: HashMap<Pid, Pid> = HashMap::new();
@@ -2418,19 +2432,23 @@ fn find_ancestor_process(
 
     // Case 2: Inside Zellij, which daemonized and broke the ancestry chain.
     // Search above each client that stands in for the current process.
-    let clients: Vec<Pid> = match scan {
+    let every_client: Vec<Pid>;
+    let clients: &[Pid] = match scan {
         ZellijScan::Off => return false,
         ZellijScan::Clients(clients) => clients,
         // Any process whose basename is exactly "zellij" (the CLI binary, not
         // "zellij-server" or other variants).
-        ZellijScan::EveryClient => comm_of
-            .iter()
-            .filter(|(_, comm)| comm_basename(comm) == ZELLIJ_PROGRAM_NAME)
-            .map(|(&pid, _)| pid)
-            .collect(),
+        ZellijScan::EveryClient => {
+            every_client = comm_of
+                .iter()
+                .filter(|(_, comm)| comm_basename(comm) == ZELLIJ_PROGRAM_NAME)
+                .map(|(&pid, _)| pid)
+                .collect();
+            &every_client
+        }
     };
 
-    for client in clients {
+    for &client in clients {
         let mut ancestor = client;
         for _ in 0..MAX_ANCESTOR_DEPTH {
             match parent_of.get(&ancestor) {
@@ -2467,7 +2485,7 @@ fn has_mosh_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) 
     find_ancestor_process(
         ps_output,
         current_pid,
-        scan_for_flag(in_zellij),
+        &scan_for_flag(in_zellij),
         "mosh-server",
     )
 }
@@ -2480,7 +2498,7 @@ fn has_et_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) ->
     find_ancestor_process(
         ps_output,
         current_pid,
-        scan_for_flag(in_zellij),
+        &scan_for_flag(in_zellij),
         "etterminal",
     )
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -452,9 +452,7 @@ fn validate_terminal_for_graphics(
             "Mosh detected. {} display does not work over Mosh.\n\
             Mosh strips the escape sequences needed for image display (Sixel, Kitty, iTerm2).\n\
             \n\
-            To display images, please use one of:\n\
-            • ssh user@host (instead of mosh user@host)\n\
-            • Eternal Terminal (et user@host) - persistent sessions with image support",
+            To display images, reconnect with ssh user@host instead of mosh user@host.",
             feature
         );
     }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -3330,6 +3330,42 @@ not_a_number  1 /bin/bash
     }
 
     // =========================================================================
+    // Tests for the Mosh message
+    // =========================================================================
+
+    /// Ask for the Mosh message that `ic` prints when it refuses an image.
+    fn mosh_refusal_message() -> String {
+        let caps = TerminalCapabilities {
+            terminal_type: TerminalType::ITerm2,
+            supports_graphics: true,
+            supports_raw_mode: true,
+        };
+        let error = validate_terminal_for_graphics(&caps, &RemoteTransport::Mosh, "Image")
+            .expect_err("Mosh must be refused");
+        error.to_string()
+    }
+
+    #[test]
+    fn the_mosh_message_does_not_recommend_eternal_terminal() {
+        // Eternal Terminal drops the session when the laptop sleeps, which is
+        // the reconnect that matters here. Do not send the reader to it.
+        let message = mosh_refusal_message();
+        assert!(
+            !message.contains("Eternal Terminal"),
+            "message still recommends Eternal Terminal: {message}"
+        );
+        assert!(
+            !message.contains("et user@host"),
+            "message still recommends the et command: {message}"
+        );
+    }
+
+    #[test]
+    fn the_mosh_message_still_offers_ssh() {
+        assert!(mosh_refusal_message().contains("ssh user@host"));
+    }
+
+    // =========================================================================
     // Tests for classify_transport (the whole transport decision)
     // =========================================================================
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2338,19 +2338,15 @@ fn classify_transport(
 
     let scan = match &zellij_session {
         None => ZellijScan::Off,
-        Some(session) => {
-            let clients = zellij_client_pids(ps_args_output, session);
-            if clients.is_empty() {
-                // The session named no client, so the careful answer is the
-                // one that treats every Zellij client on the machine as a
-                // candidate. It can over-report Mosh, which hides an image
-                // that would have worked. The opposite mistake writes escape
-                // sequences that Mosh strips.
-                ZellijScan::EveryClient
-            } else {
-                ZellijScan::Clients(clients)
-            }
-        }
+        Some(session) => match ClientPids::new(zellij_client_pids(ps_args_output, session)) {
+            Some(clients) => ZellijScan::Clients(clients),
+            // The session named no client, so the careful answer is the one
+            // that treats every Zellij client on the machine as a candidate.
+            // It can over-report Mosh, which hides an image that would have
+            // worked. The opposite mistake writes escape sequences that Mosh
+            // strips.
+            None => ZellijScan::EveryClient,
+        },
     };
 
     // ET detected via env var or process tree (including Zellij heuristic).
@@ -2368,7 +2364,7 @@ fn classify_transport(
         // Zellij sends the output of a pane to every attached client. One
         // client that can show images is enough, so Mosh only blocks when
         // every client of this session is a Mosh client.
-        ZellijScan::Clients(clients) => clients.iter().all(|&client| {
+        ZellijScan::Clients(clients) => clients.as_slice().iter().all(|&client| {
             find_ancestor_process(ps_comm_output, client, &ZellijScan::Off, "mosh-server")
         }),
         ZellijScan::EveryClient => {
@@ -2403,6 +2399,9 @@ mod client_pids {
     impl ClientPids {
         /// Wraps `pids`, or answers `None` when there is no client to wrap.
         pub(crate) fn new(pids: Vec<Pid>) -> Option<Self> {
+            if pids.is_empty() {
+                return None;
+            }
             Some(Self(pids))
         }
 
@@ -2433,10 +2432,11 @@ enum ZellijScan {
     /// The clients that are attached to this session, found by
     /// [`zellij_client_pids`].
     ///
-    /// The list must not be empty. `classify_transport` asks whether *every*
-    /// client is a Mosh client, and an empty list answers yes for no reason.
-    /// A session with no named client uses [`ZellijScan::EveryClient`].
-    Clients(Vec<Pid>),
+    /// [`ClientPids`] holds at least one client, so `classify_transport` can
+    /// ask whether *every* client is a Mosh client and get an answer that a
+    /// client stands behind. A session with no named client cannot arrive
+    /// here at all: it uses [`ZellijScan::EveryClient`].
+    Clients(ClientPids),
 }
 
 /// Determines whether a target process (identified by basename) is an ancestor
@@ -2500,7 +2500,7 @@ fn find_ancestor_process(
     let every_client: Vec<Pid>;
     let clients: &[Pid] = match scan {
         ZellijScan::Off => return false,
-        ZellijScan::Clients(clients) => clients,
+        ZellijScan::Clients(clients) => clients.as_slice(),
         // Any process whose basename is exactly "zellij" (the CLI binary, not
         // "zellij-server" or other variants).
         ZellijScan::EveryClient => {

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2382,6 +2382,39 @@ fn classify_transport(
     RemoteTransport::None
 }
 
+/// Holds [`ClientPids`] so that its field stays private to this module. In a
+/// single-module program a private tuple field is still reachable from every
+/// other line of the file, and an invariant that the rest of the file can
+/// bypass is a comment, not a guarantee.
+mod client_pids {
+    use super::Pid;
+
+    /// A list of Zellij clients that holds at least one client.
+    ///
+    /// [`ClientPids::new`] is the only way to build one, so the empty case is
+    /// answered once instead of at every call site. The emptiness matters
+    /// because `classify_transport` asks whether *every* client of the session
+    /// is a Mosh client: `all` over an empty list answers yes, so a session
+    /// with no named client would be reported as Mosh for no reason. That
+    /// session belongs to [`super::ZellijScan::EveryClient`] instead.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct ClientPids(Vec<Pid>);
+
+    impl ClientPids {
+        /// Wraps `pids`, or answers `None` when there is no client to wrap.
+        pub(crate) fn new(pids: Vec<Pid>) -> Option<Self> {
+            Some(Self(pids))
+        }
+
+        /// The clients, in the order `ps` reported them. Never empty.
+        pub(crate) fn as_slice(&self) -> &[Pid] {
+            &self.0
+        }
+    }
+}
+
+use client_pids::ClientPids;
+
 /// Which Zellij clients stand in for the current process during the search.
 ///
 /// Zellij daemonizes its server, so the chain from the current process stops
@@ -3684,6 +3717,24 @@ not_a_number zellij a work
     fn zellij_client_pids_ignores_an_empty_session_name() {
         // ZELLIJ_SESSION_NAME is unset or empty. No client can be identified.
         assert!(zellij_client_pids(PS_ARGS_TWO_SESSIONS, "").is_empty());
+    }
+
+    // =========================================================================
+    // Tests for ClientPids (the client list that cannot be empty)
+    // =========================================================================
+
+    #[test]
+    fn client_pids_refuses_an_empty_list() {
+        // An empty list would answer "every client is a Mosh client" for no
+        // reason, so it must not be possible to build one.
+        assert!(ClientPids::new(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn client_pids_keeps_a_non_empty_list_in_order() {
+        let clients =
+            ClientPids::new(vec![Pid(57053), Pid(32269)]).expect("a list with clients is accepted");
+        assert_eq!(clients.as_slice(), [Pid(57053), Pid(32269)]);
     }
 
     // =========================================================================

--- a/src/ic/tests/will-display.rs
+++ b/src/ic/tests/will-display.rs
@@ -1,0 +1,102 @@
+//! Black-box tests for the `--will-display` flag, which answers "can `ic` show
+//! an image here?" as a process exit status.
+//!
+//! Every test drives the real binary with a cleared environment, so the answer
+//! comes from the variables the test sets and from nothing the test runner
+//! inherited. The `PATH` points at a directory that does not exist, which keeps
+//! `ps` out of reach: the remote-transport detection then finds no process tree
+//! to walk, so a test runner that is itself under mosh cannot change the
+//! verdict. The path holds the process id and a nanosecond stamp, so two
+//! concurrent runs of this file never name the same directory.
+
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A directory that does not exist, unique to this process.
+fn unreachable_path_dir() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("the clock must be after the epoch")
+        .as_nanos();
+    format!(
+        "/nonexistent-ic-will-display-{}-{nanos}",
+        std::process::id()
+    )
+}
+
+/// Invoke the freshly-built `ic` binary in a known-empty environment.
+fn ic(term: &str) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ic"));
+    command.env_clear();
+    command.env("PATH", unreachable_path_dir());
+    command.env("TERM", term);
+    command
+}
+
+fn run(output: Output) -> (Option<i32>, String, String) {
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// A terminal that renders graphics, with no multiplexer and no remote
+/// transport. `ic` must report that it can display an image, and say nothing.
+#[test]
+fn will_display_succeeds_silently_in_a_graphics_capable_session() {
+    let (code, stdout, stderr) = run(ic("xterm-256color")
+        .arg("--will-display")
+        .output()
+        .expect("ic must run"));
+
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert_eq!(stdout, "", "success must print nothing to stdout");
+    assert_eq!(stderr, "", "success must print nothing to stderr");
+}
+
+/// The Linux console renders no graphics protocol. `ic` must fail with the
+/// reason on stderr.
+#[test]
+fn will_display_fails_and_names_the_terminal_when_graphics_are_unsupported() {
+    let (code, _stdout, stderr) = run(ic("linux")
+        .arg("--will-display")
+        .output()
+        .expect("ic must run"));
+
+    assert_eq!(code, Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("not supported in this terminal"),
+        "stderr must give the reason: {stderr}"
+    );
+}
+
+/// tmux strips the escape sequences that carry an image. `ic` must fail and
+/// name tmux.
+#[test]
+fn will_display_fails_and_names_tmux() {
+    let (code, _stdout, stderr) = run(ic("xterm-256color")
+        .arg("--will-display")
+        .env("TMUX", "/private/tmp/tmux-501/default,1,0")
+        .output()
+        .expect("ic must run"));
+
+    assert_eq!(code, Some(1), "stderr: {stderr}");
+    assert!(stderr.contains("tmux"), "stderr must name tmux: {stderr}");
+}
+
+/// The flag asks a question. It does not display a file, so pairing it with a
+/// file is a mistake `ic` must report instead of quietly ignoring one of them.
+#[test]
+fn will_display_refuses_to_share_the_command_with_a_file() {
+    let (code, _stdout, stderr) = run(ic("xterm-256color")
+        .args(["--will-display", "picture.png"])
+        .output()
+        .expect("ic must run"));
+
+    assert_eq!(code, Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("multiple input modes"),
+        "stderr must explain the conflict: {stderr}"
+    );
+}


### PR DESCRIPTION
`ic` decided the transport from every zellij client on the machine. A mosh
client attached to a different session made `ic` report mosh for this session.
Now `ic` finds the client PIDs of the named session only, and it decides the
transport from those clients.

The mosh message also stops the recommendation of Eternal Terminal.
