### PR TITLE
fix(ic): give every display routine one cursor contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,7 @@ dependencies = [
  "notify",
  "terminal_size",
  "termion",
+ "unicode-width",
 ]
 
 [[package]]

--- a/src/ic/Cargo.toml
+++ b/src/ic/Cargo.toml
@@ -19,6 +19,7 @@ libc.workspace = true
 notify.workspace = true
 terminal_size.workspace = true
 termion.workspace = true
+unicode-width.workspace = true
 
 [lints]
 workspace = true

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -130,6 +130,14 @@ terminal, and the terminal then wraps it onto more than one row. `ic` measures
 the display width of each header line and counts the rows that the line takes,
 so a wrapped name pays for every row that it occupies.
 
+All three display routines obey that row count. The Kitty protocol and the
+iTerm2 protocol take the size of the image in character cells, so they take the
+count as it is. Sixel takes the size in pixels, and `ic` multiplies the count by
+the height of one character cell. Some terminals also report their own size in
+pixels, and `ic` keeps a margin inside that size. The image then gets the
+smaller of the two, because the margin knows nothing about the header rows and
+the row count knows nothing about the edge of the screen.
+
 ### muxiavelli Panels
 
 Inside a [muxiavelli](https://github.com/timmattison/muxiavelli) panel, the web terminal is ttyd's xterm.js with `@xterm/addon-image`, which renders **Sixel and iTerm2's inline image protocol (IIP) only — not the Kitty graphics protocol**.

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -124,8 +124,11 @@ image. Video playback uses that mode, because it puts the cursor where it wants
 it before every frame.
 
 The auto-fit size also pays for the rows that `ic` prints above the image. The
-file name row, the image, and the row that the shell prompt returns to together
-fit inside the height of the terminal.
+file name rows, the image, and the row that the shell prompt returns to together
+fit inside the height of the terminal. A long file name is wider than the
+terminal, and the terminal then wraps it onto more than one row. `ic` measures
+the display width of each header line and counts the rows that the line takes,
+so a wrapped name pays for every row that it occupies.
 
 ### muxiavelli Panels
 

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -84,7 +84,7 @@ The flag asks the same question the display path asks — the terminal, the mult
 - `--height <HEIGHT>` - Height in characters (defaults to auto-sizing)
 - `--preserve-aspect` - Preserve aspect ratio when resizing (default: true)
 - `--stdin` - Read from stdin instead of file
-- `-n, --no-newline` - Don't output newline after image
+- `-n, --no-newline` - Leave the cursor to the caller and write only the image (see [Where the Cursor Ends](#where-the-cursor-ends))
 - `--will-display` - Report whether this session can display an image, then exit (0 = yes, 1 = no with the reason on stderr)
 - `-h, --help` - Print help information
 - `-V, --version` - Print version information

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -97,6 +97,33 @@ Kitty support is experimental.
 
 Inside Zellij, `ic` uses Sixel instead, since the Kitty protocol does not pass through Zellij's renderer.
 
+### Where the Cursor Ends
+
+`ic` puts the cursor at column 1 of the first row below the image. It does the
+same thing for all three display routines, and the position does not depend on
+how the renderer moves the cursor.
+
+No inline-image protocol gives a usable contract for the position of the cursor
+after an image. Sixel gives none at all, so each renderer decides for itself.
+The Kitty protocol and the iTerm2 protocol each have a flag that holds the
+cursor still, but then the caller must move it. `ic` therefore states the
+position itself. Each routine writes four parts:
+
+1. One newline for each row of the image. The reservation makes an image at the
+   bottom of the screen scroll the terminal instead of run off it.
+2. CUU, which goes back to the top of the reservation.
+3. DECSC, the image, and DECRC. The brackets make sure that cursor motion inside
+   the image cannot change the final position.
+4. CUD by the row count, and a carriage return.
+
+`-n, --no-newline` suppresses all four parts, and `ic` then writes only the
+image. Video playback uses that mode, because it puts the cursor where it wants
+it before every frame.
+
+The auto-fit size also pays for the rows that `ic` prints above the image. The
+file name row, the image, and the row that the shell prompt returns to together
+fit inside the height of the terminal.
+
 ### muxiavelli Panels
 
 Inside a [muxiavelli](https://github.com/timmattison/muxiavelli) panel, the web terminal is ttyd's xterm.js with `@xterm/addon-image`, which renders **Sixel and iTerm2's inline image protocol (IIP) only — not the Kitty graphics protocol**.

--- a/src/ic/README.md
+++ b/src/ic/README.md
@@ -109,8 +109,11 @@ The Kitty protocol and the iTerm2 protocol each have a flag that holds the
 cursor still, but then the caller must move it. `ic` therefore states the
 position itself. Each routine writes four parts:
 
-1. One newline for each row of the image. The reservation makes an image at the
-   bottom of the screen scroll the terminal instead of run off it.
+1. One newline for each row of the image, bounded by the height of the terminal.
+   The reservation makes an image at the bottom of the screen scroll the
+   terminal instead of run off it. An image taller than the screen cannot have a
+   row below it, because the cursor stops at the edge of the screen. The bound
+   therefore holds the scroll to one screen.
 2. CUU, which goes back to the top of the reservation.
 3. DECSC, the image, and DECRC. The brackets make sure that cursor motion inside
    the image cannot change the final position.

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -50,6 +50,9 @@ const SIXEL_HORIZONTAL_MARGIN: f64 = 0.95;
 /// Leaves more vertical margin as some terminals have status bars or prompts.
 const SIXEL_VERTICAL_MARGIN: f64 = 0.90;
 
+/// Control sequence introducer. It starts a CSI escape sequence.
+const CSI: &str = "\x1b[";
+
 #[derive(Debug, Clone)]
 enum VideoControl {
     Exit,
@@ -1819,6 +1822,24 @@ fn calculate_sixel_dimensions(
     }
 }
 
+/// Calculate the number of terminal rows that an image fills.
+///
+/// The image height in pixels divides by the height of one character cell, and
+/// the result rounds up, because a partial row still uses a full row.
+///
+/// # Arguments
+/// * `height_px` - The height of the image in pixels.
+/// * `cell_height_px` - The height of one character cell in pixels.
+///
+/// # Returns
+/// The row count. The result is always 1 or more, so the caller never asks the
+/// terminal for a movement of zero rows. A `cell_height_px` of 0 counts as 1,
+/// because `get_cell_pixel_dimensions` divides the terminal pixel height by the
+/// row count and can give 0.
+fn image_rows(height_px: u32, cell_height_px: u32) -> u32 {
+    height_px.div_ceil(cell_height_px.max(1)).max(1)
+}
+
 /// Sixel display for terminals that support Sixel graphics (e.g., Zellij passthrough).
 ///
 /// # Arguments
@@ -1889,9 +1910,17 @@ fn display_image_sixel(
     // Output the sixel data
     let mut stdout = io::stdout().lock();
     write!(stdout, "{}", sixel_output)?;
+
     if !no_newline {
-        writeln!(stdout)?;
+        // Sixel gives no contract for the position of the cursor after the
+        // string terminator, so state the position instead of a guess of one
+        // newline. CUD moves the cursor down by the row count of the image and
+        // the carriage return puts it at column 1.
+        let (_, cell_height_px) = get_cell_pixel_dimensions();
+        let rows = image_rows(resized_img.height(), cell_height_px);
+        write!(stdout, "{CSI}{rows}B\r")?;
     }
+
     stdout.flush().context("Failed to flush output")?;
 
     Ok(())
@@ -4080,5 +4109,38 @@ not_a_number zellij a work
         // The running test binary is a regular file that is guaranteed to exist.
         let real_file = std::env::current_exe().expect("current exe path");
         assert!(ensure_file_exists(&real_file).is_ok());
+    }
+
+    // =========================================================================
+    // Tests for image_rows
+    // =========================================================================
+
+    #[test]
+    fn image_rows_divides_an_exact_multiple() {
+        assert_eq!(image_rows(100, 20), 5);
+        assert_eq!(image_rows(20, 20), 1);
+    }
+
+    #[test]
+    fn image_rows_rounds_up_a_partial_row() {
+        // A partial row still uses a full row.
+        assert_eq!(image_rows(101, 20), 6);
+        assert_eq!(image_rows(21, 20), 2);
+        assert_eq!(image_rows(1, 20), 1);
+    }
+
+    #[test]
+    fn image_rows_never_gives_zero() {
+        // A movement of zero rows means one row to a terminal, so the row count
+        // must stay at 1 or more.
+        assert_eq!(image_rows(0, 20), 1);
+        assert_eq!(image_rows(0, 0), 1);
+    }
+
+    #[test]
+    fn image_rows_survives_a_zero_cell_height() {
+        // get_cell_pixel_dimensions divides the terminal pixel height by the row
+        // count, so it can give 0. A cell height of 0 counts as 1 pixel.
+        assert_eq!(image_rows(100, 0), 100);
     }
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1927,6 +1927,16 @@ fn display_image_sixel(
         let (_, cell_height_px) = get_cell_pixel_dimensions();
         let rows = image_rows(resized_img.height(), cell_height_px);
 
+        // Reserve the rows before the image goes out. An image at the bottom of
+        // the screen then scrolls the terminal instead of running off it. CUU
+        // then goes back to the top of the reservation. image_rows never gives
+        // 0, so this never asks for a movement of zero rows, which a terminal
+        // reads as one row.
+        for _ in 0..rows {
+            writeln!(stdout)?;
+        }
+        write!(stdout, "{CSI}{rows}A")?;
+
         // DECSC and DECRC bracket the payload, so cursor motion inside it
         // cannot change the final position.
         write!(stdout, "{SAVE_CURSOR}{}{RESTORE_CURSOR}", sixel_output)?;

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1641,14 +1641,9 @@ fn display_image(
         DisplayRoutine::Sixel => {
             display_image_sixel(&img, scaled_width, scaled_height, args, no_newline)
         }
-        DisplayRoutine::Kitty => display_image_kitty(
-            &img,
-            scaled_width,
-            scaled_height,
-            args,
-            under_remote_proxy,
-            no_newline,
-        ),
+        DisplayRoutine::Kitty => {
+            display_image_kitty(&img, scaled_width, scaled_height, args, no_newline)
+        }
         DisplayRoutine::Iterm2 => display_image_iterm2(
             &img,
             scaled_width,
@@ -1792,7 +1787,6 @@ fn display_image_kitty(
     width: Option<u32>,
     height: Option<u32>,
     args: &Args,
-    under_remote_proxy: bool,
     no_newline: bool,
 ) -> Result<()> {
     // display_width/display_height are in terminal cells (character columns/rows).
@@ -1824,7 +1818,6 @@ fn display_image_kitty(
         display_width,
         display_height,
         no_newline,
-        under_remote_proxy,
     )
 }
 
@@ -1921,6 +1914,135 @@ fn image_rows(height_px: u32, cell_height_px: u32) -> u32 {
     height_px.div_ceil(cell_height_px.max(1)).max(1)
 }
 
+/// Calculate the number of terminal rows that a rendered image fills, for the
+/// protocols that take the size of the image in character cells.
+///
+/// The Kitty graphics protocol and the iTerm2 inline image protocol both take a
+/// width and a height in character cells, and both make their own decision when
+/// one of the two is absent. There are four cases, and each one follows a rule
+/// of the protocols:
+///
+/// * `display_height` is `Some(h)`, with or without a width. Both protocols
+///   scale the image into the rows that `ic` asks for, so the answer is `h`.
+/// * Only `display_width` is `Some(w)`. Both protocols then compute the other
+///   dimension to keep the aspect ratio of the image. The rendered height in
+///   pixels is `img_height_px * (w * cell_width_px) / img_width_px`.
+/// * Neither is given. Both protocols render the image at its own pixel size,
+///   so the answer comes from the pixel height of the image.
+///
+/// # Arguments
+/// * `img_width_px` - The width of the image in pixels.
+/// * `img_height_px` - The height of the image in pixels.
+/// * `display_width` - The width that `ic` asks for, in character cells.
+/// * `display_height` - The height that `ic` asks for, in character cells.
+/// * `cell_width_px` - The width of one character cell in pixels.
+/// * `cell_height_px` - The height of one character cell in pixels.
+///
+/// # Returns
+/// The row count. The result is always 1 or more, so the caller never asks the
+/// terminal for a movement of zero rows, which a terminal reads as one row. An
+/// `img_width_px` of 0 gives no scale factor, so the width-only case falls back
+/// to the pixel height of the image.
+fn image_rows_in_cells(
+    img_width_px: u32,
+    img_height_px: u32,
+    display_width: Option<u32>,
+    display_height: Option<u32>,
+    cell_width_px: u32,
+    cell_height_px: u32,
+) -> u32 {
+    if let Some(rows) = display_height {
+        return rows.max(1);
+    }
+
+    match display_width {
+        // The arithmetic runs in u64, because a wide image and a tall image
+        // together overflow u32 long before they overflow u64.
+        Some(cols) if img_width_px > 0 => {
+            let rendered_height_px =
+                u64::from(img_height_px) * u64::from(cols) * u64::from(cell_width_px)
+                    / u64::from(img_width_px);
+            image_rows(
+                u32::try_from(rendered_height_px).unwrap_or(u32::MAX),
+                cell_height_px,
+            )
+        }
+        _ => image_rows(img_height_px, cell_height_px),
+    }
+}
+
+/// Where a display routine must leave the cursor after it writes an image.
+///
+/// Sixel gives no contract for the position of the cursor after the string
+/// terminator, and each renderer decides for itself. The Kitty protocol and the
+/// iTerm2 protocol each have a flag that holds the cursor still, but then the
+/// caller must move it. `ic` therefore states the position of the cursor
+/// instead of a guess.
+enum CursorContract {
+    /// The caller puts the cursor where it wants it (`--no-newline`, video
+    /// playback). The routine writes the payload and nothing else.
+    CallerManaged,
+    /// Column 1 of the first row below the image.
+    BelowImage {
+        /// The height of the image in terminal rows.
+        rows: u32,
+    },
+}
+
+/// Write an image payload and keep the promise of a [`CursorContract`].
+///
+/// Every display routine of `ic` owes the caller the same promise: the cursor
+/// ends at column 1 of the first row below the image, unless the caller asked
+/// for no newline. This function holds the one implementation of that promise,
+/// so a new display routine cannot forget it.
+///
+/// [`CursorContract::BelowImage`] writes four parts:
+///
+/// 1. One newline for each row of the image. The reservation makes an image at
+///    the bottom of the screen scroll the terminal instead of run off it.
+/// 2. CUU, which goes back to the top of the reservation.
+/// 3. DECSC, the payload and DECRC. The brackets make sure that cursor motion
+///    inside the payload cannot change the final position of the cursor.
+/// 4. CUD by the row count and a carriage return, which together put the cursor
+///    at column 1 of the first row below the image.
+///
+/// The payload arrives as a closure, because the Kitty routine writes its
+/// payload in more than one chunk and cannot make one string.
+///
+/// # Arguments
+/// * `out` - The stream that takes the bytes.
+/// * `contract` - The promise that the routine must keep.
+/// * `payload` - A closure that writes the image payload to `out`.
+///
+/// # Returns
+/// An error when a write to `out` fails.
+fn write_image_with_cursor_contract<W, F>(
+    out: &mut W,
+    contract: CursorContract,
+    payload: F,
+) -> io::Result<()>
+where
+    W: Write,
+    F: FnOnce(&mut W) -> io::Result<()>,
+{
+    let CursorContract::BelowImage { rows } = contract else {
+        return payload(out);
+    };
+
+    // The row count is always 1 or more, so this never asks the terminal for a
+    // movement of zero rows.
+    for _ in 0..rows {
+        writeln!(out)?;
+    }
+    write!(out, "{CSI}{rows}A")?;
+
+    write!(out, "{SAVE_CURSOR}")?;
+    payload(out)?;
+    write!(out, "{RESTORE_CURSOR}")?;
+
+    write!(out, "{CSI}{rows}B\r")
+}
+
 /// Sixel display for terminals that support Sixel graphics (e.g., Zellij passthrough).
 ///
 /// # Arguments
@@ -1991,35 +2113,16 @@ fn display_image_sixel(
     // Output the sixel data
     let mut stdout = io::stdout().lock();
 
-    if no_newline {
-        // Video playback puts the cursor where it wants it, so write only the
-        // payload.
-        write!(stdout, "{}", sixel_output)?;
+    let contract = if no_newline {
+        CursorContract::CallerManaged
     } else {
-        // Sixel gives no contract for the position of the cursor after the
-        // string terminator, so state the position instead of a guess of one
-        // newline.
         let (_, cell_height_px) = get_cell_pixel_dimensions();
-        let rows = image_rows(resized_img.height(), cell_height_px);
-
-        // Reserve the rows before the image goes out. An image at the bottom of
-        // the screen then scrolls the terminal instead of running off it. CUU
-        // then goes back to the top of the reservation. image_rows never gives
-        // 0, so this never asks for a movement of zero rows, which a terminal
-        // reads as one row.
-        for _ in 0..rows {
-            writeln!(stdout)?;
+        CursorContract::BelowImage {
+            rows: image_rows(resized_img.height(), cell_height_px),
         }
-        write!(stdout, "{CSI}{rows}A")?;
+    };
 
-        // DECSC and DECRC bracket the payload, so cursor motion inside it
-        // cannot change the final position.
-        write!(stdout, "{SAVE_CURSOR}{}{RESTORE_CURSOR}", sixel_output)?;
-
-        // CUD moves the cursor down by the row count of the image and the
-        // carriage return puts it at column 1.
-        write!(stdout, "{CSI}{rows}B\r")?;
-    }
+    write_image_with_cursor_contract(&mut stdout, contract, |out| write!(out, "{}", sixel_output))?;
 
     stdout.flush().context("Failed to flush output")?;
 
@@ -2697,6 +2800,25 @@ fn has_et_in_process_tree(ps_output: &str, current_pid: Pid, in_zellij: bool) ->
     )
 }
 
+/// Write an image with the Kitty graphics protocol.
+///
+/// The command is `ESC _ G <key>=<value>,... ; <base64 data> ESC \`. A large
+/// image goes out in more than one command, because the protocol limits the
+/// size of one command.
+///
+/// The routine holds the cursor still with `C=1` and then states the position
+/// of the cursor itself through [`write_image_with_cursor_contract`].
+///
+/// # Arguments
+/// * `rgb_data` - The pixels of the image, three bytes for each pixel.
+/// * `img_width` - The width of the image in pixels.
+/// * `img_height` - The height of the image in pixels.
+/// * `display_width` - The width that `ic` asks for, in character cells.
+/// * `display_height` - The height that `ic` asks for, in character cells.
+/// * `no_newline` - True when the caller controls the position of the cursor.
+///
+/// # Returns
+/// An error when a write to stdout fails.
 fn print_kitty_image(
     rgb_data: &[u8],
     img_width: u32,
@@ -2704,66 +2826,48 @@ fn print_kitty_image(
     display_width: Option<u32>,
     display_height: Option<u32>,
     no_newline: bool,
-    under_remote_proxy: bool,
 ) -> Result<()> {
     let mut stdout = io::stdout().lock();
-
-    // Kitty graphics protocol format:
-    // ESC _ G <key>=<value>,<key>=<value>,... ; <base64_data> ESC \
-    // For large images, we need to chunk the data
 
     let base64_data = BASE64_STANDARD.encode(rgb_data);
     let chunk_size = 4096; // Kitty recommended chunk size
 
-    // Under a remote proxy (e.g. Eternal Terminal), the proxy's virtual terminal
-    // doesn't understand the Kitty graphics protocol, so it can't track cursor
-    // movement caused by image rendering. We synchronize by:
-    //   1. Pre-filling blank lines so the proxy allocates screen space
-    //   2. Moving the cursor back up (both proxy and client process this)
-    //   3. Rendering the image with C=1 (don't move cursor)
-    //   4. Moving the cursor back down with CUD (both process this)
-    // This keeps both terminals' cursor positions in sync.
-    // In video mode (no_newline), skip proxy cursor sync — the caller handles
-    // cursor positioning explicitly with \x1b[row;colH and \x1b[J. The pre-fill
-    // newlines would cause scrolling every frame.
-    let proxy_rows = if under_remote_proxy && !no_newline {
-        let rows = display_height.unwrap_or(1);
-        // Pre-fill: emit newlines to create space in the proxy's screen buffer
-        for _ in 0..rows {
-            writeln!(stdout)?;
-        }
-        // Move cursor back up to where the image should be rendered
-        write!(stdout, "\x1b[{}A", rows)?;
-        rows
+    let contract = if no_newline {
+        CursorContract::CallerManaged
     } else {
-        0
+        let (cell_width_px, cell_height_px) = get_cell_pixel_dimensions();
+        CursorContract::BelowImage {
+            rows: image_rows_in_cells(
+                img_width,
+                img_height,
+                display_width,
+                display_height,
+                cell_width_px,
+                cell_height_px,
+            ),
+        }
     };
 
-    if base64_data.len() <= chunk_size {
-        // Small image, send in one chunk
-        write!(stdout, "\x1b_Ga=T,f=24,s={},v={}", img_width, img_height)?;
+    // The key list that opens the first command. `C=1` tells Kitty not to move
+    // the cursor, because this routine states the position of the cursor
+    // itself. In video mode, fixed image and placement ids make each frame
+    // replace the last one in place, which holds the memory of the renderer
+    // flat.
+    let cursor_keys = if no_newline { ",i=1,p=1,C=1" } else { ",C=1" };
+    // The display size, in character cells.
+    let width_key = display_width.map_or_else(String::new, |w| format!(",c={w}"));
+    let height_key = display_height.map_or_else(String::new, |h| format!(",r={h}"));
+    let header =
+        format!("\x1b_Ga=T,f=24,s={img_width},v={img_height}{cursor_keys}{width_key}{height_key}");
 
-        // C=1 tells Kitty not to move the cursor. This routine states the
-        // position of the cursor itself, so the renderer must not move it too.
-        // In video mode, fixed image and placement ids make each frame replace
-        // the last one in place, which holds the memory of the renderer flat.
-        if no_newline {
-            write!(stdout, ",i=1,p=1,C=1")?;
-        } else {
-            write!(stdout, ",C=1")?;
+    write_image_with_cursor_contract(&mut stdout, contract, |out| {
+        if base64_data.len() <= chunk_size {
+            // A small image goes out in one command.
+            return write!(out, "{header};{base64_data}\x1b\\");
         }
 
-        // Add display size if specified (in character cells)
-        if let Some(w) = display_width {
-            write!(stdout, ",c={}", w)?;
-        }
-        if let Some(h) = display_height {
-            write!(stdout, ",r={}", h)?;
-        }
-
-        write!(stdout, ";{}\x1b\\", base64_data)?;
-    } else {
-        // Large image, send in chunks
+        // A large image goes out in more than one command. `m=1` says that more
+        // data follows and `m=0` closes the image.
         let chunks: Vec<&str> = base64_data
             .as_bytes()
             .chunks(chunk_size)
@@ -2772,45 +2876,16 @@ fn print_kitty_image(
 
         for (i, chunk) in chunks.iter().enumerate() {
             if i == 0 {
-                // First chunk
-                write!(stdout, "\x1b_Ga=T,f=24,s={},v={}", img_width, img_height)?;
-
-                if no_newline {
-                    write!(stdout, ",i=1,p=1,C=1")?;
-                } else {
-                    write!(stdout, ",C=1")?;
-                }
-
-                // Add display size if specified (in character cells)
-                if let Some(w) = display_width {
-                    write!(stdout, ",c={}", w)?;
-                }
-                if let Some(h) = display_height {
-                    write!(stdout, ",r={}", h)?;
-                }
-
-                write!(stdout, ",m=1;{}\x1b\\", chunk)?;
+                write!(out, "{header},m=1;{chunk}\x1b\\")?;
             } else if i == chunks.len() - 1 {
-                // Last chunk
-                write!(stdout, "\x1b_Gm=0;{}\x1b\\", chunk)?;
+                write!(out, "\x1b_Gm=0;{chunk}\x1b\\")?;
             } else {
-                // Middle chunk
-                write!(stdout, "\x1b_Gm=1;{}\x1b\\", chunk)?;
+                write!(out, "\x1b_Gm=1;{chunk}\x1b\\")?;
             }
         }
-    }
 
-    if under_remote_proxy && !no_newline {
-        // Move cursor down past the image area using CUD (Cursor Down).
-        // Both the proxy and local terminal process this identically.
-        // NOTE: This intentionally overrides `no_newline`. The proxy's virtual
-        // terminal needs explicit cursor advancement to stay in sync with the
-        // real terminal — without it, subsequent output overwrites the image.
-        write!(stdout, "\x1b[{}B", proxy_rows)?;
-        writeln!(stdout)?;
-    } else if !no_newline {
-        writeln!(stdout)?;
-    }
+        Ok(())
+    })?;
 
     stdout.flush().context("Failed to flush output")?;
     Ok(())
@@ -4243,6 +4318,152 @@ not_a_number zellij a work
         // get_cell_pixel_dimensions divides the terminal pixel height by the row
         // count, so it can give 0. A cell height of 0 counts as 1 pixel.
         assert_eq!(image_rows(100, 0), 100);
+    }
+
+    // =========================================================================
+    // Tests for image_rows_in_cells
+    // =========================================================================
+
+    /// The width of one character cell in the tests below, in pixels.
+    const TEST_CELL_WIDTH_PX: u32 = 10;
+
+    /// The height of one character cell in the tests below, in pixels.
+    const TEST_CELL_HEIGHT_PX: u32 = 20;
+
+    #[test]
+    fn image_rows_in_cells_takes_a_given_height() {
+        // Both protocols scale the image into the rows that ic asks for, so a
+        // given height is the answer, with or without a width.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                100,
+                Some(10),
+                Some(5),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            5
+        );
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                100,
+                None,
+                Some(7),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            7
+        );
+    }
+
+    #[test]
+    fn image_rows_in_cells_keeps_the_aspect_ratio_of_a_width() {
+        // A width of 10 cells is 100 pixels. The image is twice as wide as it
+        // is tall, so it renders 50 pixels high, which is 3 rows of 20 pixels.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                50,
+                Some(10),
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            3
+        );
+        // A width of 20 cells is 200 pixels, which doubles the image to 200
+        // pixels high, which is 10 rows.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                100,
+                Some(20),
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            10
+        );
+    }
+
+    #[test]
+    fn image_rows_in_cells_falls_back_to_the_pixel_height() {
+        // With no width and no height both protocols render the image at its
+        // own pixel size.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                100,
+                None,
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            5
+        );
+        // A partial row still uses a full row.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                101,
+                None,
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            6
+        );
+    }
+
+    #[test]
+    fn image_rows_in_cells_survives_a_zero_image_width() {
+        // A width of zero pixels gives no scale factor, so the width-only case
+        // falls back to the pixel height of the image.
+        assert_eq!(
+            image_rows_in_cells(
+                0,
+                100,
+                Some(10),
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            5
+        );
+    }
+
+    #[test]
+    fn image_rows_in_cells_never_gives_zero() {
+        // A movement of zero rows means one row to a terminal, so the row count
+        // must stay at 1 or more.
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                100,
+                None,
+                Some(0),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            1
+        );
+        assert_eq!(
+            image_rows_in_cells(100, 0, None, None, TEST_CELL_WIDTH_PX, TEST_CELL_HEIGHT_PX),
+            1
+        );
+        assert_eq!(
+            image_rows_in_cells(
+                100,
+                1,
+                Some(1),
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            1
+        );
     }
 
     // =========================================================================

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2743,12 +2743,13 @@ fn print_kitty_image(
         // Small image, send in one chunk
         write!(stdout, "\x1b_Ga=T,f=24,s={},v={}", img_width, img_height)?;
 
-        // In video mode, use fixed image and placement IDs so each frame replaces
-        // the previous one in-place (zero memory accumulation), and C=1 to prevent
-        // cursor movement that could trigger terminal scrolling.
+        // C=1 tells Kitty not to move the cursor. This routine states the
+        // position of the cursor itself, so the renderer must not move it too.
+        // In video mode, fixed image and placement ids make each frame replace
+        // the last one in place, which holds the memory of the renderer flat.
         if no_newline {
             write!(stdout, ",i=1,p=1,C=1")?;
-        } else if under_remote_proxy {
+        } else {
             write!(stdout, ",C=1")?;
         }
 
@@ -2776,7 +2777,7 @@ fn print_kitty_image(
 
                 if no_newline {
                     write!(stdout, ",i=1,p=1,C=1")?;
-                } else if under_remote_proxy {
+                } else {
                     write!(stdout, ",C=1")?;
                 }
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1937,6 +1937,51 @@ fn calculate_sixel_dimensions(
     }
 }
 
+/// Give the size in pixels that a Sixel image can occupy.
+///
+/// The budget comes from the first source that has an answer. The terminal
+/// reports its size in pixels, and a margin of that size keeps the image off
+/// the edge of the screen. If the terminal reports no pixel size, the budget in
+/// character cells that the caller gives becomes the answer. If the caller
+/// gives no budget, a default size becomes the answer.
+///
+/// # Arguments
+/// * `terminal_pixel_size` - The width and the height of the terminal in
+///   pixels, when the terminal reports them.
+/// * `cell_cols` - The width of the budget of the caller in character cells.
+/// * `cell_rows` - The height of the budget of the caller in character cells.
+/// * `cell_width_px` - The width of one character cell in pixels.
+/// * `cell_height_px` - The height of one character cell in pixels.
+///
+/// # Returns
+/// The width and the height of the budget in pixels.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "pixel dimensions are always positive and fit in u32"
+)]
+fn sixel_pixel_budget(
+    terminal_pixel_size: Option<(u32, u32)>,
+    cell_cols: Option<u32>,
+    cell_rows: Option<u32>,
+    cell_width_px: u32,
+    cell_height_px: u32,
+) -> (u32, u32) {
+    if let Some((px_w, px_h)) = terminal_pixel_size {
+        // Leave some margin to avoid overflow
+        (
+            (f64::from(px_w) * SIXEL_HORIZONTAL_MARGIN) as u32,
+            (f64::from(px_h) * SIXEL_VERTICAL_MARGIN) as u32,
+        )
+    } else if let (Some(cols), Some(rows)) = (cell_cols, cell_rows) {
+        // Fall back to the budget of the caller in character cells
+        (cols * cell_width_px, rows * cell_height_px)
+    } else {
+        // Default to reasonable size when no size info available
+        (DEFAULT_SIXEL_WIDTH_PX, DEFAULT_SIXEL_HEIGHT_PX)
+    }
+}
+
 /// Calculate the number of terminal rows that an image fills.
 ///
 /// The image height in pixels divides by the height of one character cell, and
@@ -2148,11 +2193,6 @@ where
 /// * `fallback_cols` - Fallback terminal width in character cells (used if pixel size unavailable)
 /// * `fallback_rows` - Fallback terminal height in character cells (used if pixel size unavailable)
 /// * `args` - Command line arguments
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    reason = "pixel dimensions are always positive and fit in u32"
-)]
 fn display_image_sixel(
     img: &DynamicImage,
     fallback_cols: Option<u32>,
@@ -2160,24 +2200,17 @@ fn display_image_sixel(
     args: &Args,
     no_newline: bool,
 ) -> Result<()> {
-    // Try to get actual terminal pixel dimensions, with fallbacks
-    let (target_pixel_width, target_pixel_height) =
-        if let Some((px_w, px_h)) = get_terminal_pixel_size() {
-            // Leave some margin to avoid overflow
-            (
-                (px_w as f64 * SIXEL_HORIZONTAL_MARGIN) as u32,
-                (px_h as f64 * SIXEL_VERTICAL_MARGIN) as u32,
-            )
-        } else if let (Some(cols), Some(rows)) = (fallback_cols, fallback_rows) {
-            // Fall back to character cell estimates using typical cell dimensions
-            (
-                cols * ESTIMATED_CELL_WIDTH_PX,
-                rows * ESTIMATED_CELL_HEIGHT_PX,
-            )
-        } else {
-            // Default to reasonable size when no size info available
-            (DEFAULT_SIXEL_WIDTH_PX, DEFAULT_SIXEL_HEIGHT_PX)
-        };
+    // The cell size comes from the terminal when it reports a pixel size, and
+    // from the estimates when it does not.
+    let (cell_width_px, cell_height_px) = get_cell_pixel_dimensions();
+
+    let (target_pixel_width, target_pixel_height) = sixel_pixel_budget(
+        get_terminal_pixel_size(),
+        fallback_cols,
+        fallback_rows,
+        cell_width_px,
+        cell_height_px,
+    );
 
     // Calculate dimensions that preserve aspect ratio
     let (final_width, final_height) = calculate_sixel_dimensions(
@@ -2212,7 +2245,6 @@ fn display_image_sixel(
     let mut stdout = io::stdout().lock();
 
     let contract = CursorContract::below_image(no_newline, || {
-        let (_, cell_height_px) = get_cell_pixel_dimensions();
         image_rows(resized_img.height(), cell_height_px)
     });
 
@@ -3190,6 +3222,179 @@ mod tests {
         // w = 100, h = 100 / infinity = 0, clamped to 1
         let result = calculate_sixel_dimensions(100, 0, 100, 100, true);
         assert_eq!(result.1, 1); // Height should be clamped to 1
+    }
+
+    // =========================================================================
+    // Tests for sixel_pixel_budget
+    // =========================================================================
+
+    /// The width of the terminal in pixels that the budget tests use. Over 80
+    /// columns it gives cells of 12 pixels, because 1000 / 80 is 12.5.
+    const TEST_TERM_WIDTH_PX: u32 = 1000;
+
+    /// The height of the terminal in pixels that the budget tests use. Over 24
+    /// rows it gives cells of 47 pixels, because 1150 / 24 is 47.9.
+    const TEST_TERM_HEIGHT_PX: u32 = 1150;
+
+    /// The width of one character cell of the terminal in the budget tests.
+    const TEST_TERM_CELL_WIDTH_PX: u32 = 12;
+
+    /// The height of one character cell of the terminal in the budget tests.
+    const TEST_TERM_CELL_HEIGHT_PX: u32 = 47;
+
+    /// The width that the margin gives, which is 1000 * 0.95.
+    const TEST_MARGIN_WIDTH_PX: u32 = 950;
+
+    /// The height that the margin gives, which is 1150 * 0.90.
+    const TEST_MARGIN_HEIGHT_PX: u32 = 1035;
+
+    /// Call `sixel_pixel_budget` with the terminal of the budget tests.
+    fn budget_with_cells(cols: Option<u32>, rows: Option<u32>) -> (u32, u32) {
+        sixel_pixel_budget(
+            Some((TEST_TERM_WIDTH_PX, TEST_TERM_HEIGHT_PX)),
+            cols,
+            rows,
+            TEST_TERM_CELL_WIDTH_PX,
+            TEST_TERM_CELL_HEIGHT_PX,
+        )
+    }
+
+    #[test]
+    fn sixel_pixel_budget_holds_the_image_inside_the_row_budget() {
+        // The terminal has 24 rows of 47 pixels, so the margin gives 1035
+        // pixels, which is 23 rows. One header row, 23 image rows and one
+        // prompt row are 25 rows in a terminal of 24. The caller therefore
+        // gives the image 22 rows, which is 1034 pixels, and that budget must
+        // win over the margin.
+        let (_, height) = budget_with_cells(None, Some(22));
+        assert_eq!(height, 1034);
+    }
+
+    #[test]
+    fn sixel_pixel_budget_holds_the_image_inside_the_column_budget() {
+        // The terminal has 80 columns of 12 pixels, so the margin gives 950
+        // pixels. The caller keeps 2 columns for the chrome of the terminal and
+        // gives the image 78 columns, which is 936 pixels.
+        let (width, _) = budget_with_cells(Some(78), None);
+        assert_eq!(width, 936);
+    }
+
+    #[test]
+    fn sixel_pixel_budget_keeps_the_margin_when_the_cell_budget_is_larger() {
+        // The margin keeps the image off the edge of the screen. A cell budget
+        // larger than the screen must not push the image past that edge.
+        assert_eq!(
+            budget_with_cells(Some(200), Some(100)),
+            (TEST_MARGIN_WIDTH_PX, TEST_MARGIN_HEIGHT_PX)
+        );
+    }
+
+    #[test]
+    fn sixel_pixel_budget_keeps_the_margin_on_an_axis_with_no_cell_budget() {
+        // The user gives only --width, so there is no budget for the rows.
+        assert_eq!(
+            budget_with_cells(Some(20), None),
+            (240, TEST_MARGIN_HEIGHT_PX)
+        );
+        // The user gives only --height, so there is no budget for the columns.
+        assert_eq!(
+            budget_with_cells(None, Some(10)),
+            (TEST_MARGIN_WIDTH_PX, 470)
+        );
+        // Neither axis has a budget, so the margin stands on both.
+        assert_eq!(
+            budget_with_cells(None, None),
+            (TEST_MARGIN_WIDTH_PX, TEST_MARGIN_HEIGHT_PX)
+        );
+    }
+
+    #[test]
+    fn sixel_pixel_budget_uses_the_cell_budget_without_a_pixel_size() {
+        // Zellij and ttyd report no pixel size, so the cells give the budget.
+        assert_eq!(
+            sixel_pixel_budget(
+                None,
+                Some(80),
+                Some(24),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            (800, 480)
+        );
+    }
+
+    #[test]
+    fn sixel_pixel_budget_falls_back_to_the_default_size() {
+        // Without a pixel size and without both axes of the cell budget there
+        // is nothing to compute a size from.
+        let default_size = (DEFAULT_SIXEL_WIDTH_PX, DEFAULT_SIXEL_HEIGHT_PX);
+        assert_eq!(
+            sixel_pixel_budget(
+                None,
+                Some(80),
+                None,
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            default_size
+        );
+        assert_eq!(
+            sixel_pixel_budget(
+                None,
+                None,
+                Some(24),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            default_size
+        );
+        assert_eq!(
+            sixel_pixel_budget(None, None, None, TEST_CELL_WIDTH_PX, TEST_CELL_HEIGHT_PX),
+            default_size
+        );
+    }
+
+    #[test]
+    fn sixel_pixel_budget_never_gives_an_axis_of_zero() {
+        // A budget of zero pixels asks the encoder for an image of no size, so
+        // each axis keeps a floor of one pixel.
+        assert_eq!(budget_with_cells(Some(0), Some(0)), (1, 1));
+        assert_eq!(
+            sixel_pixel_budget(
+                Some((TEST_TERM_WIDTH_PX, TEST_TERM_HEIGHT_PX)),
+                Some(80),
+                Some(24),
+                0,
+                0
+            ),
+            (1, 1)
+        );
+        assert_eq!(
+            sixel_pixel_budget(
+                None,
+                Some(0),
+                Some(0),
+                TEST_CELL_WIDTH_PX,
+                TEST_CELL_HEIGHT_PX
+            ),
+            (1, 1)
+        );
+        // A terminal of one pixel gives a margin of less than one pixel.
+        assert_eq!(sixel_pixel_budget(Some((1, 1)), None, None, 1, 1), (1, 1));
+    }
+
+    #[test]
+    fn sixel_pixel_budget_survives_a_cell_budget_that_overflows() {
+        // A terminal that reports an absurd size must not panic the tool. The
+        // product saturates, so the margin wins.
+        assert_eq!(
+            budget_with_cells(Some(u32::MAX), Some(u32::MAX)),
+            (TEST_MARGIN_WIDTH_PX, TEST_MARGIN_HEIGHT_PX)
+        );
+        assert_eq!(
+            sixel_pixel_budget(None, Some(u32::MAX), Some(u32::MAX), u32::MAX, u32::MAX),
+            (u32::MAX, u32::MAX)
+        );
     }
 
     // =========================================================================

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -19,6 +19,7 @@ use terminal_size::{terminal_size, Height, Width};
 use termion::event::Key;
 use termion::input::TermRead;
 use termion::raw::IntoRawMode;
+use unicode_width::UnicodeWidthStr;
 
 // ============================================================================
 // Constants for Sixel and terminal display calculations
@@ -62,7 +63,11 @@ const RESTORE_CURSOR: &str = "\x1b8";
 /// The row that the shell prompt returns to below an image.
 const PROMPT_ROWS: u32 = 1;
 
-/// The number of rows that `ic` prints above an image.
+/// The number of screen rows that `ic` prints above an image.
+///
+/// The count is a count of rows, not a count of header lines. A line that is
+/// wider than the terminal wraps onto more than one row, and every one of those
+/// rows takes height away from the image. Use [`header_rows`] to get the count.
 ///
 /// The auto-fit path must subtract these rows from the height of the terminal.
 /// If it does not, the header rows and the image together fill the screen, and
@@ -89,8 +94,34 @@ fn auto_fit_rows(term_height: u32, header: HeaderRows) -> u32 {
         .max(1)
 }
 
-fn header_rows(lines: &[String], _term_width: u32) -> HeaderRows {
-    HeaderRows(u32::try_from(lines.len()).unwrap_or(u32::MAX))
+/// Give the number of rows that the header lines occupy on the screen.
+///
+/// A terminal wraps a line that is wider than the screen, so one header line
+/// can take more than one row. A count of the lines is therefore too small, and
+/// the auto-fit height that comes from it is too large. The function measures
+/// the display width of each line, because one character can take two columns,
+/// and it divides that width by the width of the terminal. Each line takes one
+/// row or more, so an empty line still counts.
+///
+/// # Arguments
+/// * `lines` - The header lines, one element per line.
+/// * `term_width` - The width of the terminal in columns. A width of 0 counts
+///   as one column.
+///
+/// # Returns
+/// The number of rows that the lines occupy after the terminal wraps them.
+fn header_rows(lines: &[String], term_width: u32) -> HeaderRows {
+    let columns = usize::try_from(term_width.max(1)).unwrap_or(usize::MAX);
+    let rows: usize = lines
+        .iter()
+        .map(|line| {
+            UnicodeWidthStr::width(line.as_str())
+                .div_ceil(columns)
+                .max(1)
+        })
+        .sum();
+
+    HeaderRows(u32::try_from(rows).unwrap_or(u32::MAX))
 }
 
 #[derive(Debug, Clone)]
@@ -1522,9 +1553,11 @@ fn get_terminal_size() -> Result<(u32, u32)> {
 
 /// Print a header and then display an image file.
 ///
-/// The function prints the header itself and then counts the lines that it
+/// The function prints the header itself and then counts the rows that it
 /// printed. The count and the print can therefore never drift apart, so a
-/// caller cannot print a header and forget to pay for the rows.
+/// caller cannot print a header and forget to pay for the rows. A header line
+/// that is wider than the terminal wraps onto more than one row, so the count
+/// comes from the display width of each line and not from the number of lines.
 ///
 /// # Arguments
 /// * `file_path` - The path of the image file.
@@ -1541,8 +1574,8 @@ fn display_image_from_file(file_path: &Path, args: &Args, header: &[String]) -> 
     let img = image::open(file_path)
         .with_context(|| format!("Failed to open image file: {}", file_path.display()))?;
 
-    let header_rows = u32::try_from(header.len()).unwrap_or(u32::MAX);
-    display_image(img, args, args.no_newline, HeaderRows(header_rows))
+    let term_width = get_terminal_size().map_or(FALLBACK_TERMINAL_COLS, |(cols, _)| cols);
+    display_image(img, args, args.no_newline, header_rows(header, term_width))
 }
 
 fn display_text_file(file_path: &Path) -> Result<()> {

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -59,6 +59,36 @@ const SAVE_CURSOR: &str = "\x1b7";
 /// DECRC. It restores the saved position of the cursor.
 const RESTORE_CURSOR: &str = "\x1b8";
 
+/// The row that the shell prompt returns to below an image.
+const PROMPT_ROWS: u32 = 1;
+
+/// The number of rows that `ic` prints above an image.
+///
+/// The auto-fit path must subtract these rows from the height of the terminal.
+/// If it does not, the header rows and the image together fill the screen, and
+/// the terminal must scroll before the prompt can appear.
+#[derive(Debug, Clone, Copy)]
+struct HeaderRows(u32);
+
+/// Give the number of rows that an auto-fit image can occupy.
+///
+/// The image gets the height of the terminal, less the header rows that `ic`
+/// prints above it, less the row that the prompt returns to. The result has a
+/// floor of 1, so a very short terminal still gets an image.
+///
+/// # Arguments
+/// * `term_height` - The height of the terminal in rows.
+/// * `header` - The number of rows that `ic` prints above the image.
+///
+/// # Returns
+/// The number of rows for the image, which is always 1 or more.
+fn auto_fit_rows(term_height: u32, header: HeaderRows) -> u32 {
+    term_height
+        .saturating_sub(header.0)
+        .saturating_sub(PROMPT_ROWS)
+        .max(1)
+}
+
 #[derive(Debug, Clone)]
 enum VideoControl {
     Exit,
@@ -175,8 +205,9 @@ fn main() -> Result<()> {
             if is_video_file(file_path) {
                 display_video_from_file(file_path, &args)?;
             } else if is_image_file(file_path) {
-                println!("{}", file_path.display());
-                display_image_from_file(file_path, &args)?;
+                // The callee prints the file name, so the auto-fit path can
+                // count the row that the name takes.
+                display_image_from_file(file_path, &args, &[file_path.display().to_string()])?;
             } else {
                 // Treat as text file
                 println!("{}", file_path.display());
@@ -327,8 +358,16 @@ fn monitor_directories(directories: &[PathBuf], args: &Args) -> Result<()> {
                             for path in event.paths {
                                 if !recent_files.contains(&path) {
                                     if is_image_file(&path) {
-                                        println!("\nFound new image: {}", path.display());
-                                        match display_image_from_file(&path, args) {
+                                        // The callee prints the two header
+                                        // rows, so the auto-fit path can count
+                                        // them. The first row is empty, which
+                                        // separates this image from the one
+                                        // before it.
+                                        let header = [
+                                            String::new(),
+                                            format!("Found new image: {}", path.display()),
+                                        ];
+                                        match display_image_from_file(&path, args, &header) {
                                             Ok(_) => {
                                                 recent_files.insert(path.clone());
                                             }
@@ -763,7 +802,9 @@ fn process_frame_display(
         move_cursor_home()?;
     }
 
-    display_image(img, args, true)?;
+    // A video frame gets no header, so the image can use the whole terminal
+    // less the row of the prompt.
+    display_image(img, args, true, HeaderRows(0))?;
 
     // Draw progress bar
     if let Some((term_width, term_height)) = current_terminal_size {
@@ -1467,11 +1508,29 @@ fn get_terminal_size() -> Result<(u32, u32)> {
     }
 }
 
-fn display_image_from_file(file_path: &Path, args: &Args) -> Result<()> {
+/// Print a header and then display an image file.
+///
+/// The function prints the header itself and then counts the lines that it
+/// printed. The count and the print can therefore never drift apart, so a
+/// caller cannot print a header and forget to pay for the rows.
+///
+/// # Arguments
+/// * `file_path` - The path of the image file.
+/// * `args` - The command line arguments.
+/// * `header` - The lines to print above the image, one line per element.
+///
+/// # Returns
+/// An error when the file does not open as an image, or when the display fails.
+fn display_image_from_file(file_path: &Path, args: &Args, header: &[String]) -> Result<()> {
+    for line in header {
+        println!("{line}");
+    }
+
     let img = image::open(file_path)
         .with_context(|| format!("Failed to open image file: {}", file_path.display()))?;
 
-    display_image(img, args, args.no_newline)
+    let header_rows = u32::try_from(header.len()).unwrap_or(u32::MAX);
+    display_image(img, args, args.no_newline, HeaderRows(header_rows))
 }
 
 fn display_text_file(file_path: &Path) -> Result<()> {
@@ -1494,10 +1553,28 @@ fn display_image_from_stdin(args: &Args) -> Result<()> {
 
     let img = image::load_from_memory(&buffer).context("Failed to decode image from stdin")?;
 
-    display_image(img, args, args.no_newline)
+    // This path prints no header, so the image can use the whole terminal less
+    // the row of the prompt.
+    display_image(img, args, args.no_newline, HeaderRows(0))
 }
 
-fn display_image(img: DynamicImage, args: &Args, no_newline: bool) -> Result<()> {
+/// Display an image in the terminal.
+///
+/// # Arguments
+/// * `img` - The image to display.
+/// * `args` - The command line arguments.
+/// * `no_newline` - True when the caller controls the position of the cursor.
+/// * `header` - The number of rows that the caller printed above the image. The
+///   auto-fit path subtracts these rows from the height of the terminal.
+///
+/// # Returns
+/// An error when the terminal cannot show graphics, or when the display fails.
+fn display_image(
+    img: DynamicImage,
+    args: &Args,
+    no_newline: bool,
+    header: HeaderRows,
+) -> Result<()> {
     let terminal_caps = detect_terminal_capabilities();
     let transport = detect_remote_transport();
 
@@ -1511,17 +1588,15 @@ fn display_image(img: DynamicImage, args: &Args, no_newline: bool) -> Result<()>
     } else {
         // Auto-fit to terminal window size
         let (term_width, term_height) = get_terminal_size()?;
-        // Leave some margin for terminal chrome and preserve one line for prompt
+        // Leave some margin for terminal chrome
         let safe_width = if term_width > 4 {
             term_width - 2
         } else {
             term_width
         };
-        let safe_height = if term_height > 2 {
-            term_height - 1
-        } else {
-            term_height
-        };
+        // The header rows and the prompt row come out of the height, so the
+        // header, the image and the prompt fit inside the terminal.
+        let safe_height = auto_fit_rows(term_height, header);
         (Some(safe_width), Some(safe_height))
     };
 
@@ -4167,5 +4242,36 @@ not_a_number zellij a work
         // get_cell_pixel_dimensions divides the terminal pixel height by the row
         // count, so it can give 0. A cell height of 0 counts as 1 pixel.
         assert_eq!(image_rows(100, 0), 100);
+    }
+
+    // =========================================================================
+    // Tests for auto_fit_rows
+    // =========================================================================
+
+    #[test]
+    fn auto_fit_rows_keeps_the_prompt_row_when_there_is_no_header() {
+        // stdin and video frames print no header, so only the prompt row goes.
+        assert_eq!(auto_fit_rows(24, HeaderRows(0)), 23);
+    }
+
+    #[test]
+    fn auto_fit_rows_pays_for_a_one_row_header() {
+        // A file argument prints the file name on one row above the image.
+        assert_eq!(auto_fit_rows(24, HeaderRows(1)), 22);
+    }
+
+    #[test]
+    fn auto_fit_rows_pays_for_a_two_row_header() {
+        // The monitor mode prints an empty row and then the name of the image.
+        assert_eq!(auto_fit_rows(24, HeaderRows(2)), 21);
+    }
+
+    #[test]
+    fn auto_fit_rows_gives_at_least_one_row_in_a_short_terminal() {
+        // A terminal too short for the header and the prompt still gets an
+        // image of one row, instead of an image of zero rows.
+        assert_eq!(auto_fit_rows(2, HeaderRows(1)), 1);
+        assert_eq!(auto_fit_rows(1, HeaderRows(2)), 1);
+        assert_eq!(auto_fit_rows(0, HeaderRows(0)), 1);
     }
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -193,7 +193,7 @@ struct Args {
     #[clap(long)]
     stdin: bool,
 
-    /// Don't output newline after image
+    /// Leave the cursor to the caller and write only the image
     #[clap(short, long)]
     no_newline: bool,
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -2345,8 +2345,7 @@ enum DisplayRoutine {
 /// muxiavelli panels.
 fn display_routine_for(terminal_type: &TerminalType) -> DisplayRoutine {
     match terminal_type {
-        // Zellij and muxiavelli-Sixel both go through the Sixel path, which the
-        // remote-proxy cursor-sync logic intentionally bypasses.
+        // Zellij and muxiavelli-Sixel both go through the Sixel path.
         TerminalType::Zellij | TerminalType::Muxiavelli(MuxiavelliImageProtocol::Sixel) => {
             DisplayRoutine::Sixel
         }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1580,7 +1580,6 @@ fn display_image(
 
     validate_terminal_for_graphics(&terminal_caps, &transport, "Image")?;
 
-    let under_remote_proxy = transport == RemoteTransport::EternalTerminal;
     // Always use character-based sizing (fit mode), but respect user-specified dimensions if provided
     let (target_width, target_height) = if args.width.is_some() || args.height.is_some() {
         // Use user-specified dimensions but still use character-based sizing
@@ -1634,9 +1633,10 @@ fn display_image(
     // types so a new variant can never silently fall through to the wrong
     // protocol. Use already-detected terminal_caps to avoid redundant env lookups.
     //
-    // The Sixel routine (Zellij and muxiavelli-Sixel) does not need proxy
-    // cursor-sync: those renderers manage their own cursor tracking, so the
-    // image protocol never reaches the remote transport's virtual terminal.
+    // No routine needs a special path for a remote proxy. Every routine holds
+    // the renderer still and then states the position of the cursor itself, so
+    // a remote proxy tracks the cursor with the same newlines, CUU and CUD that
+    // a local terminal does.
     match display_routine_for(&terminal_caps.terminal_type) {
         DisplayRoutine::Sixel => {
             display_image_sixel(&img, scaled_width, scaled_height, args, no_newline)
@@ -1644,14 +1644,9 @@ fn display_image(
         DisplayRoutine::Kitty => {
             display_image_kitty(&img, scaled_width, scaled_height, args, no_newline)
         }
-        DisplayRoutine::Iterm2 => display_image_iterm2(
-            &img,
-            scaled_width,
-            scaled_height,
-            args,
-            under_remote_proxy,
-            no_newline,
-        ),
+        DisplayRoutine::Iterm2 => {
+            display_image_iterm2(&img, scaled_width, scaled_height, args, no_newline)
+        }
     }
 }
 
@@ -2139,7 +2134,6 @@ fn display_image_iterm2(
     width: Option<u32>,
     height: Option<u32>,
     args: &Args,
-    under_remote_proxy: bool,
     no_newline: bool,
 ) -> Result<()> {
     // Calculate aspect-corrected display dimensions in terminal cells, then use them
@@ -2173,10 +2167,11 @@ fn display_image_iterm2(
 
     print_iterm2_image(
         &encoded,
+        img.width(),
+        img.height(),
         display_width,
         display_height,
         no_newline,
-        under_remote_proxy,
     )
 }
 
@@ -2891,68 +2886,62 @@ fn print_kitty_image(
     Ok(())
 }
 
-/// Optimized iTerm2 image printing with reduced protocol overhead
+/// Write an image with the iTerm2 inline image protocol.
+///
+/// The command is `ESC ] 1337 ; File = <arguments> : <base64 data> BEL`.
+///
+/// The routine holds the cursor still with `doNotMoveCursor=1` and then states
+/// the position of the cursor itself through
+/// [`write_image_with_cursor_contract`].
+///
+/// # Arguments
+/// * `base64_data` - The image, in base64.
+/// * `img_width_px` - The width of the image in pixels.
+/// * `img_height_px` - The height of the image in pixels.
+/// * `width` - The width that `ic` asks for, in character cells.
+/// * `height` - The height that `ic` asks for, in character cells.
+/// * `no_newline` - True when the caller controls the position of the cursor.
+///
+/// # Returns
+/// An error when a write to stdout fails.
 fn print_iterm2_image(
     base64_data: &str,
+    img_width_px: u32,
+    img_height_px: u32,
     width: Option<u32>,
     height: Option<u32>,
     no_newline: bool,
-    under_remote_proxy: bool,
 ) -> Result<()> {
     let mut stdout = io::stdout().lock();
 
-    // Under a remote proxy (e.g. Eternal Terminal), the proxy's virtual terminal
-    // doesn't understand the iTerm2 image protocol, so it can't track cursor
-    // movement caused by image rendering. We synchronize by:
-    //   1. Pre-filling blank lines so the proxy allocates screen space
-    //   2. Moving the cursor back up (both proxy and client process this)
-    //   3. Rendering the image with doNotMoveCursor=1
-    //   4. Moving the cursor back down with CUD (both process this)
-    // This keeps both terminals' cursor positions in sync.
-    // In video mode (no_newline), skip proxy cursor sync — the caller handles
-    // cursor positioning explicitly with \x1b[row;colH and \x1b[J.
-    let proxy_rows = if under_remote_proxy && !no_newline {
-        let rows = height.unwrap_or(1);
-        for _ in 0..rows {
-            writeln!(stdout)?;
-        }
-        write!(stdout, "\x1b[{}A", rows)?;
-        rows
+    let contract = if no_newline {
+        CursorContract::CallerManaged
     } else {
-        0
+        let (cell_width_px, cell_height_px) = get_cell_pixel_dimensions();
+        CursorContract::BelowImage {
+            rows: image_rows_in_cells(
+                img_width_px,
+                img_height_px,
+                width,
+                height,
+                cell_width_px,
+                cell_height_px,
+            ),
+        }
     };
 
-    // iTerm2 inline image protocol
-    // ESC ] 1337 ; File = [arguments] : base64_data BEL
-    write!(stdout, "\x1b]1337;File=inline=1")?;
+    // The width and the height are in character cells, so they carry no `px`
+    // suffix. `doNotMoveCursor=1` tells iTerm2 not to move the cursor, because
+    // this routine states the position of the cursor itself.
+    let width_argument = width.map_or_else(String::new, |w| format!(";width={w}"));
+    let height_argument = height.map_or_else(String::new, |h| format!(";height={h}"));
 
-    // Add width and height in character units (without 'px' suffix)
-    if let Some(w) = width {
-        write!(stdout, ";width={}", w)?;
-    }
-    if let Some(h) = height {
-        write!(stdout, ";height={}", h)?;
-    }
-
-    // Preserve aspect ratio when fitting to terminal
-    write!(stdout, ";preserveAspectRatio=1")?;
-
-    // Don't move cursor after image to prevent scrollback accumulation
-    write!(stdout, ";doNotMoveCursor=1")?;
-
-    write!(stdout, ":{}\x07", base64_data)?;
-
-    if under_remote_proxy && !no_newline {
-        // Move cursor down past the image area using CUD (Cursor Down).
-        // Both the proxy and local terminal process this identically.
-        // NOTE: This intentionally overrides `no_newline`. The proxy's virtual
-        // terminal needs explicit cursor advancement to stay in sync with the
-        // real terminal — without it, subsequent output overwrites the image.
-        write!(stdout, "\x1b[{}B", proxy_rows)?;
-        writeln!(stdout)?;
-    } else if !no_newline {
-        writeln!(stdout)?;
-    }
+    write_image_with_cursor_contract(&mut stdout, contract, |out| {
+        write!(
+            out,
+            "\x1b]1337;File=inline=1{width_argument}{height_argument};preserveAspectRatio=1;doNotMoveCursor=1:{base64_data}\x07"
+        )
+    })?;
 
     stdout.flush().context("Failed to flush output")?;
     Ok(())

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -89,6 +89,10 @@ fn auto_fit_rows(term_height: u32, header: HeaderRows) -> u32 {
         .max(1)
 }
 
+fn header_rows(lines: &[String], _term_width: u32) -> HeaderRows {
+    HeaderRows(u32::try_from(lines.len()).unwrap_or(u32::MAX))
+}
+
 #[derive(Debug, Clone)]
 enum VideoControl {
     Exit,
@@ -4566,5 +4570,85 @@ not_a_number zellij a work
         assert_eq!(auto_fit_rows(2, HeaderRows(1)), 1);
         assert_eq!(auto_fit_rows(1, HeaderRows(2)), 1);
         assert_eq!(auto_fit_rows(0, HeaderRows(0)), 1);
+    }
+
+    // =========================================================================
+    // Tests for header_rows
+    // =========================================================================
+
+    /// The width of the terminal that the header tests use.
+    const TEST_TERMINAL_COLS: u32 = 80;
+
+    /// Make the header lines that `header_rows` takes.
+    fn header_lines(lines: &[&str]) -> Vec<String> {
+        lines.iter().map(|line| (*line).to_string()).collect()
+    }
+
+    #[test]
+    fn header_rows_gives_one_row_for_a_line_that_fits() {
+        // A short file name stays on the row that `ic` prints it on.
+        let lines = header_lines(&["/tmp/cat.png"]);
+        assert_eq!(header_rows(&lines, TEST_TERMINAL_COLS).0, 1);
+    }
+
+    #[test]
+    fn header_rows_keeps_a_full_row_on_one_row() {
+        // A terminal wraps on the column after the last one, so a line of
+        // exactly the width of the terminal still takes one row.
+        let lines = header_lines(&["a".repeat(80).as_str()]);
+        assert_eq!(header_rows(&lines, TEST_TERMINAL_COLS).0, 1);
+    }
+
+    #[test]
+    fn header_rows_counts_the_rows_of_a_wrapped_line() {
+        // A line wider than the terminal wraps, and each wrapped part takes a
+        // row of the screen away from the image.
+        let one_column_over = header_lines(&["a".repeat(81).as_str()]);
+        assert_eq!(header_rows(&one_column_over, TEST_TERMINAL_COLS).0, 2);
+
+        let two_rows_and_one_column = header_lines(&["a".repeat(161).as_str()]);
+        assert_eq!(
+            header_rows(&two_rows_and_one_column, TEST_TERMINAL_COLS).0,
+            3
+        );
+    }
+
+    #[test]
+    fn header_rows_gives_one_row_to_an_empty_line() {
+        // An empty line still moves the cursor down one row.
+        let lines = header_lines(&[""]);
+        assert_eq!(header_rows(&lines, TEST_TERMINAL_COLS).0, 1);
+    }
+
+    #[test]
+    fn header_rows_adds_the_rows_of_every_line() {
+        // The monitor mode prints an empty line and then a line that can wrap.
+        let lines = header_lines(&["", format!("Found new image: {}", "b".repeat(80)).as_str()]);
+        assert_eq!(header_rows(&lines, TEST_TERMINAL_COLS).0, 3);
+    }
+
+    #[test]
+    fn header_rows_counts_display_columns_not_characters() {
+        // A Japanese character takes two columns, and so does an emoji, so 41
+        // of them fill 82 columns and wrap in a terminal of 80 columns.
+        let short = header_lines(&["日本語"]);
+        assert_eq!(header_rows(&short, TEST_TERMINAL_COLS).0, 1);
+
+        let japanese = header_lines(&["日".repeat(41).as_str()]);
+        assert_eq!(header_rows(&japanese, TEST_TERMINAL_COLS).0, 2);
+
+        let full_row_of_emoji = header_lines(&["🎉".repeat(40).as_str()]);
+        assert_eq!(header_rows(&full_row_of_emoji, TEST_TERMINAL_COLS).0, 1);
+
+        let emoji = header_lines(&["🎉".repeat(41).as_str()]);
+        assert_eq!(header_rows(&emoji, TEST_TERMINAL_COLS).0, 2);
+    }
+
+    #[test]
+    fn header_rows_survives_a_terminal_of_no_width() {
+        // A width of zero must not divide by zero. One column per row gives one
+        // row for each column of the line.
+        let lines = header_lines(&["abc"]);
+        assert_eq!(header_rows(&lines, 0).0, 3);
     }
 }

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -45,10 +45,20 @@ const DEFAULT_SIXEL_HEIGHT_PX: u32 = 600;
 
 /// Horizontal margin factor for Sixel output (95% of terminal width).
 /// Leaves some margin to avoid horizontal overflow.
+///
+/// The margin is one of the two bounds on the size of a Sixel image, and it is
+/// not the bound that keeps the image inside the rows that `ic` gives it. See
+/// [`sixel_pixel_budget`], which takes the smaller of the margin and the budget
+/// of the caller in character cells.
 const SIXEL_HORIZONTAL_MARGIN: f64 = 0.95;
 
 /// Vertical margin factor for Sixel output (90% of terminal height).
 /// Leaves more vertical margin as some terminals have status bars or prompts.
+///
+/// The margin knows nothing about the header rows that `ic` prints above the
+/// image, and it is not the bound that keeps the prompt on the screen. See
+/// [`sixel_pixel_budget`], which takes the smaller of the margin and the budget
+/// of the caller in character cells.
 const SIXEL_VERTICAL_MARGIN: f64 = 0.90;
 
 /// Control sequence introducer. It starts a CSI escape sequence.
@@ -1939,11 +1949,20 @@ fn calculate_sixel_dimensions(
 
 /// Give the size in pixels that a Sixel image can occupy.
 ///
-/// The budget comes from the first source that has an answer. The terminal
-/// reports its size in pixels, and a margin of that size keeps the image off
-/// the edge of the screen. If the terminal reports no pixel size, the budget in
-/// character cells that the caller gives becomes the answer. If the caller
-/// gives no budget, a default size becomes the answer.
+/// Two bounds hold the image, and the image must obey both. The margin bounds
+/// the image by the pixel size that the terminal reports, which keeps the image
+/// off the edge of the screen. The budget of the caller bounds the image by a
+/// count of character cells, which is the size of the terminal less the header
+/// rows and the prompt row, or the `--width` and the `--height` that the user
+/// asks for. The smaller of the two wins on each axis, so the header, the image
+/// and the prompt all fit inside the terminal.
+///
+/// The two bounds come from different sources, and each one can be absent. A
+/// terminal in Zellij or in ttyd reports no pixel size, and the budget of the
+/// caller is then the only bound. An axis of the budget is absent when the user
+/// gives only one of `--width` and `--height`, and the margin is then the only
+/// bound on that axis. With no pixel size and only one axis of the budget there
+/// is nothing to compute a size from, so a default size becomes the answer.
 ///
 /// # Arguments
 /// * `terminal_pixel_size` - The width and the height of the terminal in
@@ -1954,7 +1973,8 @@ fn calculate_sixel_dimensions(
 /// * `cell_height_px` - The height of one character cell in pixels.
 ///
 /// # Returns
-/// The width and the height of the budget in pixels.
+/// The width and the height of the budget in pixels. Each axis is 1 or more, so
+/// a degenerate terminal cannot ask the encoder for an image of no size.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
@@ -1967,19 +1987,27 @@ fn sixel_pixel_budget(
     cell_width_px: u32,
     cell_height_px: u32,
 ) -> (u32, u32) {
-    if let Some((px_w, px_h)) = terminal_pixel_size {
-        // Leave some margin to avoid overflow
+    // A count of cells that is absurdly large overflows the product. The
+    // product saturates instead, and a saturated product bounds nothing.
+    let cell_budget_px =
+        |cells: Option<u32>, cell_px: u32| cells.map(|count| count.saturating_mul(cell_px));
+    let cols_px = cell_budget_px(cell_cols, cell_width_px);
+    let rows_px = cell_budget_px(cell_rows, cell_height_px);
+
+    let (width_px, height_px) = if let Some((px_w, px_h)) = terminal_pixel_size {
+        let margin_width_px = (f64::from(px_w) * SIXEL_HORIZONTAL_MARGIN) as u32;
+        let margin_height_px = (f64::from(px_h) * SIXEL_VERTICAL_MARGIN) as u32;
         (
-            (f64::from(px_w) * SIXEL_HORIZONTAL_MARGIN) as u32,
-            (f64::from(px_h) * SIXEL_VERTICAL_MARGIN) as u32,
+            cols_px.map_or(margin_width_px, |budget| margin_width_px.min(budget)),
+            rows_px.map_or(margin_height_px, |budget| margin_height_px.min(budget)),
         )
-    } else if let (Some(cols), Some(rows)) = (cell_cols, cell_rows) {
-        // Fall back to the budget of the caller in character cells
-        (cols * cell_width_px, rows * cell_height_px)
+    } else if let (Some(width_px), Some(height_px)) = (cols_px, rows_px) {
+        (width_px, height_px)
     } else {
-        // Default to reasonable size when no size info available
         (DEFAULT_SIXEL_WIDTH_PX, DEFAULT_SIXEL_HEIGHT_PX)
-    }
+    };
+
+    (width_px.max(1), height_px.max(1))
 }
 
 /// Calculate the number of terminal rows that an image fills.
@@ -2190,13 +2218,18 @@ where
 ///
 /// # Arguments
 /// * `img` - The image to display
-/// * `fallback_cols` - Fallback terminal width in character cells (used if pixel size unavailable)
-/// * `fallback_rows` - Fallback terminal height in character cells (used if pixel size unavailable)
+/// * `budget_cols` - The width that the image can occupy, in character cells.
+///   It is the width of the terminal less the chrome, or the `--width` that the
+///   user asks for. [`sixel_pixel_budget`] holds the image inside it.
+/// * `budget_rows` - The height that the image can occupy, in character cells.
+///   It is the height of the terminal less the header rows and the prompt row,
+///   or the `--height` that the user asks for. [`sixel_pixel_budget`] holds the
+///   image inside it.
 /// * `args` - Command line arguments
 fn display_image_sixel(
     img: &DynamicImage,
-    fallback_cols: Option<u32>,
-    fallback_rows: Option<u32>,
+    budget_cols: Option<u32>,
+    budget_rows: Option<u32>,
     args: &Args,
     no_newline: bool,
 ) -> Result<()> {
@@ -2206,8 +2239,8 @@ fn display_image_sixel(
 
     let (target_pixel_width, target_pixel_height) = sixel_pixel_budget(
         get_terminal_pixel_size(),
-        fallback_cols,
-        fallback_rows,
+        budget_cols,
+        budget_rows,
         cell_width_px,
         cell_height_px,
     );

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -53,6 +53,12 @@ const SIXEL_VERTICAL_MARGIN: f64 = 0.90;
 /// Control sequence introducer. It starts a CSI escape sequence.
 const CSI: &str = "\x1b[";
 
+/// DECSC. It saves the position of the cursor.
+const SAVE_CURSOR: &str = "\x1b7";
+
+/// DECRC. It restores the saved position of the cursor.
+const RESTORE_CURSOR: &str = "\x1b8";
+
 #[derive(Debug, Clone)]
 enum VideoControl {
     Exit,
@@ -1909,15 +1915,24 @@ fn display_image_sixel(
 
     // Output the sixel data
     let mut stdout = io::stdout().lock();
-    write!(stdout, "{}", sixel_output)?;
 
-    if !no_newline {
+    if no_newline {
+        // Video playback puts the cursor where it wants it, so write only the
+        // payload.
+        write!(stdout, "{}", sixel_output)?;
+    } else {
         // Sixel gives no contract for the position of the cursor after the
         // string terminator, so state the position instead of a guess of one
-        // newline. CUD moves the cursor down by the row count of the image and
-        // the carriage return puts it at column 1.
+        // newline.
         let (_, cell_height_px) = get_cell_pixel_dimensions();
         let rows = image_rows(resized_img.height(), cell_height_px);
+
+        // DECSC and DECRC bracket the payload, so cursor motion inside it
+        // cannot change the final position.
+        write!(stdout, "{SAVE_CURSOR}{}{RESTORE_CURSOR}", sixel_output)?;
+
+        // CUD moves the cursor down by the row count of the image and the
+        // carriage return puts it at column 1.
         write!(stdout, "{CSI}{rows}B\r")?;
     }
 

--- a/src/ic/src/main.rs
+++ b/src/ic/src/main.rs
@@ -1499,12 +1499,20 @@ fn draw_progress_bar(
     Ok(())
 }
 
+/// The width of the terminal that `ic` assumes when it cannot read the real
+/// width.
+const FALLBACK_TERMINAL_COLS: u32 = 80;
+
+/// The height of the terminal that `ic` assumes when it cannot read the real
+/// height.
+const FALLBACK_TERMINAL_ROWS: u32 = 24;
+
 fn get_terminal_size() -> Result<(u32, u32)> {
     if let Some((Width(w), Height(h))) = terminal_size() {
         Ok((w as u32, h as u32))
     } else {
         // Fallback to common terminal size if detection fails
-        Ok((80, 24))
+        Ok((FALLBACK_TERMINAL_COLS, FALLBACK_TERMINAL_ROWS))
     }
 }
 
@@ -1716,7 +1724,8 @@ fn calculate_aspect_preserving_size(
 /// estimated constants if the ioctl fails or the terminal reports zero dimensions.
 fn get_cell_pixel_dimensions() -> (u32, u32) {
     if let Some((total_px_w, total_px_h)) = get_terminal_pixel_size() {
-        let (term_cols, term_rows) = get_terminal_size().unwrap_or((80, 24));
+        let (term_cols, term_rows) =
+            get_terminal_size().unwrap_or((FALLBACK_TERMINAL_COLS, FALLBACK_TERMINAL_ROWS));
         if term_cols > 0 && term_rows > 0 {
             return (total_px_w / term_cols, total_px_h / term_rows);
         }
@@ -1966,6 +1975,27 @@ fn image_rows_in_cells(
     }
 }
 
+/// Calculate the number of rows that the cursor contract reserves for an image.
+///
+/// The reservation is one newline for each row of the image, but the height of
+/// the terminal bounds it. An image taller than the screen has no row below it,
+/// and CUU and CUD both stop at the edge of the screen, so no reservation can
+/// put the cursor below such an image. A reservation larger than the screen only
+/// scrolls the content of the user out of view and gives nothing back for it.
+/// The bound therefore holds the scroll to one screen.
+///
+/// # Arguments
+/// * `image_rows` - The height of the image in terminal rows.
+/// * `term_height` - The height of the terminal in rows.
+///
+/// # Returns
+/// The number of rows to reserve. The result leaves one row for the cursor to
+/// land on, and it is always 1 or more, so the contract never asks the terminal
+/// for a movement of zero rows, which a terminal reads as one row.
+fn reservation_rows(image_rows: u32, term_height: u32) -> u32 {
+    image_rows.min(term_height.saturating_sub(1)).max(1)
+}
+
 /// Where a display routine must leave the cursor after it writes an image.
 ///
 /// Sixel gives no contract for the position of the cursor after the string
@@ -1979,9 +2009,42 @@ enum CursorContract {
     CallerManaged,
     /// Column 1 of the first row below the image.
     BelowImage {
-        /// The height of the image in terminal rows.
+        /// The number of rows that the contract reserves, which is the height
+        /// of the image in terminal rows bounded by the height of the terminal.
+        /// [`reservation_rows`] gives the value.
         rows: u32,
     },
+}
+
+impl CursorContract {
+    /// Give the contract for one image of a display routine.
+    ///
+    /// This is the one place that reads the height of the terminal and bounds
+    /// the reservation with [`reservation_rows`], so no display routine can
+    /// reserve more rows than the terminal has.
+    ///
+    /// The row count of the image arrives as a closure, because the caller must
+    /// read the size of a character cell from the terminal to compute it. Video
+    /// playback asks for [`CursorContract::CallerManaged`] one time for each
+    /// frame, and the closure keeps that path clear of the terminal.
+    ///
+    /// # Arguments
+    /// * `no_newline` - True when the caller puts the cursor where it wants it.
+    /// * `image_rows` - Gives the height of the image in terminal rows.
+    ///
+    /// # Returns
+    /// The promise that the display routine must keep.
+    fn below_image(no_newline: bool, image_rows: impl FnOnce() -> u32) -> Self {
+        if no_newline {
+            return CursorContract::CallerManaged;
+        }
+
+        let term_height = get_terminal_size().map_or(FALLBACK_TERMINAL_ROWS, |(_, rows)| rows);
+
+        CursorContract::BelowImage {
+            rows: reservation_rows(image_rows(), term_height),
+        }
+    }
 }
 
 /// Write an image payload and keep the promise of a [`CursorContract`].
@@ -1993,8 +2056,11 @@ enum CursorContract {
 ///
 /// [`CursorContract::BelowImage`] writes four parts:
 ///
-/// 1. One newline for each row of the image. The reservation makes an image at
-///    the bottom of the screen scroll the terminal instead of run off it.
+/// 1. One newline for each row of the image, bounded by the height of the
+///    terminal. The reservation makes an image at the bottom of the screen
+///    scroll the terminal instead of run off it. An image taller than the
+///    screen cannot have a row below it, so the bound holds the scroll to one
+///    screen. [`CursorContract::below_image`] applies the bound.
 /// 2. CUU, which goes back to the top of the reservation.
 /// 3. DECSC, the payload and DECRC. The brackets make sure that cursor motion
 ///    inside the payload cannot change the final position of the cursor.
@@ -2108,14 +2174,10 @@ fn display_image_sixel(
     // Output the sixel data
     let mut stdout = io::stdout().lock();
 
-    let contract = if no_newline {
-        CursorContract::CallerManaged
-    } else {
+    let contract = CursorContract::below_image(no_newline, || {
         let (_, cell_height_px) = get_cell_pixel_dimensions();
-        CursorContract::BelowImage {
-            rows: image_rows(resized_img.height(), cell_height_px),
-        }
-    };
+        image_rows(resized_img.height(), cell_height_px)
+    });
 
     write_image_with_cursor_contract(&mut stdout, contract, |out| write!(out, "{}", sixel_output))?;
 
@@ -2826,21 +2888,17 @@ fn print_kitty_image(
     let base64_data = BASE64_STANDARD.encode(rgb_data);
     let chunk_size = 4096; // Kitty recommended chunk size
 
-    let contract = if no_newline {
-        CursorContract::CallerManaged
-    } else {
+    let contract = CursorContract::below_image(no_newline, || {
         let (cell_width_px, cell_height_px) = get_cell_pixel_dimensions();
-        CursorContract::BelowImage {
-            rows: image_rows_in_cells(
-                img_width,
-                img_height,
-                display_width,
-                display_height,
-                cell_width_px,
-                cell_height_px,
-            ),
-        }
-    };
+        image_rows_in_cells(
+            img_width,
+            img_height,
+            display_width,
+            display_height,
+            cell_width_px,
+            cell_height_px,
+        )
+    });
 
     // The key list that opens the first command. `C=1` tells Kitty not to move
     // the cursor, because this routine states the position of the cursor
@@ -2913,21 +2971,17 @@ fn print_iterm2_image(
 ) -> Result<()> {
     let mut stdout = io::stdout().lock();
 
-    let contract = if no_newline {
-        CursorContract::CallerManaged
-    } else {
+    let contract = CursorContract::below_image(no_newline, || {
         let (cell_width_px, cell_height_px) = get_cell_pixel_dimensions();
-        CursorContract::BelowImage {
-            rows: image_rows_in_cells(
-                img_width_px,
-                img_height_px,
-                width,
-                height,
-                cell_width_px,
-                cell_height_px,
-            ),
-        }
-    };
+        image_rows_in_cells(
+            img_width_px,
+            img_height_px,
+            width,
+            height,
+            cell_width_px,
+            cell_height_px,
+        )
+    });
 
     // The width and the height are in character cells, so they carry no `px`
     // suffix. `doNotMoveCursor=1` tells iTerm2 not to move the cursor, because
@@ -4452,6 +4506,35 @@ not_a_number zellij a work
             ),
             1
         );
+    }
+
+    // =========================================================================
+    // Tests for reservation_rows
+    // =========================================================================
+
+    #[test]
+    fn reservation_rows_takes_the_whole_image_when_it_fits() {
+        // An image that leaves room for the row below it keeps every row.
+        assert_eq!(reservation_rows(5, 24), 5);
+        assert_eq!(reservation_rows(23, 24), 23);
+    }
+
+    #[test]
+    fn reservation_rows_stops_at_the_height_of_the_terminal() {
+        // An image taller than the screen has no row below it, so the
+        // reservation keeps the scroll to one screen.
+        assert_eq!(reservation_rows(39, 24), 23);
+        assert_eq!(reservation_rows(100, 24), 23);
+        assert_eq!(reservation_rows(24, 24), 23);
+    }
+
+    #[test]
+    fn reservation_rows_never_gives_zero() {
+        // A movement of zero rows means one row to a terminal, so the
+        // reservation must stay at 1 or more, even in a terminal of no height.
+        assert_eq!(reservation_rows(1, 1), 1);
+        assert_eq!(reservation_rows(5, 0), 1);
+        assert_eq!(reservation_rows(0, 24), 1);
     }
 
     // =========================================================================

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -229,3 +229,30 @@ fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
         "DECRC must come immediately after the payload"
     );
 }
+
+/// The stream must reserve the rows of the image before it draws. It asks for
+/// the rows and then takes them back, so an image at the bottom of the screen
+/// scrolls the terminal instead of running off it.
+#[test]
+fn sixel_reserves_the_rows_before_it_draws() {
+    let stdout = run_ic_sixel();
+
+    let save = find(&stdout, SAVE_CURSOR).expect("the stream must save the cursor");
+    let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
+    assert!(
+        save < payload_start,
+        "the reservation must come before the payload"
+    );
+
+    let reservation = &stdout[..save];
+    let movement = scan_cursor_movement(reservation);
+    assert_eq!(
+        movement.down, EXPECTED_ROWS,
+        "the reservation must ask for {EXPECTED_ROWS} rows before the payload"
+    );
+    assert_eq!(
+        movement.net(),
+        0,
+        "the reservation must take the rows back, so the image starts at the top of them"
+    );
+}

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -6,6 +6,11 @@
 //! caller must move it. `ic` must therefore state where the cursor ends, in
 //! every routine, instead of a guess of one newline.
 //!
+//! Each routine reserves one row for each row of the image before it draws, and
+//! the height of the terminal bounds that reservation. An image taller than the
+//! screen cannot have a row below it, so the bound holds the scroll to one
+//! screen.
+//!
 //! These tests drive the real binary and look at the bytes it writes. They
 //! measure the cursor movement that the stream *requests*, not the exact escape
 //! sequences, so a change of spelling keeps them alive.
@@ -279,7 +284,9 @@ fn rfind(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 ///
 /// 1. The stream reserves the rows of the image before the payload and then
 ///    takes them back, so an image at the bottom of the screen scrolls the
-///    terminal instead of running off it.
+///    terminal instead of running off it. The height of the terminal bounds the
+///    reservation, and the image of these tests is much shorter than that, so
+///    the reservation here is the full height of the image.
 /// 2. DECSC comes immediately before the payload and DECRC immediately after
 ///    it, so cursor motion inside the payload cannot change the final position
 ///    of the cursor.

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -23,8 +23,17 @@ const CURSOR_UP_FINAL: u8 = b'A';
 /// The final byte of a CUD (cursor down) sequence.
 const CURSOR_DOWN_FINAL: u8 = b'B';
 
+/// The device control string introducer that opens the Sixel payload.
+const SIXEL_START: &[u8] = b"\x1bP";
+
 /// The string terminator that closes the Sixel payload.
 const STRING_TERMINATOR: &[u8] = b"\x1b\\";
+
+/// DECSC. It saves the position of the cursor.
+const SAVE_CURSOR: &[u8] = b"\x1b7";
+
+/// DECRC. It restores the saved position of the cursor.
+const RESTORE_CURSOR: &[u8] = b"\x1b8";
 
 /// The image that the tests send to `ic` on stdin.
 const TEST_IMAGE: &[u8] = include_bytes!(concat!(
@@ -185,5 +194,38 @@ fn sixel_advances_the_cursor_below_the_image() {
     assert!(
         tail.ends_with(b"\r") || tail.ends_with(b"\n"),
         "the stream must end the line, to put the cursor at column 1"
+    );
+}
+
+/// DECSC must come immediately before the payload and DECRC immediately after
+/// it. The brackets make sure that cursor motion inside the payload cannot
+/// change the final position of the cursor.
+#[test]
+fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
+    let stdout = run_ic_sixel();
+
+    let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
+    let terminator = find(&stdout, STRING_TERMINATOR)
+        .expect("the output must hold a Sixel string terminator");
+
+    assert!(
+        payload_start >= SAVE_CURSOR.len(),
+        "the stream must save the cursor before the payload"
+    );
+    assert_eq!(
+        &stdout[payload_start - SAVE_CURSOR.len()..payload_start],
+        SAVE_CURSOR,
+        "DECSC must come immediately before the payload"
+    );
+
+    let payload_end = terminator + STRING_TERMINATOR.len();
+    assert!(
+        stdout.len() >= payload_end + RESTORE_CURSOR.len(),
+        "the stream must restore the cursor after the payload"
+    );
+    assert_eq!(
+        &stdout[payload_end..payload_end + RESTORE_CURSOR.len()],
+        RESTORE_CURSOR,
+        "DECRC must come immediately after the payload"
     );
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -36,10 +36,8 @@ const SAVE_CURSOR: &[u8] = b"\x1b7";
 const RESTORE_CURSOR: &[u8] = b"\x1b8";
 
 /// The image that the tests send to `ic` on stdin.
-const TEST_IMAGE: &[u8] = include_bytes!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/tests/test_image.png"
-));
+const TEST_IMAGE: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_image.png"));
 
 /// The search path for the child process. `ic` starts `ps` to look at the
 /// process tree, so the child needs a path.
@@ -182,8 +180,8 @@ fn run_ic_sixel() -> Vec<u8> {
 fn sixel_advances_the_cursor_below_the_image() {
     let stdout = run_ic_sixel();
 
-    let terminator = find(&stdout, STRING_TERMINATOR)
-        .expect("the output must hold a Sixel string terminator");
+    let terminator =
+        find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
     let tail = &stdout[terminator + STRING_TERMINATOR.len()..];
 
     assert_eq!(
@@ -205,8 +203,8 @@ fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
     let stdout = run_ic_sixel();
 
     let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
-    let terminator = find(&stdout, STRING_TERMINATOR)
-        .expect("the output must hold a Sixel string terminator");
+    let terminator =
+        find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
 
     assert!(
         payload_start >= SAVE_CURSOR.len(),

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -336,6 +336,36 @@ fn assert_cursor_contract(routine: Routine, stdout: &[u8]) {
     );
 }
 
+/// Check that a byte stream asks for no cursor movement at all.
+///
+/// `--no-newline` must suppress the whole cursor contract, because video
+/// playback puts the cursor where it wants it before every frame. A stream that
+/// moves the cursor on its own scrolls the terminal once per frame.
+///
+/// # Arguments
+/// * `routine` - The display routine that wrote the stream.
+/// * `stdout` - The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the stream asks the terminal to move the cursor.
+fn assert_no_cursor_contract(routine: Routine, stdout: &[u8]) {
+    let payload_end = rfind(stdout, routine.payload_end())
+        .unwrap_or_else(|| panic!("the output of {routine:?} must close its image payload"))
+        + routine.payload_end().len();
+    let after_payload = scan_cursor_movement(&stdout[payload_end..]);
+
+    assert_eq!(
+        (after_payload.down, after_payload.up),
+        (0, 0),
+        "--no-newline must write no cursor movement after the payload"
+    );
+    assert_eq!(
+        scan_cursor_movement(stdout).net(),
+        0,
+        "--no-newline must leave the cursor where the caller put it"
+    );
+}
+
 /// Give the key list of the first Kitty graphics command in a byte stream.
 ///
 /// A Kitty graphics command is `ESC _ G <key list> ; <payload> ESC \`. The key
@@ -624,4 +654,25 @@ fn kitty_holds_the_cursor_still_while_it_draws() {
 #[test]
 fn iterm2_meets_the_cursor_contract() {
     assert_cursor_contract(Routine::Iterm2, &run_ic(Routine::Iterm2, &[]));
+}
+
+/// `--no-newline` must suppress the whole cursor contract of the Kitty routine,
+/// the same way it does for the Sixel routine.
+///
+/// The behavior already held when this test arrived, so a mutation proved that
+/// the test can fail: with the trailing advance moved out of the `no_newline`
+/// gate of `write_image_with_cursor_contract`, the tail asks for 5 rows and the
+/// whole stream nets 5 rows, and both assertions report the failure.
+#[test]
+fn no_newline_suppresses_the_cursor_contract_for_kitty() {
+    assert_no_cursor_contract(Routine::Kitty, &run_ic(Routine::Kitty, &["--no-newline"]));
+}
+
+/// `--no-newline` must suppress the whole cursor contract of the iTerm2
+/// routine, the same way it does for the Sixel routine. The same mutation as
+/// [`no_newline_suppresses_the_cursor_contract_for_kitty`] proved that this
+/// test can fail.
+#[test]
+fn no_newline_suppresses_the_cursor_contract_for_iterm2() {
+    assert_no_cursor_contract(Routine::Iterm2, &run_ic(Routine::Iterm2, &["--no-newline"]));
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -71,6 +71,15 @@ const TERMINAL_ROWS: i64 = 24;
 /// The row that the shell prompt returns to below the image.
 const PROMPT_ROWS: i64 = 1;
 
+/// The largest reservation that fits inside the terminal of the tests.
+///
+/// The cursor lands on the first row below the image, so the reservation must
+/// leave that row inside the screen.
+const MAX_RESERVATION_ROWS: i64 = TERMINAL_ROWS - 1;
+
+/// A command line that asks for an image taller than the terminal of the tests.
+const OVERSIZED_ARGS: &[&str] = &["--stdin", "--width", "78", "--height", "50"];
+
 /// The terminal type of a child process that must not look like Kitty.
 const TERM_XTERM_256COLOR: &str = "xterm-256color";
 
@@ -461,7 +470,24 @@ fn run_ic(routine: Routine, extra_args: &[&str]) -> Vec<u8> {
     let mut args: Vec<&str> = vec!["--stdin", "--width", "10", "--height", "5"];
     args.extend_from_slice(extra_args);
 
-    let mut child = ic_command(routine, &args)
+    run_ic_with_args(routine, &args)
+}
+
+/// Run `ic` through one display routine, with the image on stdin and a full
+/// command line, and give back its stdout.
+///
+/// # Arguments
+/// * `routine` - The display routine that `ic` must use.
+/// * `args` - The full command line for `ic`.
+///
+/// # Returns
+/// The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the child process does not start, does not accept the image, or
+/// exits with a failure.
+fn run_ic_with_args(routine: Routine, args: &[&str]) -> Vec<u8> {
+    let mut child = ic_command(routine, args)
         .spawn()
         .expect("failed to start ic");
 
@@ -675,4 +701,29 @@ fn no_newline_suppresses_the_cursor_contract_for_kitty() {
 #[test]
 fn no_newline_suppresses_the_cursor_contract_for_iterm2() {
     assert_no_cursor_contract(Routine::Iterm2, &run_ic(Routine::Iterm2, &["--no-newline"]));
+}
+
+/// No routine can ask the terminal to move down more rows than the terminal
+/// has.
+///
+/// An image taller than the screen has no row below it, so no reservation can
+/// keep the contract: CUU stops at the top row and CUD stops at the bottom row,
+/// and the cursor lands on top of the image. A reservation larger than the
+/// screen scrolls the content of the user out of view and gives nothing back
+/// for it. Every routine must therefore bound the scroll to one screen.
+#[test]
+fn the_reservation_never_exceeds_the_height_of_the_terminal() {
+    for routine in [Routine::Sixel, Routine::Kitty, Routine::Iterm2] {
+        let stdout = run_ic_with_args(routine, OVERSIZED_ARGS);
+
+        let save = find(&stdout, SAVE_CURSOR)
+            .unwrap_or_else(|| panic!("{routine:?} must save the cursor before the payload"));
+        let reservation = scan_cursor_movement(&stdout[..save]);
+
+        assert!(
+            reservation.down <= MAX_RESERVATION_ROWS,
+            "{routine:?} reserves {} rows, but the terminal has {TERMINAL_ROWS} rows, so the reservation must ask for {MAX_RESERVATION_ROWS} rows at most",
+            reservation.down
+        );
+    }
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -41,6 +41,22 @@ const RESTORE_CURSOR: &[u8] = b"\x1b8";
 const TEST_IMAGE: &[u8] =
     include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_image.png"));
 
+/// The path of the image that the tests give to `ic` as an argument.
+///
+/// The file is in the repository and no test writes to it, so two concurrent
+/// runs of this file cannot disturb each other.
+const TEST_IMAGE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_image.png");
+
+/// The number of rows of the terminal that `ic` sees in these tests.
+///
+/// `get_terminal_size` falls back to 80 columns by 24 rows when it cannot read
+/// the size of the terminal. The tests give `ic` a pipe for stdout, so `ic`
+/// always uses this fallback.
+const TERMINAL_ROWS: i64 = 24;
+
+/// The row that the shell prompt returns to below the image.
+const PROMPT_ROWS: i64 = 1;
+
 /// The terminal type for the child process.
 const TEST_TERM: &str = "xterm-256color";
 
@@ -149,23 +165,21 @@ fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// Run `ic` through the Sixel display routine and give back its stdout.
+/// Make a command that runs `ic` through the Sixel display routine.
 ///
 /// `MUXIAVELLI` selects the Sixel routine. `ZELLIJ` selects the same routine
 /// but it also turns on a process tree heuristic that reads the real process
 /// list of the host, which makes the result depend on the machine.
 ///
 /// # Arguments
-/// * `extra_args` - More command line arguments for `ic`, after the arguments
-///   that fix the size of the image.
+/// * `args` - The full command line for `ic`.
 ///
-/// # Panics
-/// Panics when the child process does not start, does not accept the image, or
-/// exits with a failure.
-fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_ic"))
-        .args(["--stdin", "--width", "10", "--height", "5"])
-        .args(extra_args)
+/// # Returns
+/// A command with the environment and the pipes of the tests already set.
+fn ic_sixel_command(args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ic"));
+    command
+        .args(args)
         .env_clear()
         .env("PATH", unreachable_path_dir())
         .env("TERM", TEST_TERM)
@@ -173,16 +187,21 @@ fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
         .env("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to start ic");
+        .stderr(Stdio::piped());
+    command
+}
 
-    let mut stdin = child.stdin.take().expect("ic has no stdin pipe");
-    stdin
-        .write_all(TEST_IMAGE)
-        .expect("failed to send the image to ic");
-    drop(stdin);
-
+/// Wait for `ic` to exit and give back its stdout.
+///
+/// # Arguments
+/// * `child` - The child process to wait for.
+///
+/// # Returns
+/// The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the wait fails or when `ic` exits with a failure.
+fn wait_for_stdout(child: process::Child) -> Vec<u8> {
     let output = child.wait_with_output().expect("failed to wait for ic");
     assert!(
         output.status.success(),
@@ -192,6 +211,54 @@ fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
     );
 
     output.stdout
+}
+
+/// Run `ic` through the Sixel display routine, with the image on stdin, and
+/// give back its stdout.
+///
+/// # Arguments
+/// * `extra_args` - More command line arguments for `ic`, after the arguments
+///   that fix the size of the image.
+///
+/// # Returns
+/// The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the child process does not start, does not accept the image, or
+/// exits with a failure.
+fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
+    let mut args: Vec<&str> = vec!["--stdin", "--width", "10", "--height", "5"];
+    args.extend_from_slice(extra_args);
+
+    let mut child = ic_sixel_command(&args).spawn().expect("failed to start ic");
+
+    let mut stdin = child.stdin.take().expect("ic has no stdin pipe");
+    stdin
+        .write_all(TEST_IMAGE)
+        .expect("failed to send the image to ic");
+    drop(stdin);
+
+    wait_for_stdout(child)
+}
+
+/// Run `ic` on an image file through the Sixel display routine, with no size
+/// arguments, and give back its stdout. The missing size arguments select the
+/// auto-fit path.
+///
+/// # Arguments
+/// * `path` - The path of the image file.
+///
+/// # Returns
+/// The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the child process does not start or exits with a failure.
+fn run_ic_sixel_auto_fit(path: &str) -> Vec<u8> {
+    let child = ic_sixel_command(&[path])
+        .spawn()
+        .expect("failed to start ic");
+
+    wait_for_stdout(child)
 }
 
 /// The bytes after the Sixel string terminator must move the cursor down by the
@@ -302,5 +369,23 @@ fn sixel_reserves_the_rows_before_it_draws() {
         movement.net(),
         0,
         "the reservation must take the rows back, so the image starts at the top of them"
+    );
+}
+
+/// The file name row, the image and the prompt must fit inside the height of
+/// the terminal. `ic` prints the file name above the image, so the auto-fit
+/// path must pay for that row.
+///
+/// The net movement of the whole stream is the number of rows that the terminal
+/// advances: the header rows plus the image rows, because the reservation and
+/// the cursor-up cancel. The prompt then takes one more row.
+#[test]
+fn auto_fit_leaves_room_for_the_file_name_and_the_prompt() {
+    let stdout = run_ic_sixel_auto_fit(TEST_IMAGE_PATH);
+
+    let rows = scan_cursor_movement(&stdout).net();
+    assert!(
+        rows + PROMPT_ROWS <= TERMINAL_ROWS,
+        "the file name row and the image take {rows} rows, and the prompt takes {PROMPT_ROWS} more, which is more than the {TERMINAL_ROWS} rows of the terminal"
     );
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -1,0 +1,189 @@
+//! Cursor contract tests for the Sixel display routine of `ic`.
+//!
+//! Sixel gives no contract for the position of the cursor after the string
+//! terminator. Each renderer makes its own decision. `ic` must therefore state
+//! where the cursor ends, instead of a guess of one newline.
+//!
+//! These tests drive the real binary and look at the bytes it writes. They
+//! measure the cursor movement that the stream *requests*, not the exact escape
+//! sequences, so a change of spelling keeps them alive.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// The escape byte that starts every escape sequence.
+const ESC: u8 = 0x1b;
+
+/// The second byte of a control sequence introducer.
+const CSI_BRACKET: u8 = b'[';
+
+/// The final byte of a CUU (cursor up) sequence.
+const CURSOR_UP_FINAL: u8 = b'A';
+
+/// The final byte of a CUD (cursor down) sequence.
+const CURSOR_DOWN_FINAL: u8 = b'B';
+
+/// The string terminator that closes the Sixel payload.
+const STRING_TERMINATOR: &[u8] = b"\x1b\\";
+
+/// The image that the tests send to `ic` on stdin.
+const TEST_IMAGE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/test_image.png"
+));
+
+/// The search path for the child process. `ic` starts `ps` to look at the
+/// process tree, so the child needs a path.
+const TEST_PATH: &str = "/usr/bin:/bin:/usr/sbin";
+
+/// The terminal type for the child process.
+const TEST_TERM: &str = "xterm-256color";
+
+/// The number of terminal rows that the test image occupies.
+///
+/// The test invocation makes a Sixel image of 100 pixels by 100 pixels. One
+/// character cell is 20 pixels high, so the image fills 5 rows.
+const EXPECTED_ROWS: i64 = 5;
+
+/// The cursor movement that a byte stream requests, in rows.
+struct CursorMovement {
+    /// The total number of rows of downward movement.
+    down: i64,
+    /// The total number of rows of upward movement.
+    up: i64,
+}
+
+impl CursorMovement {
+    /// Give the net movement in rows. A positive result is downward.
+    fn net(&self) -> i64 {
+        self.down - self.up
+    }
+}
+
+/// Scan a byte slice and measure the cursor movement that it requests.
+///
+/// A newline moves the cursor down one row. A CUD sequence (`ESC [ n B`) moves
+/// the cursor down `n` rows and a CUU sequence (`ESC [ n A`) moves it up `n`
+/// rows. A missing or zero parameter means one row, which is what a terminal
+/// does. The scan ignores all other bytes.
+///
+/// # Arguments
+/// * `bytes` - The byte stream to scan.
+///
+/// # Returns
+/// The total downward and upward movement in rows.
+fn scan_cursor_movement(bytes: &[u8]) -> CursorMovement {
+    let mut movement = CursorMovement { down: 0, up: 0 };
+    let mut index = 0_usize;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\n' {
+            movement.down += 1;
+            index += 1;
+            continue;
+        }
+
+        if bytes[index] != ESC || bytes.get(index + 1) != Some(&CSI_BRACKET) {
+            index += 1;
+            continue;
+        }
+
+        let mut end = index + 2;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+
+        let parameter: i64 = std::str::from_utf8(&bytes[index + 2..end])
+            .ok()
+            .and_then(|digits| digits.parse().ok())
+            .unwrap_or(0);
+        // A missing or zero parameter means one row.
+        let rows = if parameter == 0 { 1 } else { parameter };
+
+        match bytes.get(end) {
+            Some(&CURSOR_DOWN_FINAL) => movement.down += rows,
+            Some(&CURSOR_UP_FINAL) => movement.up += rows,
+            _ => {}
+        }
+
+        index = end.saturating_add(1).min(bytes.len());
+    }
+
+    movement
+}
+
+/// Find the first position of a byte pattern in a byte slice.
+///
+/// # Arguments
+/// * `haystack` - The byte slice to search.
+/// * `needle` - The byte pattern to look for.
+///
+/// # Returns
+/// The index of the first byte of the match, or `None` when there is no match.
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Run `ic` through the Sixel display routine and give back its stdout.
+///
+/// `MUXIAVELLI` selects the Sixel routine. `ZELLIJ` selects the same routine
+/// but it also turns on a process tree heuristic that reads the real process
+/// list of the host, which makes the result depend on the machine.
+///
+/// # Panics
+/// Panics when the child process does not start, does not accept the image, or
+/// exits with a failure.
+fn run_ic_sixel() -> Vec<u8> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_ic"))
+        .args(["--stdin", "--width", "10", "--height", "5"])
+        .env_clear()
+        .env("PATH", TEST_PATH)
+        .env("TERM", TEST_TERM)
+        .env("MUXIAVELLI", "1")
+        .env("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to start ic");
+
+    let mut stdin = child.stdin.take().expect("ic has no stdin pipe");
+    stdin
+        .write_all(TEST_IMAGE)
+        .expect("failed to send the image to ic");
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("failed to wait for ic");
+    assert!(
+        output.status.success(),
+        "ic exited with {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    output.stdout
+}
+
+/// The bytes after the Sixel string terminator must move the cursor down by the
+/// row count of the image, and must put it at column 1. This implementation
+/// ends the line with a carriage return.
+#[test]
+fn sixel_advances_the_cursor_below_the_image() {
+    let stdout = run_ic_sixel();
+
+    let terminator = find(&stdout, STRING_TERMINATOR)
+        .expect("the output must hold a Sixel string terminator");
+    let tail = &stdout[terminator + STRING_TERMINATOR.len()..];
+
+    assert_eq!(
+        scan_cursor_movement(tail).net(),
+        EXPECTED_ROWS,
+        "the bytes after the payload must move the cursor down {EXPECTED_ROWS} rows"
+    );
+    assert!(
+        tail.ends_with(b"\r") || tail.ends_with(b"\n"),
+        "the stream must end the line, to put the cursor at column 1"
+    );
+}

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -33,6 +33,12 @@ const SIXEL_START: &[u8] = b"\x1bP";
 /// The application program command that opens a Kitty graphics command.
 const KITTY_START: &[u8] = b"\x1b_G";
 
+/// The operating system command that opens an iTerm2 inline image.
+const ITERM2_START: &[u8] = b"\x1b]1337;";
+
+/// The bell that closes an iTerm2 inline image.
+const ITERM2_END: &[u8] = b"\x07";
+
 /// The Kitty graphics key that tells the renderer not to move the cursor.
 const KITTY_NO_CURSOR_MOVE: &str = "C=1";
 
@@ -81,6 +87,8 @@ enum Routine {
     Sixel,
     /// The Kitty graphics routine, which Kitty, WezTerm and Ghostty use.
     Kitty,
+    /// The iTerm2 inline image routine.
+    Iterm2,
 }
 
 impl Routine {
@@ -104,6 +112,7 @@ impl Routine {
                 ("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel"),
             ],
             Routine::Kitty => vec![("TERM", TERM_XTERM_KITTY), ("KITTY_WINDOW_ID", "1")],
+            Routine::Iterm2 => vec![("TERM", TERM_XTERM_256COLOR), ("TERM_PROGRAM", "iTerm.app")],
         }
     }
 
@@ -115,6 +124,7 @@ impl Routine {
         match self {
             Routine::Sixel => SIXEL_START,
             Routine::Kitty => KITTY_START,
+            Routine::Iterm2 => ITERM2_START,
         }
     }
 
@@ -127,6 +137,7 @@ impl Routine {
     fn payload_end(self) -> &'static [u8] {
         match self {
             Routine::Sixel | Routine::Kitty => STRING_TERMINATOR,
+            Routine::Iterm2 => ITERM2_END,
         }
     }
 }
@@ -605,4 +616,12 @@ fn kitty_holds_the_cursor_still_while_it_draws() {
         keys.iter().any(|key| key == KITTY_NO_CURSOR_MOVE),
         "the Kitty key list must carry {KITTY_NO_CURSOR_MOVE}, but it is {keys:?}"
     );
+}
+
+/// The iTerm2 stream must keep the same cursor contract as the other two
+/// routines. It already tells the renderer not to move the cursor with
+/// `doNotMoveCursor=1`, so it owes the caller the movement itself.
+#[test]
+fn iterm2_meets_the_cursor_contract() {
+    assert_cursor_contract(Routine::Iterm2, &run_ic(Routine::Iterm2, &[]));
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -1,8 +1,10 @@
-//! Cursor contract tests for the Sixel display routine of `ic`.
+//! Cursor contract tests for the display routines of `ic`.
 //!
 //! Sixel gives no contract for the position of the cursor after the string
-//! terminator. Each renderer makes its own decision. `ic` must therefore state
-//! where the cursor ends, instead of a guess of one newline.
+//! terminator. Each renderer makes its own decision. The Kitty protocol and the
+//! iTerm2 protocol both have a flag that holds the cursor still, but then the
+//! caller must move it. `ic` must therefore state where the cursor ends, in
+//! every routine, instead of a guess of one newline.
 //!
 //! These tests drive the real binary and look at the bytes it writes. They
 //! measure the cursor movement that the stream *requests*, not the exact escape
@@ -27,6 +29,12 @@ const CURSOR_DOWN_FINAL: u8 = b'B';
 
 /// The device control string introducer that opens the Sixel payload.
 const SIXEL_START: &[u8] = b"\x1bP";
+
+/// The application program command that opens a Kitty graphics command.
+const KITTY_START: &[u8] = b"\x1b_G";
+
+/// The Kitty graphics key that tells the renderer not to move the cursor.
+const KITTY_NO_CURSOR_MOVE: &str = "C=1";
 
 /// The string terminator that closes the Sixel payload.
 const STRING_TERMINATOR: &[u8] = b"\x1b\\";
@@ -57,8 +65,48 @@ const TERMINAL_ROWS: i64 = 24;
 /// The row that the shell prompt returns to below the image.
 const PROMPT_ROWS: i64 = 1;
 
-/// The terminal type for the child process.
-const TEST_TERM: &str = "xterm-256color";
+/// The terminal type of a child process that must not look like Kitty.
+const TERM_XTERM_256COLOR: &str = "xterm-256color";
+
+/// The terminal type that Kitty sets.
+const TERM_XTERM_KITTY: &str = "xterm-kitty";
+
+/// A display routine of `ic` that a test selects.
+///
+/// `ic` picks the routine from the environment, so a test names the routine it
+/// wants and [`Routine::environment`] gives the variables that select it.
+#[derive(Clone, Copy, Debug)]
+enum Routine {
+    /// The Sixel routine, which muxiavelli panels and Zellij use.
+    Sixel,
+    /// The Kitty graphics routine, which Kitty, WezTerm and Ghostty use.
+    Kitty,
+}
+
+impl Routine {
+    /// Give the environment variables that select this routine.
+    ///
+    /// The variables go on top of a cleared environment, so nothing that the
+    /// test runner inherited can change the routine.
+    ///
+    /// `MUXIAVELLI` selects the Sixel routine. `ZELLIJ` selects the same
+    /// routine but it also turns on a process tree heuristic that reads the
+    /// real process list of the host, which makes the result depend on the
+    /// machine.
+    ///
+    /// # Returns
+    /// The name and the value of each variable.
+    fn environment(self) -> Vec<(&'static str, &'static str)> {
+        match self {
+            Routine::Sixel => vec![
+                ("TERM", TERM_XTERM_256COLOR),
+                ("MUXIAVELLI", "1"),
+                ("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel"),
+            ],
+            Routine::Kitty => vec![("TERM", TERM_XTERM_KITTY), ("KITTY_WINDOW_ID", "1")],
+        }
+    }
+}
 
 /// A directory that does not exist, unique to this process.
 ///
@@ -165,29 +213,58 @@ fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// Make a command that runs `ic` through the Sixel display routine.
+/// Give the key list of the first Kitty graphics command in a byte stream.
 ///
-/// `MUXIAVELLI` selects the Sixel routine. `ZELLIJ` selects the same routine
-/// but it also turns on a process tree heuristic that reads the real process
-/// list of the host, which makes the result depend on the machine.
+/// A Kitty graphics command is `ESC _ G <key list> ; <payload> ESC \`. The key
+/// list is a comma separated list of `<key>=<value>` pairs.
 ///
 /// # Arguments
+/// * `bytes` - The byte stream to read.
+///
+/// # Returns
+/// One entry for each `<key>=<value>` pair of the first graphics command.
+///
+/// # Panics
+/// Panics when the stream holds no Kitty graphics command, or when the command
+/// holds no key list.
+fn kitty_key_list(bytes: &[u8]) -> Vec<String> {
+    let start = find(bytes, KITTY_START).expect("the output must hold a Kitty graphics command")
+        + KITTY_START.len();
+    let tail = &bytes[start..];
+    let end = tail
+        .iter()
+        .position(|byte| *byte == b';')
+        .expect("a Kitty graphics command must close its key list with a semicolon");
+
+    std::str::from_utf8(&tail[..end])
+        .expect("a Kitty key list must be UTF-8")
+        .split(',')
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Make a command that runs `ic` through one display routine.
+///
+/// # Arguments
+/// * `routine` - The display routine that `ic` must use.
 /// * `args` - The full command line for `ic`.
 ///
 /// # Returns
 /// A command with the environment and the pipes of the tests already set.
-fn ic_sixel_command(args: &[&str]) -> Command {
+fn ic_command(routine: Routine, args: &[&str]) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_ic"));
     command
         .args(args)
         .env_clear()
         .env("PATH", unreachable_path_dir())
-        .env("TERM", TEST_TERM)
-        .env("MUXIAVELLI", "1")
-        .env("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+
+    for (name, value) in routine.environment() {
+        command.env(name, value);
+    }
+
     command
 }
 
@@ -213,10 +290,11 @@ fn wait_for_stdout(child: process::Child) -> Vec<u8> {
     output.stdout
 }
 
-/// Run `ic` through the Sixel display routine, with the image on stdin, and
-/// give back its stdout.
+/// Run `ic` through one display routine, with the image on stdin, and give back
+/// its stdout.
 ///
 /// # Arguments
+/// * `routine` - The display routine that `ic` must use.
 /// * `extra_args` - More command line arguments for `ic`, after the arguments
 ///   that fix the size of the image.
 ///
@@ -226,11 +304,13 @@ fn wait_for_stdout(child: process::Child) -> Vec<u8> {
 /// # Panics
 /// Panics when the child process does not start, does not accept the image, or
 /// exits with a failure.
-fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
+fn run_ic(routine: Routine, extra_args: &[&str]) -> Vec<u8> {
     let mut args: Vec<&str> = vec!["--stdin", "--width", "10", "--height", "5"];
     args.extend_from_slice(extra_args);
 
-    let mut child = ic_sixel_command(&args).spawn().expect("failed to start ic");
+    let mut child = ic_command(routine, &args)
+        .spawn()
+        .expect("failed to start ic");
 
     let mut stdin = child.stdin.take().expect("ic has no stdin pipe");
     stdin
@@ -254,7 +334,7 @@ fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
 /// # Panics
 /// Panics when the child process does not start or exits with a failure.
 fn run_ic_sixel_auto_fit(path: &str) -> Vec<u8> {
-    let child = ic_sixel_command(&[path])
+    let child = ic_command(Routine::Sixel, &[path])
         .spawn()
         .expect("failed to start ic");
 
@@ -266,7 +346,7 @@ fn run_ic_sixel_auto_fit(path: &str) -> Vec<u8> {
 /// ends the line with a carriage return.
 #[test]
 fn sixel_advances_the_cursor_below_the_image() {
-    let stdout = run_ic_sixel(&[]);
+    let stdout = run_ic(Routine::Sixel, &[]);
 
     let terminator =
         find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
@@ -288,7 +368,7 @@ fn sixel_advances_the_cursor_below_the_image() {
 /// change the final position of the cursor.
 #[test]
 fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
-    let stdout = run_ic_sixel(&[]);
+    let stdout = run_ic(Routine::Sixel, &[]);
 
     let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
     let terminator =
@@ -326,7 +406,7 @@ fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
 /// below report the failure.
 #[test]
 fn no_newline_suppresses_the_cursor_contract() {
-    let stdout = run_ic_sixel(&["--no-newline"]);
+    let stdout = run_ic(Routine::Sixel, &["--no-newline"]);
 
     let terminator =
         find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
@@ -350,7 +430,7 @@ fn no_newline_suppresses_the_cursor_contract() {
 /// scrolls the terminal instead of running off it.
 #[test]
 fn sixel_reserves_the_rows_before_it_draws() {
-    let stdout = run_ic_sixel(&[]);
+    let stdout = run_ic(Routine::Sixel, &[]);
 
     let save = find(&stdout, SAVE_CURSOR).expect("the stream must save the cursor");
     let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
@@ -387,5 +467,21 @@ fn auto_fit_leaves_room_for_the_file_name_and_the_prompt() {
     assert!(
         rows + PROMPT_ROWS <= TERMINAL_ROWS,
         "the file name row and the image take {rows} rows, and the prompt takes {PROMPT_ROWS} more, which is more than the {TERMINAL_ROWS} rows of the terminal"
+    );
+}
+
+/// The Kitty graphics command must carry `C=1`, which tells the renderer not to
+/// move the cursor.
+///
+/// The routine states the position of the cursor itself. A renderer that also
+/// moves the cursor doubles the movement, so the routine must hold it still.
+#[test]
+fn kitty_holds_the_cursor_still_while_it_draws() {
+    let stdout = run_ic(Routine::Kitty, &[]);
+
+    let keys = kitty_key_list(&stdout);
+    assert!(
+        keys.iter().any(|key| key == KITTY_NO_CURSOR_MOVE),
+        "the Kitty key list must carry {KITTY_NO_CURSOR_MOVE}, but it is {keys:?}"
     );
 }

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -106,6 +106,29 @@ impl Routine {
             Routine::Kitty => vec![("TERM", TERM_XTERM_KITTY), ("KITTY_WINDOW_ID", "1")],
         }
     }
+
+    /// Give the bytes that open the image payload of this routine.
+    ///
+    /// # Returns
+    /// The introducer of the image protocol.
+    fn payload_start(self) -> &'static [u8] {
+        match self {
+            Routine::Sixel => SIXEL_START,
+            Routine::Kitty => KITTY_START,
+        }
+    }
+
+    /// Give the bytes that close the image payload of this routine.
+    ///
+    /// # Returns
+    /// The terminator of the image protocol. The Kitty routine sends a large
+    /// image in more than one command, so the *last* terminator of the stream
+    /// closes the payload.
+    fn payload_end(self) -> &'static [u8] {
+        match self {
+            Routine::Sixel | Routine::Kitty => STRING_TERMINATOR,
+        }
+    }
 }
 
 /// A directory that does not exist, unique to this process.
@@ -129,7 +152,9 @@ fn unreachable_path_dir() -> String {
 /// The number of terminal rows that the test image occupies.
 ///
 /// The test invocation makes a Sixel image of 100 pixels by 100 pixels. One
-/// character cell is 20 pixels high, so the image fills 5 rows.
+/// character cell is 20 pixels high, so the image fills 5 rows. The Kitty
+/// routine and the iTerm2 routine take the size of the image in character
+/// cells, and the same test invocation asks them for 5 rows.
 const EXPECTED_ROWS: i64 = 5;
 
 /// The cursor movement that a byte stream requests, in rows.
@@ -211,6 +236,93 @@ fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+/// Find the last position of a byte pattern in a byte slice.
+///
+/// # Arguments
+/// * `haystack` - The byte slice to search.
+/// * `needle` - The byte pattern to look for.
+///
+/// # Returns
+/// The index of the first byte of the last match, or `None` when there is no
+/// match.
+fn rfind(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .rposition(|window| window == needle)
+}
+
+/// Check that a byte stream keeps the cursor contract of `ic`.
+///
+/// The contract has three parts:
+///
+/// 1. The stream reserves the rows of the image before the payload and then
+///    takes them back, so an image at the bottom of the screen scrolls the
+///    terminal instead of running off it.
+/// 2. DECSC comes immediately before the payload and DECRC immediately after
+///    it, so cursor motion inside the payload cannot change the final position
+///    of the cursor.
+/// 3. The bytes after the payload move the cursor down by the row count of the
+///    image and put it at column 1.
+///
+/// # Arguments
+/// * `routine` - The display routine that wrote the stream.
+/// * `stdout` - The bytes that `ic` wrote to stdout.
+///
+/// # Panics
+/// Panics when the stream breaks any part of the contract.
+fn assert_cursor_contract(routine: Routine, stdout: &[u8]) {
+    let payload_start = find(stdout, routine.payload_start())
+        .unwrap_or_else(|| panic!("the output of {routine:?} must hold an image payload"));
+    let payload_end = rfind(stdout, routine.payload_end())
+        .unwrap_or_else(|| panic!("the output of {routine:?} must close its image payload"))
+        + routine.payload_end().len();
+
+    // Part 1. The reservation runs from the start of the stream to DECSC.
+    assert!(
+        payload_start >= SAVE_CURSOR.len(),
+        "the stream must save the cursor before the payload"
+    );
+    let save = payload_start - SAVE_CURSOR.len();
+    let reservation = scan_cursor_movement(&stdout[..save]);
+    assert_eq!(
+        reservation.down, EXPECTED_ROWS,
+        "the reservation must ask for {EXPECTED_ROWS} rows before the payload"
+    );
+    assert_eq!(
+        reservation.net(),
+        0,
+        "the reservation must take the rows back, so the image starts at the top of them"
+    );
+
+    // Part 2.
+    assert_eq!(
+        &stdout[save..payload_start],
+        SAVE_CURSOR,
+        "DECSC must come immediately before the payload"
+    );
+    assert!(
+        stdout.len() >= payload_end + RESTORE_CURSOR.len(),
+        "the stream must restore the cursor after the payload"
+    );
+    assert_eq!(
+        &stdout[payload_end..payload_end + RESTORE_CURSOR.len()],
+        RESTORE_CURSOR,
+        "DECRC must come immediately after the payload"
+    );
+
+    // Part 3.
+    let tail = &stdout[payload_end..];
+    assert_eq!(
+        scan_cursor_movement(tail).net(),
+        EXPECTED_ROWS,
+        "the bytes after the payload must move the cursor down {EXPECTED_ROWS} rows"
+    );
+    assert!(
+        tail.ends_with(b"\r") || tail.ends_with(b"\n"),
+        "the stream must end the line, to put the cursor at column 1"
+    );
 }
 
 /// Give the key list of the first Kitty graphics command in a byte stream.
@@ -468,6 +580,15 @@ fn auto_fit_leaves_room_for_the_file_name_and_the_prompt() {
         rows + PROMPT_ROWS <= TERMINAL_ROWS,
         "the file name row and the image take {rows} rows, and the prompt takes {PROMPT_ROWS} more, which is more than the {TERMINAL_ROWS} rows of the terminal"
     );
+}
+
+/// The Kitty stream must keep the same cursor contract as the Sixel stream. It
+/// reserves the rows of the image and takes them back, it brackets the payload
+/// with DECSC and DECRC, and it then moves the cursor down by the row count and
+/// puts it at column 1.
+#[test]
+fn kitty_meets_the_cursor_contract() {
+    assert_cursor_contract(Routine::Kitty, &run_ic(Routine::Kitty, &[]));
 }
 
 /// The Kitty graphics command must carry `C=1`, which tells the renderer not to

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -9,7 +9,9 @@
 //! sequences, so a change of spelling keeps them alive.
 
 use std::io::Write;
+use std::process;
 use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// The escape byte that starts every escape sequence.
 const ESC: u8 = 0x1b;
@@ -39,12 +41,26 @@ const RESTORE_CURSOR: &[u8] = b"\x1b8";
 const TEST_IMAGE: &[u8] =
     include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/test_image.png"));
 
-/// The search path for the child process. `ic` starts `ps` to look at the
-/// process tree, so the child needs a path.
-const TEST_PATH: &str = "/usr/bin:/bin:/usr/sbin";
-
 /// The terminal type for the child process.
 const TEST_TERM: &str = "xterm-256color";
+
+/// A directory that does not exist, unique to this process.
+///
+/// The `PATH` of the child points here, which keeps `ps` out of reach. The
+/// remote transport detection then finds no process tree to walk, so a test
+/// runner that is itself under a remote transport cannot change the bytes that
+/// `ic` writes. The directory holds the process id and a nanosecond stamp, so
+/// two concurrent runs of this file never name the same directory.
+///
+/// # Returns
+/// The path of a directory that no process creates.
+fn unreachable_path_dir() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("the clock must be after the epoch")
+        .as_nanos();
+    format!("/nonexistent-ic-cursor-contract-{}-{nanos}", process::id())
+}
 
 /// The number of terminal rows that the test image occupies.
 ///
@@ -146,7 +162,7 @@ fn run_ic_sixel() -> Vec<u8> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_ic"))
         .args(["--stdin", "--width", "10", "--height", "5"])
         .env_clear()
-        .env("PATH", TEST_PATH)
+        .env("PATH", unreachable_path_dir())
         .env("TERM", TEST_TERM)
         .env("MUXIAVELLI", "1")
         .env("MUXIAVELLI_IMAGE_PROTOCOLS", "sixel")

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -155,12 +155,17 @@ fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// but it also turns on a process tree heuristic that reads the real process
 /// list of the host, which makes the result depend on the machine.
 ///
+/// # Arguments
+/// * `extra_args` - More command line arguments for `ic`, after the arguments
+///   that fix the size of the image.
+///
 /// # Panics
 /// Panics when the child process does not start, does not accept the image, or
 /// exits with a failure.
-fn run_ic_sixel() -> Vec<u8> {
+fn run_ic_sixel(extra_args: &[&str]) -> Vec<u8> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_ic"))
         .args(["--stdin", "--width", "10", "--height", "5"])
+        .args(extra_args)
         .env_clear()
         .env("PATH", unreachable_path_dir())
         .env("TERM", TEST_TERM)
@@ -194,7 +199,7 @@ fn run_ic_sixel() -> Vec<u8> {
 /// ends the line with a carriage return.
 #[test]
 fn sixel_advances_the_cursor_below_the_image() {
-    let stdout = run_ic_sixel();
+    let stdout = run_ic_sixel(&[]);
 
     let terminator =
         find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
@@ -216,7 +221,7 @@ fn sixel_advances_the_cursor_below_the_image() {
 /// change the final position of the cursor.
 #[test]
 fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
-    let stdout = run_ic_sixel();
+    let stdout = run_ic_sixel(&[]);
 
     let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");
     let terminator =
@@ -244,12 +249,41 @@ fn sixel_brackets_the_payload_against_renderer_cursor_motion() {
     );
 }
 
+/// `--no-newline` must suppress the whole cursor contract, because video
+/// playback puts the cursor where it wants it before every frame. A stream that
+/// moves the cursor on its own scrolls the terminal once per frame.
+///
+/// The behavior already held when this test arrived, so a mutation proved that
+/// the test can fail: with the advance moved outside the `no_newline` gate, the
+/// tail asks for 5 rows and the whole stream nets 5 rows, and both assertions
+/// below report the failure.
+#[test]
+fn no_newline_suppresses_the_cursor_contract() {
+    let stdout = run_ic_sixel(&["--no-newline"]);
+
+    let terminator =
+        find(&stdout, STRING_TERMINATOR).expect("the output must hold a Sixel string terminator");
+    let tail = &stdout[terminator + STRING_TERMINATOR.len()..];
+    let after_payload = scan_cursor_movement(tail);
+
+    assert_eq!(
+        (after_payload.down, after_payload.up),
+        (0, 0),
+        "--no-newline must write no cursor movement after the payload"
+    );
+    assert_eq!(
+        scan_cursor_movement(&stdout).net(),
+        0,
+        "--no-newline must leave the cursor where the caller put it"
+    );
+}
+
 /// The stream must reserve the rows of the image before it draws. It asks for
 /// the rows and then takes them back, so an image at the bottom of the screen
 /// scrolls the terminal instead of running off it.
 #[test]
 fn sixel_reserves_the_rows_before_it_draws() {
-    let stdout = run_ic_sixel();
+    let stdout = run_ic_sixel(&[]);
 
     let save = find(&stdout, SAVE_CURSOR).expect("the stream must save the cursor");
     let payload_start = find(&stdout, SIXEL_START).expect("the output must hold a Sixel payload");

--- a/src/ic/tests/cursor_contract.rs
+++ b/src/ic/tests/cursor_contract.rs
@@ -638,13 +638,16 @@ fn sixel_reserves_the_rows_before_it_draws() {
     );
 }
 
-/// The file name row, the image and the prompt must fit inside the height of
+/// The file name rows, the image and the prompt must fit inside the height of
 /// the terminal. `ic` prints the file name above the image, so the auto-fit
-/// path must pay for that row.
+/// path must pay for the rows that the name occupies. A name wider than the
+/// terminal wraps onto more than one row, and `ic` pays for every one of them.
 ///
 /// The net movement of the whole stream is the number of rows that the terminal
-/// advances: the header rows plus the image rows, because the reservation and
-/// the cursor-up cancel. The prompt then takes one more row.
+/// advances: the header lines plus the image rows, because the reservation and
+/// the cursor-up cancel. A wrapped row of the header comes from the terminal and
+/// not from the stream, so this count is a lower bound on the rows that the
+/// screen gives to the header. The prompt then takes one more row.
 #[test]
 fn auto_fit_leaves_room_for_the_file_name_and_the_prompt() {
     let stdout = run_ic_sixel_auto_fit(TEST_IMAGE_PATH);
@@ -652,7 +655,7 @@ fn auto_fit_leaves_room_for_the_file_name_and_the_prompt() {
     let rows = scan_cursor_movement(&stdout).net();
     assert!(
         rows + PROMPT_ROWS <= TERMINAL_ROWS,
-        "the file name row and the image take {rows} rows, and the prompt takes {PROMPT_ROWS} more, which is more than the {TERMINAL_ROWS} rows of the terminal"
+        "the file name rows and the image take {rows} rows, and the prompt takes {PROMPT_ROWS} more, which is more than the {TERMINAL_ROWS} rows of the terminal"
     );
 }
 


### PR DESCRIPTION
Closes #348.

## The problem

`ic` left the cursor inside the image. The exit code and the shell prompt then printed over the last row of the image. The Sixel routine wrote one newline after the payload and let the renderer supply the rest of the movement. Sixel gives no contract for the cursor position, so the shortfall changed from renderer to renderer.

## The change

All three display routines now share one cursor contract:

1. Reserve the rows of the image with newlines, then move the cursor back up to the top of them.
2. Bracket the payload with DECSC and DECRC, so cursor motion inside the payload cannot change the final position.
3. Move the cursor down by the row count of the image and to column 1.

The Sixel routine derives the row count from the pixel height of the image and the pixel height of a character cell. The Kitty routine writes the no-cursor-move key on every image, not only behind a proxy. The iTerm2 routine uses the same contract. The remote-proxy flag is gone, because the contract no longer depends on it.

`--no-newline` suppresses the trailing advance for all three routines, so video playback keeps control of the cursor.

The auto-fit height now pays for the file name row. The file name, the image and the prompt fit within the terminal height.

## Tests

`src/ic/tests/cursor_contract.rs` holds 678 lines of new integration tests. Each test drives the real binary with a cleared environment, selects one routine, and reads the bytes from a pipe. The tests assert on the net cursor movement that the stream requests, not on an exact escape sequence, so a change of spelling does not break them.

Every commit came from a red/green pair. The run ends with the closing empty commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
