### PR TITLE
feat(gsw): add a p key that confirms, then pushes the current branch

### DIFF
--- a/.review-decisions.md
+++ b/.review-decisions.md
@@ -50,3 +50,40 @@ the client set can be partial, is settled here. A refusal observed in the wild
 reopens it, as does any finding that this scan is wrong on a client it *can* see.
 Findings about this code on a different axis — a bug in the walk, a panic, a
 performance problem — are not covered.
+
+## Commit messages on a pushed branch — not rewritten to satisfy a review
+
+**Settled** 2026-08-13 (branch gsw-push, finding R-20260813T173044Z#N1)
+
+The review found that `a83e2ca`, the tip of this branch, is an empty commit whose
+message is the single word `test`, where the TDD convention in `CLAUDE.md` calls
+for `chore: full pre-commit checks after TDD sequence`. It also observed that the
+pre-commit hook here is gated on staged files, so an empty commit runs no gates at
+all — the verification that the red/green bargain defers to the end of a run never
+happened in that commit.
+
+Both halves of the finding are accurate. Neither is fixed, for different reasons.
+
+**The verification gap is already closed, and not by a commit.** The four gates were
+run directly against the tree: `cargo fmt --all -- --check`, `cargo clippy -p gsw
+--all-targets`, `cargo machete`, and `cargo test -p gsw`, all green. Running them is
+what verification *is*. A commit that re-runs nothing is a record of the run, not the
+run, so the record is worth having but is not worth a history rewrite on its own.
+
+**Rewriting the message costs a force-push, and buys nothing durable.** The branch is
+published as PR #351, so amending `a83e2ca` makes the local history diverge from
+`origin/gsw-push` and the next push needs `--force-with-lease`. Against that: this
+repository squash-merges every PR with an explicit `--subject`/`--body`, so no commit
+message on this branch reaches `main`. The word `test` is discarded by the merge
+either way. Paying a force-push — and the window where a collaborator's fetch
+disagrees with the remote — to improve a string that is about to be deleted is the
+wrong trade.
+
+**The boundary.** This decision settles *the messages of already-pushed commits on a
+squash-merged branch*. A finding that a commit on such a branch is misnamed, or that
+its message does not match a convention, is settled here. It does not settle
+anything about commit *content*: a commit that is empty when it should carry a
+change, or that bundles unrelated work, is a real finding. It does not cover the
+squash-merge subject and body themselves, which do reach `main` and are the thing
+the convention actually protects. And it does not license skipping verification —
+the gates are run, or the finding stands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,7 @@ dependencies = [
  "crossterm",
  "gix",
  "ignore",
+ "libc",
  "notify",
  "tempfile",
  "terminal_size",

--- a/README.md
+++ b/README.md
@@ -433,7 +433,10 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - Watch-mode keys: `q` or Ctrl-C quits, `r` forces an immediate refresh, and `p` pushes the
     current branch. Ctrl-C quits from anywhere, including while a push is in flight.
   - `p` always asks first, and the question names the branch, the remote, and how much is going —
-    so what you confirm is what runs. A branch that is **not on the remote yet** gets a different,
+    so what you confirm is what runs. If the checkout moves in another pane between the question
+    and your answer, the push is refused rather than redirected at the branch that is there now:
+    gsw says the branch changed and you press `p` again for a question about the new one.
+    A branch that is **not on the remote yet** gets a different,
     yellow confirmation (`Create new remote branch origin/my-branch?`) rather than the routine
     `Push 3 commits to origin/my-branch?`, because creating a branch on a shared remote is not the
     same act as moving one that is already there. Answer with `y`/Enter or `n`/Esc. A branch that

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     - The push runs off the render thread, so the countdown, the ages, and resizes keep working
       while it is in flight, and a second `p` cannot start an overlapping push. git's own error
       text is shown under the frame in red (up to three rows, `hint:` advice dropped first, and
-    fewer rows still on a pane too short to spare three — the frame always keeps a row) and
+      fewer rows still on a pane too short to spare three — the frame always keeps a row) and
       stays there until you press a key. A push that succeeds re-walks the repository immediately,
       so the ahead/behind arrows match what just happened. Nothing the push runs can prompt at the
       terminal — it would be reading the same keystrokes gsw is. The push is started detached from

--- a/README.md
+++ b/README.md
@@ -440,9 +440,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     yellow confirmation (`Create new remote branch origin/my-branch?`) rather than the routine
     `Push 3 commits to origin/my-branch?`, because creating a branch on a shared remote is not the
     same act as moving one that is already there. Answer with `y`/Enter or `n`/Esc. A branch that
-    is already fully pushed says so instead of asking. A pane too short to draw the question in —
-    one row, all of which the frame keeps — cancels the question instead of asking invisibly, so
-    Enter can never confirm something you were not shown; make the pane taller and press `p` again.
+    is already fully pushed says so instead of asking. In a pane too short to draw the question in
+    — one row, all of which the frame keeps — `p` asks nothing at all rather than asking invisibly,
+    and the keys go on meaning what they mean everywhere else, so Enter can never confirm something
+    you were not shown; make the pane taller and press `p` again. A pane resized down to that size
+    with a question already up drops the question for the same reason.
     - An untracked branch is published with `git push -u`, so the upstream is recorded and the
       header's tracking segment appears; a tracked one runs a bare `git push` and lets git supply
       the remote and refspec. The remote for a new branch is `remote.pushDefault` if set, else the

--- a/README.md
+++ b/README.md
@@ -430,6 +430,26 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     gsw purely event-driven. On a repository where a status walk is expensive, the 1% duty-cycle
     budget pushes the timed refresh out past the interval, and the countdown shows the longer wait
     rather than promising one it will not keep.
+  - Watch-mode keys: `q` or Ctrl-C quits, `r` forces an immediate refresh, and `p` pushes the
+    current branch. Ctrl-C quits from anywhere, including while a push is in flight.
+  - `p` always asks first, and the question names the branch, the remote, and how much is going —
+    so what you confirm is what runs. A branch that is **not on the remote yet** gets a different,
+    yellow confirmation (`Create new remote branch origin/my-branch?`) rather than the routine
+    `Push 3 commits to origin/my-branch?`, because creating a branch on a shared remote is not the
+    same act as moving one that is already there. Answer with `y`/Enter or `n`/Esc. A branch that
+    is already fully pushed says so instead of asking.
+    - An untracked branch is published with `git push -u`, so the upstream is recorded and the
+      header's tracking segment appears; a tracked one runs a bare `git push` and lets git supply
+      the remote and refspec. The remote for a new branch is `remote.pushDefault` if set, else the
+      only remote whatever it is called, else `origin` — and gsw refuses rather than guess when a
+      repository has several remotes and none of them settles it. `p` never force-pushes.
+    - The push runs off the render thread, so the countdown, the ages, and resizes keep working
+      while it is in flight, and a second `p` cannot start an overlapping push. git's own error
+      text is shown under the frame in red (up to three rows, `hint:` advice dropped first) and
+      stays there until you press a key. A push that succeeds re-walks the repository immediately,
+      so the ahead/behind arrows match what just happened. git can never prompt for credentials at
+      the terminal — it would be reading the same keystrokes gsw is — so an authenticated remote
+      that needs a password fails fast and says so; credential helpers and a GUI askpass still work.
   - To install: `cargo install --git https://github.com/timmattison/tools gsw`
 - seescc (sccache stats viewer)
   - Self-refreshing terminal viewer for [sccache](https://github.com/mozilla/sccache) statistics —

--- a/README.md
+++ b/README.md
@@ -440,7 +440,9 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     yellow confirmation (`Create new remote branch origin/my-branch?`) rather than the routine
     `Push 3 commits to origin/my-branch?`, because creating a branch on a shared remote is not the
     same act as moving one that is already there. Answer with `y`/Enter or `n`/Esc. A branch that
-    is already fully pushed says so instead of asking.
+    is already fully pushed says so instead of asking. A pane too short to draw the question in —
+    one row, all of which the frame keeps — cancels the question instead of asking invisibly, so
+    Enter can never confirm something you were not shown; make the pane taller and press `p` again.
     - An untracked branch is published with `git push -u`, so the upstream is recorded and the
       header's tracking segment appears; a tracked one runs a bare `git push` and lets git supply
       the remote and refspec. The remote for a new branch is `remote.pushDefault` if set, else the

--- a/README.md
+++ b/README.md
@@ -456,10 +456,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     fewer rows still on a pane too short to spare three — the frame always keeps a row) and
       stays there until you press a key. A push that succeeds re-walks the repository immediately,
       so the ahead/behind arrows match what just happened. Nothing the push runs can prompt at the
-      terminal — it would be reading the same keystrokes gsw is. The push gets a session of its own
-      with no controlling terminal, so `/dev/tty` is unopenable for git, for ssh, and for anything
-      below them: an HTTPS remote that wants a password, a passphrase-protected key with no agent,
-      and an unknown host key all fail fast and say so under the frame instead of hanging behind a
+      terminal — it would be reading the same keystrokes gsw is. The push is started detached from
+      the terminal — its own session on Unix, no inherited console on Windows — so nothing in its
+      process tree can reach the keyboard gsw is reading, not git, not ssh, and not anything below
+      them: an HTTPS remote that wants a password, a passphrase-protected key with no agent, and an
+      unknown host key all fail fast and say so under the frame instead of hanging behind a
       question gsw never drew. Credential helpers and a GUI askpass still work — neither needs the
       terminal.
   - To install: `cargo install --git https://github.com/timmattison/tools gsw`

--- a/README.md
+++ b/README.md
@@ -448,7 +448,8 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       repository has several remotes and none of them settles it. `p` never force-pushes.
     - The push runs off the render thread, so the countdown, the ages, and resizes keep working
       while it is in flight, and a second `p` cannot start an overlapping push. git's own error
-      text is shown under the frame in red (up to three rows, `hint:` advice dropped first) and
+      text is shown under the frame in red (up to three rows, `hint:` advice dropped first, and
+    fewer rows still on a pane too short to spare three — the frame always keeps a row) and
       stays there until you press a key. A push that succeeds re-walks the repository immediately,
       so the ahead/behind arrows match what just happened. Nothing the push runs can prompt at the
       terminal — it would be reading the same keystrokes gsw is. The push gets a session of its own

--- a/README.md
+++ b/README.md
@@ -450,9 +450,13 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       while it is in flight, and a second `p` cannot start an overlapping push. git's own error
       text is shown under the frame in red (up to three rows, `hint:` advice dropped first) and
       stays there until you press a key. A push that succeeds re-walks the repository immediately,
-      so the ahead/behind arrows match what just happened. git can never prompt for credentials at
-      the terminal — it would be reading the same keystrokes gsw is — so an authenticated remote
-      that needs a password fails fast and says so; credential helpers and a GUI askpass still work.
+      so the ahead/behind arrows match what just happened. Nothing the push runs can prompt at the
+      terminal — it would be reading the same keystrokes gsw is. The push gets a session of its own
+      with no controlling terminal, so `/dev/tty` is unopenable for git, for ssh, and for anything
+      below them: an HTTPS remote that wants a password, a passphrase-protected key with no agent,
+      and an unknown host key all fail fast and say so under the frame instead of hanging behind a
+      question gsw never drew. Credential helpers and a GUI askpass still work — neither needs the
+      terminal.
   - To install: `cargo install --git https://github.com/timmattison/tools gsw`
 - seescc (sccache stats viewer)
   - Self-refreshing terminal viewer for [sccache](https://github.com/mozilla/sccache) statistics —

--- a/TLDR.md
+++ b/TLDR.md
@@ -25,7 +25,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `goup` | Updates Go dependencies across all `go.mod` files in a repo. |
 | `gr8` | Displays GitHub API rate limit info, color-coded, via the GitHub CLI. |
 | `grist` | Ranks the orders you could squash-merge a set of branches in, cheapest conflicts first, by replaying each one in a throwaway worktree. |
-| `gsw` | Git Status Watch — compact status dashboard that watches on a TTY (refresh clock in the separator) and renders once when piped; a merge or rebase in progress gets its own row, `⚠ merge` / `⚠ rebase 1/2 · 1 conflict to resolve`. |
+| `gsw` | Git Status Watch — compact status dashboard that watches on a TTY (refresh clock in the separator) and renders once when piped; a merge or rebase in progress gets its own row, `⚠ merge` / `⚠ rebase 1/2 · 1 conflict to resolve`. Press `p` to push the current branch after a confirmation. |
 | `hexfind` | Searches for a hex string in a binary file and shows a hex dump with offsets. |
 | `htmlboard` | Pretty-prints HTML on the clipboard and puts it back. |
 | `ic` | Fast terminal image/video display utility (an `imgcat` alternative; video needs ffmpeg). |

--- a/src/gsw/Cargo.toml
+++ b/src/gsw/Cargo.toml
@@ -16,10 +16,12 @@ colored.workspace = true
 crossterm.workspace = true
 gix.workspace = true
 ignore.workspace = true
-libc.workspace = true
 notify.workspace = true
 terminal_size.workspace = true
 unicode-width.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/gsw/Cargo.toml
+++ b/src/gsw/Cargo.toml
@@ -16,6 +16,7 @@ colored.workspace = true
 crossterm.workspace = true
 gix.workspace = true
 ignore.workspace = true
+libc.workspace = true
 notify.workspace = true
 terminal_size.workspace = true
 unicode-width.workspace = true

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -482,6 +482,7 @@ pub(crate) fn collect_snapshot(repo: &gix::Repository, cfg: &RenderConfig) -> Re
     snapshot.log = fetch_log(repo, cfg.log_lines);
 
     snapshot.upstream = repo::upstream_status(repo);
+    snapshot.push_remote = repo::push_remote(repo);
 
     // Surface an in-progress merge/rebase. The conflict count comes for free
     // from the status walk already done — every unmerged path is a
@@ -783,6 +784,7 @@ mod tests {
             log: Vec::new(),
             upstream: None,
             operation: Some(Operation::Merge { conflicts: 1 }),
+            push_remote: None,
         };
         let frame = render_frame(&snap, &cfg, dims, FrameTiming::at_walk(None));
         let lines = frame.output.lines().count();
@@ -838,6 +840,7 @@ mod tests {
             log,
             upstream: None,
             operation: None,
+            push_remote: None,
         }
     }
 
@@ -959,6 +962,7 @@ mod tests {
             }],
             upstream: None,
             operation: None,
+            push_remote: None,
         };
         let cfg = RenderConfig {
             base: None,

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -42,7 +42,9 @@ mod watch;
                   it renders once and exits.\n\n\
                   Watch-mode keys: q or Ctrl-C quits, r refreshes now, and p pushes the current \
                   branch after a confirmation that names what it will do — a branch not yet on \
-                  the remote is confirmed as creating one. p never force-pushes."
+                  the remote is confirmed as creating one. A push whose branch stopped being \
+                  checked out between the question and the answer is refused, not redirected. \
+                  p never force-pushes."
 )]
 struct Cli {
     /// Render once and exit instead of entering the live watch loop. This is

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -39,7 +39,10 @@ mod watch;
                   re-walks the repository every --refresh-interval seconds, with the \
                   separator under the header showing how stale the screen is and how long \
                   until the next refresh; with `--one-shot` (or when its output is piped) \
-                  it renders once and exits."
+                  it renders once and exits.\n\n\
+                  Watch-mode keys: q or Ctrl-C quits, r refreshes now, and p pushes the current \
+                  branch after a confirmation that names what it will do — a branch not yet on \
+                  the remote is confirmed as creating one. p never force-pushes."
 )]
 struct Cli {
     /// Render once and exit instead of entering the live watch loop. This is

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -17,6 +17,7 @@ use crate::snapshot::build_snapshot;
 mod age;
 mod bar;
 mod git;
+mod push;
 mod render;
 mod repo;
 mod snapshot;

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -70,8 +70,30 @@ impl PushPlan {
         remote: Option<&str>,
         upstream: Option<&UpstreamStatus>,
     ) -> Option<Self> {
-        let _ = (branch, remote, upstream, DETACHED_HEAD);
-        None
+        // Checked before the upstream, so a tracking status left over from
+        // before the checkout cannot make a detached HEAD look pushable.
+        if branch == DETACHED_HEAD {
+            return None;
+        }
+
+        match upstream {
+            // Level with the upstream, or behind it only: `git push` would
+            // report "Everything up-to-date". Say so without the round trip.
+            Some(up) if up.ahead == 0 => Some(Self::UpToDate {
+                target: up.name.clone(),
+            }),
+            // Ahead — including ahead *and* behind. A diverged branch is very
+            // likely rejected as a non-fast-forward, and that rejection is what
+            // the user needs to read. gsw does not pre-empt git's decision.
+            Some(up) => Some(Self::Update {
+                target: up.name.clone(),
+                commits: up.ahead,
+            }),
+            None => remote.map(|remote| Self::Create {
+                remote: remote.to_string(),
+                branch: branch.to_string(),
+            }),
+        }
     }
 
     /// The arguments to pass to `git`, not including the program name.
@@ -81,8 +103,21 @@ impl PushPlan {
     /// Panics on [`PushPlan::UpToDate`], which describes a push that must never
     /// run. Callers prompt only for the other two variants.
     pub(crate) fn command_args(&self) -> Vec<String> {
-        let _ = self;
-        Vec::new()
+        match self {
+            // Bare `push`: git reads the remote and the refspec out of the
+            // branch config, so a branch tracking something other than the
+            // repository's default remote still goes to the right place.
+            Self::Update { .. } => vec!["push".to_string()],
+            Self::Create { remote, branch } => vec![
+                "push".to_string(),
+                "-u".to_string(),
+                remote.clone(),
+                branch.clone(),
+            ],
+            Self::UpToDate { target } => {
+                unreachable!("gsw never runs a push for an up-to-date branch ({target})")
+            }
+        }
     }
 }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -107,9 +107,40 @@ pub(crate) fn prompt_for(
     remote: Option<&str>,
     upstream: Option<&UpstreamStatus>,
 ) -> PushPrompt {
-    let _ = PushPlan::resolve(branch, remote, upstream);
-    PushPrompt::Refuse {
-        message: String::new(),
+    let plan = PushPlan::resolve(branch, remote, upstream);
+    let question = match &plan {
+        // Named as the act it is. A branch that nobody on the remote has seen
+        // appearing there is not the same event as an existing branch moving
+        // forward, and the sentence has to be the thing that says so — the user
+        // reads it in the half second before pressing `y`.
+        PushPlan::Create { remote, branch } => {
+            format!("Create new remote branch {remote}/{branch}?")
+        }
+        PushPlan::Update { target, commits } => {
+            let unit = if *commits == 1 { "commit" } else { "commits" };
+            format!("Push {commits} {unit} to {target}?")
+        }
+        PushPlan::UpToDate { target } => {
+            return PushPrompt::Refuse {
+                message: format!("{target} is already up to date"),
+            }
+        }
+        PushPlan::Detached => {
+            return PushPrompt::Refuse {
+                message: format!("{DETACHED_HEAD} is detached — check out a branch to push"),
+            }
+        }
+        PushPlan::NoRemote => {
+            return PushPrompt::Refuse {
+                message: "no remote to push to".to_string(),
+            }
+        }
+    };
+
+    PushPrompt::Confirm {
+        question,
+        creates_remote_branch: matches!(plan, PushPlan::Create { .. }),
+        args: plan.command_args(),
     }
 }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -15,7 +15,7 @@ use colored::Colorize;
 
 use crate::render::{truncate_right, Snapshot, UpstreamStatus};
 use crate::repo::DETACHED_HEAD;
-use crate::watch::InputMode;
+use crate::watch::{Dimensions, InputMode};
 
 /// Most rows a status message is allowed to occupy under the frame.
 ///
@@ -23,6 +23,10 @@ use crate::watch::InputMode;
 /// what the user is actually watching. Three rows is enough for git's
 /// `To <remote>` / `! [rejected] …` / `error: failed to push …` triple, which
 /// is the part that says what went wrong.
+///
+/// A ceiling, not a promise: a pane with fewer than four rows cannot spare
+/// three and still show a frame, so [`PushUi::overlay`] clips the message
+/// further. This is the most the user will ever see, not the least.
 const MAX_STATUS_ROWS: usize = 3;
 
 /// Git's prefix for advice lines. They follow the real error and explain
@@ -333,8 +337,9 @@ fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
 
     // stderr first: `git push` reports what it did — `To <remote>`, the ref
     // updates, and every rejection — on stderr, and writes to stdout only under
-    // flags gsw does not pass. Leading with it puts the useful lines in the
-    // three rows a status message gets.
+    // flags gsw does not pass. Leading with it puts the useful lines at the
+    // head, which is the part a status message has room for — at most
+    // [`MAX_STATUS_ROWS`], and fewer on a short pane.
     let mut text = String::from_utf8_lossy(&output.stderr).into_owned();
     text.push_str(&String::from_utf8_lossy(&output.stdout));
     // Carriage returns are how a progress meter redraws in place. Capturing
@@ -450,23 +455,24 @@ pub(crate) struct PushOutcome {
 /// Everything the push feature puts on screen, and the input mode that goes
 /// with it.
 ///
-/// Watch mode holds one of these and asks it three questions — what mode are we
-/// in, how many rows do you need, and what do they say. It never learns whether
-/// a prompt or an error is up, so the states below can grow without the render
-/// loop growing a branch for each one.
+/// Watch mode holds one of these and asks it two questions — what mode are we
+/// in, and what does the pane show. It never learns whether a prompt or an
+/// error is up, so the states below can grow without the render loop growing a
+/// branch for each one.
 pub(crate) struct PushUi {
     state: State,
 }
 
 /// What the push feature is currently doing. Private: the loop drives this
 /// through [`PushUi`]'s methods and reads it only through
-/// [`PushUi::mode`]/[`PushUi::rows`]/[`PushUi::overlay`].
+/// [`PushUi::mode`]/[`PushUi::overlay`].
 enum State {
     /// Nothing on screen and nothing pending.
     Idle,
     /// A message under the frame, staying until the user presses a key.
     Status {
-        /// Lines to show, already trimmed to [`MAX_STATUS_ROWS`].
+        /// Lines to show, already trimmed to [`MAX_STATUS_ROWS`]. How many of
+        /// them a given pane has room for is [`PushUi::overlay`]'s call.
         lines: Vec<String>,
         /// Whether this reports a failure, which the display colors red.
         failed: bool,
@@ -589,24 +595,26 @@ impl PushUi {
         }
     }
 
-    /// How many rows the overlay needs under the frame, so the caller can
-    /// render the frame that much shorter and nothing falls off the bottom.
-    pub(crate) fn rows(&self) -> usize {
-        match &self.state {
-            State::Idle => 0,
-            State::Asking { .. } | State::Running { .. } => 1,
-            State::Status { lines, .. } => lines.len(),
-        }
-    }
-
-    /// The overlay itself: [`PushUi::rows`] lines, none wider than `width`.
+    /// What the push feature shows in a pane of `dims`: the lines that fit
+    /// there, and — as [`Overlay::rows`] — how many rows the frame must give up
+    /// to make room for them.
     ///
-    /// Truncation is by display column and UTF-8 safe, because gsw's standing
-    /// contract is that nothing it prints ever wraps — a folded line would push
-    /// the frame's bottom row off the pane it was measured to fit.
-    pub(crate) fn overlay(&self, width: usize) -> String {
+    /// Both come out of this one call because a row count and a body computed
+    /// apart can disagree, and either direction of disagreement is a bug: a
+    /// count larger than the text leaves a blank strip between the frame and
+    /// the message, a count smaller than it paints past the bottom of the pane.
+    ///
+    /// Two clamps, one contract. gsw's standing rule is that nothing it paints
+    /// ever wraps or scrolls the pane it was measured to fill, so each line is
+    /// truncated to `dims.width` by display column (UTF-8 safe), and the
+    /// overlay as a whole is capped at one row short of `dims.height`. The
+    /// frame therefore always keeps a row of its own, and a message too tall
+    /// for what is left loses its last lines — [`failure_lines`] puts git's
+    /// most useful output first, so the head is the part worth keeping.
+    pub(crate) fn overlay(&self, dims: Dimensions) -> Overlay {
+        let width = dims.width;
         let lines: Vec<String> = match &self.state {
-            State::Idle => return String::new(),
+            State::Idle => Vec::new(),
             State::Asking {
                 question,
                 creates_remote_branch,
@@ -635,7 +643,41 @@ impl PushUi {
                 })
                 .collect(),
         };
-        lines.join("\n")
+        // The frame never gives up its last row. A pane painted entirely by the
+        // push feature would leave the user watching an error with nothing
+        // under it to say which repository it belongs to — and the frame is
+        // what watch mode is for.
+        Overlay {
+            lines: lines
+                .into_iter()
+                .take(dims.height.saturating_sub(1))
+                .collect(),
+        }
+    }
+}
+
+/// What the push feature paints under the frame, sized for one particular pane.
+///
+/// Built only by [`PushUi::overlay`], which is what makes the row count and the
+/// text impossible to disagree about: they are the same `Vec` — one measured,
+/// the other joined.
+pub(crate) struct Overlay {
+    /// Painted lines, each already truncated to the pane's width, and at most
+    /// one fewer of them than the pane has rows.
+    lines: Vec<String>,
+}
+
+impl Overlay {
+    /// How many rows the frame must give up. Always at least one short of the
+    /// pane, so the frame keeps a row whatever the overlay wanted to say.
+    pub(crate) fn rows(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// The text to paint under the frame: exactly [`Overlay::rows`] lines, and
+    /// empty when there are none.
+    pub(crate) fn text(&self) -> String {
+        self.lines.join("\n")
     }
 }
 
@@ -1050,6 +1092,15 @@ mod ui_tests {
         unicode_width::UnicodeWidthStr::width(visible.as_str())
     }
 
+    /// A pane `width` columns wide with more rows than any overlay can want, so
+    /// a test about wording or row count is not also a test about clipping.
+    fn tall_pane(width: usize) -> Dimensions {
+        Dimensions {
+            width,
+            height: MAX_STATUS_ROWS + 10,
+        }
+    }
+
     /// A UI with the confirmation already on screen for an untracked branch.
     fn asking() -> PushUi {
         let mut ui = PushUi::new();
@@ -1061,8 +1112,8 @@ mod ui_tests {
     fn a_fresh_ui_shows_nothing_and_leaves_the_keys_alone() {
         let ui = PushUi::new();
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert_eq!(ui.rows(), 0);
-        assert_eq!(ui.overlay(80), "");
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 0);
+        assert_eq!(ui.overlay(tall_pane(80)).text(), "");
     }
 
     #[test]
@@ -1071,8 +1122,8 @@ mod ui_tests {
         // the key table, or `y` would be read as an ordinary key.
         let ui = asking();
         assert_eq!(ui.mode(), InputMode::Confirm);
-        assert_eq!(ui.rows(), 1);
-        let overlay = ui.overlay(80);
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
+        let overlay = ui.overlay(tall_pane(80)).text();
         assert!(
             overlay.contains("Create new remote branch origin/gsw-push?"),
             "the question must be on screen, got {overlay:?}",
@@ -1094,12 +1145,13 @@ mod ui_tests {
         let mut ui = PushUi::new();
         ui.request(&snapshot(tracked(0)));
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert_eq!(ui.rows(), 1);
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         assert!(ui
-            .overlay(80)
+            .overlay(tall_pane(80))
+            .text()
             .contains("origin/gsw-push is already up to date"));
         assert!(
-            !ui.overlay(80).contains(CONFIRM_HINT),
+            !ui.overlay(tall_pane(80)).text().contains(CONFIRM_HINT),
             "a refusal must not offer keys that do nothing",
         );
     }
@@ -1115,7 +1167,11 @@ mod ui_tests {
             "the branch the question named must reach the runner",
         );
         assert_eq!(ui.mode(), InputMode::Pushing);
-        assert_eq!(ui.rows(), 1, "the running push stays on screen");
+        assert_eq!(
+            ui.overlay(tall_pane(80)).rows(),
+            1,
+            "the running push stays on screen"
+        );
     }
 
     #[test]
@@ -1142,7 +1198,11 @@ mod ui_tests {
         let mut ui = asking();
         ui.cancel();
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert_eq!(ui.rows(), 0, "a cancelled prompt leaves nothing behind");
+        assert_eq!(
+            ui.overlay(tall_pane(80)).rows(),
+            0,
+            "a cancelled prompt leaves nothing behind"
+        );
     }
 
     #[test]
@@ -1156,7 +1216,10 @@ mod ui_tests {
             output: "To /tmp/origin\n * [new branch] gsw-push -> gsw-push\n".to_string(),
         });
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert!(ui.overlay(80).contains("Created origin/gsw-push"));
+        assert!(ui
+            .overlay(tall_pane(80))
+            .text()
+            .contains("Created origin/gsw-push"));
     }
 
     #[test]
@@ -1169,7 +1232,8 @@ mod ui_tests {
             output: String::new(),
         });
         assert!(ui
-            .overlay(80)
+            .overlay(tall_pane(80))
+            .text()
             .contains("Pushed 3 commits to origin/gsw-push"));
     }
 
@@ -1186,7 +1250,7 @@ mod ui_tests {
                 .to_string(),
         });
         assert_eq!(ui.mode(), InputMode::Normal);
-        let overlay = ui.overlay(120);
+        let overlay = ui.overlay(tall_pane(120)).text();
         assert!(overlay.contains("! [rejected]"), "got {overlay:?}");
         assert!(
             overlay.contains("error: failed to push some refs"),
@@ -1210,7 +1274,7 @@ mod ui_tests {
                      error: failed to push some refs\n"
                 .to_string(),
         });
-        let overlay = ui.overlay(120);
+        let overlay = ui.overlay(tall_pane(120)).text();
         assert!(
             !overlay.contains("hint:"),
             "hints must not survive, got {overlay:?}"
@@ -1235,8 +1299,80 @@ mod ui_tests {
             success: false,
             output,
         });
-        assert_eq!(ui.rows(), MAX_STATUS_ROWS);
-        assert_eq!(ui.overlay(80).lines().count(), MAX_STATUS_ROWS);
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), MAX_STATUS_ROWS);
+        assert_eq!(
+            ui.overlay(tall_pane(80)).text().lines().count(),
+            MAX_STATUS_ROWS
+        );
+    }
+
+    #[test]
+    fn a_message_taller_than_the_pane_keeps_the_rows_the_frame_can_spare() {
+        // Three rows of error in a three-row pane: the frame is laid out to
+        // fill the pane exactly, so every row the overlay takes is a row the
+        // frame gave up, and the last one is not the frame's to give.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "To /tmp/origin\n\
+                     ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+                     error: failed to push some refs\n"
+                .to_string(),
+        });
+        let overlay = ui.overlay(Dimensions {
+            width: 80,
+            height: 3,
+        });
+        assert_eq!(overlay.rows(), 2, "the frame keeps the third row");
+        // git leads with the part worth reading, so the tail is what goes.
+        let text = overlay.text();
+        assert!(text.contains("To /tmp/origin"), "got {text:?}");
+        assert!(
+            !text.contains("error: failed to push some refs"),
+            "the last line is the one to drop, got {text:?}",
+        );
+    }
+
+    #[test]
+    fn a_one_row_pane_is_all_frame() {
+        // Nothing is left to overlay onto, and a pane showing only a question
+        // with no frame under it is not watch mode.
+        let ui = asking();
+        let overlay = ui.overlay(Dimensions {
+            width: 80,
+            height: 1,
+        });
+        assert_eq!(overlay.rows(), 0);
+        assert_eq!(overlay.text(), "");
+    }
+
+    #[test]
+    fn the_row_count_always_matches_the_text() {
+        // The whole reason these are one call: a count that disagrees with the
+        // text either leaves a blank strip under the frame or paints past the
+        // bottom of the pane.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: (1..=20)
+                .map(|n| format!("error: line {n}\n"))
+                .collect::<String>(),
+        });
+        for height in 0..8 {
+            let overlay = ui.overlay(Dimensions { width: 80, height });
+            let painted = if overlay.text().is_empty() {
+                0
+            } else {
+                overlay.text().lines().count()
+            };
+            assert_eq!(painted, overlay.rows(), "disagreed in a {height}-row pane");
+            assert!(
+                overlay.rows() < height.max(1),
+                "the frame lost its last row in a {height}-row pane",
+            );
+        }
     }
 
     #[test]
@@ -1249,9 +1385,9 @@ mod ui_tests {
             success: false,
             output: "   \n\n".to_string(),
         });
-        assert_eq!(ui.rows(), 1);
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         assert!(
-            !ui.overlay(80).trim().is_empty(),
+            !ui.overlay(tall_pane(80)).text().trim().is_empty(),
             "a failure must always say that it failed",
         );
     }
@@ -1266,10 +1402,14 @@ mod ui_tests {
             success: false,
             output: "error: failed to push some refs\n".to_string(),
         });
-        assert_eq!(ui.rows(), 1);
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         ui.dismiss();
-        assert_eq!(ui.rows(), 0, "a key press clears the message");
-        assert_eq!(ui.overlay(80), "");
+        assert_eq!(
+            ui.overlay(tall_pane(80)).rows(),
+            0,
+            "a key press clears the message"
+        );
+        assert_eq!(ui.overlay(tall_pane(80)).text(), "");
     }
 
     #[test]
@@ -1293,7 +1433,7 @@ mod ui_tests {
     fn a_running_push_says_so() {
         let mut ui = asking();
         ui.confirm();
-        let overlay = ui.overlay(80);
+        let overlay = ui.overlay(tall_pane(80)).text();
         assert!(
             overlay.to_lowercase().contains("push"),
             "the running notice must name what is happening, got {overlay:?}",
@@ -1309,7 +1449,7 @@ mod ui_tests {
         snap.branch = "a-branch-name-long-enough-to-need-truncating-on-a-narrow-pane".to_string();
         ui.request(&snap);
         for width in [10, 20, 40] {
-            let overlay = ui.overlay(width);
+            let overlay = ui.overlay(tall_pane(width)).text();
             for line in overlay.lines() {
                 assert!(
                     visible_width(line) <= width,
@@ -1328,7 +1468,7 @@ mod ui_tests {
         snap.branch = "日本語のブランチ名-🎉-café".to_string();
         ui.request(&snap);
         for width in 1..40 {
-            let overlay = ui.overlay(width);
+            let overlay = ui.overlay(tall_pane(width)).text();
             for line in overlay.lines() {
                 assert!(
                     visible_width(line) <= width,
@@ -1350,8 +1490,8 @@ mod ui_tests {
         });
         ui.request(&snapshot(None));
         assert_eq!(ui.mode(), InputMode::Confirm);
-        assert_eq!(ui.rows(), 1);
-        assert!(!ui.overlay(120).contains("error:"));
+        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
+        assert!(!ui.overlay(tall_pane(120)).text().contains("error:"));
     }
 }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -477,7 +477,10 @@ enum State {
         /// Whether this reports a failure, which the display colors red.
         failed: bool,
     },
-    /// A confirmation is on screen, waiting for an answer.
+    /// A confirmation is on screen, waiting for an answer. "On screen" is the
+    /// load-bearing half: [`PushUi::overlay`] leaves this state when it finds a
+    /// pane with no row to draw the question in, so the mode below can never
+    /// promise a question the user was not shown.
     Asking {
         question: String,
         creates_remote_branch: bool,
@@ -495,6 +498,10 @@ impl PushUi {
     }
 
     /// What keys mean right now.
+    ///
+    /// [`InputMode::Confirm`] is only ever reported while the question is
+    /// actually painted, which is why a render can move this back to
+    /// [`InputMode::Normal`] with no key pressed: see [`PushUi::overlay`].
     pub(crate) fn mode(&self) -> InputMode {
         match self.state {
             State::Asking { .. } => InputMode::Confirm,
@@ -615,7 +622,20 @@ impl PushUi {
     /// frame therefore always keeps a row of its own, and a message too tall
     /// for what is left loses its last lines — [`failure_lines`] puts git's
     /// most useful output first, so the head is the part worth keeping.
-    pub(crate) fn overlay(&self, dims: Dimensions) -> Overlay {
+    ///
+    /// That second clamp is why this takes `&mut self`. In a pane with no row
+    /// to spare it cuts a status down to nothing, which costs the user a
+    /// message and no more. It would cut a *confirmation* down to nothing too —
+    /// and a confirmation is not only text. [`PushUi::mode`] would go on
+    /// reporting [`InputMode::Confirm`], so Enter would go on meaning push: the
+    /// user presses `p`, sees a frame that did not change, presses Enter out of
+    /// reflex, and gsw pushes to a shared remote having asked nothing. A
+    /// question the user cannot see must not be answerable, so a question this
+    /// pane cannot draw is cancelled here, exactly as `n` cancels one. The keys
+    /// go back to normal in the same breath as the question leaves the screen,
+    /// because on this prompt they are the same fact. Nothing is lost but the
+    /// question: `p` in a pane with a row to spare asks it again.
+    pub(crate) fn overlay(&mut self, dims: Dimensions) -> Overlay {
         let width = dims.width;
         let lines: Vec<String> = match &self.state {
             State::Idle => Vec::new(),
@@ -655,6 +675,13 @@ impl PushUi {
             .into_iter()
             .take(dims.height.saturating_sub(1))
             .collect();
+        // Nothing survived the clamp. For a status that is the end of it, but a
+        // question that is not on screen must not still be answerable — the
+        // keys and the question go together, so the question goes. `cancel`
+        // does nothing in the states where there is no question to drop.
+        if lines.is_empty() {
+            self.cancel();
+        }
         // The frame gets what the overlay did not take. The clamp at one covers
         // only a degenerate zero-row pane: the take above already leaves a row
         // for the frame in every pane that has one, so this floor never fights
@@ -728,6 +755,11 @@ impl Overlay {
 /// means "this is what Enter gives you", and Enter *confirms* here — so `[y/N]`
 /// would promise that the key people reach for by reflex is the safe one, on
 /// the one prompt in gsw that writes to a shared remote.
+///
+/// The same reasoning is why a question this hint cannot be drawn with is
+/// cancelled rather than left pending (see [`PushUi::overlay`]). What makes
+/// Enter safe to bind to a push is that the user is looking at the sentence
+/// saying so. Off the screen, the binding keeps the risk and loses the sentence.
 const CONFIRM_HINT: &str = "[y/Enter = push, n/Esc = cancel]";
 
 /// What a running push says while the network round trip is in flight.
@@ -1151,7 +1183,7 @@ mod ui_tests {
 
     #[test]
     fn a_fresh_ui_shows_nothing_and_leaves_the_keys_alone() {
-        let ui = PushUi::new();
+        let mut ui = PushUi::new();
         assert_eq!(ui.mode(), InputMode::Normal);
         assert_eq!(ui.overlay(tall_pane(80)).rows(), 0);
         assert_eq!(ui.overlay(tall_pane(80)).text(), "");
@@ -1161,7 +1193,7 @@ mod ui_tests {
     fn requesting_a_push_asks_the_question_and_takes_the_keys() {
         // `p` on a pushable branch must put the question on screen AND switch
         // the key table, or `y` would be read as an ordinary key.
-        let ui = asking();
+        let mut ui = asking();
         assert_eq!(ui.mode(), InputMode::Confirm);
         assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         let overlay = ui.overlay(tall_pane(80)).text();
@@ -1379,13 +1411,39 @@ mod ui_tests {
     fn a_one_row_pane_is_all_frame() {
         // Nothing is left to overlay onto, and a pane showing only a question
         // with no frame under it is not watch mode.
-        let ui = asking();
+        let mut ui = asking();
         let overlay = ui.overlay(Dimensions {
             width: 80,
             height: 1,
         });
         assert_eq!(overlay.rows(), 0);
         assert_eq!(overlay.text(), "");
+    }
+
+    #[test]
+    fn a_question_the_pane_cannot_show_cannot_be_answered() {
+        // What the user sees in a one-row pane after pressing `p` is a frame
+        // that did not change, because there is no row left to draw the
+        // question in. If the keys still meant "push", the Enter they press out
+        // of reflex would push to a shared remote having asked nothing. So the
+        // question goes when its row does, and the keys go with it.
+        let mut ui = asking();
+        assert_eq!(ui.mode(), InputMode::Confirm, "the question was raised");
+        let overlay = ui.overlay(Dimensions {
+            width: 80,
+            height: 1,
+        });
+        assert_eq!(overlay.text(), "", "the pane had no row to ask in");
+        assert_eq!(
+            ui.mode(),
+            InputMode::Normal,
+            "a question that was never drawn must not leave the keys meaning push",
+        );
+        assert_eq!(
+            ui.confirm(),
+            None,
+            "Enter must not start a push nobody was asked about",
+        );
     }
 
     #[test]
@@ -1517,8 +1575,14 @@ mod ui_tests {
         // at the first pair and hide the rest behind a fix.
         let mut broken: Vec<String> = Vec::new();
 
-        for (name, ui) in every_state() {
-            for height in 0..=SWEEP_MAX_HEIGHT {
+        // Every pane gets its own freshly built states, rather than one
+        // `PushUi` being carried across the whole range of heights. `overlay`
+        // can change the state it was asked about — a question the pane cannot
+        // draw is cancelled there — so a carried instance would be idle by the
+        // second pane, and each state would be swept exactly once instead of
+        // nine times.
+        for height in 0..=SWEEP_MAX_HEIGHT {
+            for (name, mut ui) in every_state() {
                 let overlay = ui.overlay(Dimensions {
                     width: SWEEP_WIDTH,
                     height,

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -277,17 +277,19 @@ const RETRY_ADVICE: &str = "press p again";
 /// Three things are forced on the child, and all of them matter because gsw is
 /// holding the alternate screen in raw mode:
 ///
-/// - **The child gets no controlling terminal** ([`detach_from_terminal`]), so
-///   `/dev/tty` cannot be opened by it or by anything it runs. This is the part
+/// - **The child is detached from the terminal** ([`detach_from_terminal`]) —
+///   its own session on Unix, no inherited console on Windows — so the terminal
+///   device cannot be opened by it or by anything it runs. This is the part
 ///   that actually holds the guarantee, because a terminal prompt usually comes
-///   from a *descendant*: OpenSSH's `read_passphrase()` opens `/dev/tty`
-///   directly for a passphrase or an unknown host key, so a closed stdin and a
-///   captured stderr never reach it, and it has no read timeout — the push
-///   would hang behind a question gsw never drew while the two processes split
-///   the user's keystrokes. With no terminal to open, ssh falls back to
-///   `SSH_ASKPASS`, and with no `DISPLAY` it fails immediately and says so. The
-///   same is true of every other descendant, credential helpers included, which
-///   is why this is done to the process rather than to one transport.
+///   from a *descendant*: OpenSSH opens the terminal directly for a passphrase
+///   or an unknown host key (`/dev/tty` through `read_passphrase()`, `CONIN$`
+///   on Windows), so a closed stdin and a captured stderr never reach it, and
+///   it has no read timeout — the push would hang behind a question gsw never
+///   drew while the two processes split the user's keystrokes. With no terminal
+///   to open, ssh falls back to `SSH_ASKPASS`, and with no GUI askpass to run
+///   it fails immediately and says so. The same is true of every other
+///   descendant, credential helpers included, which is why this is done to the
+///   process rather than to one transport.
 /// - **stdin is closed** and **`GIT_TERMINAL_PROMPT=0`**, which is git's own
 ///   half of the same rule: git asks for HTTP usernames and passwords itself,
 ///   and this refuses those before the detachment has to. Disabled, git fails
@@ -361,22 +363,22 @@ fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
     }
 }
 
-/// Arrange for `command`'s child to run with no controlling terminal, so
-/// nothing in its process tree can open `/dev/tty`.
+/// Arrange for `command`'s child to run detached from the terminal, so nothing
+/// in its process tree can reach the keyboard gsw is reading.
+///
+/// Each platform names the terminal differently, so each gets its own arm: a
+/// session of its own on Unix, no inherited console on Windows. Both deny the
+/// same thing — the direct path to the terminal device, the one a closed stdin
+/// and captured output streams do not cover, because it bypasses the inherited
+/// descriptors entirely.
 ///
 /// The Unix half asks for a new session before the exec. A session leader has
 /// no controlling terminal until it deliberately acquires one, and no program
 /// git runs does that — so `open("/dev/tty")` returns `ENXIO` for the child,
-/// for ssh, and for every credential helper below them. That is what a prompt
-/// needs: it is the one path to the terminal that a closed stdin and captured
-/// output streams do not cover, because it bypasses the descriptors entirely.
-/// Refused it, OpenSSH sets `use_askpass` and either runs `SSH_ASKPASS` (a GUI
-/// prompt, which is fine — it does not touch the pane gsw is drawing on) or
-/// gives up at once with a message that reaches the status rows.
-///
-/// The Windows half is a no-op, and honestly so: there is no `/dev/tty` and no
-/// session to leave. `GIT_TERMINAL_PROMPT=0` and the closed stdin are the whole
-/// defense there.
+/// for ssh, and for every credential helper below them. Refused it, OpenSSH
+/// sets `use_askpass` and either runs `SSH_ASKPASS` (a GUI prompt, which is
+/// fine — it does not touch the pane gsw is drawing on) or gives up at once
+/// with a message that reaches the status rows.
 #[cfg(unix)]
 fn detach_from_terminal(command: &mut Command) {
     use std::os::unix::process::CommandExt;
@@ -400,9 +402,55 @@ fn detach_from_terminal(command: &mut Command) {
     }
 }
 
-/// See the Unix half above: Windows has no controlling terminal to leave and no
-/// `/dev/tty` to deny, so there is nothing to arrange.
-#[cfg(not(unix))]
+/// `CreateProcess`'s `DETACHED_PROCESS`: the new process does not inherit the
+/// console of the process that started it, and Windows will not give it one of
+/// its own. Deliberately not combined with `CREATE_NEW_CONSOLE`, which is its
+/// opposite and which `CreateProcess` rejects alongside it, and not written as
+/// `CREATE_NO_WINDOW`, which only hides a console the child still has and can
+/// still read from.
+///
+/// Spelled out here rather than pulled in from `windows-sys` or `winapi`: it is
+/// one integer fixed by the Win32 ABI, and a dependency the whole crate would
+/// carry for it is a worse trade than a constant with its value written down.
+#[cfg(windows)]
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+/// See the Unix half above. Windows has no `/dev/tty`, but it has the same
+/// hazard by a different door: a console. OpenSSH for Windows asks for a key
+/// passphrase or an unknown-host-key answer by opening `CONIN$` itself, which
+/// reaches the console the child inherited no matter what was done to its
+/// standard handles — so a closed stdin and captured output streams leave the
+/// push free to paint a prompt over gsw's alternate screen and race the event
+/// thread for the user's keystrokes, with no timeout to end it.
+///
+/// [`DETACHED_PROCESS`] closes that door the way `setsid` closes the Unix one.
+/// The child inherits no console and cannot be assigned one, so `CONIN$` and
+/// `CONOUT$` fail to open for it, for ssh, and for every credential helper
+/// below them. Denied the console, OpenSSH does what it does on Unix: it falls
+/// back to `SSH_ASKPASS` (a GUI prompt, which does not touch the pane gsw is
+/// drawing on) or fails immediately with a message that arrives on the captured
+/// stderr and lands in the status rows like any other error. The pipes are
+/// unaffected — the flag governs the console, not the standard handles, which
+/// the caller has already set.
+///
+/// **Not covered by any test in this repository.** The Unix half has a runtime
+/// test, `the_push_child_cannot_open_the_controlling_terminal`, which plants a
+/// fake ssh and asserts the child was refused the terminal. There is no Windows
+/// equivalent: no Windows host runs these tests and this repository has no CI,
+/// so such a test would be one nobody has ever seen pass or fail. This arm is
+/// verified by compiling for `x86_64-pc-windows-msvc` and by nothing else.
+#[cfg(windows)]
+fn detach_from_terminal(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(DETACHED_PROCESS);
+}
+
+/// Neither Unix nor Windows, so there is no terminal this code knows how to
+/// take away. The arm exists so the crate still builds for such a target rather
+/// than failing to find `detach_from_terminal`; on one, `GIT_TERMINAL_PROMPT=0`
+/// and the closed stdin are the whole defense.
+#[cfg(not(any(unix, windows)))]
 fn detach_from_terminal(_command: &mut Command) {}
 
 /// The branch checked out in `workdir` right now, or [`DETACHED_HEAD`] when
@@ -2011,8 +2059,9 @@ mod run_tests {
 
     /// What the push child's *descendants* can reach, which is where a terminal
     /// prompt actually comes from: the ssh transport, a credential helper, anything
-    /// git execs. Unix-only because `/dev/tty` is — Windows has no such device and
-    /// nothing to deny access to.
+    /// git execs. Unix-only because `/dev/tty` is: Windows denies the same access
+    /// by denying the child a console, and nothing here runs on Windows to check
+    /// it — see [`detach_from_terminal`]'s Windows arm, which says so plainly.
     #[cfg(unix)]
     mod terminal_tests {
         use super::*;

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -1416,6 +1416,172 @@ mod ui_tests {
         }
     }
 
+    /// A rejection as git writes one: several lines, more than a short pane can
+    /// hold. The status states are only worth sweeping against a message that
+    /// wants more rows than it can have.
+    const REJECTION: &str = "To /tmp/origin\n\
+                             ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+                             error: failed to push some refs to '/tmp/origin'\n";
+
+    /// Wide enough that no line is truncated, so the sweep below measures rows
+    /// and nothing else.
+    const SWEEP_WIDTH: usize = 80;
+
+    /// The tallest pane the sweep tries. Comfortably past [`MAX_STATUS_ROWS`],
+    /// so the sweep covers panes that are short, panes that are exactly full,
+    /// and panes with room to spare.
+    const SWEEP_MAX_HEIGHT: usize = 8;
+
+    /// A UI reporting the outcome of a push it asked about and ran.
+    fn reporting(outcome: PushOutcome) -> PushUi {
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(outcome);
+        ui
+    }
+
+    /// One `PushUi` in each state the push feature can hold, plus the two ways
+    /// it comes back to rest, each with a name the sweep can report.
+    ///
+    /// Built through `request`, `confirm`, `finished`, `cancel` and `dismiss` —
+    /// the same calls the watch loop makes — rather than by assembling a
+    /// `State` directly. A state built by hand could be one the loop can never
+    /// reach, and an invariant that holds only for unreachable states holds
+    /// nothing.
+    fn every_state() -> Vec<(&'static str, PushUi)> {
+        let cancelled = {
+            let mut ui = asking();
+            ui.cancel();
+            ui
+        };
+        let dismissed = {
+            let mut ui = reporting(PushOutcome {
+                success: false,
+                output: REJECTION.to_string(),
+            });
+            ui.dismiss();
+            ui
+        };
+        let refusing = {
+            let mut ui = PushUi::new();
+            ui.request(&snapshot(tracked(0)));
+            ui
+        };
+        let asking_to_update = {
+            let mut ui = PushUi::new();
+            ui.request(&snapshot(tracked(3)));
+            ui
+        };
+        let running = {
+            let mut ui = asking();
+            ui.confirm();
+            ui
+        };
+        vec![
+            ("idle", PushUi::new()),
+            ("asking to create a remote branch", asking()),
+            ("asking to update a remote branch", asking_to_update),
+            ("running a push", running),
+            (
+                "reporting a successful push",
+                reporting(PushOutcome {
+                    success: true,
+                    output: String::new(),
+                }),
+            ),
+            (
+                "reporting a failed push",
+                reporting(PushOutcome {
+                    success: false,
+                    output: REJECTION.to_string(),
+                }),
+            ),
+            ("refusing a branch with nothing to push", refusing),
+            ("a cancelled question", cancelled),
+            ("a dismissed status", dismissed),
+        ]
+    }
+
+    #[test]
+    fn the_row_split_holds_in_every_state_and_every_small_pane() {
+        // This arithmetic has now produced two separate review findings — an
+        // overlay that took more rows than the pane had, and a question that
+        // vanished on a one-row pane while the keys still meant "push". Both
+        // hid in a state and a pane size nobody spot-checked. So every state
+        // the feature can reach is swept against every pane from zero rows to
+        // eight, and all four rules are checked on each pair, rather than one
+        // rule being sampled at one size.
+        //
+        // Every broken pair is collected and reported together. A guard for a
+        // recurring class of defect must say how far the damage goes, not stop
+        // at the first pair and hide the rest behind a fix.
+        let mut broken: Vec<String> = Vec::new();
+
+        for (name, ui) in every_state() {
+            for height in 0..=SWEEP_MAX_HEIGHT {
+                let overlay = ui.overlay(Dimensions {
+                    width: SWEEP_WIDTH,
+                    height,
+                });
+
+                // The count and the body must be the same rows. A count larger
+                // than the text leaves a blank strip under the frame; a count
+                // smaller than it paints past the bottom of the pane.
+                let text = overlay.text();
+                let painted = if text.is_empty() {
+                    0
+                } else {
+                    text.lines().count()
+                };
+                if painted != overlay.rows() {
+                    broken.push(format!(
+                        "{name} in a {height}-row pane: rows() says {} but the text has \
+                         {painted} lines",
+                        overlay.rows(),
+                    ));
+                }
+
+                // The frame never loses its last row. A pane holding only a
+                // message says nothing about which repository it belongs to,
+                // and the repository is what watch mode is for.
+                if overlay.frame_rows() == 0 {
+                    broken.push(format!(
+                        "{name} in a {height}-row pane: the frame was left no rows at all",
+                    ));
+                }
+
+                // The two together must fit. The frame fills exactly the height
+                // it is given, so one row too many scrolls the alternate screen
+                // — the failure the last review found.
+                if overlay.rows() + overlay.frame_rows() > height.max(1) {
+                    broken.push(format!(
+                        "{name} in a {height}-row pane: {} overlay rows and {} frame rows \
+                         overflow it",
+                        overlay.rows(),
+                        overlay.frame_rows(),
+                    ));
+                }
+
+                // Whenever the keys mean "push", the question has to be on
+                // screen. A confirmation the user cannot read is a push they
+                // did not agree to.
+                if ui.mode() == InputMode::Confirm && overlay.rows() == 0 {
+                    broken.push(format!(
+                        "{name} in a {height}-row pane: the keys mean push, but the question \
+                         is not on screen",
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            broken.is_empty(),
+            "{} state/pane pairs broke the row split:\n{}",
+            broken.len(),
+            broken.join("\n"),
+        );
+    }
+
     #[test]
     fn a_failed_push_that_said_nothing_still_says_something() {
         // A push that fails with no output at all must not leave a blank row

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -478,9 +478,10 @@ enum State {
         failed: bool,
     },
     /// A confirmation is on screen, waiting for an answer. "On screen" is the
-    /// load-bearing half: [`PushUi::overlay`] leaves this state when it finds a
-    /// pane with no row to draw the question in, so the mode below can never
-    /// promise a question the user was not shown.
+    /// load-bearing half, and two rules keep it true: [`PushUi::request`] does
+    /// not enter this state in a pane with no row to draw the question in, and
+    /// [`PushUi::overlay`] leaves it when a resize takes that row away. So the
+    /// mode below can never promise a question the user was not shown.
     Asking {
         question: String,
         creates_remote_branch: bool,
@@ -500,8 +501,10 @@ impl PushUi {
     /// What keys mean right now.
     ///
     /// [`InputMode::Confirm`] is only ever reported while the question is
-    /// actually painted, which is why a render can move this back to
-    /// [`InputMode::Normal`] with no key pressed: see [`PushUi::overlay`].
+    /// actually painted. [`PushUi::request`] holds that up front, by not asking
+    /// a question the pane cannot show; [`PushUi::overlay`] holds it afterwards,
+    /// for a pane resized down while the question is up — which is why a render
+    /// can move this back to [`InputMode::Normal`] with no key pressed.
     pub(crate) fn mode(&self) -> InputMode {
         match self.state {
             State::Asking { .. } => InputMode::Confirm,
@@ -514,12 +517,35 @@ impl PushUi {
     ///
     /// Replaces whatever was on screen, so pressing `p` with a stale error up
     /// asks the new question instead of stacking a row under the old one.
-    pub(crate) fn request(&mut self, snapshot: &Snapshot, _dims: Dimensions) {
+    ///
+    /// A question is only ever raised in a pane that has a row to draw it in.
+    /// `dims` is the pane that is decided against, through
+    /// [`Overlay::rows_to_spare`] — the same rule the render path divides the
+    /// pane with, so the two cannot reach different answers about the same row.
+    /// A pane with nothing to spare is left [`State::Idle`]: nothing on screen,
+    /// and [`InputMode::Normal`], so the `y` or Enter behind the `p` is an
+    /// ordinary key. There is deliberately no "the pane is too short" notice —
+    /// a pane with no row for a one-line question has no row for a one-line
+    /// status either, and an explanation that cannot be drawn explains nothing.
+    ///
+    /// Declining the question *here* is what closes the burst. The watch loop
+    /// drains events until the channel has been quiet for a debounce interval,
+    /// and classifies each one against the mode as it stands mid-drain, so a
+    /// `p` and the Enter behind it — key autorepeat, a paste, a fast
+    /// double-tap — are read back to back with no render in between. Any rule
+    /// applied at render time is applied after the answer has already been
+    /// classified. [`PushUi::overlay`] still drops a question it cannot draw,
+    /// but that now covers only the pane resized down while a question is
+    /// already up: the render path is the only thing that sees the new size.
+    pub(crate) fn request(&mut self, snapshot: &Snapshot, dims: Dimensions) {
         self.state = match prompt_for(
             &snapshot.branch,
             snapshot.push_remote.as_deref(),
             snapshot.upstream.as_ref(),
         ) {
+            // Nowhere to put the question, so it is not asked. Idle rather than
+            // a message: see above.
+            PushPrompt::Confirm { .. } if Overlay::rows_to_spare(dims) == 0 => State::Idle,
             PushPrompt::Confirm {
                 question,
                 creates_remote_branch,
@@ -628,13 +654,22 @@ impl PushUi {
     /// message and no more. It would cut a *confirmation* down to nothing too —
     /// and a confirmation is not only text. [`PushUi::mode`] would go on
     /// reporting [`InputMode::Confirm`], so Enter would go on meaning push: the
-    /// user presses `p`, sees a frame that did not change, presses Enter out of
-    /// reflex, and gsw pushes to a shared remote having asked nothing. A
-    /// question the user cannot see must not be answerable, so a question this
-    /// pane cannot draw is cancelled here, exactly as `n` cancels one. The keys
-    /// go back to normal in the same breath as the question leaves the screen,
-    /// because on this prompt they are the same fact. Nothing is lost but the
-    /// question: `p` in a pane with a row to spare asks it again.
+    /// user presses Enter out of reflex at a frame that did not change, and gsw
+    /// pushes to a shared remote having asked nothing. A question the user
+    /// cannot see must not be answerable, so a question this pane cannot draw
+    /// is cancelled here, exactly as `n` cancels one. The keys go back to
+    /// normal in the same breath as the question leaves the screen, because on
+    /// this prompt they are the same fact.
+    ///
+    /// This is the backstop, not the rule. [`PushUi::request`] refuses to raise
+    /// a question a pane has no row for, using [`Overlay::rows_to_spare`] as
+    /// this does, and that is what covers a `p` pressed in a pane that is
+    /// already too short — it has to, because the watch loop can classify a
+    /// whole burst of keys with no render between them. What is left for the
+    /// cancel here is the pane that *shrinks* with a question already up: it
+    /// fitted when it was asked, a resize took its row, and this is the only
+    /// place that sees the new size. Nothing is lost but the question either
+    /// way: `p` in a pane with a row to spare asks it again.
     pub(crate) fn overlay(&mut self, dims: Dimensions) -> Overlay {
         let width = dims.width;
         let lines: Vec<String> = match &self.state {
@@ -673,7 +708,7 @@ impl PushUi {
         // what watch mode is for.
         let lines: Vec<String> = lines
             .into_iter()
-            .take(dims.height.saturating_sub(1))
+            .take(Overlay::rows_to_spare(dims))
             .collect();
         // Nothing survived the clamp. For a status that is the end of it, but a
         // question that is not on screen must not still be answerable — the
@@ -714,6 +749,20 @@ pub(crate) struct Overlay {
 }
 
 impl Overlay {
+    /// How many rows an overlay may take in a pane of `dims`: every row but the
+    /// one the frame keeps.
+    ///
+    /// The single place that rule is written down. [`PushUi::overlay`] clamps
+    /// its lines to it, and [`PushUi::request`] asks it whether a question can
+    /// be shown at all before raising one — two decisions about the same row,
+    /// and exactly the pair that must not drift. Spelled out in both places,
+    /// one of them would eventually go on offering a question the other refuses
+    /// to draw, which is the defect this whole type exists to make
+    /// unrepresentable.
+    fn rows_to_spare(dims: Dimensions) -> usize {
+        dims.height.saturating_sub(1)
+    }
+
     /// How many rows the frame must give up. Always at least one short of the
     /// pane, so the frame keeps a row whatever the overlay wanted to say.
     ///
@@ -756,10 +805,11 @@ impl Overlay {
 /// would promise that the key people reach for by reflex is the safe one, on
 /// the one prompt in gsw that writes to a shared remote.
 ///
-/// The same reasoning is why a question this hint cannot be drawn with is
-/// cancelled rather than left pending (see [`PushUi::overlay`]). What makes
-/// Enter safe to bind to a push is that the user is looking at the sentence
-/// saying so. Off the screen, the binding keeps the risk and loses the sentence.
+/// The same reasoning is why a question this hint cannot be drawn with is never
+/// raised (see [`PushUi::request`], and [`PushUi::overlay`] for the pane that
+/// shrinks under one). What makes Enter safe to bind to a push is that the user
+/// is looking at the sentence saying so. Off the screen, the binding keeps the
+/// risk and loses the sentence.
 const CONFIRM_HINT: &str = "[y/Enter = push, n/Esc = cancel]";
 
 /// What a running push says while the network round trip is in flight.

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -1465,6 +1465,131 @@ mod run_tests {
         );
     }
 
+    /// What the push child's *descendants* can reach, which is where a terminal
+    /// prompt actually comes from: the ssh transport, a credential helper, anything
+    /// git execs. Unix-only because `/dev/tty` is — Windows has no such device and
+    /// nothing to deny access to.
+    #[cfg(unix)]
+    mod terminal_tests {
+        use super::*;
+        use std::os::unix::fs::PermissionsExt;
+
+        /// What the fake ssh below writes when it *could* open the controlling
+        /// terminal — the failure this test exists to catch.
+        const TTY_OPENED: &str = "opened";
+
+        /// What the fake ssh writes when `/dev/tty` was unopenable, which is the
+        /// only outcome that keeps a transport from painting a prompt over gsw's
+        /// frame and racing it for the user's keystrokes.
+        const TTY_REFUSED: &str = "refused";
+
+        /// Whether the *test process* can open the controlling terminal.
+        ///
+        /// The assertion below is only worth making when there is a terminal for
+        /// the child to be denied. A `cargo test` started from a script, a CI
+        /// runner, or this repository's own pre-commit hook has no controlling
+        /// terminal at all, and `/dev/tty` is then unopenable for every process in
+        /// the tree whether or not the push child is detached — so the test would
+        /// pass while exercising nothing. It skips rather than bank a vacancy as a
+        /// green.
+        fn test_process_can_open_the_terminal() -> bool {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/tty")
+                .is_ok()
+        }
+
+        #[test]
+        fn the_push_child_cannot_open_the_controlling_terminal() {
+            // `GIT_TERMINAL_PROMPT=0` governs git's *own* prompts. The ssh
+            // transport is a separate program, and OpenSSH's `read_passphrase()`
+            // opens `/dev/tty` directly — a closed stdin and a captured stderr
+            // never reach it. So a passphrase-protected key with no agent, or an
+            // unknown host key, would paint a prompt gsw cannot see over the
+            // alternate screen and read the keystrokes the event thread is waiting
+            // for, with no timeout to end it. Nothing in the process tree may be
+            // able to open the terminal.
+            if !test_process_can_open_the_terminal() {
+                eprintln!(
+                    "skipped: this test process has no controlling terminal, so /dev/tty is \
+                 unopenable for every child regardless — the assertion would hold vacuously",
+                );
+                return;
+            }
+
+            let (_origin, clone) = clone_with_feature_branch();
+            let p = clone.path();
+
+            // Its own tempdir: two copies of this test run at once under a parallel
+            // `cargo test`, and a shared script or record path would have them
+            // overwrite each other's answer.
+            let probe = tempfile::tempdir().expect("tempdir");
+            let record = probe.path().join("tty-probe");
+            let fake_ssh = probe.path().join("fake-ssh");
+            // The subshell is deliberate: a failed `exec` redirection exits the
+            // shell it runs in, so the probe has to be a shell of its own for the
+            // `else` branch to be reachable.
+            std::fs::write(
+                &fake_ssh,
+                format!(
+                    "#!/bin/sh\n\
+                 if ( exec 3<>/dev/tty ) 2>/dev/null; then\n\
+                 \tprintf '{TTY_OPENED}' > '{record}'\n\
+                 else\n\
+                 \tprintf '{TTY_REFUSED}' > '{record}'\n\
+                 fi\n\
+                 exit 1\n",
+                    record = record.display(),
+                ),
+            )
+            .expect("write the fake ssh");
+            std::fs::set_permissions(
+                &fake_ssh,
+                std::fs::Permissions::from_mode(FAKE_SSH_EXECUTABLE_MODE),
+            )
+            .expect("make the fake ssh executable");
+
+            // `core.sshCommand` rather than `GIT_SSH_COMMAND`: the environment is
+            // process-global and this binary runs many git commands concurrently,
+            // so an env var would reach every other test's push. The config entry
+            // reaches this repository only. Nothing leaves the machine either —
+            // the fake ssh replaces the transport before any socket is opened.
+            git(
+                p,
+                &[
+                    "config",
+                    "core.sshCommand",
+                    fake_ssh.to_str().expect("utf-8 tempdir path"),
+                ],
+            );
+            git(
+                p,
+                &["remote", "add", "tty-probe", "ssh://127.0.0.1/nope.git"],
+            );
+
+            let outcome = run_push(&confirmed(&["push", "tty-probe", "feature"]), p);
+            assert!(
+                !outcome.success,
+                "the fake ssh connects to nothing, so the push must fail: {}",
+                outcome.output,
+            );
+
+            let recorded = std::fs::read_to_string(&record)
+                .expect("git never ran the ssh transport, so the probe proved nothing");
+            assert_eq!(
+                recorded.trim(),
+                TTY_REFUSED,
+                "the push child's own children can still open the controlling terminal, \
+             so ssh can prompt over gsw's frame and steal its keystrokes",
+            );
+        }
+
+        /// `rwxr-xr-x` — git has to be able to execute the fake ssh it is pointed
+        /// at, and a file written by `std::fs::write` is not executable.
+        const FAKE_SSH_EXECUTABLE_MODE: u32 = 0o755;
+    }
+
     /// The commit `refs/heads/<branch>` points at in the repository at `dir`,
     /// or `""` when there is no such branch. Compared before and after a push
     /// to say whether anything was actually sent.

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -131,49 +131,47 @@ pub(crate) fn prompt_for(
     remote: Option<&str>,
     upstream: Option<&UpstreamStatus>,
 ) -> PushPrompt {
-    let plan = PushPlan::resolve(branch, remote, upstream);
-    let success_message = match &plan {
-        PushPlan::Create { remote, branch } => format!("Created {remote}/{branch}"),
-        PushPlan::Update { target, commits } => {
-            let unit = if *commits == 1 { "commit" } else { "commits" };
-            format!("Pushed {commits} {unit} to {target}")
-        }
-        _ => String::new(),
-    };
-    let question = match &plan {
+    // One match, so a plan's wording and the command that carries it out are
+    // written side by side. The variants that never push return here, which is
+    // why no later step has to describe a push it can never be asked for.
+    match PushPlan::resolve(branch, remote, upstream) {
         // Named as the act it is. A branch that nobody on the remote has seen
         // appearing there is not the same event as an existing branch moving
         // forward, and the sentence has to be the thing that says so — the user
         // reads it in the half second before pressing `y`.
         PushPlan::Create { remote, branch } => {
-            format!("Create new remote branch {remote}/{branch}?")
+            let question = format!("Create new remote branch {remote}/{branch}?");
+            let success_message = format!("Created {remote}/{branch}");
+            PushPrompt::Confirm {
+                question,
+                creates_remote_branch: true,
+                // `-u` records the new remote branch as the upstream, so the
+                // push after this one is a plain update.
+                args: vec!["push".to_string(), "-u".to_string(), remote, branch],
+                success_message,
+            }
         }
         PushPlan::Update { target, commits } => {
-            let unit = if *commits == 1 { "commit" } else { "commits" };
-            format!("Push {commits} {unit} to {target}?")
-        }
-        PushPlan::UpToDate { target } => {
-            return PushPrompt::Refuse {
-                message: format!("{target} is already up to date"),
+            let unit = if commits == 1 { "commit" } else { "commits" };
+            PushPrompt::Confirm {
+                question: format!("Push {commits} {unit} to {target}?"),
+                creates_remote_branch: false,
+                // Bare `push`: git reads the remote and the refspec out of the
+                // branch config, so a branch tracking something other than the
+                // repository's default remote still goes to the right place.
+                args: vec!["push".to_string()],
+                success_message: format!("Pushed {commits} {unit} to {target}"),
             }
         }
-        PushPlan::Detached => {
-            return PushPrompt::Refuse {
-                message: format!("{DETACHED_HEAD} is detached — check out a branch to push"),
-            }
-        }
-        PushPlan::NoRemote => {
-            return PushPrompt::Refuse {
-                message: "no remote to push to".to_string(),
-            }
-        }
-    };
-
-    PushPrompt::Confirm {
-        question,
-        creates_remote_branch: matches!(plan, PushPlan::Create { .. }),
-        args: plan.command_args(),
-        success_message,
+        PushPlan::UpToDate { target } => PushPrompt::Refuse {
+            message: format!("{target} is already up to date"),
+        },
+        PushPlan::Detached => PushPrompt::Refuse {
+            message: format!("{DETACHED_HEAD} is detached — check out a branch to push"),
+        },
+        PushPlan::NoRemote => PushPrompt::Refuse {
+            message: "no remote to push to".to_string(),
+        },
     }
 }
 
@@ -545,29 +543,6 @@ impl PushPlan {
             },
         }
     }
-
-    /// The arguments to pass to `git`, not including the program name.
-    ///
-    /// # Panics
-    ///
-    /// Panics on any variant that describes a push which must never run.
-    /// Unreachable in practice: [`prompt_for`] is the only caller and it calls
-    /// this only for the two variants that do push.
-    fn command_args(&self) -> Vec<String> {
-        match self {
-            // Bare `push`: git reads the remote and the refspec out of the
-            // branch config, so a branch tracking something other than the
-            // repository's default remote still goes to the right place.
-            Self::Update { .. } => vec!["push".to_string()],
-            Self::Create { remote, branch } => vec![
-                "push".to_string(),
-                "-u".to_string(),
-                remote.clone(),
-                branch.clone(),
-            ],
-            other => unreachable!("gsw never runs a push for {other:?}"),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -591,21 +566,34 @@ mod tests {
         }
     }
 
+    /// The command a confirmable prompt carries. Panics on a refusal, so a test
+    /// that expected a push and got a message fails on the line that asked.
+    fn args(prompt: &PushPrompt) -> &[String] {
+        match prompt {
+            PushPrompt::Confirm { args, .. } => args,
+            PushPrompt::Refuse { message } => {
+                panic!("expected a confirmable prompt, got a refusal: {message}")
+            }
+        }
+    }
+
     #[test]
     fn a_branch_with_no_upstream_creates_it_on_the_remote() {
         // The common case in this workflow: a fresh worktree branch that has
         // never been pushed. The push must create the remote branch and record
         // it as the upstream, so the header's tracking segment appears and the
         // next push is a plain update.
-        let plan = PushPlan::resolve("gsw-push", Some("origin"), None);
         assert_eq!(
-            plan,
+            PushPlan::resolve("gsw-push", Some("origin"), None),
             PushPlan::Create {
                 remote: "origin".to_string(),
                 branch: "gsw-push".to_string(),
             },
         );
-        assert_eq!(plan.command_args(), ["push", "-u", "origin", "gsw-push"]);
+        assert_eq!(
+            args(&prompt_for("gsw-push", Some("origin"), None)),
+            ["push", "-u", "origin", "gsw-push"],
+        );
     }
 
     #[test]
@@ -614,15 +602,17 @@ mod tests {
         // A bare `git push` uses them, which keeps gsw from re-deriving a
         // refspec git would only override.
         let up = upstream("origin/gsw-push", 3, 0);
-        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up));
         assert_eq!(
-            plan,
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)),
             PushPlan::Update {
                 target: "origin/gsw-push".to_string(),
                 commits: 3,
             },
         );
-        assert_eq!(plan.command_args(), ["push"]);
+        assert_eq!(
+            args(&prompt_for("gsw-push", Some("origin"), Some(&up))),
+            ["push"]
+        );
     }
 
     #[test]
@@ -704,8 +694,10 @@ mod tests {
     fn the_create_plan_uses_the_remote_it_was_given() {
         // A repository whose only remote is not named `origin`. The plan must
         // carry that name through to the command rather than assuming `origin`.
-        let plan = PushPlan::resolve("gsw-push", Some("fork"), None);
-        assert_eq!(plan.command_args(), ["push", "-u", "fork", "gsw-push"]);
+        assert_eq!(
+            args(&prompt_for("gsw-push", Some("fork"), None)),
+            ["push", "-u", "fork", "gsw-push"],
+        );
     }
 
     #[test]

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -4,7 +4,9 @@
 //! `gix` cannot push, so the push itself is a `git` child process. Everything
 //! that *decides* — which remote, which arguments, what the confirmation says,
 //! and what an outcome means — lives here as pure, terminal-free code so it can
-//! be tested without a network or a pty. Only [`spawn`] touches a process.
+//! be tested without a network or a pty. Only [`run_push`], the blocking half of
+//! [`spawn`], starts a process: the push itself, and the read of HEAD that
+//! checks the repository is still on the branch the confirmation named.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -238,6 +240,10 @@ pub(crate) fn prompt_for(
 /// down the loop's own channel, so it re-enters the loop the same way every
 /// other event does — no shared state, and the outcome is applied between
 /// frames rather than during one.
+///
+/// Takes the whole [`PushCommand`] by value, so the branch the confirmation
+/// named crosses onto the thread with the arguments and [`run_push`] can still
+/// refuse a repository that moved on in the meantime.
 pub(crate) fn spawn<F>(command: PushCommand, workdir: PathBuf, on_finish: F)
 where
     F: FnOnce(PushOutcome) + Send + 'static,
@@ -245,10 +251,24 @@ where
     std::thread::spawn(move || on_finish(run_push(&command, &workdir)));
 }
 
+/// What a refused push tells the user to do. Pressing `p` again re-resolves the
+/// plan against the branch that is checked out now, so the next question
+/// describes the repository as it actually stands — which is the whole remedy.
+const RETRY_ADVICE: &str = "press p again";
+
 /// Run `git push` to completion and describe how it went.
 ///
 /// The blocking half of [`spawn`], separated so it can be tested against a real
 /// repository without a thread or a channel in the way.
+///
+/// **The branch is checked first.** A confirmation describes the repository as
+/// it stood when `p` was pressed, and the answer arrives whenever the user
+/// presses `y` — long enough for a checkout in another pane to land in between.
+/// So the branch [`PushCommand`] carries is compared against the one checked out
+/// *now*, and a mismatch refuses the push instead of running it against a
+/// repository the question never described. The gap between that read and git's
+/// own is microseconds rather than seconds; nothing here can close it entirely,
+/// short of a lock git does not offer.
 ///
 /// Two things are forced on the child, and both matter because gsw is holding
 /// the alternate screen in raw mode:
@@ -264,6 +284,21 @@ where
 ///   it renders only to a terminal, so a pipe removes the carriage-return
 ///   redraws that would otherwise arrive as unreadable status rows.
 fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
+    // `None` means git could not be run at all, which the push below reports in
+    // git's own terms. Refusing here instead would blame a branch change that
+    // did not happen — and a git that cannot start cannot push either.
+    if let Some(current) = current_branch(workdir) {
+        if current != command.branch() {
+            return PushOutcome {
+                success: false,
+                output: format!(
+                    "branch changed from {} to {current} since the confirmation — {RETRY_ADVICE}",
+                    command.branch(),
+                ),
+            };
+        }
+    }
+
     let result = Command::new("git")
         .args(command.args())
         .current_dir(workdir)
@@ -307,6 +342,40 @@ fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
         success,
         output: text,
     }
+}
+
+/// The branch checked out in `workdir` right now, or [`DETACHED_HEAD`] when
+/// there is none. `None` only when `git` could not be run at all.
+///
+/// Asked of `git` rather than of `gix`, for two reasons. It is the same
+/// question, put to the same program, from the same working directory, a
+/// moment before that program resolves HEAD for the push itself — so the answer
+/// cannot disagree with git's for a reason gsw would have to model, the way a
+/// second implementation of HEAD resolution eventually would. And it keeps the
+/// runner taking nothing but a [`PushCommand`] and a path: a `gix::Repository`
+/// is not `Send`, so a handle for this could not simply be carried onto the
+/// push thread, and the tests here would have to build one instead of pointing
+/// at a directory.
+///
+/// A detached HEAD reports as [`DETACHED_HEAD`], matching
+/// [`crate::repo::branch_name`] and the header gsw draws. git refuses `HEAD` as
+/// a branch name, so it can never equal a branch a confirmation named — a
+/// detached checkout always reads as a change.
+fn current_branch(workdir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
+        .current_dir(workdir)
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+
+    // Detached HEAD is a non-zero exit with nothing on stdout; both spellings
+    // of "no branch here" collapse to the sentinel.
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() || name.is_empty() {
+        return Some(DETACHED_HEAD.to_string());
+    }
+    Some(name)
 }
 
 /// How a finished `git push` came out.
@@ -565,7 +634,10 @@ impl PushPlan {
     /// `remote` is only consulted for [`PushPlan::Create`]. An
     /// [`PushPlan::Update`] runs a bare `git push` and lets git read the remote
     /// out of the branch config, so a branch tracking a remote other than the
-    /// repository's default still pushes to the right place.
+    /// repository's default still pushes to the right place. *Which* branch's
+    /// config git reads is decided by HEAD when the child runs, so the branch
+    /// resolved here travels with the arguments in a [`PushCommand`] and
+    /// [`run_push`] refuses the push if the checkout has moved by then.
     fn resolve(branch: &str, remote: Option<&str>, upstream: Option<&UpstreamStatus>) -> Self {
         // Checked before the upstream, so a tracking status left over from
         // before the checkout cannot make a detached HEAD look pushable.
@@ -1501,6 +1573,31 @@ mod run_tests {
         assert!(
             outcome.output.contains("press p again"),
             "the outcome must say how to retry, got {:?}",
+            outcome.output,
+        );
+    }
+
+    #[test]
+    fn a_detached_head_after_the_confirmation_is_not_pushed() {
+        // The other way the checkout can move: `git rebase`, `git bisect`, or a
+        // plain `git checkout <sha>` in another pane leaves no branch at all.
+        // `HEAD` is not a name git accepts for a branch, so it can never match
+        // the one the confirmation named.
+        let (origin, clone) = clone_with_feature_branch();
+        let p = clone.path();
+        let command = confirmed(&["push", "-u", "origin", "feature"]);
+        git(p, &["checkout", "-q", "--detach"]);
+
+        let outcome = run_push(&command, p);
+
+        assert!(!outcome.success, "got {:?}", outcome.output);
+        assert!(
+            !origin_has_feature(origin.path()),
+            "a detached checkout must stop the push like any other change",
+        );
+        assert!(
+            outcome.output.contains(DETACHED_HEAD),
+            "the outcome must name what HEAD is now, got {:?}",
             outcome.output,
         );
     }

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -315,7 +315,6 @@ impl PushUi {
 
     /// What keys mean right now.
     pub(crate) fn mode(&self) -> InputMode {
-        let _ = &self.state;
         match self.state {
             State::Asking { .. } => InputMode::Confirm,
             State::Running { .. } => InputMode::Pushing,

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -596,13 +596,17 @@ impl PushUi {
     }
 
     /// What the push feature shows in a pane of `dims`: the lines that fit
-    /// there, and — as [`Overlay::rows`] — how many rows the frame must give up
-    /// to make room for them.
+    /// there, how many rows the frame must give up to make room for them
+    /// ([`Overlay::rows`]), and how many rows the frame keeps
+    /// ([`Overlay::frame_rows`]).
     ///
-    /// Both come out of this one call because a row count and a body computed
-    /// apart can disagree, and either direction of disagreement is a bug: a
-    /// count larger than the text leaves a blank strip between the frame and
-    /// the message, a count smaller than it paints past the bottom of the pane.
+    /// All three come out of this one call because they are one decision — how
+    /// to divide `dims.height` between the frame and the message — and a
+    /// decision split across two modules is a decision that can disagree with
+    /// itself. A row count larger than the text leaves a blank strip between
+    /// the frame and the message; a count smaller than it paints past the
+    /// bottom of the pane; a frame height that does not match what is left over
+    /// scrolls the screen gsw was measured to fill exactly.
     ///
     /// Two clamps, one contract. gsw's standing rule is that nothing it paints
     /// ever wraps or scrolls the pane it was measured to fill, so each line is
@@ -647,31 +651,68 @@ impl PushUi {
         // push feature would leave the user watching an error with nothing
         // under it to say which repository it belongs to — and the frame is
         // what watch mode is for.
-        Overlay {
-            lines: lines
-                .into_iter()
-                .take(dims.height.saturating_sub(1))
-                .collect(),
-        }
+        let lines: Vec<String> = lines
+            .into_iter()
+            .take(dims.height.saturating_sub(1))
+            .collect();
+        // The frame gets what the overlay did not take. The clamp at one covers
+        // only a degenerate zero-row pane: the take above already leaves a row
+        // for the frame in every pane that has one, so this floor never fights
+        // the line above it for a row a real terminal reported.
+        let frame_rows = dims.height.saturating_sub(lines.len()).max(1);
+        Overlay { lines, frame_rows }
     }
 }
 
-/// What the push feature paints under the frame, sized for one particular pane.
+/// What the push feature paints under the frame, sized for one particular pane
+/// — and, with it, how tall the frame above it must be rendered.
 ///
 /// Built only by [`PushUi::overlay`], which is what makes the row count and the
 /// text impossible to disagree about: they are the same `Vec` — one measured,
 /// the other joined.
+///
+/// The frame's height is carried here for the same reason. The pane is divided
+/// once, and both halves of that division are read off the same value, so the
+/// caller cannot re-derive one of them and land somewhere else. It used to
+/// subtract [`Overlay::rows`] from the pane height itself, in another module —
+/// two expressions that had to agree by inspection, about arithmetic that has
+/// already produced two review findings.
 pub(crate) struct Overlay {
     /// Painted lines, each already truncated to the pane's width, and at most
     /// one fewer of them than the pane has rows.
     lines: Vec<String>,
+    /// Rows left for the frame, which is the pane's height less the lines
+    /// above, floored at one.
+    frame_rows: usize,
 }
 
 impl Overlay {
     /// How many rows the frame must give up. Always at least one short of the
     /// pane, so the frame keeps a row whatever the overlay wanted to say.
+    ///
+    /// Test-only, and that is the point of the refactor that made it so. The
+    /// watch loop used to read this and subtract it from the pane height
+    /// itself; it now asks for [`Overlay::frame_rows`] and gets the answer this
+    /// type already worked out. Nothing outside the tests needs the count on
+    /// its own any more, and a production caller that took it would be holding
+    /// half of a division it could complete differently. The tests still
+    /// measure it, because it is the number both halves of the split are made
+    /// of.
+    #[cfg(test)]
     pub(crate) fn rows(&self) -> usize {
         self.lines.len()
+    }
+
+    /// How many rows the frame is rendered with under this overlay.
+    ///
+    /// The frame is laid out to fill exactly the height it is given, so this is
+    /// the number that keeps the two together inside the pane: appending the
+    /// overlay to a full-height frame would push the frame's bottom row off the
+    /// screen. Never zero — a pane with nothing but a message in it is not
+    /// watch mode, so the frame keeps a row even when the pane reports none to
+    /// share.
+    pub(crate) fn frame_rows(&self) -> usize {
+        self.frame_rows
     }
 
     /// The text to paint under the frame: exactly [`Overlay::rows`] lines, and

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -13,14 +13,23 @@ use crate::repo::DETACHED_HEAD;
 /// confirmation appears — so the prompt describes the command that will run
 /// rather than a guess the user has to check afterwards.
 ///
-/// The three variants are the three answers the user needs: nothing will
-/// happen, an existing remote branch moves, or a branch appears on the remote
-/// that was not there before. That last one is the reason this is an enum
-/// rather than a struct with a `create: bool`: creating a remote branch is a
-/// different act from updating one, and it gets different wording and a
-/// different command.
+/// Two variants say a push will run — an existing remote branch moves, or a
+/// branch appears on the remote that was not there before. That split is the
+/// reason this is an enum rather than a struct with a `create: bool`: creating
+/// a remote branch is a different act from updating one, and it gets different
+/// wording and a different command.
+///
+/// The other three say a push will not run, and each carries *why*. Totality is
+/// deliberate: an `Option` would hand the caller a bare `None` and force it to
+/// re-derive the reason it was refused, which is the one piece of knowledge this
+/// module exists to own. Every plan can state its own case, so
+/// [`prompt_for`] — the only way in — always has something to say.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PushPlan {
+enum PushPlan {
+    /// HEAD is detached, so there is no branch to push.
+    Detached,
+    /// No remote gsw can push an untracked branch to.
+    NoRemote,
     /// The upstream already carries every local commit, so a push would send
     /// nothing. Kept as a plan rather than folded into `None` so the caller can
     /// say *why* it is not prompting.
@@ -48,51 +57,96 @@ pub(crate) enum PushPlan {
     },
 }
 
+/// What the watch loop does when the user presses `p`.
+///
+/// This is the whole interface [`prompt_for`] hands back, and it is deliberately
+/// two cases rather than five: the caller asks a question or shows a message,
+/// and never learns which plan produced either. A [`PushPlan`] variant added
+/// later — a rejected force push, a protected branch — changes the wording here
+/// without touching the loop that displays it.
+///
+/// [`PushPrompt::Confirm`] carries the command with the question, so the
+/// arguments cannot be requested for a push that must never run. The invariant
+/// is structural: there is no way to hold a `Confirm` without holding the exact
+/// argument list the confirmation described.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PushPrompt {
+    /// Ask before running the push.
+    Confirm {
+        /// The question, without the key hint — the display layer owns the
+        /// `[y/N]` convention.
+        question: String,
+        /// Whether this push creates a branch on the remote. The display layer
+        /// colors this case differently, so a create can never be mistaken for
+        /// a routine update at a glance.
+        creates_remote_branch: bool,
+        /// Arguments to pass to `git`, not including the program name.
+        args: Vec<String>,
+    },
+    /// Run nothing and show this instead. Not an error: the common cause is a
+    /// branch that is already fully pushed.
+    Refuse {
+        /// Why no push is going to happen.
+        message: String,
+    },
+}
+
+/// Decide what pressing `p` does, given the branch state gsw already renders.
+///
+/// The one way into this module. Callers pass what the snapshot holds and get
+/// back either a question with its command or a message — never a plan they
+/// have to interpret, and never an argument list they could run against the
+/// wrong question.
+///
+/// `upstream` is the snapshot's tracking status, which is `Some` only when the
+/// upstream is configured *and* its remote-tracking ref resolves. That is
+/// exactly the signal the wording needs: a branch whose remote ref is missing
+/// gets the create wording, because a push really will create it.
+pub(crate) fn prompt_for(
+    branch: &str,
+    remote: Option<&str>,
+    upstream: Option<&UpstreamStatus>,
+) -> PushPrompt {
+    let _ = PushPlan::resolve(branch, remote, upstream);
+    PushPrompt::Refuse {
+        message: String::new(),
+    }
+}
+
 impl PushPlan {
-    /// Resolve what a push would do, or `None` when there is nothing gsw can
-    /// push *from* or *to*.
+    /// Resolve what a push would do, including the reasons it would do nothing.
     ///
-    /// `None` covers the two cases where a prompt would be a lie: a detached
-    /// HEAD (no branch to push) and a repository with no usable remote. Both
-    /// are reported to the user as a status line rather than a prompt.
-    ///
-    /// `upstream` is the snapshot's tracking status, which is `Some` only when
-    /// the upstream is configured *and* its remote-tracking ref resolves. That
-    /// is exactly the signal the wording needs: a branch whose remote ref is
-    /// missing gets the create wording, because a push really will create it.
-    ///
-    /// `remote` is only consulted for [`PushPlan::Create`]. An [`PushPlan::Update`]
-    /// runs a bare `git push` and lets git read the remote out of the branch
-    /// config, so a branch tracking a remote other than the repository's default
-    /// still pushes to the right place.
-    pub(crate) fn resolve(
-        branch: &str,
-        remote: Option<&str>,
-        upstream: Option<&UpstreamStatus>,
-    ) -> Option<Self> {
+    /// `remote` is only consulted for [`PushPlan::Create`]. An
+    /// [`PushPlan::Update`] runs a bare `git push` and lets git read the remote
+    /// out of the branch config, so a branch tracking a remote other than the
+    /// repository's default still pushes to the right place.
+    fn resolve(branch: &str, remote: Option<&str>, upstream: Option<&UpstreamStatus>) -> Self {
         // Checked before the upstream, so a tracking status left over from
         // before the checkout cannot make a detached HEAD look pushable.
         if branch == DETACHED_HEAD {
-            return None;
+            return Self::Detached;
         }
 
         match upstream {
             // Level with the upstream, or behind it only: `git push` would
             // report "Everything up-to-date". Say so without the round trip.
-            Some(up) if up.ahead == 0 => Some(Self::UpToDate {
+            Some(up) if up.ahead == 0 => Self::UpToDate {
                 target: up.name.clone(),
-            }),
+            },
             // Ahead — including ahead *and* behind. A diverged branch is very
             // likely rejected as a non-fast-forward, and that rejection is what
             // the user needs to read. gsw does not pre-empt git's decision.
-            Some(up) => Some(Self::Update {
+            Some(up) => Self::Update {
                 target: up.name.clone(),
                 commits: up.ahead,
-            }),
-            None => remote.map(|remote| Self::Create {
-                remote: remote.to_string(),
-                branch: branch.to_string(),
-            }),
+            },
+            None => match remote {
+                Some(remote) => Self::Create {
+                    remote: remote.to_string(),
+                    branch: branch.to_string(),
+                },
+                None => Self::NoRemote,
+            },
         }
     }
 
@@ -100,9 +154,10 @@ impl PushPlan {
     ///
     /// # Panics
     ///
-    /// Panics on [`PushPlan::UpToDate`], which describes a push that must never
-    /// run. Callers prompt only for the other two variants.
-    pub(crate) fn command_args(&self) -> Vec<String> {
+    /// Panics on any variant that describes a push which must never run.
+    /// Unreachable in practice: [`prompt_for`] is the only caller and it calls
+    /// this only for the two variants that do push.
+    fn command_args(&self) -> Vec<String> {
         match self {
             // Bare `push`: git reads the remote and the refspec out of the
             // branch config, so a branch tracking something other than the
@@ -114,9 +169,7 @@ impl PushPlan {
                 remote.clone(),
                 branch.clone(),
             ],
-            Self::UpToDate { target } => {
-                unreachable!("gsw never runs a push for an up-to-date branch ({target})")
-            }
+            other => unreachable!("gsw never runs a push for {other:?}"),
         }
     }
 }
@@ -133,14 +186,22 @@ mod tests {
         }
     }
 
+    /// The question a prompt asks, or the reason it refuses — whichever this
+    /// prompt carries. Keeps each assertion to the one string under test.
+    fn text(prompt: &PushPrompt) -> &str {
+        match prompt {
+            PushPrompt::Confirm { question, .. } => question,
+            PushPrompt::Refuse { message } => message,
+        }
+    }
+
     #[test]
     fn a_branch_with_no_upstream_creates_it_on_the_remote() {
         // The common case in this workflow: a fresh worktree branch that has
         // never been pushed. The push must create the remote branch and record
         // it as the upstream, so the header's tracking segment appears and the
         // next push is a plain update.
-        let plan = PushPlan::resolve("gsw-push", Some("origin"), None)
-            .expect("a branch plus a remote is enough to push");
+        let plan = PushPlan::resolve("gsw-push", Some("origin"), None);
         assert_eq!(
             plan,
             PushPlan::Create {
@@ -157,8 +218,7 @@ mod tests {
         // A bare `git push` uses them, which keeps gsw from re-deriving a
         // refspec git would only override.
         let up = upstream("origin/gsw-push", 3, 0);
-        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up))
-            .expect("a tracked branch that is ahead has something to push");
+        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up));
         assert_eq!(
             plan,
             PushPlan::Update {
@@ -174,10 +234,8 @@ mod tests {
         // Level with the upstream: a push would send nothing, so the plan says
         // so and the caller shows a status line instead of a prompt.
         let up = upstream("origin/gsw-push", 0, 0);
-        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up))
-            .expect("a level branch still resolves, so the caller can say why");
         assert_eq!(
-            plan,
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)),
             PushPlan::UpToDate {
                 target: "origin/gsw-push".to_string(),
             },
@@ -190,10 +248,8 @@ mod tests {
         // Prompting for that wastes a network round trip and reads as a failure
         // when nothing failed.
         let up = upstream("origin/gsw-push", 0, 7);
-        let plan =
-            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)).expect("still resolves");
         assert_eq!(
-            plan,
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)),
             PushPlan::UpToDate {
                 target: "origin/gsw-push".to_string(),
             },
@@ -206,10 +262,8 @@ mod tests {
         // and that rejection is exactly what the user needs to see — gsw must
         // not pre-empt git's decision by refusing to try.
         let up = upstream("origin/gsw-push", 2, 5);
-        let plan =
-            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)).expect("still resolves");
         assert_eq!(
-            plan,
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)),
             PushPlan::Update {
                 target: "origin/gsw-push".to_string(),
                 commits: 2,
@@ -221,7 +275,10 @@ mod tests {
     fn a_branch_with_no_upstream_and_no_remote_cannot_be_pushed() {
         // A repository with no remote at all (or none gsw can pick). There is
         // nowhere to push, so there is nothing to confirm.
-        assert_eq!(PushPlan::resolve("gsw-push", None, None), None);
+        assert_eq!(
+            PushPlan::resolve("gsw-push", None, None),
+            PushPlan::NoRemote,
+        );
     }
 
     #[test]
@@ -230,7 +287,10 @@ mod tests {
         // refuses `HEAD` as a branch name, so this sentinel can never collide
         // with a real branch. Pushing it would create a remote branch literally
         // named `HEAD`.
-        assert_eq!(PushPlan::resolve(DETACHED_HEAD, Some("origin"), None), None);
+        assert_eq!(
+            PushPlan::resolve(DETACHED_HEAD, Some("origin"), None),
+            PushPlan::Detached,
+        );
     }
 
     #[test]
@@ -240,7 +300,7 @@ mod tests {
         let up = upstream("origin/main", 4, 0);
         assert_eq!(
             PushPlan::resolve(DETACHED_HEAD, Some("origin"), Some(&up)),
-            None,
+            PushPlan::Detached,
         );
     }
 
@@ -248,7 +308,105 @@ mod tests {
     fn the_create_plan_uses_the_remote_it_was_given() {
         // A repository whose only remote is not named `origin`. The plan must
         // carry that name through to the command rather than assuming `origin`.
-        let plan = PushPlan::resolve("gsw-push", Some("fork"), None).expect("one remote is enough");
+        let plan = PushPlan::resolve("gsw-push", Some("fork"), None);
         assert_eq!(plan.command_args(), ["push", "-u", "fork", "gsw-push"]);
+    }
+
+    #[test]
+    fn creating_a_remote_branch_says_so_and_is_marked() {
+        // The point of the whole variant: a branch that does not exist on the
+        // remote must not be confirmed with the same sentence as a routine
+        // update. The wording names the act, and the flag lets the display
+        // layer color it apart.
+        let prompt = prompt_for("gsw-push", Some("origin"), None);
+        assert_eq!(text(&prompt), "Create new remote branch origin/gsw-push?");
+        assert!(
+            matches!(
+                prompt,
+                PushPrompt::Confirm {
+                    creates_remote_branch: true,
+                    ..
+                },
+            ),
+            "a create must be flagged so the display layer can set it apart",
+        );
+    }
+
+    #[test]
+    fn updating_an_existing_remote_branch_counts_the_commits() {
+        // The routine case. It names the target and how much is going, and it
+        // is NOT flagged as a create — nothing new appears on the remote.
+        let up = upstream("origin/gsw-push", 3, 0);
+        let prompt = prompt_for("gsw-push", Some("origin"), Some(&up));
+        assert_eq!(text(&prompt), "Push 3 commits to origin/gsw-push?");
+        assert!(
+            matches!(
+                prompt,
+                PushPrompt::Confirm {
+                    creates_remote_branch: false,
+                    ..
+                },
+            ),
+            "updating an existing branch must not be flagged as a create",
+        );
+    }
+
+    #[test]
+    fn one_commit_is_singular() {
+        // "Push 1 commits" reads as a bug in the tool and undermines trust in
+        // the number right next to it.
+        let up = upstream("origin/gsw-push", 1, 0);
+        assert_eq!(
+            text(&prompt_for("gsw-push", Some("origin"), Some(&up))),
+            "Push 1 commit to origin/gsw-push?",
+        );
+    }
+
+    #[test]
+    fn the_confirmation_carries_the_command_it_describes() {
+        // The question and the argument list travel together, so what runs on
+        // `y` is what the sentence promised.
+        let PushPrompt::Confirm { args, .. } = prompt_for("gsw-push", Some("origin"), None) else {
+            panic!("an untracked branch with a remote must be confirmable");
+        };
+        assert_eq!(args, ["push", "-u", "origin", "gsw-push"]);
+    }
+
+    #[test]
+    fn an_up_to_date_branch_is_refused_by_name() {
+        // Not an error, and not a prompt either: pressing `p` on a fully-pushed
+        // branch must say why nothing happened, naming the branch it checked.
+        assert_eq!(
+            prompt_for(
+                "gsw-push",
+                Some("origin"),
+                Some(&upstream("origin/gsw-push", 0, 0))
+            ),
+            PushPrompt::Refuse {
+                message: "origin/gsw-push is already up to date".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn a_detached_head_is_refused_with_the_way_out() {
+        // The message names the fix, because "cannot push" alone leaves the
+        // user guessing at what gsw objected to.
+        assert_eq!(
+            prompt_for(DETACHED_HEAD, Some("origin"), None),
+            PushPrompt::Refuse {
+                message: "HEAD is detached — check out a branch to push".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn a_repository_with_no_remote_is_refused() {
+        assert_eq!(
+            prompt_for("gsw-push", None, None),
+            PushPrompt::Refuse {
+                message: "no remote to push to".to_string(),
+            },
+        );
     }
 }

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -1,0 +1,219 @@
+//! Pushing the current branch from watch mode: what a push will do, how it is
+//! described to the user before it runs, and how it is run.
+//!
+//! `gix` cannot push, so the push itself is a `git` child process. Everything
+//! that *decides* — which remote, which arguments, what the confirmation says,
+//! and what an outcome means — lives here as pure, terminal-free code so it can
+//! be tested without a network or a pty. Only [`spawn`] touches a process.
+
+use crate::render::UpstreamStatus;
+use crate::repo::DETACHED_HEAD;
+
+/// What pressing `p` will actually do, resolved from the snapshot *before* the
+/// confirmation appears — so the prompt describes the command that will run
+/// rather than a guess the user has to check afterwards.
+///
+/// The three variants are the three answers the user needs: nothing will
+/// happen, an existing remote branch moves, or a branch appears on the remote
+/// that was not there before. That last one is the reason this is an enum
+/// rather than a struct with a `create: bool`: creating a remote branch is a
+/// different act from updating one, and it gets different wording and a
+/// different command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PushPlan {
+    /// The upstream already carries every local commit, so a push would send
+    /// nothing. Kept as a plan rather than folded into `None` so the caller can
+    /// say *why* it is not prompting.
+    UpToDate {
+        /// Short upstream name, e.g. `origin/gsw-push`.
+        target: String,
+    },
+    /// The branch tracks a remote branch that exists and is behind HEAD. Runs a
+    /// bare `git push`, which follows the configured upstream — so gsw never
+    /// has to re-derive a remote and a refspec git already knows.
+    Update {
+        /// Short upstream name, e.g. `origin/gsw-push`.
+        target: String,
+        /// Commits HEAD has that the upstream does not.
+        commits: u32,
+    },
+    /// The branch has no upstream, so the push creates the branch on the remote
+    /// and records it as the upstream (`-u`). This is the case the confirmation
+    /// must call out: it puts a branch on a shared remote that nobody has seen.
+    Create {
+        /// Remote to create the branch on.
+        remote: String,
+        /// Local branch name, which is also the remote branch name.
+        branch: String,
+    },
+}
+
+impl PushPlan {
+    /// Resolve what a push would do, or `None` when there is nothing gsw can
+    /// push *from* or *to*.
+    ///
+    /// `None` covers the two cases where a prompt would be a lie: a detached
+    /// HEAD (no branch to push) and a repository with no usable remote. Both
+    /// are reported to the user as a status line rather than a prompt.
+    ///
+    /// `upstream` is the snapshot's tracking status, which is `Some` only when
+    /// the upstream is configured *and* its remote-tracking ref resolves. That
+    /// is exactly the signal the wording needs: a branch whose remote ref is
+    /// missing gets the create wording, because a push really will create it.
+    ///
+    /// `remote` is only consulted for [`PushPlan::Create`]. An [`PushPlan::Update`]
+    /// runs a bare `git push` and lets git read the remote out of the branch
+    /// config, so a branch tracking a remote other than the repository's default
+    /// still pushes to the right place.
+    pub(crate) fn resolve(
+        branch: &str,
+        remote: Option<&str>,
+        upstream: Option<&UpstreamStatus>,
+    ) -> Option<Self> {
+        let _ = (branch, remote, upstream, DETACHED_HEAD);
+        None
+    }
+
+    /// The arguments to pass to `git`, not including the program name.
+    ///
+    /// # Panics
+    ///
+    /// Panics on [`PushPlan::UpToDate`], which describes a push that must never
+    /// run. Callers prompt only for the other two variants.
+    pub(crate) fn command_args(&self) -> Vec<String> {
+        let _ = self;
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn upstream(name: &str, ahead: u32, behind: u32) -> UpstreamStatus {
+        UpstreamStatus {
+            name: name.to_string(),
+            ahead,
+            behind,
+        }
+    }
+
+    #[test]
+    fn a_branch_with_no_upstream_creates_it_on_the_remote() {
+        // The common case in this workflow: a fresh worktree branch that has
+        // never been pushed. The push must create the remote branch and record
+        // it as the upstream, so the header's tracking segment appears and the
+        // next push is a plain update.
+        let plan = PushPlan::resolve("gsw-push", Some("origin"), None)
+            .expect("a branch plus a remote is enough to push");
+        assert_eq!(
+            plan,
+            PushPlan::Create {
+                remote: "origin".to_string(),
+                branch: "gsw-push".to_string(),
+            },
+        );
+        assert_eq!(plan.command_args(), ["push", "-u", "origin", "gsw-push"]);
+    }
+
+    #[test]
+    fn a_tracked_branch_that_is_ahead_updates_the_remote_branch() {
+        // The upstream exists, so git already knows the remote and the refspec.
+        // A bare `git push` uses them, which keeps gsw from re-deriving a
+        // refspec git would only override.
+        let up = upstream("origin/gsw-push", 3, 0);
+        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up))
+            .expect("a tracked branch that is ahead has something to push");
+        assert_eq!(
+            plan,
+            PushPlan::Update {
+                target: "origin/gsw-push".to_string(),
+                commits: 3,
+            },
+        );
+        assert_eq!(plan.command_args(), ["push"]);
+    }
+
+    #[test]
+    fn a_tracked_branch_that_is_level_has_nothing_to_push() {
+        // Level with the upstream: a push would send nothing, so the plan says
+        // so and the caller shows a status line instead of a prompt.
+        let up = upstream("origin/gsw-push", 0, 0);
+        let plan = PushPlan::resolve("gsw-push", Some("origin"), Some(&up))
+            .expect("a level branch still resolves, so the caller can say why");
+        assert_eq!(
+            plan,
+            PushPlan::UpToDate {
+                target: "origin/gsw-push".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn a_tracked_branch_that_is_only_behind_has_nothing_to_push() {
+        // Behind but not ahead: `git push` would report "Everything up-to-date".
+        // Prompting for that wastes a network round trip and reads as a failure
+        // when nothing failed.
+        let up = upstream("origin/gsw-push", 0, 7);
+        let plan =
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)).expect("still resolves");
+        assert_eq!(
+            plan,
+            PushPlan::UpToDate {
+                target: "origin/gsw-push".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn a_tracked_branch_that_is_ahead_and_behind_still_pushes() {
+        // Diverged. The push will very likely be rejected as a non-fast-forward,
+        // and that rejection is exactly what the user needs to see — gsw must
+        // not pre-empt git's decision by refusing to try.
+        let up = upstream("origin/gsw-push", 2, 5);
+        let plan =
+            PushPlan::resolve("gsw-push", Some("origin"), Some(&up)).expect("still resolves");
+        assert_eq!(
+            plan,
+            PushPlan::Update {
+                target: "origin/gsw-push".to_string(),
+                commits: 2,
+            },
+        );
+    }
+
+    #[test]
+    fn a_branch_with_no_upstream_and_no_remote_cannot_be_pushed() {
+        // A repository with no remote at all (or none gsw can pick). There is
+        // nowhere to push, so there is nothing to confirm.
+        assert_eq!(PushPlan::resolve("gsw-push", None, None), None);
+    }
+
+    #[test]
+    fn a_detached_head_cannot_be_pushed() {
+        // `repo::branch_name` reports `HEAD` when HEAD is detached, and git
+        // refuses `HEAD` as a branch name, so this sentinel can never collide
+        // with a real branch. Pushing it would create a remote branch literally
+        // named `HEAD`.
+        assert_eq!(PushPlan::resolve(DETACHED_HEAD, Some("origin"), None), None);
+    }
+
+    #[test]
+    fn a_detached_head_cannot_be_pushed_even_with_a_stale_upstream() {
+        // Belt and braces: a detached HEAD must be refused before the upstream
+        // is consulted, so a leftover tracking status cannot make it pushable.
+        let up = upstream("origin/main", 4, 0);
+        assert_eq!(
+            PushPlan::resolve(DETACHED_HEAD, Some("origin"), Some(&up)),
+            None,
+        );
+    }
+
+    #[test]
+    fn the_create_plan_uses_the_remote_it_was_given() {
+        // A repository whose only remote is not named `origin`. The plan must
+        // carry that name through to the command rather than assuming `origin`.
+        let plan = PushPlan::resolve("gsw-push", Some("fork"), None).expect("one remote is enough");
+        assert_eq!(plan.command_args(), ["push", "-u", "fork", "gsw-push"]);
+    }
+}

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -837,6 +837,33 @@ mod ui_tests {
         })
     }
 
+    /// The display width of `line` in terminal columns, ignoring ANSI escapes.
+    ///
+    /// The escapes have to be stripped rather than assumed absent.
+    /// `colored` decides whether to emit them from process-global state that
+    /// other tests in this binary toggle (`colored::control::set_override`), so
+    /// a raw `UnicodeWidthStr::width` counts escape bytes as columns in some
+    /// runs and not others — the assertion would pass or fail depending on test
+    /// order. Columns on screen are also the thing under test: the overlay
+    /// colors *after* truncating, so the escapes cost the user nothing.
+    fn visible_width(line: &str) -> usize {
+        let mut visible = String::new();
+        let mut chars = line.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                // A CSI sequence runs until a letter terminates it.
+                for tail in chars.by_ref() {
+                    if tail.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                visible.push(c);
+            }
+        }
+        unicode_width::UnicodeWidthStr::width(visible.as_str())
+    }
+
     /// A UI with the confirmation already on screen for an untracked branch.
     fn asking() -> PushUi {
         let mut ui = PushUi::new();
@@ -1101,7 +1128,7 @@ mod ui_tests {
             let overlay = ui.overlay(width);
             for line in overlay.lines() {
                 assert!(
-                    unicode_width::UnicodeWidthStr::width(line) <= width,
+                    visible_width(line) <= width,
                     "line {line:?} exceeds width {width}",
                 );
             }
@@ -1120,7 +1147,7 @@ mod ui_tests {
             let overlay = ui.overlay(width);
             for line in overlay.lines() {
                 assert!(
-                    unicode_width::UnicodeWidthStr::width(line) <= width,
+                    visible_width(line) <= width,
                     "line {line:?} exceeds width {width}",
                 );
             }

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -514,7 +514,7 @@ impl PushUi {
     ///
     /// Replaces whatever was on screen, so pressing `p` with a stale error up
     /// asks the new question instead of stacking a row under the old one.
-    pub(crate) fn request(&mut self, snapshot: &Snapshot) {
+    pub(crate) fn request(&mut self, snapshot: &Snapshot, _dims: Dimensions) {
         self.state = match prompt_for(
             &snapshot.branch,
             snapshot.push_remote.as_deref(),
@@ -1177,7 +1177,7 @@ mod ui_tests {
     /// A UI with the confirmation already on screen for an untracked branch.
     fn asking() -> PushUi {
         let mut ui = PushUi::new();
-        ui.request(&snapshot(None));
+        ui.request(&snapshot(None), tall_pane(80));
         ui
     }
 
@@ -1216,7 +1216,7 @@ mod ui_tests {
         // The refusal is a message, not a question: the keys must stay normal,
         // so `y` does not answer a prompt that is not there.
         let mut ui = PushUi::new();
-        ui.request(&snapshot(tracked(0)));
+        ui.request(&snapshot(tracked(0)), tall_pane(80));
         assert_eq!(ui.mode(), InputMode::Normal);
         assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         assert!(ui
@@ -1298,7 +1298,7 @@ mod ui_tests {
     #[test]
     fn a_successful_update_counts_what_it_pushed() {
         let mut ui = PushUi::new();
-        ui.request(&snapshot(tracked(3)));
+        ui.request(&snapshot(tracked(3)), tall_pane(80));
         ui.confirm();
         ui.finished(PushOutcome {
             success: true,
@@ -1447,6 +1447,33 @@ mod ui_tests {
     }
 
     #[test]
+    fn a_pane_with_no_room_for_the_question_is_never_asked_it() {
+        // The cancel above runs at render time, and there is no render between
+        // the `p` and the `y` of one burst of keys. So the pane has to be
+        // consulted where the question is raised: a `p` in a pane with no row
+        // to spare leaves the keys alone, and there is no question for a later
+        // key to answer.
+        let mut ui = PushUi::new();
+        ui.request(
+            &snapshot(None),
+            Dimensions {
+                width: 80,
+                height: 1,
+            },
+        );
+        assert_eq!(
+            ui.mode(),
+            InputMode::Normal,
+            "a question the pane cannot hold must not switch the key table",
+        );
+        assert_eq!(
+            ui.confirm(),
+            None,
+            "there must be no question waiting for a `y` that never saw one",
+        );
+    }
+
+    #[test]
     fn the_row_count_always_matches_the_text() {
         // The whole reason these are one call: a count that disagrees with the
         // text either leaves a blank strip under the frame or paints past the
@@ -1522,12 +1549,12 @@ mod ui_tests {
         };
         let refusing = {
             let mut ui = PushUi::new();
-            ui.request(&snapshot(tracked(0)));
+            ui.request(&snapshot(tracked(0)), tall_pane(80));
             ui
         };
         let asking_to_update = {
             let mut ui = PushUi::new();
-            ui.request(&snapshot(tracked(3)));
+            ui.request(&snapshot(tracked(3)), tall_pane(80));
             ui
         };
         let running = {
@@ -1718,7 +1745,7 @@ mod ui_tests {
         let mut ui = PushUi::new();
         let mut snap = snapshot(None);
         snap.branch = "a-branch-name-long-enough-to-need-truncating-on-a-narrow-pane".to_string();
-        ui.request(&snap);
+        ui.request(&snap, tall_pane(80));
         for width in [10, 20, 40] {
             let overlay = ui.overlay(tall_pane(width)).text();
             for line in overlay.lines() {
@@ -1737,7 +1764,7 @@ mod ui_tests {
         let mut ui = PushUi::new();
         let mut snap = snapshot(None);
         snap.branch = "日本語のブランチ名-🎉-café".to_string();
-        ui.request(&snap);
+        ui.request(&snap, tall_pane(80));
         for width in 1..40 {
             let overlay = ui.overlay(tall_pane(width)).text();
             for line in overlay.lines() {
@@ -1759,7 +1786,7 @@ mod ui_tests {
             success: false,
             output: "error: failed to push some refs\n".to_string(),
         });
-        ui.request(&snapshot(None));
+        ui.request(&snapshot(None), tall_pane(80));
         assert_eq!(ui.mode(), InputMode::Confirm);
         assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
         assert!(!ui.overlay(tall_pane(120)).text().contains("error:"));

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -270,16 +270,26 @@ const RETRY_ADVICE: &str = "press p again";
 /// own is microseconds rather than seconds; nothing here can close it entirely,
 /// short of a lock git does not offer.
 ///
-/// Two things are forced on the child, and both matter because gsw is holding
-/// the alternate screen in raw mode:
+/// Three things are forced on the child, and all of them matter because gsw is
+/// holding the alternate screen in raw mode:
 ///
-/// - **stdin is closed** and **`GIT_TERMINAL_PROMPT=0`**, so git can never ask
-///   for a username or a passphrase. Left able to prompt, it would read from the
-///   same terminal the event-reader thread is reading, and the two would fight
-///   over the user's keystrokes with a question on screen that gsw did not draw.
-///   Disabled, git fails immediately and says why, which lands in the status
-///   rows like any other error. Credential helpers and a GUI `SSH_ASKPASS` are
-///   untouched — only prompting *at the terminal* is refused.
+/// - **The child gets no controlling terminal** ([`detach_from_terminal`]), so
+///   `/dev/tty` cannot be opened by it or by anything it runs. This is the part
+///   that actually holds the guarantee, because a terminal prompt usually comes
+///   from a *descendant*: OpenSSH's `read_passphrase()` opens `/dev/tty`
+///   directly for a passphrase or an unknown host key, so a closed stdin and a
+///   captured stderr never reach it, and it has no read timeout — the push
+///   would hang behind a question gsw never drew while the two processes split
+///   the user's keystrokes. With no terminal to open, ssh falls back to
+///   `SSH_ASKPASS`, and with no `DISPLAY` it fails immediately and says so. The
+///   same is true of every other descendant, credential helpers included, which
+///   is why this is done to the process rather than to one transport.
+/// - **stdin is closed** and **`GIT_TERMINAL_PROMPT=0`**, which is git's own
+///   half of the same rule: git asks for HTTP usernames and passwords itself,
+///   and this refuses those before the detachment has to. Disabled, git fails
+///   immediately and says why, which lands in the status rows like any other
+///   error. Credential helpers and a GUI `SSH_ASKPASS` are untouched — they do
+///   not need the terminal, and only prompting *at the terminal* is refused.
 /// - **Both streams are captured**, which also suppresses git's progress meter:
 ///   it renders only to a terminal, so a pipe removes the carriage-return
 ///   redraws that would otherwise arrive as unreadable status rows.
@@ -299,12 +309,14 @@ fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
         }
     }
 
-    let result = Command::new("git")
+    let mut child = Command::new("git");
+    child
         .args(command.args())
         .current_dir(workdir)
         .stdin(Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output();
+        .env("GIT_TERMINAL_PROMPT", "0");
+    detach_from_terminal(&mut child);
+    let result = child.output();
 
     let output = match result {
         Ok(output) => output,
@@ -343,6 +355,50 @@ fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
         output: text,
     }
 }
+
+/// Arrange for `command`'s child to run with no controlling terminal, so
+/// nothing in its process tree can open `/dev/tty`.
+///
+/// The Unix half asks for a new session before the exec. A session leader has
+/// no controlling terminal until it deliberately acquires one, and no program
+/// git runs does that — so `open("/dev/tty")` returns `ENXIO` for the child,
+/// for ssh, and for every credential helper below them. That is what a prompt
+/// needs: it is the one path to the terminal that a closed stdin and captured
+/// output streams do not cover, because it bypasses the descriptors entirely.
+/// Refused it, OpenSSH sets `use_askpass` and either runs `SSH_ASKPASS` (a GUI
+/// prompt, which is fine — it does not touch the pane gsw is drawing on) or
+/// gives up at once with a message that reaches the status rows.
+///
+/// The Windows half is a no-op, and honestly so: there is no `/dev/tty` and no
+/// session to leave. `GIT_TERMINAL_PROMPT=0` and the closed stdin are the whole
+/// defense there.
+#[cfg(unix)]
+fn detach_from_terminal(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: the closure runs in the forked child, between `fork` and `exec`,
+    // where only async-signal-safe functions may be called. `setsid` is one
+    // (POSIX.1-2017, "Signal Concepts"); it is a bare syscall that allocates
+    // nothing and takes no lock the parent's other threads could be holding.
+    unsafe {
+        command.pre_exec(|| {
+            // The return value is deliberately dropped. `setsid` fails with
+            // EPERM when the caller is already a process group leader, which
+            // means a new session was not available — harmless, and not worth
+            // failing a push over: the terminal defenses below it still stand,
+            // and returning an error here would abort the exec and report a
+            // push failure to a user who has done nothing wrong. There is no
+            // other failure mode.
+            let _ = libc::setsid();
+            Ok(())
+        });
+    }
+}
+
+/// See the Unix half above: Windows has no controlling terminal to leave and no
+/// `/dev/tty` to deny, so there is nothing to arrange.
+#[cfg(not(unix))]
+fn detach_from_terminal(_command: &mut Command) {}
 
 /// The branch checked out in `workdir` right now, or [`DETACHED_HEAD`] when
 /// there is none. `None` only when `git` could not be run at all.

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -214,10 +214,48 @@ where
 ///   it renders only to a terminal, so a pipe removes the carriage-return
 ///   redraws that would otherwise arrive as unreadable status rows.
 fn run_push(args: &[String], workdir: &Path) -> PushOutcome {
-    let _ = (args, workdir, Command::new("git"), Stdio::null());
+    let result = Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .stdin(Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output();
+
+    let output = match result {
+        Ok(output) => output,
+        // git is missing, or not executable. Rare, and worth saying plainly:
+        // every other failure here is git's own words, and this one would
+        // otherwise arrive as an empty message.
+        Err(error) => {
+            return PushOutcome {
+                success: false,
+                output: format!("cannot run git: {error}"),
+            }
+        }
+    };
+
+    // stderr first: `git push` reports what it did — `To <remote>`, the ref
+    // updates, and every rejection — on stderr, and writes to stdout only under
+    // flags gsw does not pass. Leading with it puts the useful lines in the
+    // three rows a status message gets.
+    let mut text = String::from_utf8_lossy(&output.stderr).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    // Carriage returns are how a progress meter redraws in place. Capturing
+    // both streams already suppresses it, so this is for anything else that
+    // emits CRLF: left in, a stray `\r` would send the cursor to column zero
+    // mid-row and scramble the frame under it.
+    let mut text = text.replace('\r', "");
+
+    let success = output.status.success();
+    if !success && text.trim().is_empty() {
+        // A failure with nothing to show would render as a blank row, which
+        // reads as success. The exit status is all git left us.
+        text = format!("git push failed ({})", output.status);
+    }
+
     PushOutcome {
-        success: true,
-        output: String::new(),
+        success,
+        output: text,
     }
 }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -6,6 +6,8 @@
 //! and what an outcome means — lives here as pure, terminal-free code so it can
 //! be tested without a network or a pty. Only [`spawn`] touches a process.
 
+use colored::Colorize;
+
 use crate::render::{truncate_right, Snapshot, UpstreamStatus};
 use crate::repo::DETACHED_HEAD;
 use crate::watch::InputMode;
@@ -229,45 +231,198 @@ impl PushUi {
     /// What keys mean right now.
     pub(crate) fn mode(&self) -> InputMode {
         let _ = &self.state;
-        InputMode::Normal
+        match self.state {
+            State::Asking { .. } => InputMode::Confirm,
+            State::Running { .. } => InputMode::Pushing,
+            State::Idle | State::Status { .. } => InputMode::Normal,
+        }
     }
 
     /// Handle `p`: work out what a push would do and either ask or explain.
+    ///
+    /// Replaces whatever was on screen, so pressing `p` with a stale error up
+    /// asks the new question instead of stacking a row under the old one.
     pub(crate) fn request(&mut self, snapshot: &Snapshot) {
-        let _ = snapshot;
+        self.state = match prompt_for(
+            &snapshot.branch,
+            snapshot.push_remote.as_deref(),
+            snapshot.upstream.as_ref(),
+        ) {
+            PushPrompt::Confirm {
+                question,
+                creates_remote_branch,
+                args,
+                success_message,
+            } => State::Asking {
+                question,
+                creates_remote_branch,
+                args,
+                success_message,
+            },
+            PushPrompt::Refuse { message } => State::Status {
+                lines: vec![message],
+                failed: false,
+            },
+        };
     }
 
     /// Handle `y`: start the push, returning the arguments to run, or `None`
     /// when no confirmation was on screen to accept.
+    ///
+    /// Moving to [`State::Running`] as it hands the arguments over is what makes
+    /// a second `y` — one that raced the mode change — return `None` rather than
+    /// start an overlapping push.
     pub(crate) fn confirm(&mut self) -> Option<Vec<String>> {
-        None
+        let State::Asking {
+            args,
+            success_message,
+            ..
+        } = std::mem::replace(&mut self.state, State::Idle)
+        else {
+            return None;
+        };
+        self.state = State::Running { success_message };
+        Some(args)
     }
 
     /// Handle `n`: drop the confirmation. The prompt disappearing is the whole
     /// feedback — a "cancelled" notice would itself need dismissing.
-    pub(crate) fn cancel(&mut self) {}
+    pub(crate) fn cancel(&mut self) {
+        if matches!(self.state, State::Asking { .. }) {
+            self.state = State::Idle;
+        }
+    }
 
     /// Handle a finished push: replace the running notice with the outcome.
+    ///
+    /// On success the wording comes from the plan that was confirmed, not from
+    /// git's output, so a create reports itself as a create. On failure it is
+    /// git's own words — a gsw paraphrase of a push error would drop exactly
+    /// the detail the user needs.
     pub(crate) fn finished(&mut self, outcome: PushOutcome) {
-        let _ = outcome;
+        let success_message = match std::mem::replace(&mut self.state, State::Idle) {
+            State::Running { success_message } => success_message,
+            // A finish with no push running: nothing to report against, so
+            // leave the screen as it is rather than inventing a message.
+            other => {
+                self.state = other;
+                return;
+            }
+        };
+
+        let lines = if outcome.success {
+            vec![success_message]
+        } else {
+            failure_lines(&outcome.output)
+        };
+        self.state = State::Status {
+            lines,
+            failed: !outcome.success,
+        };
     }
 
     /// Handle a key with no other meaning: clear a status message if one is up.
     /// Leaves a question or a running push alone — neither is the user's to
     /// dismiss by pressing an unrelated key.
-    pub(crate) fn dismiss(&mut self) {}
+    pub(crate) fn dismiss(&mut self) {
+        if matches!(self.state, State::Status { .. }) {
+            self.state = State::Idle;
+        }
+    }
 
     /// How many rows the overlay needs under the frame, so the caller can
     /// render the frame that much shorter and nothing falls off the bottom.
     pub(crate) fn rows(&self) -> usize {
-        0
+        match &self.state {
+            State::Idle => 0,
+            State::Asking { .. } | State::Running { .. } => 1,
+            State::Status { lines, .. } => lines.len(),
+        }
     }
 
     /// The overlay itself: [`PushUi::rows`] lines, none wider than `width`.
+    ///
+    /// Truncation is by display column and UTF-8 safe, because gsw's standing
+    /// contract is that nothing it prints ever wraps — a folded line would push
+    /// the frame's bottom row off the pane it was measured to fit.
     pub(crate) fn overlay(&self, width: usize) -> String {
-        let _ = (width, truncate_right, MAX_STATUS_ROWS, HINT_PREFIX);
-        String::new()
+        let lines: Vec<String> = match &self.state {
+            State::Idle => return String::new(),
+            State::Asking {
+                question,
+                creates_remote_branch,
+                ..
+            } => {
+                let line = truncate_right(&format!("{question}  {CONFIRM_HINT}"), width);
+                // Yellow marks the push that puts something new on a shared
+                // remote. The wording says so too — the color is what carries
+                // it in the half second before the words are read.
+                vec![if *creates_remote_branch {
+                    line.yellow().to_string()
+                } else {
+                    line
+                }]
+            }
+            State::Running { .. } => vec![truncate_right(RUNNING_NOTICE, width)],
+            State::Status { lines, failed } => lines
+                .iter()
+                .map(|line| {
+                    let line = truncate_right(line, width);
+                    if *failed {
+                        line.red().to_string()
+                    } else {
+                        line
+                    }
+                })
+                .collect(),
+        };
+        lines.join("\n")
     }
+}
+
+/// The key hint shown with every confirmation.
+///
+/// Spelled out rather than the usual `[y/N]`. That convention's capital letter
+/// means "this is what Enter gives you", and Enter *confirms* here — so `[y/N]`
+/// would promise that the key people reach for by reflex is the safe one, on
+/// the one prompt in gsw that writes to a shared remote.
+const CONFIRM_HINT: &str = "[y/Enter = push, n/Esc = cancel]";
+
+/// What a running push says while the network round trip is in flight.
+const RUNNING_NOTICE: &str = "Pushing…";
+
+/// What a failed push says when git said nothing gsw could show.
+const SILENT_FAILURE: &str = "git push failed";
+
+/// Pick the lines of a failed push's output worth the rows they cost.
+///
+/// git leads with the useful part — `To <remote>`, `! [rejected] …`,
+/// `error: failed to push …` — and follows with `hint:` advice that repeats in
+/// every rejection. So the hints are dropped first, and only if that leaves
+/// nothing are they let back in: a message the user cannot read beats a blank
+/// row that reads as success.
+fn failure_lines(output: &str) -> Vec<String> {
+    let meaningful = |line: &&str| !line.trim().is_empty();
+    let mut lines: Vec<String> = output
+        .lines()
+        .filter(meaningful)
+        .filter(|line| !line.trim_start().starts_with(HINT_PREFIX))
+        .take(MAX_STATUS_ROWS)
+        .map(|line| line.trim_end().to_string())
+        .collect();
+
+    if lines.is_empty() {
+        lines = output
+            .lines()
+            .filter(meaningful)
+            .take(MAX_STATUS_ROWS)
+            .map(|line| line.trim_end().to_string())
+            .collect();
+    }
+    if lines.is_empty() {
+        lines.push(SILENT_FAILURE.to_string());
+    }
+    lines
 }
 
 impl PushPlan {
@@ -624,8 +779,12 @@ mod ui_tests {
             overlay.contains("Create new remote branch origin/gsw-push?"),
             "the question must be on screen, got {overlay:?}",
         );
+        // Spelled out rather than the usual `[y/N]`, because a capital `N` is
+        // the convention for "Enter means no" and Enter confirms here. A hint
+        // that lies about the riskiest key on the prompt is worse than a long
+        // one.
         assert!(
-            overlay.contains("[y/N]"),
+            overlay.contains(CONFIRM_HINT),
             "the overlay owns the key hint, got {overlay:?}",
         );
     }
@@ -642,7 +801,7 @@ mod ui_tests {
             .overlay(80)
             .contains("origin/gsw-push is already up to date"));
         assert!(
-            !ui.overlay(80).contains("[y/N]"),
+            !ui.overlay(80).contains(CONFIRM_HINT),
             "a refusal must not offer keys that do nothing",
         );
     }

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -6,6 +6,9 @@
 //! and what an outcome means — lives here as pure, terminal-free code so it can
 //! be tested without a network or a pty. Only [`spawn`] touches a process.
 
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
 use colored::Colorize;
 
 use crate::render::{truncate_right, Snapshot, UpstreamStatus};
@@ -171,6 +174,50 @@ pub(crate) fn prompt_for(
         creates_remote_branch: matches!(plan, PushPlan::Create { .. }),
         args: plan.command_args(),
         success_message,
+    }
+}
+
+/// Run `git push` on a thread of its own and hand the outcome to `on_finish`.
+///
+/// Off the render thread on purpose. A push is a network round trip, and the
+/// watch loop is what keeps the refresh countdown moving, the ages advancing,
+/// and a resize repainting. Blocking it for the seconds a push takes would
+/// freeze the monitor at exactly the moment the user is watching it.
+///
+/// `on_finish` runs on that thread. The one production caller sends the outcome
+/// down the loop's own channel, so it re-enters the loop the same way every
+/// other event does — no shared state, and the outcome is applied between
+/// frames rather than during one.
+pub(crate) fn spawn<F>(args: Vec<String>, workdir: PathBuf, on_finish: F)
+where
+    F: FnOnce(PushOutcome) + Send + 'static,
+{
+    std::thread::spawn(move || on_finish(run_push(&args, &workdir)));
+}
+
+/// Run `git push` to completion and describe how it went.
+///
+/// The blocking half of [`spawn`], separated so it can be tested against a real
+/// repository without a thread or a channel in the way.
+///
+/// Two things are forced on the child, and both matter because gsw is holding
+/// the alternate screen in raw mode:
+///
+/// - **stdin is closed** and **`GIT_TERMINAL_PROMPT=0`**, so git can never ask
+///   for a username or a passphrase. Left able to prompt, it would read from the
+///   same terminal the event-reader thread is reading, and the two would fight
+///   over the user's keystrokes with a question on screen that gsw did not draw.
+///   Disabled, git fails immediately and says why, which lands in the status
+///   rows like any other error. Credential helpers and a GUI `SSH_ASKPASS` are
+///   untouched — only prompting *at the terminal* is refused.
+/// - **Both streams are captured**, which also suppresses git's progress meter:
+///   it renders only to a terminal, so a pipe removes the carriage-return
+///   redraws that would otherwise arrive as unreadable status rows.
+fn run_push(args: &[String], workdir: &Path) -> PushOutcome {
+    let _ = (args, workdir, Command::new("git"), Stdio::null());
+    PushOutcome {
+        success: true,
+        output: String::new(),
     }
 }
 
@@ -1056,5 +1103,196 @@ mod ui_tests {
         assert_eq!(ui.mode(), InputMode::Confirm);
         assert_eq!(ui.rows(), 1);
         assert!(!ui.overlay(120).contains("error:"));
+    }
+}
+
+#[cfg(test)]
+mod run_tests {
+    use super::*;
+    use crate::testrepo::{git, init_repo_with_upstream};
+
+    /// A clone with a `feature` branch holding one commit, ready to push.
+    ///
+    /// `feature` rather than `main` because the origin fixture is a normal
+    /// checkout, and git refuses to push to the branch a non-bare repository
+    /// has checked out.
+    fn clone_with_feature_branch() -> (tempfile::TempDir, tempfile::TempDir) {
+        let (origin, clone) = init_repo_with_upstream();
+        let p = clone.path();
+        git(p, &["checkout", "-q", "-b", "feature"]);
+        std::fs::write(p.join("feature.txt"), "work\n").expect("write feature.txt");
+        git(p, &["add", "feature.txt"]);
+        git(p, &["commit", "-q", "-m", "feature work"]);
+        (origin, clone)
+    }
+
+    /// Whether `origin` has a `feature` branch, read from the origin itself.
+    fn origin_has_feature(origin: &Path) -> bool {
+        Command::new("git")
+            .args(["rev-parse", "--verify", "--quiet", "refs/heads/feature"])
+            .current_dir(origin)
+            .output()
+            .expect("invoke git")
+            .status
+            .success()
+    }
+
+    #[test]
+    fn creating_a_remote_branch_really_creates_it() {
+        // The end-to-end create: the branch must exist on the remote
+        // afterwards, and the local branch must now track it — which is what
+        // makes the next `p` a plain update.
+        let (origin, clone) = clone_with_feature_branch();
+        assert!(
+            !origin_has_feature(origin.path()),
+            "the fixture must start without the branch",
+        );
+
+        let args: Vec<String> = ["push", "-u", "origin", "feature"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let outcome = run_push(&args, clone.path());
+
+        assert!(outcome.success, "push failed: {}", outcome.output);
+        assert!(
+            origin_has_feature(origin.path()),
+            "the branch must exist on the remote after the push",
+        );
+
+        let upstream = Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "feature@{upstream}"])
+            .current_dir(clone.path())
+            .output()
+            .expect("invoke git");
+        assert_eq!(
+            String::from_utf8_lossy(&upstream.stdout).trim(),
+            "origin/feature",
+            "-u must record the upstream, or the next push asks the same question",
+        );
+    }
+
+    #[test]
+    fn updating_a_tracked_branch_sends_the_new_commit() {
+        // The plain `git push` path: no remote or refspec is passed, so this
+        // also proves git really does read them out of the branch config.
+        let (origin, clone) = clone_with_feature_branch();
+        let p = clone.path();
+        git(p, &["push", "-q", "-u", "origin", "feature"]);
+        std::fs::write(p.join("feature.txt"), "more work\n").expect("write feature.txt");
+        git(p, &["commit", "-q", "-am", "more work"]);
+
+        let outcome = run_push(&["push".to_string()], p);
+        assert!(outcome.success, "push failed: {}", outcome.output);
+
+        let subject = Command::new("git")
+            .args(["log", "-1", "--format=%s", "refs/heads/feature"])
+            .current_dir(origin.path())
+            .output()
+            .expect("invoke git");
+        assert_eq!(
+            String::from_utf8_lossy(&subject.stdout).trim(),
+            "more work",
+            "the remote branch must carry the new commit",
+        );
+    }
+
+    #[test]
+    fn a_rejected_push_reports_the_rejection() {
+        // A diverged branch: the commit is amended after being pushed, so the
+        // remote holds one the local branch no longer has. git rejects it, and
+        // that rejection must survive into the outcome rather than being
+        // flattened into a bare failure.
+        let (_origin, clone) = clone_with_feature_branch();
+        let p = clone.path();
+        git(p, &["push", "-q", "-u", "origin", "feature"]);
+        git(p, &["commit", "-q", "--amend", "-m", "rewritten"]);
+
+        let outcome = run_push(&["push".to_string()], p);
+        assert!(!outcome.success, "a diverged push must fail");
+        assert!(
+            outcome.output.contains("rejected"),
+            "git's rejection must reach the outcome, got {:?}",
+            outcome.output,
+        );
+    }
+
+    #[test]
+    fn a_push_to_a_remote_that_does_not_exist_reports_it() {
+        let (_origin, clone) = clone_with_feature_branch();
+        let args: Vec<String> = ["push", "no-such-remote", "feature"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let outcome = run_push(&args, clone.path());
+        assert!(!outcome.success, "pushing to a missing remote must fail");
+        assert!(
+            !outcome.output.trim().is_empty(),
+            "a failure must carry something to show the user",
+        );
+    }
+
+    #[test]
+    fn a_failure_always_carries_something_to_show() {
+        // Belt and braces on the whole error path: whatever git does, an
+        // unsuccessful outcome never arrives with an empty message, because a
+        // blank status row reads as success.
+        let (_origin, clone) = clone_with_feature_branch();
+        let args: Vec<String> = ["push", "--no-such-flag"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let outcome = run_push(&args, clone.path());
+        assert!(!outcome.success);
+        assert!(!failure_lines(&outcome.output).is_empty());
+        assert!(!outcome.output.trim().is_empty());
+    }
+
+    #[test]
+    fn git_cannot_prompt_at_the_terminal() {
+        // gsw holds the alternate screen in raw mode. A git that can prompt
+        // would read the same keystrokes the event reader is reading, behind a
+        // question gsw did not draw. It must fail fast instead of waiting.
+        let (_origin, clone) = clone_with_feature_branch();
+        let args: Vec<String> = ["push", "https://user@127.0.0.1:1/nope.git", "feature"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let outcome = run_push(&args, clone.path());
+        assert!(
+            !outcome.success,
+            "an unreachable authenticated remote must fail"
+        );
+        assert!(
+            !outcome.output.trim().is_empty(),
+            "the failure must say something, got {:?}",
+            outcome.output,
+        );
+    }
+
+    #[test]
+    fn spawn_delivers_the_outcome_off_the_calling_thread() {
+        // The loop learns a push finished only through this callback, so a
+        // push that completes without calling it would leave the monitor stuck
+        // in the pushing mode forever.
+        let (origin, clone) = clone_with_feature_branch();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let args: Vec<String> = ["push", "-u", "origin", "feature"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        spawn(args, clone.path().to_path_buf(), move |outcome| {
+            let _ = tx.send(outcome);
+        });
+
+        let outcome = rx
+            .recv_timeout(std::time::Duration::from_secs(60))
+            .expect("the callback must fire when the push finishes");
+        assert!(outcome.success, "push failed: {}", outcome.output);
+        assert!(origin_has_feature(origin.path()));
     }
 }

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -77,6 +77,50 @@ enum PushPlan {
     },
 }
 
+/// A confirmed push: the branch the confirmation named, and the `git`
+/// arguments that carry it out.
+///
+/// The two are one value because they are one sentence — push *this branch*,
+/// *this way* — and the arguments alone do not say which branch. An
+/// [`PushPlan::Update`] runs a bare `git push`, which git resolves against
+/// whatever HEAD points at when the child process starts. That is not
+/// necessarily what HEAD pointed at when the question went on screen: the
+/// answer arrives whenever the user presses `y`, and a checkout in another pane
+/// fits in between. Carrying the branch alongside the arguments is what lets
+/// [`run_push`] confirm the repository is still on that branch, microseconds
+/// before git reads it.
+///
+/// Built only by [`prompt_for`], so a command nobody confirmed cannot be
+/// assembled somewhere else and handed to the runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PushCommand {
+    /// The branch the confirmation named, as [`crate::repo::branch_name`]
+    /// reports it.
+    branch: String,
+    /// Arguments to pass to `git`, not including the program name.
+    args: Vec<String>,
+}
+
+impl PushCommand {
+    /// The command that pushes `branch` by running `git <args>`.
+    fn new(branch: impl Into<String>, args: Vec<String>) -> Self {
+        Self {
+            branch: branch.into(),
+            args,
+        }
+    }
+
+    /// The branch the confirmation named.
+    pub(crate) fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    /// The arguments to pass to `git`, not including the program name.
+    pub(crate) fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
 /// What the watch loop does when the user presses `p`.
 ///
 /// This is the whole interface [`prompt_for`] hands back, and it is deliberately
@@ -88,7 +132,9 @@ enum PushPlan {
 /// [`PushPrompt::Confirm`] carries the command with the question, so the
 /// arguments cannot be requested for a push that must never run. The invariant
 /// is structural: there is no way to hold a `Confirm` without holding the exact
-/// argument list the confirmation described.
+/// [`PushCommand`] the confirmation described — the argument list *and* the
+/// branch it was written for, which is what the runner re-checks before it
+/// pushes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PushPrompt {
     /// Ask before running the push.
@@ -100,8 +146,8 @@ pub(crate) enum PushPrompt {
         /// colors this case differently, so a create can never be mistaken for
         /// a routine update at a glance.
         creates_remote_branch: bool,
-        /// Arguments to pass to `git`, not including the program name.
-        args: Vec<String>,
+        /// The branch and the arguments this question described.
+        command: PushCommand,
         /// What to show once this push succeeds. Composed here, with the
         /// question, so the two sentences describe the same act — a push
         /// confirmed as a create reports itself as a create.
@@ -147,7 +193,10 @@ pub(crate) fn prompt_for(
                 creates_remote_branch: true,
                 // `-u` records the new remote branch as the upstream, so the
                 // push after this one is a plain update.
-                args: vec!["push".to_string(), "-u".to_string(), remote, branch],
+                command: PushCommand::new(
+                    branch.clone(),
+                    vec!["push".to_string(), "-u".to_string(), remote, branch],
+                ),
                 success_message,
             }
         }
@@ -159,7 +208,10 @@ pub(crate) fn prompt_for(
                 // Bare `push`: git reads the remote and the refspec out of the
                 // branch config, so a branch tracking something other than the
                 // repository's default remote still goes to the right place.
-                args: vec!["push".to_string()],
+                // Which branch's config it reads is decided by HEAD at exec
+                // time, which is why the command carries the branch this
+                // question was written for.
+                command: PushCommand::new(branch, vec!["push".to_string()]),
                 success_message: format!("Pushed {commits} {unit} to {target}"),
             }
         }
@@ -186,11 +238,11 @@ pub(crate) fn prompt_for(
 /// down the loop's own channel, so it re-enters the loop the same way every
 /// other event does — no shared state, and the outcome is applied between
 /// frames rather than during one.
-pub(crate) fn spawn<F>(args: Vec<String>, workdir: PathBuf, on_finish: F)
+pub(crate) fn spawn<F>(command: PushCommand, workdir: PathBuf, on_finish: F)
 where
     F: FnOnce(PushOutcome) + Send + 'static,
 {
-    std::thread::spawn(move || on_finish(run_push(&args, &workdir)));
+    std::thread::spawn(move || on_finish(run_push(&command, &workdir)));
 }
 
 /// Run `git push` to completion and describe how it went.
@@ -211,9 +263,9 @@ where
 /// - **Both streams are captured**, which also suppresses git's progress meter:
 ///   it renders only to a terminal, so a pipe removes the carriage-return
 ///   redraws that would otherwise arrive as unreadable status rows.
-fn run_push(args: &[String], workdir: &Path) -> PushOutcome {
+fn run_push(command: &PushCommand, workdir: &Path) -> PushOutcome {
     let result = Command::new("git")
-        .args(args)
+        .args(command.args())
         .current_dir(workdir)
         .stdin(Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -298,7 +350,7 @@ enum State {
     Asking {
         question: String,
         creates_remote_branch: bool,
-        args: Vec<String>,
+        command: PushCommand,
         success_message: String,
     },
     /// `git push` is running.
@@ -333,12 +385,12 @@ impl PushUi {
             PushPrompt::Confirm {
                 question,
                 creates_remote_branch,
-                args,
+                command,
                 success_message,
             } => State::Asking {
                 question,
                 creates_remote_branch,
-                args,
+                command,
                 success_message,
             },
             PushPrompt::Refuse { message } => State::Status {
@@ -348,15 +400,15 @@ impl PushUi {
         };
     }
 
-    /// Handle `y`: start the push, returning the arguments to run, or `None`
-    /// when no confirmation was on screen to accept.
+    /// Handle `y`: start the push, returning the [`PushCommand`] to run, or
+    /// `None` when no confirmation was on screen to accept.
     ///
-    /// Moving to [`State::Running`] as it hands the arguments over is what makes
+    /// Moving to [`State::Running`] as it hands the command over is what makes
     /// a second `y` — one that raced the mode change — return `None` rather than
     /// start an overlapping push.
-    pub(crate) fn confirm(&mut self) -> Option<Vec<String>> {
+    pub(crate) fn confirm(&mut self) -> Option<PushCommand> {
         let State::Asking {
-            args,
+            command,
             success_message,
             ..
         } = std::mem::replace(&mut self.state, State::Idle)
@@ -364,7 +416,7 @@ impl PushUi {
             return None;
         };
         self.state = State::Running { success_message };
-        Some(args)
+        Some(command)
     }
 
     /// Handle `n`: drop the confirmation. The prompt disappearing is the whole
@@ -568,9 +620,9 @@ mod tests {
 
     /// The command a confirmable prompt carries. Panics on a refusal, so a test
     /// that expected a push and got a message fails on the line that asked.
-    fn args(prompt: &PushPrompt) -> &[String] {
+    fn command(prompt: &PushPrompt) -> &PushCommand {
         match prompt {
-            PushPrompt::Confirm { args, .. } => args,
+            PushPrompt::Confirm { command, .. } => command,
             PushPrompt::Refuse { message } => {
                 panic!("expected a confirmable prompt, got a refusal: {message}")
             }
@@ -591,7 +643,7 @@ mod tests {
             },
         );
         assert_eq!(
-            args(&prompt_for("gsw-push", Some("origin"), None)),
+            command(&prompt_for("gsw-push", Some("origin"), None)).args(),
             ["push", "-u", "origin", "gsw-push"],
         );
     }
@@ -610,7 +662,7 @@ mod tests {
             },
         );
         assert_eq!(
-            args(&prompt_for("gsw-push", Some("origin"), Some(&up))),
+            command(&prompt_for("gsw-push", Some("origin"), Some(&up))).args(),
             ["push"]
         );
     }
@@ -695,7 +747,7 @@ mod tests {
         // A repository whose only remote is not named `origin`. The plan must
         // carry that name through to the command rather than assuming `origin`.
         assert_eq!(
-            args(&prompt_for("gsw-push", Some("fork"), None)),
+            command(&prompt_for("gsw-push", Some("fork"), None)).args(),
             ["push", "-u", "fork", "gsw-push"],
         );
     }
@@ -752,12 +804,27 @@ mod tests {
 
     #[test]
     fn the_confirmation_carries_the_command_it_describes() {
-        // The question and the argument list travel together, so what runs on
-        // `y` is what the sentence promised.
-        let PushPrompt::Confirm { args, .. } = prompt_for("gsw-push", Some("origin"), None) else {
+        // The question, the argument list, and the branch the question named
+        // travel together, so what runs on `y` is what the sentence promised —
+        // and the runner can still tell whether the repository moved under it.
+        let PushPrompt::Confirm { command, .. } = prompt_for("gsw-push", Some("origin"), None)
+        else {
             panic!("an untracked branch with a remote must be confirmable");
         };
-        assert_eq!(args, ["push", "-u", "origin", "gsw-push"]);
+        assert_eq!(command.args(), ["push", "-u", "origin", "gsw-push"]);
+        assert_eq!(command.branch(), "gsw-push");
+    }
+
+    #[test]
+    fn a_bare_push_still_names_the_branch_it_was_confirmed_for() {
+        // The argument list for an update says nothing about which branch it
+        // pushes — git resolves that from HEAD when it runs. The command has to
+        // carry the branch anyway, or nothing downstream can tell that the
+        // checkout changed between the question and the answer.
+        let up = upstream("origin/gsw-push", 3, 0);
+        let prompt = prompt_for("gsw-push", Some("origin"), Some(&up));
+        assert_eq!(command(&prompt).args(), ["push"]);
+        assert_eq!(command(&prompt).branch(), "gsw-push");
     }
 
     #[test]
@@ -912,14 +979,12 @@ mod ui_tests {
     #[test]
     fn confirming_hands_back_the_command_and_switches_to_pushing() {
         let mut ui = asking();
+        let command = ui.confirm().expect("a question on screen must confirm");
+        assert_eq!(command.args(), ["push", "-u", "origin", "gsw-push"]);
         assert_eq!(
-            ui.confirm(),
-            Some(vec![
-                "push".to_string(),
-                "-u".to_string(),
-                "origin".to_string(),
-                "gsw-push".to_string(),
-            ]),
+            command.branch(),
+            "gsw-push",
+            "the branch the question named must reach the runner",
         );
         assert_eq!(ui.mode(), InputMode::Pushing);
         assert_eq!(ui.rows(), 1, "the running push stays on screen");
@@ -1182,6 +1247,15 @@ mod run_tests {
         (origin, clone)
     }
 
+    /// The command a confirmation shown on `feature` would have carried.
+    ///
+    /// Every fixture here is checked out on `feature`, so this is what the
+    /// confirmation named — and the runner refuses anything whose branch no
+    /// longer matches the checkout.
+    fn confirmed(args: &[&str]) -> PushCommand {
+        PushCommand::new("feature", args.iter().map(|s| (*s).to_string()).collect())
+    }
+
     /// Whether `origin` has a `feature` branch, read from the origin itself.
     fn origin_has_feature(origin: &Path) -> bool {
         Command::new("git")
@@ -1204,11 +1278,10 @@ mod run_tests {
             "the fixture must start without the branch",
         );
 
-        let args: Vec<String> = ["push", "-u", "origin", "feature"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-        let outcome = run_push(&args, clone.path());
+        let outcome = run_push(
+            &confirmed(&["push", "-u", "origin", "feature"]),
+            clone.path(),
+        );
 
         assert!(outcome.success, "push failed: {}", outcome.output);
         assert!(
@@ -1238,7 +1311,7 @@ mod run_tests {
         std::fs::write(p.join("feature.txt"), "more work\n").expect("write feature.txt");
         git(p, &["commit", "-q", "-am", "more work"]);
 
-        let outcome = run_push(&["push".to_string()], p);
+        let outcome = run_push(&confirmed(&["push"]), p);
         assert!(outcome.success, "push failed: {}", outcome.output);
 
         let subject = Command::new("git")
@@ -1264,7 +1337,7 @@ mod run_tests {
         git(p, &["push", "-q", "-u", "origin", "feature"]);
         git(p, &["commit", "-q", "--amend", "-m", "rewritten"]);
 
-        let outcome = run_push(&["push".to_string()], p);
+        let outcome = run_push(&confirmed(&["push"]), p);
         assert!(!outcome.success, "a diverged push must fail");
         assert!(
             outcome.output.contains("rejected"),
@@ -1276,12 +1349,10 @@ mod run_tests {
     #[test]
     fn a_push_to_a_remote_that_does_not_exist_reports_it() {
         let (_origin, clone) = clone_with_feature_branch();
-        let args: Vec<String> = ["push", "no-such-remote", "feature"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-
-        let outcome = run_push(&args, clone.path());
+        let outcome = run_push(
+            &confirmed(&["push", "no-such-remote", "feature"]),
+            clone.path(),
+        );
         assert!(!outcome.success, "pushing to a missing remote must fail");
         assert!(
             !outcome.output.trim().is_empty(),
@@ -1295,12 +1366,7 @@ mod run_tests {
         // unsuccessful outcome never arrives with an empty message, because a
         // blank status row reads as success.
         let (_origin, clone) = clone_with_feature_branch();
-        let args: Vec<String> = ["push", "--no-such-flag"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-
-        let outcome = run_push(&args, clone.path());
+        let outcome = run_push(&confirmed(&["push", "--no-such-flag"]), clone.path());
         assert!(!outcome.success);
         assert!(!failure_lines(&outcome.output).is_empty());
         assert!(!outcome.output.trim().is_empty());
@@ -1312,12 +1378,10 @@ mod run_tests {
         // would read the same keystrokes the event reader is reading, behind a
         // question gsw did not draw. It must fail fast instead of waiting.
         let (_origin, clone) = clone_with_feature_branch();
-        let args: Vec<String> = ["push", "https://user@127.0.0.1:1/nope.git", "feature"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-
-        let outcome = run_push(&args, clone.path());
+        let outcome = run_push(
+            &confirmed(&["push", "https://user@127.0.0.1:1/nope.git", "feature"]),
+            clone.path(),
+        );
         assert!(
             !outcome.success,
             "an unreachable authenticated remote must fail"
@@ -1329,6 +1393,118 @@ mod run_tests {
         );
     }
 
+    /// The commit `refs/heads/<branch>` points at in the repository at `dir`,
+    /// or `""` when there is no such branch. Compared before and after a push
+    /// to say whether anything was actually sent.
+    fn tip(dir: &Path, branch: &str) -> String {
+        let output = Command::new("git")
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch}"),
+            ])
+            .current_dir(dir)
+            .output()
+            .expect("invoke git");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn an_update_whose_branch_changed_since_the_confirmation_is_not_pushed() {
+        // The window the confirmation opens: `p` resolves the command while
+        // `feature` is checked out, `y` arrives seconds later, and a checkout in
+        // another pane lands in between. A bare `git push` names no branch, so
+        // git would resolve it against the *new* HEAD and send a branch the
+        // question never mentioned. Nothing may be pushed in that case.
+        let (origin, clone) = clone_with_feature_branch();
+        let p = clone.path();
+        git(p, &["push", "-q", "-u", "origin", "feature"]);
+        // A second branch that also tracks the origin, so a mis-resolved bare
+        // push would succeed rather than being stopped by something else.
+        git(p, &["checkout", "-q", "-b", "other", "main"]);
+        std::fs::write(p.join("other.txt"), "other work\n").expect("write other.txt");
+        git(p, &["add", "other.txt"]);
+        git(p, &["commit", "-q", "-m", "other work"]);
+        git(p, &["push", "-q", "-u", "origin", "other"]);
+        std::fs::write(p.join("other.txt"), "more other work\n").expect("write other.txt");
+        git(p, &["commit", "-q", "-am", "more other work"]);
+
+        // Confirmed on `feature`, which is what the question named…
+        let command = PushCommand::new("feature", vec!["push".to_string()]);
+        // …but `other` is what is checked out when the answer arrives.
+        let before_other = tip(origin.path(), "other");
+        let before_feature = tip(origin.path(), "feature");
+
+        let outcome = run_push(&command, p);
+
+        assert!(
+            !outcome.success,
+            "a push whose branch changed must not report success: {}",
+            outcome.output,
+        );
+        assert_eq!(
+            tip(origin.path(), "other"),
+            before_other,
+            "the branch that was checked out at exec time must not be pushed",
+        );
+        assert_eq!(
+            tip(origin.path(), "feature"),
+            before_feature,
+            "nothing at all may be pushed once the checkout no longer matches",
+        );
+        assert!(
+            outcome.output.contains("branch changed"),
+            "the outcome must say the branch changed, got {:?}",
+            outcome.output,
+        );
+        assert!(
+            outcome.output.contains("press p again"),
+            "the outcome must say how to retry, got {:?}",
+            outcome.output,
+        );
+    }
+
+    #[test]
+    fn a_create_whose_branch_changed_since_the_confirmation_is_not_pushed() {
+        // A create names its branch in the arguments, so it would still push the
+        // right ref — but the check is one rule, not a per-variant exception: a
+        // confirmation is an answer about the repository as it stood, and gsw
+        // asks again rather than acting on a repository that moved.
+        let (origin, clone) = clone_with_feature_branch();
+        let p = clone.path();
+        let command = PushCommand::new(
+            "feature",
+            ["push", "-u", "origin", "feature"]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        );
+        git(p, &["checkout", "-q", "main"]);
+
+        let outcome = run_push(&command, p);
+
+        assert!(
+            !outcome.success,
+            "a create whose branch changed must not report success: {}",
+            outcome.output,
+        );
+        assert!(
+            !origin_has_feature(origin.path()),
+            "the confirmed branch must not reach the remote after the checkout changed",
+        );
+        assert!(
+            outcome.output.contains("branch changed"),
+            "the outcome must say the branch changed, got {:?}",
+            outcome.output,
+        );
+        assert!(
+            outcome.output.contains("press p again"),
+            "the outcome must say how to retry, got {:?}",
+            outcome.output,
+        );
+    }
+
     #[test]
     fn spawn_delivers_the_outcome_off_the_calling_thread() {
         // The loop learns a push finished only through this callback, so a
@@ -1336,14 +1512,14 @@ mod run_tests {
         // in the pushing mode forever.
         let (origin, clone) = clone_with_feature_branch();
         let (tx, rx) = std::sync::mpsc::channel();
-        let args: Vec<String> = ["push", "-u", "origin", "feature"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
 
-        spawn(args, clone.path().to_path_buf(), move |outcome| {
-            let _ = tx.send(outcome);
-        });
+        spawn(
+            confirmed(&["push", "-u", "origin", "feature"]),
+            clone.path().to_path_buf(),
+            move |outcome| {
+                let _ = tx.send(outcome);
+            },
+        );
 
         let outcome = rx
             .recv_timeout(std::time::Duration::from_secs(60))

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -6,8 +6,23 @@
 //! and what an outcome means — lives here as pure, terminal-free code so it can
 //! be tested without a network or a pty. Only [`spawn`] touches a process.
 
-use crate::render::UpstreamStatus;
+use crate::render::{truncate_right, Snapshot, UpstreamStatus};
 use crate::repo::DETACHED_HEAD;
+use crate::watch::InputMode;
+
+/// Most rows a status message is allowed to occupy under the frame.
+///
+/// A rejected push can produce a dozen lines of hints, and the frame below is
+/// what the user is actually watching. Three rows is enough for git's
+/// `To <remote>` / `! [rejected] …` / `error: failed to push …` triple, which
+/// is the part that says what went wrong.
+const MAX_STATUS_ROWS: usize = 3;
+
+/// Git's prefix for advice lines. They follow the real error and explain
+/// general remedies, so they are the first thing to drop when the message has
+/// to fit in [`MAX_STATUS_ROWS`]. A lexical prefix is the right matcher here:
+/// this is git's own output convention, not a syntactic property of anything.
+const HINT_PREFIX: &str = "hint:";
 
 /// What pressing `p` will actually do, resolved from the snapshot *before* the
 /// confirmation appears — so the prompt describes the command that will run
@@ -82,6 +97,10 @@ pub(crate) enum PushPrompt {
         creates_remote_branch: bool,
         /// Arguments to pass to `git`, not including the program name.
         args: Vec<String>,
+        /// What to show once this push succeeds. Composed here, with the
+        /// question, so the two sentences describe the same act — a push
+        /// confirmed as a create reports itself as a create.
+        success_message: String,
     },
     /// Run nothing and show this instead. Not an error: the common cause is a
     /// branch that is already fully pushed.
@@ -108,6 +127,14 @@ pub(crate) fn prompt_for(
     upstream: Option<&UpstreamStatus>,
 ) -> PushPrompt {
     let plan = PushPlan::resolve(branch, remote, upstream);
+    let success_message = match &plan {
+        PushPlan::Create { remote, branch } => format!("Created {remote}/{branch}"),
+        PushPlan::Update { target, commits } => {
+            let unit = if *commits == 1 { "commit" } else { "commits" };
+            format!("Pushed {commits} {unit} to {target}")
+        }
+        _ => String::new(),
+    };
     let question = match &plan {
         // Named as the act it is. A branch that nobody on the remote has seen
         // appearing there is not the same event as an existing branch moving
@@ -141,6 +168,105 @@ pub(crate) fn prompt_for(
         question,
         creates_remote_branch: matches!(plan, PushPlan::Create { .. }),
         args: plan.command_args(),
+        success_message,
+    }
+}
+
+/// How a finished `git push` came out.
+///
+/// `output` is git's own stdout and stderr, kept whole: choosing which of it to
+/// show is [`PushUi`]'s job, and a runner that pre-digested it would decide the
+/// wording from a place with no idea how many rows are free.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PushOutcome {
+    /// Whether `git push` exited zero.
+    pub success: bool,
+    /// Everything git wrote, both streams, in the order they were captured.
+    pub output: String,
+}
+
+/// Everything the push feature puts on screen, and the input mode that goes
+/// with it.
+///
+/// Watch mode holds one of these and asks it three questions — what mode are we
+/// in, how many rows do you need, and what do they say. It never learns whether
+/// a prompt or an error is up, so the states below can grow without the render
+/// loop growing a branch for each one.
+pub(crate) struct PushUi {
+    state: State,
+}
+
+/// What the push feature is currently doing. Private: the loop drives this
+/// through [`PushUi`]'s methods and reads it only through
+/// [`PushUi::mode`]/[`PushUi::rows`]/[`PushUi::overlay`].
+enum State {
+    /// Nothing on screen and nothing pending.
+    Idle,
+    /// A message under the frame, staying until the user presses a key.
+    Status {
+        /// Lines to show, already trimmed to [`MAX_STATUS_ROWS`].
+        lines: Vec<String>,
+        /// Whether this reports a failure, which the display colors red.
+        failed: bool,
+    },
+    /// A confirmation is on screen, waiting for an answer.
+    Asking {
+        question: String,
+        creates_remote_branch: bool,
+        args: Vec<String>,
+        success_message: String,
+    },
+    /// `git push` is running.
+    Running { success_message: String },
+}
+
+impl PushUi {
+    /// A UI with nothing on screen.
+    pub(crate) fn new() -> Self {
+        Self { state: State::Idle }
+    }
+
+    /// What keys mean right now.
+    pub(crate) fn mode(&self) -> InputMode {
+        let _ = &self.state;
+        InputMode::Normal
+    }
+
+    /// Handle `p`: work out what a push would do and either ask or explain.
+    pub(crate) fn request(&mut self, snapshot: &Snapshot) {
+        let _ = snapshot;
+    }
+
+    /// Handle `y`: start the push, returning the arguments to run, or `None`
+    /// when no confirmation was on screen to accept.
+    pub(crate) fn confirm(&mut self) -> Option<Vec<String>> {
+        None
+    }
+
+    /// Handle `n`: drop the confirmation. The prompt disappearing is the whole
+    /// feedback — a "cancelled" notice would itself need dismissing.
+    pub(crate) fn cancel(&mut self) {}
+
+    /// Handle a finished push: replace the running notice with the outcome.
+    pub(crate) fn finished(&mut self, outcome: PushOutcome) {
+        let _ = outcome;
+    }
+
+    /// Handle a key with no other meaning: clear a status message if one is up.
+    /// Leaves a question or a running push alone — neither is the user's to
+    /// dismiss by pressing an unrelated key.
+    pub(crate) fn dismiss(&mut self) {}
+
+    /// How many rows the overlay needs under the frame, so the caller can
+    /// render the frame that much shorter and nothing falls off the bottom.
+    pub(crate) fn rows(&self) -> usize {
+        0
+    }
+
+    /// The overlay itself: [`PushUi::rows`] lines, none wider than `width`.
+    pub(crate) fn overlay(&self, width: usize) -> String {
+        let _ = (width, truncate_right, MAX_STATUS_ROWS, HINT_PREFIX);
+        String::new()
     }
 }
 
@@ -439,5 +565,337 @@ mod tests {
                 message: "no remote to push to".to_string(),
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod ui_tests {
+    use super::*;
+    use crate::render::Snapshot;
+
+    /// A snapshot on `gsw-push` with `origin` available and the given tracking
+    /// status. Only the four fields the push feature reads matter here.
+    fn snapshot(upstream: Option<UpstreamStatus>) -> Snapshot {
+        Snapshot {
+            branch: "gsw-push".to_string(),
+            base: "main".to_string(),
+            commits_ahead: 0,
+            commits_behind: 0,
+            files: Vec::new(),
+            log: Vec::new(),
+            upstream,
+            operation: None,
+            push_remote: Some("origin".to_string()),
+        }
+    }
+
+    fn tracked(ahead: u32) -> Option<UpstreamStatus> {
+        Some(UpstreamStatus {
+            name: "origin/gsw-push".to_string(),
+            ahead,
+            behind: 0,
+        })
+    }
+
+    /// A UI with the confirmation already on screen for an untracked branch.
+    fn asking() -> PushUi {
+        let mut ui = PushUi::new();
+        ui.request(&snapshot(None));
+        ui
+    }
+
+    #[test]
+    fn a_fresh_ui_shows_nothing_and_leaves_the_keys_alone() {
+        let ui = PushUi::new();
+        assert_eq!(ui.mode(), InputMode::Normal);
+        assert_eq!(ui.rows(), 0);
+        assert_eq!(ui.overlay(80), "");
+    }
+
+    #[test]
+    fn requesting_a_push_asks_the_question_and_takes_the_keys() {
+        // `p` on a pushable branch must put the question on screen AND switch
+        // the key table, or `y` would be read as an ordinary key.
+        let ui = asking();
+        assert_eq!(ui.mode(), InputMode::Confirm);
+        assert_eq!(ui.rows(), 1);
+        let overlay = ui.overlay(80);
+        assert!(
+            overlay.contains("Create new remote branch origin/gsw-push?"),
+            "the question must be on screen, got {overlay:?}",
+        );
+        assert!(
+            overlay.contains("[y/N]"),
+            "the overlay owns the key hint, got {overlay:?}",
+        );
+    }
+
+    #[test]
+    fn requesting_a_push_with_nothing_to_push_explains_instead_of_asking() {
+        // The refusal is a message, not a question: the keys must stay normal,
+        // so `y` does not answer a prompt that is not there.
+        let mut ui = PushUi::new();
+        ui.request(&snapshot(tracked(0)));
+        assert_eq!(ui.mode(), InputMode::Normal);
+        assert_eq!(ui.rows(), 1);
+        assert!(ui
+            .overlay(80)
+            .contains("origin/gsw-push is already up to date"));
+        assert!(
+            !ui.overlay(80).contains("[y/N]"),
+            "a refusal must not offer keys that do nothing",
+        );
+    }
+
+    #[test]
+    fn confirming_hands_back_the_command_and_switches_to_pushing() {
+        let mut ui = asking();
+        assert_eq!(
+            ui.confirm(),
+            Some(vec![
+                "push".to_string(),
+                "-u".to_string(),
+                "origin".to_string(),
+                "gsw-push".to_string(),
+            ]),
+        );
+        assert_eq!(ui.mode(), InputMode::Pushing);
+        assert_eq!(ui.rows(), 1, "the running push stays on screen");
+    }
+
+    #[test]
+    fn confirming_with_no_question_up_runs_nothing() {
+        // Belt and braces against a stray PushConfirmed: with no confirmation
+        // on screen there is no command to run, and inventing one would push
+        // without asking.
+        let mut ui = PushUi::new();
+        assert_eq!(ui.confirm(), None);
+        assert_eq!(ui.mode(), InputMode::Normal);
+    }
+
+    #[test]
+    fn confirming_twice_runs_the_push_once() {
+        // The second `y` arrives after the mode has already moved to Pushing.
+        // It must not produce a second command.
+        let mut ui = asking();
+        assert!(ui.confirm().is_some());
+        assert_eq!(ui.confirm(), None, "a second confirm must not push again");
+    }
+
+    #[test]
+    fn cancelling_clears_the_question_without_a_notice() {
+        let mut ui = asking();
+        ui.cancel();
+        assert_eq!(ui.mode(), InputMode::Normal);
+        assert_eq!(ui.rows(), 0, "a cancelled prompt leaves nothing behind");
+    }
+
+    #[test]
+    fn a_successful_push_reports_what_it_did() {
+        // The wording comes from the plan, so a create reports itself as a
+        // create rather than as a generic success.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: true,
+            output: "To /tmp/origin\n * [new branch] gsw-push -> gsw-push\n".to_string(),
+        });
+        assert_eq!(ui.mode(), InputMode::Normal);
+        assert!(ui.overlay(80).contains("Created origin/gsw-push"));
+    }
+
+    #[test]
+    fn a_successful_update_counts_what_it_pushed() {
+        let mut ui = PushUi::new();
+        ui.request(&snapshot(tracked(3)));
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: true,
+            output: String::new(),
+        });
+        assert!(ui
+            .overlay(80)
+            .contains("Pushed 3 commits to origin/gsw-push"));
+    }
+
+    #[test]
+    fn a_failed_push_shows_what_git_said() {
+        // The whole point of the feature's error path: git's own words, not a
+        // gsw paraphrase.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "To /tmp/origin\n ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+                     error: failed to push some refs to '/tmp/origin'\n"
+                .to_string(),
+        });
+        assert_eq!(ui.mode(), InputMode::Normal);
+        let overlay = ui.overlay(120);
+        assert!(overlay.contains("! [rejected]"), "got {overlay:?}");
+        assert!(
+            overlay.contains("error: failed to push some refs"),
+            "got {overlay:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_push_drops_the_hints_before_the_error() {
+        // git follows a rejection with several `hint:` lines. They must not
+        // crowd out the error itself when only three rows are free.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "To /tmp/origin\n\
+                     hint: Updates were rejected because the tip is behind\n\
+                     hint: its remote counterpart. Integrate the changes\n\
+                     hint: before pushing again.\n\
+                     ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+                     error: failed to push some refs\n"
+                .to_string(),
+        });
+        let overlay = ui.overlay(120);
+        assert!(
+            !overlay.contains("hint:"),
+            "hints must not survive, got {overlay:?}"
+        );
+        assert!(overlay.contains("! [rejected]"), "got {overlay:?}");
+        assert!(
+            overlay.contains("error: failed to push some refs"),
+            "got {overlay:?}"
+        );
+    }
+
+    #[test]
+    fn a_failed_push_never_takes_more_than_three_rows() {
+        // The frame below is what the user is watching. A wall of git output
+        // must not push it off the screen.
+        let mut ui = asking();
+        ui.confirm();
+        let output = (1..=20)
+            .map(|n| format!("error: line {n}\n"))
+            .collect::<String>();
+        ui.finished(PushOutcome {
+            success: false,
+            output,
+        });
+        assert_eq!(ui.rows(), MAX_STATUS_ROWS);
+        assert_eq!(ui.overlay(80).lines().count(), MAX_STATUS_ROWS);
+    }
+
+    #[test]
+    fn a_failed_push_that_said_nothing_still_says_something() {
+        // A push that fails with no output at all must not leave a blank row
+        // that reads as success.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "   \n\n".to_string(),
+        });
+        assert_eq!(ui.rows(), 1);
+        assert!(
+            !ui.overlay(80).trim().is_empty(),
+            "a failure must always say that it failed",
+        );
+    }
+
+    #[test]
+    fn a_status_stays_until_a_key_arrives() {
+        // Tim's requirement: an error must survive every decay tick and
+        // repaint, and go away only when the user has pressed something.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "error: failed to push some refs\n".to_string(),
+        });
+        assert_eq!(ui.rows(), 1);
+        ui.dismiss();
+        assert_eq!(ui.rows(), 0, "a key press clears the message");
+        assert_eq!(ui.overlay(80), "");
+    }
+
+    #[test]
+    fn dismissing_leaves_a_question_and_a_running_push_alone() {
+        // `dismiss` is what an unrelated key does. It must not answer a
+        // question or hide a push that is still running.
+        let mut ui = asking();
+        ui.dismiss();
+        assert_eq!(ui.mode(), InputMode::Confirm, "a stray key must not cancel");
+
+        ui.confirm();
+        ui.dismiss();
+        assert_eq!(
+            ui.mode(),
+            InputMode::Pushing,
+            "a stray key must not hide a running push",
+        );
+    }
+
+    #[test]
+    fn a_running_push_says_so() {
+        let mut ui = asking();
+        ui.confirm();
+        let overlay = ui.overlay(80);
+        assert!(
+            overlay.to_lowercase().contains("push"),
+            "the running notice must name what is happening, got {overlay:?}",
+        );
+    }
+
+    #[test]
+    fn the_overlay_never_exceeds_the_width_it_is_given() {
+        // gsw's standing contract: nothing it prints wraps. A long remote name
+        // or a long git error must be truncated, not folded onto a new row.
+        let mut ui = PushUi::new();
+        let mut snap = snapshot(None);
+        snap.branch = "a-branch-name-long-enough-to-need-truncating-on-a-narrow-pane".to_string();
+        ui.request(&snap);
+        for width in [10, 20, 40] {
+            let overlay = ui.overlay(width);
+            for line in overlay.lines() {
+                assert!(
+                    unicode_width::UnicodeWidthStr::width(line) <= width,
+                    "line {line:?} exceeds width {width}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_overlay_truncates_multibyte_text_without_panicking() {
+        // Branch names can hold multi-byte characters, and byte-slicing one at
+        // a narrow width is a panic in the middle of the alternate screen.
+        let mut ui = PushUi::new();
+        let mut snap = snapshot(None);
+        snap.branch = "日本語のブランチ名-🎉-café".to_string();
+        ui.request(&snap);
+        for width in 1..40 {
+            let overlay = ui.overlay(width);
+            for line in overlay.lines() {
+                assert!(
+                    unicode_width::UnicodeWidthStr::width(line) <= width,
+                    "line {line:?} exceeds width {width}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_new_request_replaces_a_stale_status() {
+        // Pressing `p` while an old error is on screen must ask the new
+        // question, not stack a second row under the first.
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(PushOutcome {
+            success: false,
+            output: "error: failed to push some refs\n".to_string(),
+        });
+        ui.request(&snapshot(None));
+        assert_eq!(ui.mode(), InputMode::Confirm);
+        assert_eq!(ui.rows(), 1);
+        assert!(!ui.overlay(120).contains("error:"));
     }
 }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -998,7 +998,7 @@ fn pad_right(s: &str, width: usize) -> String {
 
 /// Truncate `s` from the right to fit within `max_width` display columns,
 /// suffixing with `…` when truncation happens. UTF-8 safe.
-fn truncate_right(s: &str, max_width: usize) -> String {
+pub(crate) fn truncate_right(s: &str, max_width: usize) -> String {
     if UnicodeWidthStr::width(s) <= max_width {
         return s.to_string();
     }

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -30,6 +30,12 @@ pub struct Snapshot {
     /// Upstream tracking branch status (ahead/behind). `None` when the
     /// current branch has no configured upstream.
     pub upstream: Option<UpstreamStatus>,
+    /// The remote a branch with no upstream would be published to, or `None`
+    /// when the repository offers no unambiguous answer. Never rendered — it is
+    /// what watch mode's push prompt names, and it rides on the snapshot so
+    /// every walk re-reads it from the freshly re-opened handle, exactly like
+    /// [`Snapshot::upstream`]. See `repo::push_remote`.
+    pub push_remote: Option<String>,
     /// In-progress git operation (merge/rebase), or `None` for a clean tree.
     pub operation: Option<Operation>,
 }
@@ -1281,6 +1287,7 @@ mod tests {
             log: vec![],
             upstream: None,
             operation: None,
+            push_remote: None,
         }
     }
 

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -299,8 +299,22 @@ pub fn upstream_status(repo: &gix::Repository) -> Option<UpstreamStatus> {
 /// remote added in another pane takes effect on the next refresh rather than at
 /// the next restart.
 pub fn push_remote(repo: &gix::Repository) -> Option<String> {
-    let _ = repo;
-    None
+    use gix::bstr::ByteSlice;
+
+    let names: Vec<String> = repo
+        .remote_names()
+        .iter()
+        .filter_map(|name| name.to_str().ok().map(str::to_owned))
+        .collect();
+
+    // The config snapshot borrows the repository, so the picked name is cloned
+    // out before it is dropped at the end of this scope.
+    let config = repo.config_snapshot();
+    let push_default = config
+        .string("remote.pushDefault")
+        .and_then(|value| value.to_str().ok().map(str::to_owned));
+
+    pick_push_remote(&names, push_default.as_deref())
 }
 
 /// Pure core of [`push_remote`]: pick the remote from the names the repository
@@ -321,9 +335,18 @@ pub fn push_remote(repo: &gix::Repository) -> Option<String> {
 ///    `pushDefault` is a genuine ambiguity, and guessing would publish a branch
 ///    to a remote the user never named.
 fn pick_push_remote(names: &[String], push_default: Option<&str>) -> Option<String> {
-    let _ = (names, push_default);
-    None
+    if let Some(configured) = push_default {
+        return Some(configured.to_string());
+    }
+    match names {
+        [only] => Some(only.clone()),
+        _ => names.iter().find(|name| *name == ORIGIN).cloned(),
+    }
 }
+
+/// The remote name every git tool assumes when a repository has several and the
+/// user has expressed no preference.
+const ORIGIN: &str = "origin";
 
 /// The in-progress git operation gsw should surface in the header, or `None`
 /// for a clean tree or an out-of-scope operation.

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -1284,6 +1284,11 @@ mod tests {
         );
     }
 
+    // Unix-only because the symlink it stages is: `std::os::unix::fs::symlink`
+    // does not exist on Windows, so an ungated test breaks the build for that
+    // target rather than failing there — which is how it hid until the crate was
+    // first checked against `x86_64-pc-windows-msvc`.
+    #[cfg(unix)]
     #[test]
     fn status_staged_typechange_file_to_symlink() {
         // Replace a tracked regular file with a symlink and stage it; git/gix

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -288,6 +288,43 @@ pub fn upstream_status(repo: &gix::Repository) -> Option<UpstreamStatus> {
     })
 }
 
+/// The remote to publish a branch that has no upstream to, or `None` when the
+/// repository gives no unambiguous answer.
+///
+/// Only consulted for a branch with no upstream. A branch that already tracks
+/// something is pushed with a bare `git push`, which reads the remote out of
+/// the branch config — so this never has to second-guess a tracking branch.
+///
+/// Read fresh on every walk, like every other configuration gsw renders: a
+/// remote added in another pane takes effect on the next refresh rather than at
+/// the next restart.
+pub fn push_remote(repo: &gix::Repository) -> Option<String> {
+    let _ = repo;
+    None
+}
+
+/// Pure core of [`push_remote`]: pick the remote from the names the repository
+/// has and whatever `remote.pushDefault` says.
+///
+/// The rules, in order:
+///
+/// 1. **`remote.pushDefault` wins outright**, and is taken verbatim — even when
+///    it names no configured remote. That setting exists precisely so the user
+///    can override the default, and git itself is the authority on whether the
+///    name resolves. Second-guessing it here would mean pushing somewhere the
+///    user did not configure. A bogus value fails in `git push`, where the error
+///    says what is actually wrong.
+/// 2. **Exactly one remote** is the answer whatever it is called, so a
+///    repository whose only remote is `fork` is not told there is no remote.
+/// 3. **`origin` among several**, matching what every other tool assumes.
+/// 4. Otherwise `None`. Several remotes, none named `origin`, and no
+///    `pushDefault` is a genuine ambiguity, and guessing would publish a branch
+///    to a remote the user never named.
+fn pick_push_remote(names: &[String], push_default: Option<&str>) -> Option<String> {
+    let _ = (names, push_default);
+    None
+}
+
 /// The in-progress git operation gsw should surface in the header, or `None`
 /// for a clean tree or an out-of-scope operation.
 ///
@@ -1545,5 +1582,137 @@ mod tests {
         git_allowing_failure(p, &["cherry-pick", "feature~1"]);
         let repo = open_at(p).unwrap();
         assert_eq!(super::operation_state(&repo, 1), None);
+    }
+}
+
+#[cfg(test)]
+mod push_remote_tests {
+    use super::{pick_push_remote, push_remote, RepoHandle};
+    use crate::testrepo::{git, init_repo, init_repo_with_upstream};
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn the_only_remote_is_the_answer_whatever_it_is_called() {
+        // A repo whose single remote is `fork` must not be told it has no
+        // remote just because the name is not `origin`.
+        assert_eq!(
+            pick_push_remote(&names(&["fork"]), None),
+            Some("fork".to_string()),
+        );
+    }
+
+    #[test]
+    fn origin_wins_among_several_remotes() {
+        assert_eq!(
+            pick_push_remote(&names(&["upstream", "origin", "fork"]), None),
+            Some("origin".to_string()),
+        );
+    }
+
+    #[test]
+    fn several_remotes_without_origin_are_ambiguous() {
+        // Guessing here would publish a branch to a remote the user never
+        // named. Refusing sends them to `git push` with their own choice.
+        assert_eq!(pick_push_remote(&names(&["upstream", "fork"]), None), None);
+    }
+
+    #[test]
+    fn no_remote_at_all_has_no_answer() {
+        assert_eq!(pick_push_remote(&[], None), None);
+    }
+
+    #[test]
+    fn push_default_overrides_origin() {
+        // The setting exists to override the default. Ignoring it would push to
+        // `origin` while the user's own config says otherwise.
+        assert_eq!(
+            pick_push_remote(&names(&["origin", "upstream"]), Some("upstream")),
+            Some("upstream".to_string()),
+        );
+    }
+
+    #[test]
+    fn push_default_resolves_an_otherwise_ambiguous_repository() {
+        assert_eq!(
+            pick_push_remote(&names(&["alpha", "beta"]), Some("beta")),
+            Some("beta".to_string()),
+        );
+    }
+
+    #[test]
+    fn push_default_is_taken_verbatim_even_when_it_names_nothing() {
+        // git is the authority on whether the name resolves. Falling back to
+        // `origin` here would push somewhere the user did not configure, and
+        // the fallback would be invisible. `git push` reports the real error.
+        assert_eq!(
+            pick_push_remote(&names(&["origin"]), Some("typo")),
+            Some("typo".to_string()),
+        );
+    }
+
+    #[test]
+    fn a_clone_reports_its_origin() {
+        // The end-to-end read, against a repository that really has a remote.
+        let (_origin, clone) = init_repo_with_upstream();
+        let handle = RepoHandle::discover(clone.path()).expect("clone is a worktree repo");
+        assert_eq!(push_remote(handle.repo()), Some("origin".to_string()));
+    }
+
+    #[test]
+    fn a_repository_with_no_remote_reports_none() {
+        let dir = init_repo();
+        let handle = RepoHandle::discover(dir.path()).expect("fixture is a worktree repo");
+        assert_eq!(push_remote(handle.repo()), None);
+    }
+
+    #[test]
+    fn a_repository_reports_its_only_remote_by_name() {
+        let dir = init_repo();
+        git(
+            dir.path(),
+            &["remote", "add", "fork", "https://example.invalid/x.git"],
+        );
+        let handle = RepoHandle::discover(dir.path()).expect("fixture is a worktree repo");
+        assert_eq!(push_remote(handle.repo()), Some("fork".to_string()));
+    }
+
+    #[test]
+    fn a_repository_reads_its_own_push_default() {
+        // The config read, end to end: `remote.pushDefault` must reach the
+        // answer, not just the pure picker.
+        let dir = init_repo();
+        git(
+            dir.path(),
+            &["remote", "add", "origin", "https://example.invalid/a.git"],
+        );
+        git(
+            dir.path(),
+            &["remote", "add", "fork", "https://example.invalid/b.git"],
+        );
+        git(dir.path(), &["config", "remote.pushDefault", "fork"]);
+        let handle = RepoHandle::discover(dir.path()).expect("fixture is a worktree repo");
+        assert_eq!(push_remote(handle.repo()), Some("fork".to_string()));
+    }
+
+    #[test]
+    fn a_walk_puts_the_remote_on_the_snapshot() {
+        // The field has to arrive where the push prompt reads it, not merely
+        // exist on the repository.
+        let (_origin, clone) = init_repo_with_upstream();
+        let handle = RepoHandle::discover(clone.path()).expect("clone is a worktree repo");
+        let cfg = crate::RenderConfig {
+            base: None,
+            max_files: None,
+            bar_width: 20,
+            log_lines: 0,
+            truecolor: false,
+            width_offset: 0,
+            refresh_interval: None,
+        };
+        let snapshot = crate::collect_snapshot(handle.repo(), &cfg).expect("walk the clone");
+        assert_eq!(snapshot.push_remote, Some("origin".to_string()));
     }
 }

--- a/src/gsw/src/repo.rs
+++ b/src/gsw/src/repo.rs
@@ -124,12 +124,22 @@ impl RepoHandle {
     }
 }
 
-/// The short current-branch name (e.g. `main`), or `"HEAD"` when detached —
-/// matching what `git rev-parse --abbrev-ref HEAD` prints.
+/// What [`branch_name`] reports when HEAD is detached, matching what
+/// `git rev-parse --abbrev-ref HEAD` prints.
+///
+/// Usable as a sentinel — "this is not a branch" — because git rejects `HEAD`
+/// as a branch name (`git branch HEAD` fails), so no real branch can ever carry
+/// it. Named rather than spelled inline at each site so the two readers
+/// ([`branch_name`] and the push planner, which must refuse to push a detached
+/// HEAD) are tied to one definition instead of two matching string literals.
+pub const DETACHED_HEAD: &str = "HEAD";
+
+/// The short current-branch name (e.g. `main`), or [`DETACHED_HEAD`] when
+/// detached — matching what `git rev-parse --abbrev-ref HEAD` prints.
 pub fn branch_name(repo: &gix::Repository) -> String {
     match repo.head_name() {
         Ok(Some(full)) => full.shorten().to_string(),
-        _ => "HEAD".to_string(),
+        _ => DETACHED_HEAD.to_string(),
     }
 }
 

--- a/src/gsw/src/snapshot.rs
+++ b/src/gsw/src/snapshot.rs
@@ -67,6 +67,7 @@ pub fn build_snapshot(
         log: Vec::new(),
         upstream: None,
         operation: None,
+        push_remote: None,
     }
 }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -3942,6 +3942,7 @@ mod push_loop_tests {
     use super::tests::{frame, timer_off, TEST_DEBOUNCE, TEST_DIMS};
     use super::*;
     use crate::push::PushOutcome;
+    use crate::render::strip_ansi;
     use crossterm::event::{KeyCode, KeyModifiers};
     use std::cell::RefCell;
 
@@ -3962,10 +3963,14 @@ mod push_loop_tests {
     }
 
     fn cache_at(collected_at: Instant) -> SnapshotCache {
+        cache_in(collected_at, TEST_DIMS)
+    }
+
+    fn cache_in(collected_at: Instant, dims: Dimensions) -> SnapshotCache {
         SnapshotCache {
             snapshot: pushable_snapshot(),
             collected_at,
-            dims: TEST_DIMS,
+            dims,
         }
     }
 
@@ -3989,6 +3994,32 @@ mod push_loop_tests {
     /// against one render, which is exactly the state the assertions are about.
     /// The queue must end with [`Event::Quit`] or the loop blocks.
     fn run_loop(events: Vec<Event>) -> (String, Seen) {
+        run_loop_with(events, TEST_DIMS, |_frame_dims| "FRAME".to_string())
+    }
+
+    /// Run the loop in a pane of the given size, with a frame that really fills
+    /// the rows it was given.
+    ///
+    /// [`run_loop`]'s canned one-line frame cannot show an overflow: what lands
+    /// in the pane is the frame's rows plus the overlay's, so a test about how
+    /// many rows are painted needs a render hook that emits as many rows as it
+    /// was asked for — which is what the production renderer does.
+    fn run_loop_in_pane(events: Vec<Event>, dims: Dimensions) -> (String, Seen) {
+        run_loop_with(events, dims, |frame_dims| {
+            (1..=frame_dims.height)
+                .map(|row| format!("ROW{row}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+    }
+
+    /// The shared body: pre-load the queue, run the loop against `dims`, and
+    /// report the last painted screen plus what the hooks saw.
+    fn run_loop_with(
+        events: Vec<Event>,
+        dims: Dimensions,
+        render_frame: fn(Dimensions) -> String,
+    ) -> (String, Seen) {
         let (tx, rx) = mpsc::channel();
         for event in events {
             tx.send(event).expect("queue event");
@@ -4001,7 +4032,7 @@ mod push_loop_tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            cache_at(base),
+            cache_in(base, dims),
             None,
             no_timed_refresh_for_push(),
             LoopHooks {
@@ -4009,11 +4040,11 @@ mod push_loop_tests {
                     seen.borrow_mut().collects += 1;
                     Ok(pushable_snapshot())
                 },
-                render: |_snap: &Snapshot, dims: Dimensions, _timing: FrameTiming| {
-                    seen.borrow_mut().frame_heights.push(dims.height);
-                    frame("FRAME")
+                render: |_snap: &Snapshot, frame_dims: Dimensions, _timing: FrameTiming| {
+                    seen.borrow_mut().frame_heights.push(frame_dims.height);
+                    frame(&render_frame(frame_dims))
                 },
-                dimensions: || TEST_DIMS,
+                dimensions: move || dims,
                 paint: |_output: &str| Ok(()),
                 clock: move || base,
                 next_tick: timer_off,
@@ -4174,6 +4205,69 @@ mod push_loop_tests {
         assert_eq!(
             seen.frame_heights.last().copied(),
             Some(TEST_DIMS.height - 3),
+        );
+    }
+
+    /// A pane exactly as tall as the tallest status message gsw can show. That
+    /// is where the frame and the overlay start competing for the same rows,
+    /// and the only size at which an unclamped overlay is visible as an
+    /// overflow rather than as a very short frame.
+    const SHORT_PANE: Dimensions = Dimensions {
+        width: 80,
+        height: 3,
+    };
+
+    /// The events that put a three-row push error on screen.
+    fn a_three_row_failure() -> Vec<Event> {
+        vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::PushFinished(PushOutcome {
+                success: false,
+                output: "To /tmp/origin\n\
+                         ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+                         error: failed to push some refs\n"
+                    .to_string(),
+            }),
+            Event::Quit,
+        ]
+    }
+
+    #[test]
+    fn the_overlay_never_overflows_a_pane_shorter_than_the_message() {
+        // gsw paints into an alternate screen it cleared and laid out to fill
+        // exactly. One row too many scrolls the pane, which is the same
+        // never-wrap contract the overlay's width truncation exists to hold.
+        let (displayed, seen) = run_loop_in_pane(a_three_row_failure(), SHORT_PANE);
+        // The failure path colors its rows red, and `colored`'s override is
+        // process-global across this test binary, so count visible rows rather
+        // than assume some other test left color off.
+        let painted = strip_ansi(&displayed);
+        assert!(
+            painted.lines().count() <= SHORT_PANE.height,
+            "painted {} rows into a {}-row pane: {painted:?}",
+            painted.lines().count(),
+            SHORT_PANE.height,
+        );
+        assert!(
+            matches!(seen.frame_heights.last().copied(), Some(rows) if rows >= 1),
+            "the frame must keep a row of its own, got {:?}",
+            seen.frame_heights,
+        );
+    }
+
+    #[test]
+    fn an_overlay_that_does_not_fit_drops_its_last_lines() {
+        // git leads with the part worth reading — `To <remote>`, then the
+        // rejection — so a message that has to lose rows loses them off the
+        // bottom.
+        let (displayed, _) = run_loop_in_pane(a_three_row_failure(), SHORT_PANE);
+        let painted = strip_ansi(&displayed);
+        assert!(painted.contains("To /tmp/origin"), "got {painted:?}");
+        assert!(painted.contains("! [rejected]"), "got {painted:?}");
+        assert!(
+            !painted.contains("error: failed to push some refs"),
+            "the tail must be the part that is dropped, got {painted:?}",
         );
     }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -2294,6 +2294,7 @@ mod tests {
             log: Vec::new(),
             upstream: None,
             operation: None,
+            push_remote: None,
         }
     }
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1234,16 +1234,18 @@ where
         if walk_now || saw_resize {
             cache.dims = (hooks.dimensions)();
         }
-        // What the push overlay will paint under the frame, and how many rows
-        // that costs — resolved together, against the pane both have to share.
-        // The frame is rendered that much shorter, because it is laid out to
-        // fill the pane exactly: appending to a full-height frame would push
-        // its bottom row, the file list, off the screen. The overlay never
-        // takes the pane's last row, so this subtraction always leaves the
-        // frame at least one; the `max` only covers a degenerate zero-row pane.
+        // What the push overlay will paint under the frame, and how tall the
+        // frame is left — one call, because they are one division of the pane
+        // both have to share. The frame is rendered shorter by exactly what the
+        // overlay took, because it is laid out to fill the pane exactly:
+        // appending to a full-height frame would push its bottom row, the file
+        // list, off the screen. The arithmetic deliberately lives in
+        // `PushUi::overlay` rather than here — a subtraction repeated in the
+        // caller is a second opinion about the same rows, and this loop must
+        // not be able to hold one.
         let overlay = ui.overlay(cache.dims);
         let frame_dims = Dimensions {
-            height: cache.dims.height.saturating_sub(overlay.rows()).max(1),
+            height: overlay.frame_rows(),
             ..cache.dims
         };
 

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1009,7 +1009,7 @@ where
             }
         }
         Event::PushRequested => ui.request(snapshot),
-        // `confirm` yields the arguments only once, so a second `y` that raced
+        // `confirm` yields the command only once, so a second `y` that raced
         // the mode change starts nothing.
         Event::PushConfirmed => {
             if let Some(command) = ui.confirm() {

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -587,11 +587,46 @@ enum Event {
     FsChanged,
     /// The terminal was resized — repaint at the new dimensions.
     Resize,
+    /// A key was pressed. Deliberately **unclassified**: what a key means
+    /// depends on whether a confirmation is on screen, and only the loop knows
+    /// that. Sending the raw key and classifying it in the loop is what makes
+    /// the mode and the key arrive in the same order the user pressed them —
+    /// were the reader thread to classify against a shared mode flag instead,
+    /// a fast `p` then `y` could be read while the flag still said
+    /// [`InputMode::Normal`], and the `y` would be silently dropped.
+    Key(KeyEvent),
     /// The user asked to quit (`q` or Ctrl-C).
     Quit,
     /// The user asked to force an immediate refresh (`r`), bypassing the
     /// throttle cooldown.
     ForceRefresh,
+    /// The user asked to push (`p`) — show the confirmation, or say why there
+    /// is nothing to confirm.
+    PushRequested,
+    /// The user confirmed the push at the prompt (`y` or Enter).
+    PushConfirmed,
+    /// The user declined the push at the prompt (`n`, Esc, or `q`).
+    PushCancelled,
+    /// A key press with no other meaning. Clears a status message if one is on
+    /// screen and does nothing otherwise, which is what keeps a push error up
+    /// until the user has actually looked at the screen.
+    Dismiss,
+}
+
+/// What keys mean right now.
+///
+/// The loop owns this, because the loop is the only place that knows what is on
+/// screen. It is an input *mode* rather than a set of booleans so the key table
+/// is total: every mode answers every key, and a mode added later cannot
+/// silently inherit another's bindings.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum InputMode {
+    /// Nothing is being asked. The monitor's ordinary keys apply.
+    Normal,
+    /// A push confirmation is on screen and is waiting for an answer.
+    Confirm,
+    /// A push is running. `p` is inert here, so two pushes cannot overlap.
+    Pushing,
 }
 
 /// The git work one watch-mode refresh performs: re-open the repository so
@@ -995,6 +1030,8 @@ where
                     saw_force = true;
                     false
                 }
+                // Push input is not wired into the loop yet.
+                Ok(_) => false,
                 Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
@@ -1012,6 +1049,8 @@ where
                     saw_force = true;
                     false
                 }
+                // Push input is not wired into the loop yet.
+                Ok(_) => false,
                 Err(_) => break,
             },
         };
@@ -1029,6 +1068,8 @@ where
                     Ok(Event::FsChanged) => saw_fs = true,
                     Ok(Event::Resize) => saw_resize = true,
                     Ok(Event::ForceRefresh) => saw_force = true,
+                    // Push input is not wired into the loop yet.
+                    Ok(_) => {}
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
@@ -1177,54 +1218,77 @@ fn current_dimensions(width_offset: usize) -> Dimensions {
 
 /// The pure, unit-testable core of [`spawn_event_reader`]: map one crossterm
 /// terminal event to the [`Event`] the watch loop should react to, or `None`
-/// when the event is irrelevant. Keeping the key→event decision here —
-/// terminal-free and side-effect-free — lets it be tested without a pty while
-/// the reader thread stays a thin `event::read` → `classify_input` → `tx.send`
-/// loop.
+/// when the event is irrelevant.
 ///
-/// - A key *release* is ignored (kitty/Windows report them; only a press acts).
-/// - `q`, or Ctrl-C, requests a [`Event::Quit`].
-/// - `r` forces an immediate refresh ([`Event::ForceRefresh`]), bypassing the
-///   throttle cooldown.
+/// Deliberately does **not** decide what a key means. Key semantics depend on
+/// the loop's [`InputMode`], which this thread cannot read without racing the
+/// loop that writes it, so a key is forwarded whole and classified by
+/// [`classify_input`] once it has arrived somewhere the mode is known.
+///
+/// - A key press becomes [`Event::Key`], carrying the key untouched.
 /// - A terminal resize becomes [`Event::Resize`].
 /// - Everything else is ignored.
-fn classify_input(event: CtEvent) -> Option<Event> {
+fn forward_input(event: CtEvent) -> Option<Event> {
     match event {
-        CtEvent::Key(KeyEvent {
-            code,
-            modifiers,
-            kind,
-            ..
-        }) => {
-            if kind == KeyEventKind::Release {
-                // Ignore key releases (kitty/Windows report them); only a press acts.
-                None
-            } else if code == KeyCode::Char('q')
-                || (modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c'))
-            {
-                Some(Event::Quit)
-            } else if code == KeyCode::Char('r') {
-                Some(Event::ForceRefresh)
-            } else {
-                None
-            }
-        }
+        CtEvent::Key(key) => Some(Event::Key(key)),
         CtEvent::Resize(_, _) => Some(Event::Resize),
         _ => None,
     }
 }
 
+/// What one key press means in `mode`, or `None` when it means nothing at all.
+///
+/// Pure and terminal-free, so the whole key table is testable without a pty:
+/// a test builds a [`KeyEvent`] and a mode and reads back the [`Event`].
+///
+/// - A key *release* is ignored in every mode (kitty/Windows report them; only
+///   a press acts).
+/// - **Ctrl-C quits from every mode**, including mid-push. A monitor that
+///   cannot be quit while it waits on the network is a monitor that has to be
+///   killed from another pane.
+/// - [`InputMode::Normal`]: `q` quits, `r` forces a refresh, `p` asks to push.
+/// - [`InputMode::Confirm`]: `y` and Enter push, `n`, Esc, and `q` cancel.
+///   Nothing else acts — with a question on screen, `q` is the answer "no",
+///   not "quit", and `r` is not a refresh. That is why the mode exists.
+/// - [`InputMode::Pushing`]: `q` quits and `r` refreshes, but `p` is inert, so
+///   an impatient second press cannot start an overlapping push.
+/// - Every other press is [`Event::Dismiss`], which clears a status message and
+///   otherwise does nothing.
+fn classify_input(key: KeyEvent, mode: InputMode) -> Option<Event> {
+    let KeyEvent {
+        code,
+        modifiers,
+        kind,
+        ..
+    } = key;
+
+    if kind == KeyEventKind::Release {
+        // Ignore key releases (kitty/Windows report them); only a press acts.
+        return None;
+    }
+
+    let _ = mode;
+    if code == KeyCode::Char('q')
+        || (modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c'))
+    {
+        Some(Event::Quit)
+    } else if code == KeyCode::Char('r') {
+        Some(Event::ForceRefresh)
+    } else {
+        None
+    }
+}
+
 /// Spawn the crossterm event-reader thread. It blocks on `event::read`, routes
-/// each event through [`classify_input`] (which maps `q`/Ctrl-C to
-/// [`Event::Quit`], `r` to [`Event::ForceRefresh`], and terminal resizes to
-/// [`Event::Resize`]), forwards any resulting [`Event`], and exits when the
-/// receiver is gone or reading fails.
+/// each event through [`forward_input`] (which passes key presses through whole
+/// and maps terminal resizes to [`Event::Resize`]), forwards any resulting
+/// [`Event`], and exits when the receiver is gone or reading fails.
 fn spawn_event_reader(tx: Sender<Event>) {
     thread::spawn(move || {
         // Loop until reading fails (terminal closed) — the `while let` exits on
         // `Err` — or a forwarded send fails because the receiver is gone.
         while let Ok(ct_event) = event::read() {
-            if let Some(event) = classify_input(ct_event) {
+            if let Some(event) = forward_input(ct_event) {
                 if tx.send(event).is_err() {
                     break;
                 }
@@ -2111,49 +2175,161 @@ mod tests {
         );
     }
 
+    /// One key press, with no modifiers.
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
     #[test]
     fn classify_input_maps_the_r_key_to_force_refresh() {
         // Pressing `r` is the manual-refresh escape hatch: the input classifier
         // must turn an `r` key PRESS into Event::ForceRefresh.
-        let r_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
-        assert!(matches!(classify_input(r_press), Some(Event::ForceRefresh)));
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('r')), InputMode::Normal),
+            Some(Event::ForceRefresh),
+        ));
     }
 
     #[test]
     fn classify_input_handles_keys_and_ignores_releases() {
         // Regression guard for the rest of the classifier's contract once `r`
         // joined it: a key RELEASE is dropped (kitty/Windows emit them and only
-        // a press should act), `q` and Ctrl-C still quit, a resize still maps to
-        // a repaint, and an unrelated key is ignored.
+        // a press should act), and `q` and Ctrl-C still quit.
 
         // A key release — even of a key we act on — is ignored.
-        let r_release = CtEvent::Key(KeyEvent {
+        let r_release = KeyEvent {
             kind: KeyEventKind::Release,
-            ..KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)
-        });
+            ..press(KeyCode::Char('r'))
+        };
         assert!(
-            classify_input(r_release).is_none(),
+            classify_input(r_release, InputMode::Normal).is_none(),
             "a key release must be ignored — only a press acts",
         );
 
         // `q` and Ctrl-C both request a quit.
-        let q_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
-        assert!(matches!(classify_input(q_press), Some(Event::Quit)));
-        let ctrl_c = CtEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
-        assert!(matches!(classify_input(ctrl_c), Some(Event::Quit)));
-
-        // A resize becomes a repaint at the new dimensions.
         assert!(matches!(
-            classify_input(CtEvent::Resize(80, 24)),
-            Some(Event::Resize)
+            classify_input(press(KeyCode::Char('q')), InputMode::Normal),
+            Some(Event::Quit),
+        ));
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(matches!(
+            classify_input(ctrl_c, InputMode::Normal),
+            Some(Event::Quit),
         ));
 
-        // An unrelated key press is ignored.
-        let x_press = CtEvent::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        // An unrelated key press acts on nothing, but is not silence: it clears
+        // a status message that may be on screen.
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('x')), InputMode::Normal),
+            Some(Event::Dismiss),
+        ));
+    }
+
+    #[test]
+    fn the_reader_forwards_key_presses_whole_and_maps_resizes() {
+        // The reader thread cannot know the mode, so it must not decide
+        // anything about a key. A resize means the same thing in every mode, so
+        // it is classified here.
+        let key = press(KeyCode::Char('p'));
         assert!(
-            classify_input(x_press).is_none(),
-            "an unrelated key must be ignored",
+            matches!(forward_input(CtEvent::Key(key)), Some(Event::Key(sent)) if sent == key),
+            "a key must reach the loop untouched",
         );
+        assert!(matches!(
+            forward_input(CtEvent::Resize(80, 24)),
+            Some(Event::Resize),
+        ));
+    }
+
+    #[test]
+    fn p_asks_to_push_only_when_nothing_else_is_happening() {
+        // The new key. It opens the confirmation from the normal mode, and is
+        // inert while a push is already running — an impatient second press
+        // must not start an overlapping push.
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('p')), InputMode::Normal),
+            Some(Event::PushRequested),
+        ));
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('p')), InputMode::Pushing),
+            Some(Event::Dismiss),
+        ));
+    }
+
+    #[test]
+    fn the_confirmation_accepts_y_and_enter() {
+        for code in [KeyCode::Char('y'), KeyCode::Char('Y'), KeyCode::Enter] {
+            assert!(
+                matches!(
+                    classify_input(press(code), InputMode::Confirm),
+                    Some(Event::PushConfirmed),
+                ),
+                "{code:?} must confirm the push",
+            );
+        }
+    }
+
+    #[test]
+    fn the_confirmation_is_cancelled_by_n_esc_and_q() {
+        // `q` cancels rather than quits while a question is on screen: the safe
+        // reading of "get me out of here" is backing out of the push, not
+        // ending the session with a prompt still up.
+        for code in [
+            KeyCode::Char('n'),
+            KeyCode::Char('N'),
+            KeyCode::Char('q'),
+            KeyCode::Esc,
+        ] {
+            assert!(
+                matches!(
+                    classify_input(press(code), InputMode::Confirm),
+                    Some(Event::PushCancelled),
+                ),
+                "{code:?} must cancel the push",
+            );
+        }
+    }
+
+    #[test]
+    fn the_confirmation_ignores_the_ordinary_keys() {
+        // With a question on screen, `r` must not refresh and `p` must not
+        // re-ask. Anything that is not an answer does nothing.
+        for code in [KeyCode::Char('r'), KeyCode::Char('p'), KeyCode::Char('x')] {
+            assert!(
+                matches!(
+                    classify_input(press(code), InputMode::Confirm),
+                    Some(Event::Dismiss),
+                ),
+                "{code:?} must not act while the confirmation is up",
+            );
+        }
+    }
+
+    #[test]
+    fn ctrl_c_quits_from_every_mode() {
+        // A monitor that cannot be quit while it waits on the network is one
+        // that has to be killed from another pane.
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        for mode in [InputMode::Normal, InputMode::Confirm, InputMode::Pushing] {
+            assert!(
+                matches!(classify_input(ctrl_c, mode), Some(Event::Quit)),
+                "Ctrl-C must quit from {mode:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn q_and_r_still_work_while_a_push_runs() {
+        // The push runs off this thread, so the monitor stays live underneath
+        // it: quitting and refreshing keep working.
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('q')), InputMode::Pushing),
+            Some(Event::Quit),
+        ));
+        assert!(matches!(
+            classify_input(press(KeyCode::Char('r')), InputMode::Pushing),
+            Some(Event::ForceRefresh),
+        ));
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -4030,6 +4030,28 @@ mod push_loop_tests {
     }
 
     #[test]
+    fn composing_does_not_double_the_frames_trailing_newline() {
+        // A real gsw frame ends with a newline. Joining with another one would
+        // leave a blank row between the frame and the overlay — and the frame
+        // was already rendered one row shorter to make room, so the overlay
+        // would be pushed off the pane it was measured to fit.
+        assert_eq!(compose("a\nb\n".to_string(), "note"), "a\nb\nnote");
+    }
+
+    #[test]
+    fn composing_separates_a_frame_that_has_no_trailing_newline() {
+        assert_eq!(compose("a\nb".to_string(), "note"), "a\nb\nnote");
+    }
+
+    #[test]
+    fn composing_an_empty_overlay_returns_the_frame_untouched() {
+        // Every frame gsw painted before the push feature existed must still be
+        // painted byte for byte, trailing newline and all.
+        assert_eq!(compose("a\nb\n".to_string(), ""), "a\nb\n");
+        assert_eq!(compose("a\nb".to_string(), ""), "a\nb");
+    }
+
+    #[test]
     fn pressing_p_puts_the_question_under_the_frame() {
         // The key has to reach the overlay through the loop, not just through
         // the classifier: the frame and the question are painted together.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -993,6 +993,7 @@ fn absorb<StartPush>(
     pending: &mut Pending,
     ui: &mut PushUi,
     snapshot: &Snapshot,
+    dims: Dimensions,
     start_push: &mut StartPush,
 ) -> Flow
 where
@@ -1005,10 +1006,10 @@ where
         Event::ForceRefresh => pending.force = true,
         Event::Key(key) => {
             if let Some(action) = classify_input(key, ui.mode()) {
-                return absorb(action, pending, ui, snapshot, start_push);
+                return absorb(action, pending, ui, snapshot, dims, start_push);
             }
         }
-        Event::PushRequested => ui.request(snapshot),
+        Event::PushRequested => ui.request(snapshot, dims),
         // `confirm` yields the command only once, so a second `y` that raced
         // the mode change starts nothing.
         Event::PushConfirmed => {
@@ -1134,6 +1135,7 @@ where
                         &mut pending,
                         &mut ui,
                         &cache.snapshot,
+                        cache.dims,
                         &mut hooks.start_push,
                     ) == Flow::Quit
                     {
@@ -1151,6 +1153,7 @@ where
                         &mut pending,
                         &mut ui,
                         &cache.snapshot,
+                        cache.dims,
                         &mut hooks.start_push,
                     ) == Flow::Quit
                     {
@@ -1174,6 +1177,7 @@ where
                             &mut pending,
                             &mut ui,
                             &cache.snapshot,
+                            cache.dims,
                             &mut hooks.start_push,
                         ) == Flow::Quit
                         {
@@ -4268,6 +4272,35 @@ mod push_loop_tests {
             "the frame must keep a row of its own, got {:?}",
             seen.frame_heights,
         );
+    }
+
+    /// A pane with nothing to spare: the frame keeps the only row there is, so
+    /// the push feature has nowhere to put a question.
+    const NO_ROOM_PANE: Dimensions = Dimensions {
+        width: 80,
+        height: 1,
+    };
+
+    #[test]
+    fn a_push_never_starts_from_a_question_the_pane_never_painted() {
+        // Key autorepeat, a paste, or a fast double-tap delivers `p` and the
+        // answer to it inside one debounce window, and every key in a window is
+        // classified before the loop renders again. Nothing in between can
+        // notice that the question was never drawn, so the pane has to be
+        // consulted when the question is raised rather than when it is painted.
+        // Enter is the key this is really about: it is what a user presses out
+        // of reflex at a frame that did not change.
+        for confirm in [KeyCode::Char('y'), KeyCode::Enter] {
+            let (_, seen) = run_loop_in_pane(
+                vec![key(KeyCode::Char('p')), key(confirm), Event::Quit],
+                NO_ROOM_PANE,
+            );
+            assert!(
+                seen.pushes.is_empty(),
+                "{confirm:?} started a push from a question the pane never painted: {:?}",
+                seen.pushes,
+            );
+        }
     }
 
     #[test]

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -607,6 +607,8 @@ enum Event {
     PushConfirmed,
     /// The user declined the push at the prompt (`n`, Esc, or `q`).
     PushCancelled,
+    /// A push that was running has finished, either way.
+    PushFinished(crate::push::PushOutcome),
     /// A key press with no other meaning. Clears a status message if one is on
     /// screen and does nothing otherwise, which is what keeps a push error up
     /// until the user has actually looked at the screen.
@@ -774,6 +776,7 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
             paint: |output: &str| paint_output(output),
             clock: Instant::now,
             next_tick: |freshest: Option<Duration>| freshest.and_then(next_tick),
+            start_push: |_args: Vec<String>| {},
         },
     )
 }
@@ -911,7 +914,7 @@ struct SnapshotCache {
 /// these to the real git collect, render, terminal-size query, painter, and
 /// clock; tests inject counters and a controllable clock to assert which hooks
 /// ran — and with what age offset — without a TTY or real time.
-struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
+struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush> {
     /// Walk the repo into a fresh [`Snapshot`] (the expensive git work).
     collect: Collect,
     /// Render a snapshot at the given dimensions and timing.
@@ -924,6 +927,11 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
     clock: Clock,
     /// Map the freshest displayed age to the decay-tick interval (`None` = off).
     next_tick: Tick,
+    /// Start a confirmed push, given the `git` arguments the confirmation
+    /// described. Production spawns a thread that runs the push and sends the
+    /// outcome back as [`Event::PushFinished`]; tests record the arguments and
+    /// decide for themselves when — or whether — the outcome arrives.
+    start_push: StartPush,
 }
 
 /// The render loop's terminal-free core: wait for a filesystem event, a resize,
@@ -975,14 +983,14 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick> {
 /// to zero. The accepted cost: a repository deleted for good leaves a frozen
 /// (but visibly aging) frame until the user quits. That is the right failure for
 /// a monitor — a wrong-but-labeled-old screen beats no screen.
-fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick>(
+fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>(
     rx: &Receiver<Event>,
     debounce: Duration,
     displayed: &mut String,
     mut cache: SnapshotCache,
     initial_freshest: Option<Duration>,
     mut schedule: WalkSchedule,
-    mut hooks: LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick>,
+    mut hooks: LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>,
 ) -> Result<()>
 where
     Collect: FnMut() -> Result<Snapshot>,
@@ -991,6 +999,7 @@ where
     Paint: FnMut(&str) -> Result<()>,
     Clock: Fn() -> Instant,
     Tick: Fn(Option<Duration>) -> Option<Duration>,
+    StartPush: FnMut(Vec<String>),
 {
     let mut freshest = initial_freshest;
     loop {
@@ -2444,7 +2453,7 @@ mod tests {
     /// before the loop runs, so they drain immediately and never actually wait
     /// out the window — only the final disconnect costs nothing — which makes
     /// these tests deterministic regardless of the exact value here.
-    const TEST_DEBOUNCE: Duration = Duration::from_millis(20);
+    pub(super) const TEST_DEBOUNCE: Duration = Duration::from_millis(20);
 
     /// No timed refresh: the loop under test is purely event-driven, so a walk
     /// can only come from a filesystem change. Every test that predates the
@@ -2456,13 +2465,13 @@ mod tests {
     /// A `next_tick` that always disables the timer, so the loop blocks purely
     /// on channel events. The event-driven tests use this to stay independent
     /// of the decay-timer behavior, which has its own dedicated tests.
-    fn timer_off(_freshest: Option<Duration>) -> Option<Duration> {
+    pub(super) fn timer_off(_freshest: Option<Duration>) -> Option<Duration> {
         None
     }
 
     /// Build a [`Render`] with the given frame and no freshest age — enough for
     /// the event-driven loop tests, which don't exercise the cadence.
-    fn frame(output: &str) -> Render {
+    pub(super) fn frame(output: &str) -> Render {
         Render {
             output: output.to_string(),
             freshest_age: None,
@@ -2486,7 +2495,7 @@ mod tests {
     }
 
     /// Dimensions used by loop tests that don't exercise resize.
-    const TEST_DIMS: Dimensions = Dimensions {
+    pub(super) const TEST_DIMS: Dimensions = Dimensions {
         width: 80,
         height: 24,
     };
@@ -2552,6 +2561,7 @@ mod tests {
                 // A decay tick on the same cadence, so the loop always wakes:
                 // the test must fail when no walk is scheduled, not block.
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2590,6 +2600,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2635,6 +2646,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: stepping_clock(base, Duration::from_secs(60)),
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2682,6 +2694,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2725,6 +2738,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2765,6 +2779,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2807,6 +2822,7 @@ mod tests {
                 // Tiny interval so the tick fires fast; the cadence-vs-age
                 // mapping is covered by the next_tick tests.
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2849,6 +2865,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2892,6 +2909,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2941,6 +2959,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || now,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -2998,6 +3017,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3077,6 +3097,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3160,6 +3181,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3224,6 +3246,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || base,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3295,6 +3318,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3365,6 +3389,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3415,6 +3440,7 @@ mod tests {
                 },
                 clock: || base,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         )
         .expect("loop");
@@ -3478,6 +3504,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         );
 
@@ -3565,6 +3592,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         );
 
@@ -3676,6 +3704,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
+                start_push: |_args: Vec<String>| {},
             },
         );
 
@@ -3765,5 +3794,295 @@ mod tests {
             watch.height, 50,
             "watch height must come from terminal_size with no chrome reserved",
         );
+    }
+}
+
+#[cfg(test)]
+mod push_loop_tests {
+    use super::tests::{frame, timer_off, TEST_DEBOUNCE, TEST_DIMS};
+    use super::*;
+    use crate::push::PushOutcome;
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use std::cell::RefCell;
+
+    /// A snapshot on an untracked `gsw-push` with `origin` available, so the
+    /// push feature has something real to plan.
+    fn pushable_snapshot() -> Snapshot {
+        Snapshot {
+            branch: "gsw-push".into(),
+            base: "main".into(),
+            commits_ahead: 2,
+            commits_behind: 0,
+            files: Vec::new(),
+            log: Vec::new(),
+            upstream: None,
+            operation: None,
+            push_remote: Some("origin".into()),
+        }
+    }
+
+    fn cache_at(collected_at: Instant) -> SnapshotCache {
+        SnapshotCache {
+            snapshot: pushable_snapshot(),
+            collected_at,
+            dims: TEST_DIMS,
+        }
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    /// What one loop run observed. The loop takes its hooks by value, so the
+    /// counters live behind `RefCell` and are read after it returns.
+    #[derive(Default)]
+    struct Seen {
+        collects: usize,
+        pushes: Vec<Vec<String>>,
+        frame_heights: Vec<usize>,
+    }
+
+    /// Run the loop over a pre-loaded event queue and report what it did.
+    ///
+    /// Every event is queued before the loop starts, so the first wake takes one
+    /// and the debounce drain absorbs the rest — the whole sequence is applied
+    /// against one render, which is exactly the state the assertions are about.
+    /// The queue must end with [`Event::Quit`] or the loop blocks.
+    fn run_loop(events: Vec<Event>) -> (String, Seen) {
+        let (tx, rx) = mpsc::channel();
+        for event in events {
+            tx.send(event).expect("queue event");
+        }
+        let seen = RefCell::new(Seen::default());
+        let mut displayed = String::new();
+        let base = Instant::now();
+
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            cache_at(base),
+            None,
+            no_timed_refresh_for_push(),
+            LoopHooks {
+                collect: || {
+                    seen.borrow_mut().collects += 1;
+                    Ok(pushable_snapshot())
+                },
+                render: |_snap: &Snapshot, dims: Dimensions, _timing: FrameTiming| {
+                    seen.borrow_mut().frame_heights.push(dims.height);
+                    frame("FRAME")
+                },
+                dimensions: || TEST_DIMS,
+                paint: |_output: &str| Ok(()),
+                clock: move || base,
+                next_tick: timer_off,
+                start_push: |args: Vec<String>| seen.borrow_mut().pushes.push(args),
+            },
+        )
+        .expect("loop");
+
+        (displayed, seen.into_inner())
+    }
+
+    /// Purely event-driven: no timed refresh, so any walk came from an event.
+    fn no_timed_refresh_for_push() -> WalkSchedule {
+        WalkSchedule::unscheduled()
+    }
+
+    #[test]
+    fn pressing_p_puts_the_question_under_the_frame() {
+        // The key has to reach the overlay through the loop, not just through
+        // the classifier: the frame and the question are painted together.
+        let (displayed, _) = run_loop(vec![key(KeyCode::Char('p')), Event::Quit]);
+        assert!(displayed.starts_with("FRAME"), "got {displayed:?}");
+        assert!(
+            displayed.contains("Create new remote branch origin/gsw-push?"),
+            "the question must be painted under the frame, got {displayed:?}",
+        );
+    }
+
+    #[test]
+    fn confirming_starts_the_push_the_question_described() {
+        // `p` then `y` must run the command the confirmation named — the whole
+        // safety property of asking first.
+        let (_, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::Quit,
+        ]);
+        assert_eq!(
+            seen.pushes,
+            vec![vec![
+                "push".to_string(),
+                "-u".to_string(),
+                "origin".to_string(),
+                "gsw-push".to_string(),
+            ]],
+        );
+    }
+
+    #[test]
+    fn a_lone_y_pushes_nothing() {
+        // Without a question on screen, `y` is an ordinary key. It must never
+        // reach the push.
+        let (_, seen) = run_loop(vec![key(KeyCode::Char('y')), Event::Quit]);
+        assert!(seen.pushes.is_empty(), "y alone must not push");
+    }
+
+    #[test]
+    fn cancelling_takes_the_question_off_the_screen_and_pushes_nothing() {
+        let (displayed, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('n')),
+            Event::Quit,
+        ]);
+        assert!(seen.pushes.is_empty(), "n must not push");
+        assert_eq!(displayed, "FRAME", "the question must be gone");
+    }
+
+    #[test]
+    fn a_successful_push_walks_git_again() {
+        // The push moved the upstream, so the header's arrows and tracking
+        // segment are stale the moment it lands. Only a walk fixes them.
+        let (displayed, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::PushFinished(PushOutcome {
+                success: true,
+                output: String::new(),
+            }),
+            Event::Quit,
+        ]);
+        assert_eq!(
+            seen.collects, 1,
+            "a successful push must re-walk so the header matches what happened",
+        );
+        assert!(
+            displayed.contains("Created origin/gsw-push"),
+            "got {displayed:?}",
+        );
+    }
+
+    #[test]
+    fn a_failed_push_shows_the_error_and_does_not_walk() {
+        // Nothing changed in the repository, so a walk would cost a status
+        // traversal to redraw the identical frame.
+        let (displayed, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::PushFinished(PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            }),
+            Event::Quit,
+        ]);
+        assert_eq!(seen.collects, 0, "a failed push changed nothing to re-read");
+        assert!(
+            displayed.contains("error: failed to push some refs"),
+            "got {displayed:?}",
+        );
+    }
+
+    #[test]
+    fn the_frame_is_rendered_shorter_while_the_overlay_is_up() {
+        // The overlay is painted under a frame that was measured to fill the
+        // pane. Without giving the rows back, the frame's bottom row — the file
+        // list — falls off the screen.
+        let (_, seen) = run_loop(vec![key(KeyCode::Char('p')), Event::Quit]);
+        assert_eq!(
+            seen.frame_heights,
+            vec![TEST_DIMS.height - 1],
+            "one overlay row must cost the frame one row",
+        );
+    }
+
+    #[test]
+    fn a_three_row_error_costs_the_frame_three_rows() {
+        let (_, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::PushFinished(PushOutcome {
+                success: false,
+                output: "error: one\nerror: two\nerror: three\nerror: four\n".to_string(),
+            }),
+            Event::Quit,
+        ]);
+        assert_eq!(
+            seen.frame_heights.last().copied(),
+            Some(TEST_DIMS.height - 3),
+        );
+    }
+
+    #[test]
+    fn the_frame_goes_back_to_full_height_once_the_status_is_dismissed() {
+        let (displayed, seen) = run_loop(vec![
+            key(KeyCode::Char('p')),
+            key(KeyCode::Char('y')),
+            Event::PushFinished(PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            }),
+            key(KeyCode::Char('x')),
+            Event::Quit,
+        ]);
+        assert_eq!(displayed, "FRAME", "the dismissed error must leave nothing");
+        assert_eq!(
+            seen.frame_heights.last().copied(),
+            Some(TEST_DIMS.height),
+            "the rows must come back",
+        );
+    }
+
+    #[test]
+    fn quitting_still_works_with_a_question_on_screen() {
+        // Ctrl-C during a confirmation must end the loop rather than being read
+        // as an answer.
+        //
+        // Run on a thread with a deadline, because the failure mode here is a
+        // loop that never ends: with no timed refresh and no decay tick, a
+        // Ctrl-C the loop does not act on leaves it blocked in `recv` forever.
+        // Asserting inline would hang the whole suite instead of failing.
+        let (done_tx, done_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (tx, rx) = mpsc::channel();
+            tx.send(key(KeyCode::Char('p'))).expect("queue p");
+            tx.send(Event::Key(KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL,
+            )))
+            .expect("queue ctrl-c");
+            let seen = RefCell::new(Seen::default());
+            let mut displayed = String::new();
+            let base = Instant::now();
+
+            event_loop(
+                &rx,
+                TEST_DEBOUNCE,
+                &mut displayed,
+                cache_at(base),
+                None,
+                no_timed_refresh_for_push(),
+                LoopHooks {
+                    collect: || Ok(pushable_snapshot()),
+                    render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {
+                        frame("FRAME")
+                    },
+                    dimensions: || TEST_DIMS,
+                    paint: |_output: &str| Ok(()),
+                    clock: move || base,
+                    next_tick: timer_off,
+                    start_push: |args: Vec<String>| seen.borrow_mut().pushes.push(args),
+                },
+            )
+            .expect("loop");
+
+            let _ = done_tx.send(seen.into_inner().pushes);
+        });
+
+        let pushes = done_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("Ctrl-C must end the loop rather than leave it blocked");
+        assert!(pushes.is_empty(), "ctrl-c must not push");
     }
 }

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -988,6 +988,15 @@ enum Flow {
 /// ahead of a `y` has already switched the mode by the time the `y` is looked
 /// at. It then recurses exactly once — [`classify_input`] never returns
 /// [`Event::Key`], so there is no second hop.
+///
+/// The exception worth naming is a `p` that switches nothing. Nothing renders
+/// between two keys of one drain, so a rule the render path applies is applied
+/// after the second key has already been classified — which is why `dims` is
+/// threaded down to [`PushUi::request`]: a pane with no row to draw the
+/// question in raises no question, the mode does not move, and the `y` or Enter
+/// behind that `p` is read as the ordinary key it is. `dims` is the pane the
+/// last render measured, which is the pane the user was looking at when they
+/// pressed the key — the loop re-measures after this drain, not during it.
 fn absorb<StartPush>(
     event: Event,
     pending: &mut Pending,
@@ -1249,12 +1258,16 @@ where
         // not be able to hold one.
         //
         // The call can also change what the keys mean, which is why it takes
-        // `&mut ui`: a pane with no row to spare for a confirmation cancels the
-        // confirmation rather than leaving a question nobody can see answerable
-        // by Enter. It runs after this wake's events have been absorbed and
-        // before the next wake reads one, so the key a user presses in reaction
-        // to what this paints is classified against the mode this pane actually
-        // showed them.
+        // `&mut ui`: a question whose row a resize took away is cancelled here
+        // rather than left answerable by an Enter nobody was asked for. That is
+        // the backstop only. A `p` pressed in a pane that was already too short
+        // raises no question in the first place — `absorb` settles that with
+        // `cache.dims`, because no render runs between two keys of one burst —
+        // so what this catches is the pane that shrank under a question that
+        // did fit when it was asked. It runs after this wake's events have been
+        // absorbed and before the next wake reads one, so the key a user
+        // presses in reaction to what this paints is classified against the
+        // mode this pane actually showed them.
         let overlay = ui.overlay(cache.dims);
         let frame_dims = Dimensions {
             height: overlay.frame_rows(),

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1234,12 +1234,16 @@ where
         if walk_now || saw_resize {
             cache.dims = (hooks.dimensions)();
         }
-        // Rows the push overlay will take under the frame. The frame is
-        // rendered that much shorter, because it is laid out to fill the pane
-        // exactly — appending to a full-height frame would push its bottom row,
-        // the file list, off the screen.
+        // What the push overlay will paint under the frame, and how many rows
+        // that costs — resolved together, against the pane both have to share.
+        // The frame is rendered that much shorter, because it is laid out to
+        // fill the pane exactly: appending to a full-height frame would push
+        // its bottom row, the file list, off the screen. The overlay never
+        // takes the pane's last row, so this subtraction always leaves the
+        // frame at least one; the `max` only covers a degenerate zero-row pane.
+        let overlay = ui.overlay(cache.dims);
         let frame_dims = Dimensions {
-            height: cache.dims.height.saturating_sub(ui.rows()).max(1),
+            height: cache.dims.height.saturating_sub(overlay.rows()).max(1),
             ..cache.dims
         };
 
@@ -1308,7 +1312,7 @@ where
         // are compared as one string, so a frame that did not change but an
         // overlay that did still repaints — and neither can repaint alone and
         // leave the other stale.
-        let output = compose(render.output, &ui.overlay(cache.dims.width));
+        let output = compose(render.output, &overlay.text());
         if should_repaint(&output, displayed) {
             (hooks.paint)(&output)?;
             *displayed = output;

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1267,16 +1267,27 @@ fn classify_input(key: KeyEvent, mode: InputMode) -> Option<Event> {
         return None;
     }
 
-    let _ = mode;
-    if code == KeyCode::Char('q')
-        || (modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c'))
-    {
-        Some(Event::Quit)
-    } else if code == KeyCode::Char('r') {
-        Some(Event::ForceRefresh)
-    } else {
-        None
+    // Checked before the mode table so no mode can trap the user mid-push.
+    if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+        return Some(Event::Quit);
     }
+
+    let event = match mode {
+        InputMode::Normal | InputMode::Pushing => match code {
+            KeyCode::Char('q') => Event::Quit,
+            KeyCode::Char('r') => Event::ForceRefresh,
+            // The one key the two modes disagree on: a push already running
+            // makes a second request meaningless rather than harmless.
+            KeyCode::Char('p') if mode == InputMode::Normal => Event::PushRequested,
+            _ => Event::Dismiss,
+        },
+        InputMode::Confirm => match code {
+            KeyCode::Char('y' | 'Y') | KeyCode::Enter => Event::PushConfirmed,
+            KeyCode::Char('n' | 'N' | 'q') | KeyCode::Esc => Event::PushCancelled,
+            _ => Event::Dismiss,
+        },
+    };
+    Some(event)
 }
 
 /// Spawn the crossterm event-reader thread. It blocks on `event::read`, routes

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -25,7 +25,7 @@ use crossterm::terminal::{
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 
-use crate::push::PushUi;
+use crate::push::{PushCommand, PushUi};
 use crate::render::Snapshot;
 use crate::repo::RepoHandle;
 use crate::{
@@ -784,14 +784,14 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
             paint: |output: &str| paint_output(output),
             clock: Instant::now,
             next_tick: |freshest: Option<Duration>| freshest.and_then(next_tick),
-            start_push: |args: Vec<String>| {
+            start_push: |command: PushCommand| {
                 // No work tree means nothing to push from. `RepoHandle` rejects
                 // a bare repository at discovery, so watch mode never gets here
                 // without one — this is the type's `Option` being honored, not
                 // a case the user can reach.
                 if let Some(workdir) = workdir.clone() {
                     let tx = push_tx.clone();
-                    crate::push::spawn(args, workdir, move |outcome| {
+                    crate::push::spawn(command, workdir, move |outcome| {
                         let _ = tx.send(Event::PushFinished(outcome));
                     });
                 }
@@ -946,10 +946,11 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush> {
     clock: Clock,
     /// Map the freshest displayed age to the decay-tick interval (`None` = off).
     next_tick: Tick,
-    /// Start a confirmed push, given the `git` arguments the confirmation
-    /// described. Production spawns a thread that runs the push and sends the
-    /// outcome back as [`Event::PushFinished`]; tests record the arguments and
-    /// decide for themselves when — or whether — the outcome arrives.
+    /// Start a confirmed push, given the [`PushCommand`] the confirmation
+    /// described — the `git` arguments and the branch they were written for.
+    /// Production spawns a thread that runs the push and sends the outcome back
+    /// as [`Event::PushFinished`]; tests record the command and decide for
+    /// themselves when — or whether — the outcome arrives.
     start_push: StartPush,
 }
 
@@ -995,7 +996,7 @@ fn absorb<StartPush>(
     start_push: &mut StartPush,
 ) -> Flow
 where
-    StartPush: FnMut(Vec<String>),
+    StartPush: FnMut(PushCommand),
 {
     match event {
         Event::Quit => return Flow::Quit,
@@ -1011,8 +1012,8 @@ where
         // `confirm` yields the arguments only once, so a second `y` that raced
         // the mode change starts nothing.
         Event::PushConfirmed => {
-            if let Some(args) = ui.confirm() {
-                start_push(args);
+            if let Some(command) = ui.confirm() {
+                start_push(command);
             }
         }
         Event::PushCancelled => ui.cancel(),
@@ -1098,7 +1099,7 @@ where
     Paint: FnMut(&str) -> Result<()>,
     Clock: Fn() -> Instant,
     Tick: Fn(Option<Duration>) -> Option<Duration>,
-    StartPush: FnMut(Vec<String>),
+    StartPush: FnMut(PushCommand),
 {
     let mut freshest = initial_freshest;
     // Everything the push feature puts on screen, plus the input mode that goes
@@ -2700,7 +2701,7 @@ mod tests {
                 // A decay tick on the same cadence, so the loop always wakes:
                 // the test must fail when no walk is scheduled, not block.
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2739,7 +2740,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2785,7 +2786,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: stepping_clock(base, Duration::from_secs(60)),
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2833,7 +2834,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2877,7 +2878,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2918,7 +2919,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -2961,7 +2962,7 @@ mod tests {
                 // Tiny interval so the tick fires fast; the cadence-vs-age
                 // mapping is covered by the next_tick tests.
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3004,7 +3005,7 @@ mod tests {
                 },
                 clock: || now,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3048,7 +3049,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3098,7 +3099,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || now,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3156,7 +3157,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3236,7 +3237,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3320,7 +3321,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3385,7 +3386,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || base,
                 next_tick: |_freshest| Some(Duration::from_millis(5)),
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3457,7 +3458,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3528,7 +3529,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3579,7 +3580,7 @@ mod tests {
                 },
                 clock: || base,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         )
         .expect("loop");
@@ -3643,7 +3644,7 @@ mod tests {
                 paint: |_output: &str| Ok(()),
                 clock: || clock_at,
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         );
 
@@ -3731,7 +3732,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         );
 
@@ -3843,7 +3844,7 @@ mod tests {
                     times[i.min(times.len() - 1)]
                 },
                 next_tick: timer_off,
-                start_push: |_args: Vec<String>| {},
+                start_push: |_command: PushCommand| {},
             },
         );
 
@@ -3977,7 +3978,7 @@ mod push_loop_tests {
     #[derive(Default)]
     struct Seen {
         collects: usize,
-        pushes: Vec<Vec<String>>,
+        pushes: Vec<PushCommand>,
         frame_heights: Vec<usize>,
     }
 
@@ -4016,7 +4017,7 @@ mod push_loop_tests {
                 paint: |_output: &str| Ok(()),
                 clock: move || base,
                 next_tick: timer_off,
-                start_push: |args: Vec<String>| seen.borrow_mut().pushes.push(args),
+                start_push: |command: PushCommand| seen.borrow_mut().pushes.push(command),
             },
         )
         .expect("loop");
@@ -4072,15 +4073,16 @@ mod push_loop_tests {
             key(KeyCode::Char('y')),
             Event::Quit,
         ]);
-        assert_eq!(
-            seen.pushes,
-            vec![vec![
-                "push".to_string(),
-                "-u".to_string(),
-                "origin".to_string(),
-                "gsw-push".to_string(),
-            ]],
-        );
+        let [command] = seen.pushes.as_slice() else {
+            panic!(
+                "one confirmed push must reach the runner, got {:?}",
+                seen.pushes
+            );
+        };
+        assert_eq!(command.args(), ["push", "-u", "origin", "gsw-push"]);
+        // The branch travels with the arguments all the way through the loop:
+        // the runner checks it against the checkout before git sees it.
+        assert_eq!(command.branch(), "gsw-push");
     }
 
     #[test]
@@ -4233,7 +4235,7 @@ mod push_loop_tests {
                     paint: |_output: &str| Ok(()),
                     clock: move || base,
                     next_tick: timer_off,
-                    start_push: |args: Vec<String>| seen.borrow_mut().pushes.push(args),
+                    start_push: |command: PushCommand| seen.borrow_mut().pushes.push(command),
                 },
             )
             .expect("loop");

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -25,6 +25,7 @@ use crossterm::terminal::{
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 
+use crate::push::PushUi;
 use crate::render::Snapshot;
 use crate::repo::RepoHandle;
 use crate::{
@@ -750,6 +751,13 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
     let (tx, rx) = mpsc::channel();
     spawn_event_reader(tx.clone());
 
+    // A push runs `git` with the work tree as its cwd, so the path is captured
+    // before the handle is borrowed for the rest of watch mode. The push thread
+    // reports back on the loop's own channel, so its outcome re-enters the loop
+    // exactly like a filesystem event — applied between frames, never during one.
+    let workdir = handle.repo().workdir().map(Path::to_path_buf);
+    let push_tx = tx.clone();
+
     // The one ignore matcher both threads share: the watcher callback reads it
     // per event, and every `walk` below rebuilds it from disk so a `.gitignore`
     // edited in another pane takes effect without a restart.
@@ -776,7 +784,18 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
             paint: |output: &str| paint_output(output),
             clock: Instant::now,
             next_tick: |freshest: Option<Duration>| freshest.and_then(next_tick),
-            start_push: |_args: Vec<String>| {},
+            start_push: |args: Vec<String>| {
+                // No work tree means nothing to push from. `RepoHandle` rejects
+                // a bare repository at discovery, so watch mode never gets here
+                // without one — this is the type's `Option` being honored, not
+                // a case the user can reach.
+                if let Some(workdir) = workdir.clone() {
+                    let tx = push_tx.clone();
+                    crate::push::spawn(args, workdir, move |outcome| {
+                        let _ = tx.send(Event::PushFinished(outcome));
+                    });
+                }
+            },
         },
     )
 }
@@ -934,6 +953,86 @@ struct LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush> {
     start_push: StartPush,
 }
 
+/// The triggers one wake collected, before the render decides what to do with
+/// them. A burst can carry several at once, and they are not exclusive: a walk
+/// forced by `r` and a resize can arrive together.
+#[derive(Default)]
+struct Pending {
+    /// A relevant filesystem path changed.
+    fs: bool,
+    /// The terminal was resized.
+    resize: bool,
+    /// A walk was demanded outright, bypassing the cooldown.
+    force: bool,
+}
+
+/// Whether the loop keeps running after an event.
+#[derive(PartialEq, Eq, Debug)]
+enum Flow {
+    /// Carry on to the render.
+    Continue,
+    /// End watch mode.
+    Quit,
+}
+
+/// Fold one received [`Event`] into the loop's pending state.
+///
+/// Extracted because the loop receives events at three points — the timed wait,
+/// the untimed wait, and the debounce drain — and a routing rule written three
+/// times is a rule that will be updated twice. Every event goes through here,
+/// so a variant added later cannot be handled in two of the three places.
+///
+/// A key arrives unclassified and is resolved here against `ui`'s *current*
+/// mode, which is what makes a burst read correctly: within one drain, the `p`
+/// ahead of a `y` has already switched the mode by the time the `y` is looked
+/// at. It then recurses exactly once — [`classify_input`] never returns
+/// [`Event::Key`], so there is no second hop.
+fn absorb<StartPush>(
+    event: Event,
+    pending: &mut Pending,
+    ui: &mut PushUi,
+    snapshot: &Snapshot,
+    start_push: &mut StartPush,
+) -> Flow
+where
+    StartPush: FnMut(Vec<String>),
+{
+    match event {
+        Event::Quit => return Flow::Quit,
+        Event::FsChanged => pending.fs = true,
+        Event::Resize => pending.resize = true,
+        Event::ForceRefresh => pending.force = true,
+        Event::Key(key) => {
+            if let Some(action) = classify_input(key, ui.mode()) {
+                return absorb(action, pending, ui, snapshot, start_push);
+            }
+        }
+        Event::PushRequested => ui.request(snapshot),
+        // `confirm` yields the arguments only once, so a second `y` that raced
+        // the mode change starts nothing.
+        Event::PushConfirmed => {
+            if let Some(args) = ui.confirm() {
+                start_push(args);
+            }
+        }
+        Event::PushCancelled => ui.cancel(),
+        Event::Dismiss => ui.dismiss(),
+        Event::PushFinished(outcome) => {
+            let succeeded = outcome.success;
+            ui.finished(outcome);
+            // A successful push moved the upstream, so the header's arrows and
+            // tracking segment are stale the moment it lands — walk now rather
+            // than leaving a wrong count on screen until the next refresh. A
+            // failure changed nothing in the repository, so walking would only
+            // pay for a status traversal to redraw the identical frame.
+            if succeeded {
+                pending.force = true;
+            }
+        }
+    }
+    Flow::Continue
+}
+
 /// The render loop's terminal-free core: wait for a filesystem event, a resize,
 /// or a timeout, then update the screen. A filesystem change walks git, and so
 /// does a timeout at which [`WalkSchedule`] owes a walk — a timed refresh, or a
@@ -1002,15 +1101,17 @@ where
     StartPush: FnMut(Vec<String>),
 {
     let mut freshest = initial_freshest;
+    // Everything the push feature puts on screen, plus the input mode that goes
+    // with it. Owned here because this is the only place that knows what is
+    // displayed — see [`Event::Key`] for why the reader thread must not.
+    let mut ui = PushUi::new();
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
         // after `interval` of quiet for a tick.
         // Track *which* triggers arrived so the render below can route them: a
         // filesystem change walks git, a resize re-renders the cache at the new
         // size, a bare timeout is a decay tick.
-        let mut saw_fs = false;
-        let mut saw_resize = false;
-        let mut saw_force = false;
+        let mut pending = Pending::default();
         // Wait window: the soonest of the decay-tick cadence, the next walk this
         // schedule owes (a timed refresh, or a walk deferred during a cooldown),
         // and — while a countdown is on screen — the cadence that countdown
@@ -1026,40 +1127,36 @@ where
         ]);
         let woke_for_timeout = match wait {
             Some(interval) => match rx.recv_timeout(interval) {
-                Ok(Event::Quit) => break,
-                Ok(Event::FsChanged) => {
-                    saw_fs = true;
+                Ok(event) => {
+                    if absorb(
+                        event,
+                        &mut pending,
+                        &mut ui,
+                        &cache.snapshot,
+                        &mut hooks.start_push,
+                    ) == Flow::Quit
+                    {
+                        break;
+                    }
                     false
                 }
-                Ok(Event::Resize) => {
-                    saw_resize = true;
-                    false
-                }
-                Ok(Event::ForceRefresh) => {
-                    saw_force = true;
-                    false
-                }
-                // Push input is not wired into the loop yet.
-                Ok(_) => false,
                 Err(RecvTimeoutError::Timeout) => true,
                 Err(RecvTimeoutError::Disconnected) => break,
             },
             None => match rx.recv() {
-                Ok(Event::Quit) => break,
-                Ok(Event::FsChanged) => {
-                    saw_fs = true;
+                Ok(event) => {
+                    if absorb(
+                        event,
+                        &mut pending,
+                        &mut ui,
+                        &cache.snapshot,
+                        &mut hooks.start_push,
+                    ) == Flow::Quit
+                    {
+                        break;
+                    }
                     false
                 }
-                Ok(Event::Resize) => {
-                    saw_resize = true;
-                    false
-                }
-                Ok(Event::ForceRefresh) => {
-                    saw_force = true;
-                    false
-                }
-                // Push input is not wired into the loop yet.
-                Ok(_) => false,
                 Err(_) => break,
             },
         };
@@ -1070,15 +1167,24 @@ where
         if !woke_for_timeout {
             loop {
                 match rx.recv_timeout(debounce) {
-                    Ok(Event::Quit) => {
-                        quitting = true;
-                        break;
+                    Ok(event) => {
+                        if absorb(
+                            event,
+                            &mut pending,
+                            &mut ui,
+                            &cache.snapshot,
+                            &mut hooks.start_push,
+                        ) == Flow::Quit
+                        {
+                            // Unlike the first wake, a quit that arrives inside
+                            // the drain still paints: the events ahead of it in
+                            // this burst have already been applied, and the
+                            // user should see the screen they asked for before
+                            // it goes away.
+                            quitting = true;
+                            break;
+                        }
                     }
-                    Ok(Event::FsChanged) => saw_fs = true,
-                    Ok(Event::Resize) => saw_resize = true,
-                    Ok(Event::ForceRefresh) => saw_force = true,
-                    // Push input is not wired into the loop yet.
-                    Ok(_) => {}
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         quitting = true;
@@ -1087,6 +1193,7 @@ where
                 }
             }
         }
+        let (saw_fs, saw_resize, saw_force) = (pending.fs, pending.resize, pending.force);
 
         // Read the clock once for this wake: the throttle decision, a walk's
         // start, and any age offset all key off the same instant.
@@ -1120,8 +1227,22 @@ where
             false
         };
 
-        let render = if walk_now {
+        // Re-measure the pane before rendering, on the same two triggers as
+        // before: a walk and a resize. Hoisted out of the branches so the frame
+        // height below is computed from dimensions that are already current.
+        if walk_now || saw_resize {
             cache.dims = (hooks.dimensions)();
+        }
+        // Rows the push overlay will take under the frame. The frame is
+        // rendered that much shorter, because it is laid out to fill the pane
+        // exactly — appending to a full-height frame would push its bottom row,
+        // the file list, off the screen.
+        let frame_dims = Dimensions {
+            height: cache.dims.height.saturating_sub(ui.rows()).max(1),
+            ..cache.dims
+        };
+
+        let render = if walk_now {
             let collected = (hooks.collect)();
             // Measure the walk's wall-clock cost around collect and feed it to
             // the throttle, which arms the next cooldown (= 100·cost) from it.
@@ -1140,7 +1261,7 @@ where
                     cache.snapshot = snapshot;
                     (hooks.render)(
                         &cache.snapshot,
-                        cache.dims,
+                        frame_dims,
                         timing(Duration::ZERO, &schedule, now),
                     )
                 }
@@ -1159,17 +1280,16 @@ where
                     let age_offset = now.saturating_duration_since(cache.collected_at);
                     (hooks.render)(
                         &cache.snapshot,
-                        cache.dims,
+                        frame_dims,
                         timing(age_offset, &schedule, now),
                     )
                 }
             }
         } else if saw_resize {
-            cache.dims = (hooks.dimensions)();
             let age_offset = now.saturating_duration_since(cache.collected_at);
             (hooks.render)(
                 &cache.snapshot,
-                cache.dims,
+                frame_dims,
                 timing(age_offset, &schedule, now),
             )
         } else {
@@ -1178,14 +1298,19 @@ where
             let age_offset = now.saturating_duration_since(cache.collected_at);
             (hooks.render)(
                 &cache.snapshot,
-                cache.dims,
+                frame_dims,
                 timing(age_offset, &schedule, now),
             )
         };
 
-        if should_repaint(&render.output, displayed) {
-            (hooks.paint)(&render.output)?;
-            *displayed = render.output;
+        // The painted screen is the frame with the push overlay under it. They
+        // are compared as one string, so a frame that did not change but an
+        // overlay that did still repaints — and neither can repaint alone and
+        // leave the other stale.
+        let output = compose(render.output, &ui.overlay(cache.dims.width));
+        if should_repaint(&output, displayed) {
+            (hooks.paint)(&output)?;
+            *displayed = output;
         }
         freshest = render.freshest_age;
 
@@ -1194,6 +1319,20 @@ where
         }
     }
     Ok(())
+}
+
+/// Join a frame and the push overlay into the one string that gets painted.
+///
+/// An empty overlay returns the frame untouched, byte for byte. That is what
+/// keeps every frame gsw painted before the push feature existed identical to
+/// what it paints now — including the trailing-newline handling, which is the
+/// frame's business and not this function's.
+fn compose(frame: String, overlay: &str) -> String {
+    if overlay.is_empty() {
+        return frame;
+    }
+    let separator = if frame.ends_with('\n') { "" } else { "\n" };
+    format!("{frame}{separator}{overlay}")
 }
 
 /// Paint `output` into the alternate screen, replacing whatever frame is there.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -1243,6 +1243,14 @@ where
         // `PushUi::overlay` rather than here — a subtraction repeated in the
         // caller is a second opinion about the same rows, and this loop must
         // not be able to hold one.
+        //
+        // The call can also change what the keys mean, which is why it takes
+        // `&mut ui`: a pane with no row to spare for a confirmation cancels the
+        // confirmation rather than leaving a question nobody can see answerable
+        // by Enter. It runs after this wake's events have been absorbed and
+        // before the next wake reads one, so the key a user presses in reaction
+        // to what this paints is classified against the mode this pane actually
+        // showed them.
         let overlay = ui.overlay(cache.dims);
         let frame_dims = Dimensions {
             height: overlay.frame_rows(),

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -620,7 +620,7 @@ enum Event {
 /// is total: every mode answers every key, and a mode added later cannot
 /// silently inherit another's bindings.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum InputMode {
+pub(crate) enum InputMode {
     /// Nothing is being asked. The monitor's ordinary keys apply.
     Normal,
     /// A push confirmation is on screen and is waiting for an answer.


### PR DESCRIPTION
Adds a `p` key to gsw's watch mode: it confirms, then pushes the current branch, and reports git's own errors under the frame.

## The confirmation names the act

```
Push 3 commits to origin/gsw-push?              [y/Enter = push, n/Esc = cancel]
Create new remote branch origin/gsw-push?       [y/Enter = push, n/Esc = cancel]
```

A branch that is not on the remote yet gets the second wording, in yellow. Putting a branch on a shared remote for the first time is not the same act as moving one that is already there, so it does not get the same sentence.

An untracked branch is published with `git push -u`, which records the upstream and makes the header's tracking segment appear. A tracked branch runs a bare `git push` and lets git supply the remote and refspec. The remote for a new branch is `remote.pushDefault` if set, else the only remote whatever it is called, else `origin` — and gsw refuses rather than guess when several remotes leave it ambiguous. `p` never force-pushes.

A branch that is already fully pushed says so instead of asking. A detached HEAD says so too, and names the way out.

## What is not visible on screen

- **The push runs off the render thread.** The refresh countdown, the ages, and resizes keep working while it is in flight. A second `p` is inert, so two pushes cannot overlap. Ctrl-C quits from every mode, including mid-push.
- **git can never prompt at the terminal** (`GIT_TERMINAL_PROMPT=0`, closed stdin). It would be reading the same keystrokes the event reader is reading, behind a question gsw did not draw. Credential helpers and a GUI askpass are untouched.
- **Errors are git's own words**, red, capped at three rows with `hint:` advice dropped first, and they stay until a key arrives.
- **A successful push re-walks the repository at once**, so the ahead/behind arrows stop lying. A failed one does not, having changed nothing to re-read.
- The frame renders shorter by exactly the rows the overlay takes, so its bottom row never falls off the pane.

## Design notes

- **The reader thread no longer classifies keys.** It forwards them whole, and the loop classifies against its own `InputMode`. Classifying on the reader thread would need a shared mode flag, and a fast `p` then `y` could be read while the flag still said `Normal` — the `y` would be silently dropped. Serializing through the channel removes the race by construction.
- **`push.rs` has one entrance.** `prompt_for` returns either a question with the exact command it describes, or a message. The loop never learns which plan produced either, and cannot request arguments for a push that must never run.
- **One router folds every event into the loop's pending state.** The loop receives at three points, and a routing rule written three times is one that will be updated twice.

## Verification

16 commits, strict red/green throughout — every green commit is preceded by a red one that fails on behavior.

- 361 tests in the gsw binary, stable over five consecutive runs.
- Workspace: `cargo fmt --check`, `cargo machete`, `cargo clippy --all-targets` (zero warnings), `cargo test` — all pass.
- Driven through a real pty against real repositories: `p` → `y` created the branch on the remote and reported it, a second `p` refused, `n` cancelled and pushed nothing, and a diverged branch showed git's rejection with hints dropped and cleared on a key.

Two deviations worth calling out:

1. The key hint spells both keys out instead of using `[y/N]`. That convention's capital letter promises Enter is the safe answer, and Enter confirms here.
2. Fixed a latent test flake found along the way: `render.rs` toggles `colored::control::set_override`, which is process-global, so width assertions elsewhere in the binary counted ANSI escapes as columns depending on test order. They now measure visible columns. Both that fix and the frame/overlay join were mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
