### PR TITLE
feat(gsw): age, fade, and expire the push status message

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,16 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       text is shown under the frame in red (up to three rows, `hint:` advice dropped first, and
       fewer rows still on a pane too short to spare three — the frame always keeps a row) and
       stays there until you press a key. A push that succeeds re-walks the repository immediately,
-      so the ahead/behind arrows match what just happened. Nothing the push runs can prompt at the
+      so the ahead/behind arrows match what just happened.
+    - Everything gsw says itself goes away on its own: `Pushed 3 commits to origin/my-branch
+      (12s ago)` counts up in place, fades toward black as it goes, and takes itself off the
+      screen after a minute — the frame gets the row back with no key pressed. Refusals
+      (`origin/my-branch is already up to date (7s ago)`) age and expire the same way, because
+      they describe the repository as it stood when `p` was pressed. **git's error text is the
+      exception and does not expire**: it is something to read and act on, so it waits for a key
+      the way it always has. The fade is the 24-bit gradient the commit log uses, under the same
+      `--truecolor`/`--no-truecolor` control; without truecolor the message simply dims halfway
+      through its life instead. Nothing the push runs can prompt at the
       terminal — it would be reading the same keystrokes gsw is. The push is started detached from
       the terminal — its own session on Unix, no inherited console on Windows — so nothing in its
       process tree can reach the keyboard gsw is reading, not git, not ssh, and not anything below

--- a/TLDR.md
+++ b/TLDR.md
@@ -25,7 +25,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `goup` | Updates Go dependencies across all `go.mod` files in a repo. |
 | `gr8` | Displays GitHub API rate limit info, color-coded, via the GitHub CLI. |
 | `grist` | Ranks the orders you could squash-merge a set of branches in, cheapest conflicts first, by replaying each one in a throwaway worktree. |
-| `gsw` | Git Status Watch — compact status dashboard that watches on a TTY (refresh clock in the separator) and renders once when piped; a merge or rebase in progress gets its own row, `⚠ merge` / `⚠ rebase 1/2 · 1 conflict to resolve`. Press `p` to push the current branch after a confirmation. |
+| `gsw` | Git Status Watch — compact status dashboard that watches on a TTY (refresh clock in the separator) and renders once when piped; a merge or rebase in progress gets its own row, `⚠ merge` / `⚠ rebase 1/2 · 1 conflict to resolve`. Press `p` to push the current branch after a confirmation; the result says how long ago it happened and fades off the screen after a minute. |
 | `hexfind` | Searches for a hex string in a binary file and shows a hex dump with offsets. |
 | `htmlboard` | Pretty-prints HTML on the clipboard and puts it back. |
 | `ic` | Fast terminal image/video display utility (an `imgcat` alternative; video needs ffmpeg). |

--- a/src/gsw/src/age.rs
+++ b/src/gsw/src/age.rs
@@ -126,15 +126,16 @@ pub fn age_fade_factor(age: Duration) -> f32 {
     (secs / end).clamp(0.0, 1.0)
 }
 
-/// Linearly interpolate `base` toward a dark floor by `factor` in `[0,1]`.
+/// Multiply the brightness of `base` by `scale`, clamped to `[0.0, 1.0]`.
 ///
-/// `factor = 0` returns `base` unchanged; `factor = 1` returns
-/// `base * FADE_FLOOR` (rounded). Out-of-range factors are clamped.
-pub fn fade_rgb(base: (u8, u8, u8), factor: f32) -> (u8, u8, u8) {
-    let f = factor.clamp(0.0, 1.0);
-    let scale = 1.0 - f * (1.0 - FADE_FLOOR);
-    // The cast is bounded: `scale` is in [FADE_FLOOR, 1.0] and `c` is u8, so
-    // the product is in [0, 255]; the explicit clamp is belt-and-braces.
+/// `scale = 1.0` returns `base` unchanged; `scale = 0.0` returns black. The one
+/// place a color is dimmed, so every fade in gsw rounds and clamps the same way
+/// — the commit-log ramp, which stops at [`FADE_FLOOR`], and the push status
+/// message, which goes all the way to black.
+pub fn scale_rgb(base: (u8, u8, u8), scale: f32) -> (u8, u8, u8) {
+    let scale = scale.clamp(0.0, 1.0);
+    // The cast is bounded: `scale` is in [0.0, 1.0] and `c` is u8, so the
+    // product is in [0, 255]; the explicit clamp is belt-and-braces.
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
@@ -142,6 +143,15 @@ pub fn fade_rgb(base: (u8, u8, u8), factor: f32) -> (u8, u8, u8) {
     )]
     let scl = |c: u8| (f32::from(c) * scale).round().clamp(0.0, 255.0) as u8;
     (scl(base.0), scl(base.1), scl(base.2))
+}
+
+/// Linearly interpolate `base` toward a dark floor by `factor` in `[0,1]`.
+///
+/// `factor = 0` returns `base` unchanged; `factor = 1` returns
+/// `base * FADE_FLOOR` (rounded). Out-of-range factors are clamped.
+pub fn fade_rgb(base: (u8, u8, u8), factor: f32) -> (u8, u8, u8) {
+    let f = factor.clamp(0.0, 1.0);
+    scale_rgb(base, 1.0 - f * (1.0 - FADE_FLOOR))
 }
 
 #[cfg(test)]

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -10,8 +10,9 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 
 use crate::render::{truncate_right, Snapshot, UpstreamStatus};
 use crate::repo::DETACHED_HEAD;
@@ -509,6 +510,13 @@ pub(crate) struct PushOutcome {
 /// branch for each one.
 pub(crate) struct PushUi {
     state: State,
+    /// Whether the terminal takes 24-bit color, as [`crate::RenderConfig`]
+    /// resolved it from the CLI flags and `COLORTERM`. Carried here because the
+    /// status message fades, and a fade
+    /// is a gradient: the same flag the commit-log ramp is gated on gates this,
+    /// so a terminal that would print the escape sequences as text gets the
+    /// coarse fallback instead.
+    truecolor: bool,
 }
 
 /// What the push feature is currently doing. Private: the loop drives this
@@ -541,9 +549,27 @@ enum State {
 }
 
 impl PushUi {
-    /// A UI with nothing on screen.
-    pub(crate) fn new() -> Self {
-        Self { state: State::Idle }
+    /// A UI with nothing on screen, drawing on a terminal that takes 24-bit
+    /// color when `truecolor` says so.
+    pub(crate) fn new(truecolor: bool) -> Self {
+        Self {
+            state: State::Idle,
+            truecolor,
+        }
+    }
+
+    /// How long until what this paints changes on its own, or `None` when
+    /// nothing on screen moves with the passage of time.
+    ///
+    /// The watch loop folds this into the same wait window as the decay tick
+    /// and the refresh countdown, so a message that ages has a deadline of its
+    /// own rather than relying on some other source to wake the loop. That
+    /// matters most where no other source exists: `--refresh-interval 0` on a
+    /// repository whose newest commit is hours old leaves the loop blocked on
+    /// the channel indefinitely, and a message that expires only when something
+    /// else happens does not expire.
+    pub(crate) fn next_tick(&self) -> Option<Duration> {
+        None
     }
 
     /// What keys mean right now.
@@ -585,7 +611,8 @@ impl PushUi {
     /// classified. [`PushUi::overlay`] still drops a question it cannot draw,
     /// but that now covers only the pane resized down while a question is
     /// already up: the render path is the only thing that sees the new size.
-    pub(crate) fn request(&mut self, snapshot: &Snapshot, dims: Dimensions) {
+    pub(crate) fn request(&mut self, snapshot: &Snapshot, dims: Dimensions, now: Instant) {
+        let _ = now;
         self.state = match prompt_for(
             &snapshot.branch,
             snapshot.push_remote.as_deref(),
@@ -645,7 +672,8 @@ impl PushUi {
     /// git's output, so a create reports itself as a create. On failure it is
     /// git's own words — a gsw paraphrase of a push error would drop exactly
     /// the detail the user needs.
-    pub(crate) fn finished(&mut self, outcome: PushOutcome) {
+    pub(crate) fn finished(&mut self, outcome: PushOutcome, now: Instant) {
+        let _ = now;
         let success_message = match std::mem::replace(&mut self.state, State::Idle) {
             State::Running { success_message } => success_message,
             // A finish with no push running: nothing to report against, so
@@ -718,7 +746,8 @@ impl PushUi {
     /// fitted when it was asked, a resize took its row, and this is the only
     /// place that sees the new size. Nothing is lost but the question either
     /// way: `p` in a pane with a row to spare asks it again.
-    pub(crate) fn overlay(&mut self, dims: Dimensions) -> Overlay {
+    pub(crate) fn overlay(&mut self, dims: Dimensions, now: Instant) -> Overlay {
+        let _ = now;
         let width = dims.width;
         let lines: Vec<String> = match &self.state {
             State::Idle => Vec::new(),
@@ -862,6 +891,27 @@ const CONFIRM_HINT: &str = "[y/Enter = push, n/Esc = cancel]";
 
 /// What a running push says while the network round trip is in flight.
 const RUNNING_NOTICE: &str = "Pushing…";
+
+/// How long a status message gsw wrote itself stays under the frame.
+///
+/// It is also the length of the fade, so the message reaches black exactly as
+/// it is removed and nothing ever blinks out at full brightness.
+const STATUS_LIFETIME: Duration = Duration::from_secs(60);
+
+/// How often such a message has to be repainted for its age text and its fade
+/// to move.
+///
+/// One second, because that is the resolution of the age text — `5s ago`, then
+/// `6s ago` — and a fade redrawn more often than the words beside it would cost
+/// repaints nobody can read. The same cadence, for the same reason, as the
+/// decay tick that advances the commit ages in the frame above.
+const STATUS_CADENCE: Duration = Duration::from_secs(1);
+
+/// Color one row of an ageing status message, `elapsed` after it was posted.
+fn colorize_status(line: &str, elapsed: Duration, truecolor: bool) -> ColoredString {
+    let _ = (elapsed, truecolor);
+    line.normal()
+}
 
 /// What a failed push says when git said nothing gsw could show.
 const SILENT_FAILURE: &str = "git push failed";
@@ -1263,6 +1313,20 @@ mod ui_tests {
         unicode_width::UnicodeWidthStr::width(visible.as_str())
     }
 
+    /// The instant every test starts from.
+    ///
+    /// `Instant` has no constructor, so the origin is read from the real clock
+    /// once and every later moment is derived by adding to it. Nothing here
+    /// waits for real time to pass: a test that wants a minute-old message adds
+    /// a minute to this and hands the result to [`PushUi::overlay`].
+    ///
+    /// Read fresh on each call rather than cached in a `static`, so no test can
+    /// leave a mutated origin behind for the next one — the value is only ever
+    /// compared against instants derived from the same call.
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
     /// A pane `width` columns wide with more rows than any overlay can want, so
     /// a test about wording or row count is not also a test about clipping.
     fn tall_pane(width: usize) -> Dimensions {
@@ -1274,17 +1338,17 @@ mod ui_tests {
 
     /// A UI with the confirmation already on screen for an untracked branch.
     fn asking() -> PushUi {
-        let mut ui = PushUi::new();
-        ui.request(&snapshot(None), tall_pane(80));
+        let mut ui = PushUi::new(false);
+        ui.request(&snapshot(None), tall_pane(80), t0());
         ui
     }
 
     #[test]
     fn a_fresh_ui_shows_nothing_and_leaves_the_keys_alone() {
-        let mut ui = PushUi::new();
+        let mut ui = PushUi::new(false);
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 0);
-        assert_eq!(ui.overlay(tall_pane(80)).text(), "");
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 0);
+        assert_eq!(ui.overlay(tall_pane(80), t0()).text(), "");
     }
 
     #[test]
@@ -1293,8 +1357,8 @@ mod ui_tests {
         // the key table, or `y` would be read as an ordinary key.
         let mut ui = asking();
         assert_eq!(ui.mode(), InputMode::Confirm);
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
-        let overlay = ui.overlay(tall_pane(80)).text();
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 1);
+        let overlay = ui.overlay(tall_pane(80), t0()).text();
         assert!(
             overlay.contains("Create new remote branch origin/gsw-push?"),
             "the question must be on screen, got {overlay:?}",
@@ -1313,16 +1377,18 @@ mod ui_tests {
     fn requesting_a_push_with_nothing_to_push_explains_instead_of_asking() {
         // The refusal is a message, not a question: the keys must stay normal,
         // so `y` does not answer a prompt that is not there.
-        let mut ui = PushUi::new();
-        ui.request(&snapshot(tracked(0)), tall_pane(80));
+        let mut ui = PushUi::new(false);
+        ui.request(&snapshot(tracked(0)), tall_pane(80), t0());
         assert_eq!(ui.mode(), InputMode::Normal);
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 1);
         assert!(ui
-            .overlay(tall_pane(80))
+            .overlay(tall_pane(80), t0())
             .text()
             .contains("origin/gsw-push is already up to date"));
         assert!(
-            !ui.overlay(tall_pane(80)).text().contains(CONFIRM_HINT),
+            !ui.overlay(tall_pane(80), t0())
+                .text()
+                .contains(CONFIRM_HINT),
             "a refusal must not offer keys that do nothing",
         );
     }
@@ -1339,7 +1405,7 @@ mod ui_tests {
         );
         assert_eq!(ui.mode(), InputMode::Pushing);
         assert_eq!(
-            ui.overlay(tall_pane(80)).rows(),
+            ui.overlay(tall_pane(80), t0()).rows(),
             1,
             "the running push stays on screen"
         );
@@ -1350,7 +1416,7 @@ mod ui_tests {
         // Belt and braces against a stray PushConfirmed: with no confirmation
         // on screen there is no command to run, and inventing one would push
         // without asking.
-        let mut ui = PushUi::new();
+        let mut ui = PushUi::new(false);
         assert_eq!(ui.confirm(), None);
         assert_eq!(ui.mode(), InputMode::Normal);
     }
@@ -1370,7 +1436,7 @@ mod ui_tests {
         ui.cancel();
         assert_eq!(ui.mode(), InputMode::Normal);
         assert_eq!(
-            ui.overlay(tall_pane(80)).rows(),
+            ui.overlay(tall_pane(80), t0()).rows(),
             0,
             "a cancelled prompt leaves nothing behind"
         );
@@ -1382,28 +1448,34 @@ mod ui_tests {
         // create rather than as a generic success.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: true,
-            output: "To /tmp/origin\n * [new branch] gsw-push -> gsw-push\n".to_string(),
-        });
+        ui.finished(
+            PushOutcome {
+                success: true,
+                output: "To /tmp/origin\n * [new branch] gsw-push -> gsw-push\n".to_string(),
+            },
+            t0(),
+        );
         assert_eq!(ui.mode(), InputMode::Normal);
         assert!(ui
-            .overlay(tall_pane(80))
+            .overlay(tall_pane(80), t0())
             .text()
             .contains("Created origin/gsw-push"));
     }
 
     #[test]
     fn a_successful_update_counts_what_it_pushed() {
-        let mut ui = PushUi::new();
-        ui.request(&snapshot(tracked(3)), tall_pane(80));
+        let mut ui = PushUi::new(false);
+        ui.request(&snapshot(tracked(3)), tall_pane(80), t0());
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: true,
-            output: String::new(),
-        });
+        ui.finished(
+            PushOutcome {
+                success: true,
+                output: String::new(),
+            },
+            t0(),
+        );
         assert!(ui
-            .overlay(tall_pane(80))
+            .overlay(tall_pane(80), t0())
             .text()
             .contains("Pushed 3 commits to origin/gsw-push"));
     }
@@ -1414,14 +1486,17 @@ mod ui_tests {
         // gsw paraphrase.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "To /tmp/origin\n ! [rejected] gsw-push -> gsw-push (fetch first)\n\
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "To /tmp/origin\n ! [rejected] gsw-push -> gsw-push (fetch first)\n\
                      error: failed to push some refs to '/tmp/origin'\n"
-                .to_string(),
-        });
+                    .to_string(),
+            },
+            t0(),
+        );
         assert_eq!(ui.mode(), InputMode::Normal);
-        let overlay = ui.overlay(tall_pane(120)).text();
+        let overlay = ui.overlay(tall_pane(120), t0()).text();
         assert!(overlay.contains("! [rejected]"), "got {overlay:?}");
         assert!(
             overlay.contains("error: failed to push some refs"),
@@ -1435,17 +1510,20 @@ mod ui_tests {
         // crowd out the error itself when only three rows are free.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "To /tmp/origin\n\
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "To /tmp/origin\n\
                      hint: Updates were rejected because the tip is behind\n\
                      hint: its remote counterpart. Integrate the changes\n\
                      hint: before pushing again.\n\
                      ! [rejected] gsw-push -> gsw-push (fetch first)\n\
                      error: failed to push some refs\n"
-                .to_string(),
-        });
-        let overlay = ui.overlay(tall_pane(120)).text();
+                    .to_string(),
+            },
+            t0(),
+        );
+        let overlay = ui.overlay(tall_pane(120), t0()).text();
         assert!(
             !overlay.contains("hint:"),
             "hints must not survive, got {overlay:?}"
@@ -1466,13 +1544,16 @@ mod ui_tests {
         let output = (1..=20)
             .map(|n| format!("error: line {n}\n"))
             .collect::<String>();
-        ui.finished(PushOutcome {
-            success: false,
-            output,
-        });
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), MAX_STATUS_ROWS);
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output,
+            },
+            t0(),
+        );
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), MAX_STATUS_ROWS);
         assert_eq!(
-            ui.overlay(tall_pane(80)).text().lines().count(),
+            ui.overlay(tall_pane(80), t0()).text().lines().count(),
             MAX_STATUS_ROWS
         );
     }
@@ -1484,17 +1565,23 @@ mod ui_tests {
         // frame gave up, and the last one is not the frame's to give.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "To /tmp/origin\n\
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "To /tmp/origin\n\
                      ! [rejected] gsw-push -> gsw-push (fetch first)\n\
                      error: failed to push some refs\n"
-                .to_string(),
-        });
-        let overlay = ui.overlay(Dimensions {
-            width: 80,
-            height: 3,
-        });
+                    .to_string(),
+            },
+            t0(),
+        );
+        let overlay = ui.overlay(
+            Dimensions {
+                width: 80,
+                height: 3,
+            },
+            t0(),
+        );
         assert_eq!(overlay.rows(), 2, "the frame keeps the third row");
         // git leads with the part worth reading, so the tail is what goes.
         let text = overlay.text();
@@ -1510,10 +1597,13 @@ mod ui_tests {
         // Nothing is left to overlay onto, and a pane showing only a question
         // with no frame under it is not watch mode.
         let mut ui = asking();
-        let overlay = ui.overlay(Dimensions {
-            width: 80,
-            height: 1,
-        });
+        let overlay = ui.overlay(
+            Dimensions {
+                width: 80,
+                height: 1,
+            },
+            t0(),
+        );
         assert_eq!(overlay.rows(), 0);
         assert_eq!(overlay.text(), "");
     }
@@ -1527,10 +1617,13 @@ mod ui_tests {
         // question goes when its row does, and the keys go with it.
         let mut ui = asking();
         assert_eq!(ui.mode(), InputMode::Confirm, "the question was raised");
-        let overlay = ui.overlay(Dimensions {
-            width: 80,
-            height: 1,
-        });
+        let overlay = ui.overlay(
+            Dimensions {
+                width: 80,
+                height: 1,
+            },
+            t0(),
+        );
         assert_eq!(overlay.text(), "", "the pane had no row to ask in");
         assert_eq!(
             ui.mode(),
@@ -1551,13 +1644,14 @@ mod ui_tests {
         // consulted where the question is raised: a `p` in a pane with no row
         // to spare leaves the keys alone, and there is no question for a later
         // key to answer.
-        let mut ui = PushUi::new();
+        let mut ui = PushUi::new(false);
         ui.request(
             &snapshot(None),
             Dimensions {
                 width: 80,
                 height: 1,
             },
+            t0(),
         );
         assert_eq!(
             ui.mode(),
@@ -1578,14 +1672,17 @@ mod ui_tests {
         // bottom of the pane.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: (1..=20)
-                .map(|n| format!("error: line {n}\n"))
-                .collect::<String>(),
-        });
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: (1..=20)
+                    .map(|n| format!("error: line {n}\n"))
+                    .collect::<String>(),
+            },
+            t0(),
+        );
         for height in 0..8 {
-            let overlay = ui.overlay(Dimensions { width: 80, height });
+            let overlay = ui.overlay(Dimensions { width: 80, height }, t0());
             let painted = if overlay.text().is_empty() {
                 0
             } else {
@@ -1619,7 +1716,7 @@ mod ui_tests {
     fn reporting(outcome: PushOutcome) -> PushUi {
         let mut ui = asking();
         ui.confirm();
-        ui.finished(outcome);
+        ui.finished(outcome, t0());
         ui
     }
 
@@ -1646,13 +1743,13 @@ mod ui_tests {
             ui
         };
         let refusing = {
-            let mut ui = PushUi::new();
-            ui.request(&snapshot(tracked(0)), tall_pane(80));
+            let mut ui = PushUi::new(false);
+            ui.request(&snapshot(tracked(0)), tall_pane(80), t0());
             ui
         };
         let asking_to_update = {
-            let mut ui = PushUi::new();
-            ui.request(&snapshot(tracked(3)), tall_pane(80));
+            let mut ui = PushUi::new(false);
+            ui.request(&snapshot(tracked(3)), tall_pane(80), t0());
             ui
         };
         let running = {
@@ -1661,7 +1758,7 @@ mod ui_tests {
             ui
         };
         vec![
-            ("idle", PushUi::new()),
+            ("idle", PushUi::new(false)),
             ("asking to create a remote branch", asking()),
             ("asking to update a remote branch", asking_to_update),
             ("running a push", running),
@@ -1708,10 +1805,13 @@ mod ui_tests {
         // nine times.
         for height in 0..=SWEEP_MAX_HEIGHT {
             for (name, mut ui) in every_state() {
-                let overlay = ui.overlay(Dimensions {
-                    width: SWEEP_WIDTH,
-                    height,
-                });
+                let overlay = ui.overlay(
+                    Dimensions {
+                        width: SWEEP_WIDTH,
+                        height,
+                    },
+                    t0(),
+                );
 
                 // The count and the body must be the same rows. A count larger
                 // than the text leaves a blank strip under the frame; a count
@@ -1777,13 +1877,16 @@ mod ui_tests {
         // that reads as success.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "   \n\n".to_string(),
-        });
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "   \n\n".to_string(),
+            },
+            t0(),
+        );
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 1);
         assert!(
-            !ui.overlay(tall_pane(80)).text().trim().is_empty(),
+            !ui.overlay(tall_pane(80), t0()).text().trim().is_empty(),
             "a failure must always say that it failed",
         );
     }
@@ -1794,18 +1897,21 @@ mod ui_tests {
         // repaint, and go away only when the user has pressed something.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "error: failed to push some refs\n".to_string(),
-        });
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            },
+            t0(),
+        );
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 1);
         ui.dismiss();
         assert_eq!(
-            ui.overlay(tall_pane(80)).rows(),
+            ui.overlay(tall_pane(80), t0()).rows(),
             0,
             "a key press clears the message"
         );
-        assert_eq!(ui.overlay(tall_pane(80)).text(), "");
+        assert_eq!(ui.overlay(tall_pane(80), t0()).text(), "");
     }
 
     #[test]
@@ -1829,7 +1935,7 @@ mod ui_tests {
     fn a_running_push_says_so() {
         let mut ui = asking();
         ui.confirm();
-        let overlay = ui.overlay(tall_pane(80)).text();
+        let overlay = ui.overlay(tall_pane(80), t0()).text();
         assert!(
             overlay.to_lowercase().contains("push"),
             "the running notice must name what is happening, got {overlay:?}",
@@ -1840,12 +1946,12 @@ mod ui_tests {
     fn the_overlay_never_exceeds_the_width_it_is_given() {
         // gsw's standing contract: nothing it prints wraps. A long remote name
         // or a long git error must be truncated, not folded onto a new row.
-        let mut ui = PushUi::new();
+        let mut ui = PushUi::new(false);
         let mut snap = snapshot(None);
         snap.branch = "a-branch-name-long-enough-to-need-truncating-on-a-narrow-pane".to_string();
-        ui.request(&snap, tall_pane(80));
+        ui.request(&snap, tall_pane(80), t0());
         for width in [10, 20, 40] {
-            let overlay = ui.overlay(tall_pane(width)).text();
+            let overlay = ui.overlay(tall_pane(width), t0()).text();
             for line in overlay.lines() {
                 assert!(
                     visible_width(line) <= width,
@@ -1859,12 +1965,12 @@ mod ui_tests {
     fn the_overlay_truncates_multibyte_text_without_panicking() {
         // Branch names can hold multi-byte characters, and byte-slicing one at
         // a narrow width is a panic in the middle of the alternate screen.
-        let mut ui = PushUi::new();
+        let mut ui = PushUi::new(false);
         let mut snap = snapshot(None);
         snap.branch = "日本語のブランチ名-🎉-café".to_string();
-        ui.request(&snap, tall_pane(80));
+        ui.request(&snap, tall_pane(80), t0());
         for width in 1..40 {
-            let overlay = ui.overlay(tall_pane(width)).text();
+            let overlay = ui.overlay(tall_pane(width), t0()).text();
             for line in overlay.lines() {
                 assert!(
                     visible_width(line) <= width,
@@ -1880,14 +1986,292 @@ mod ui_tests {
         // question, not stack a second row under the first.
         let mut ui = asking();
         ui.confirm();
-        ui.finished(PushOutcome {
-            success: false,
-            output: "error: failed to push some refs\n".to_string(),
-        });
-        ui.request(&snapshot(None), tall_pane(80));
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            },
+            t0(),
+        );
+        ui.request(&snapshot(None), tall_pane(80), t0());
         assert_eq!(ui.mode(), InputMode::Confirm);
-        assert_eq!(ui.overlay(tall_pane(80)).rows(), 1);
-        assert!(!ui.overlay(tall_pane(120)).text().contains("error:"));
+        assert_eq!(ui.overlay(tall_pane(80), t0()).rows(), 1);
+        assert!(!ui.overlay(tall_pane(120), t0()).text().contains("error:"));
+    }
+
+    /// A UI holding the message a finished update push leaves behind, posted at
+    /// `at`. The state every test below about ageing starts from.
+    fn pushed_at(at: Instant) -> PushUi {
+        let mut ui = PushUi::new(false);
+        ui.request(&snapshot(tracked(3)), tall_pane(80), at);
+        ui.confirm();
+        ui.finished(
+            PushOutcome {
+                success: true,
+                output: String::new(),
+            },
+            at,
+        );
+        ui
+    }
+
+    #[test]
+    fn a_successful_push_says_how_long_ago_it_happened() {
+        // A monitor's rows all say when. "Pushed 3 commits" on its own stops
+        // being news the moment the user looks away, and nothing on screen
+        // tells them whether they are reading something from five seconds ago
+        // or from before lunch.
+        let start = t0();
+        let mut ui = pushed_at(start);
+
+        let fresh = ui.overlay(tall_pane(80), start).text();
+        assert!(
+            fresh.contains("Pushed 3 commits to origin/gsw-push"),
+            "the message itself must survive the age being added, got {fresh:?}",
+        );
+        assert!(
+            fresh.contains("(0s ago)"),
+            "a message just posted must say so, got {fresh:?}",
+        );
+
+        let later = ui
+            .overlay(tall_pane(80), start + Duration::from_secs(5))
+            .text();
+        assert!(
+            later.contains("Pushed 3 commits to origin/gsw-push"),
+            "got {later:?}",
+        );
+        assert!(
+            later.contains("(5s ago)"),
+            "the age must advance with the clock, got {later:?}",
+        );
+    }
+
+    #[test]
+    fn a_successful_push_takes_itself_off_the_screen() {
+        // The complaint this feature answers: the message stayed until a key
+        // was pressed, which on a monitor nobody is typing at means forever.
+        let start = t0();
+        let mut ui = pushed_at(start);
+
+        assert_eq!(
+            ui.overlay(tall_pane(80), start + STATUS_LIFETIME - STATUS_CADENCE)
+                .rows(),
+            1,
+            "the message must last its whole lifetime",
+        );
+
+        let expired = ui.overlay(tall_pane(80), start + STATUS_LIFETIME);
+        assert_eq!(expired.rows(), 0, "the message must remove itself");
+        assert_eq!(expired.text(), "");
+        assert_eq!(
+            expired.frame_rows(),
+            tall_pane(80).height,
+            "the row it was using must go back to the frame",
+        );
+        assert_eq!(ui.mode(), InputMode::Normal);
+    }
+
+    #[test]
+    fn a_refused_push_also_says_when_and_also_goes_away() {
+        // A refusal describes the repository as it stood when `p` was pressed,
+        // so it goes stale exactly the way a success does — and it costs the
+        // frame the same row until it does.
+        let start = t0();
+        let mut ui = PushUi::new(false);
+        ui.request(&snapshot(tracked(0)), tall_pane(80), start);
+
+        let text = ui
+            .overlay(tall_pane(80), start + Duration::from_secs(7))
+            .text();
+        assert!(
+            text.contains("origin/gsw-push is already up to date"),
+            "got {text:?}",
+        );
+        assert!(text.contains("(7s ago)"), "got {text:?}");
+
+        assert_eq!(
+            ui.overlay(tall_pane(80), start + STATUS_LIFETIME).rows(),
+            0,
+            "a refusal must expire like any other message gsw wrote",
+        );
+    }
+
+    #[test]
+    fn a_failed_push_stays_however_long_it_takes() {
+        // The one message gsw must not remove by itself. git's error text is
+        // what the user has to read and act on, and a remedy that expires
+        // while they are looking at another pane is worse than a row spent.
+        let start = t0();
+        let mut ui = asking();
+        ui.confirm();
+        ui.finished(
+            PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            },
+            start,
+        );
+
+        let hours_later = ui.overlay(tall_pane(80), start + Duration::from_secs(3 * 60 * 60));
+        assert_eq!(hours_later.rows(), 1, "an error must not expire");
+        assert!(
+            hours_later
+                .text()
+                .contains("error: failed to push some refs"),
+            "got {:?}",
+            hours_later.text(),
+        );
+        assert!(
+            !hours_later.text().contains("ago"),
+            "an error that never expires has no countdown to report, got {:?}",
+            hours_later.text(),
+        );
+
+        ui.dismiss();
+        assert_eq!(
+            ui.overlay(tall_pane(80), start).rows(),
+            0,
+            "a key press is still what clears it",
+        );
+    }
+
+    #[test]
+    fn an_ageing_message_darkens_all_the_way_to_black() {
+        // The fade is the other half of the age text: a message on its way out
+        // should look like it, and be gone rather than dark by the end.
+        //
+        // Asserted on the typed color rather than on the escape bytes, because
+        // whether `colored` emits any is process-global state other tests in
+        // this binary toggle.
+        let brightness = |elapsed: Duration| match colorize_status(TEXT, elapsed, true).fgcolor {
+            Some(colored::Color::TrueColor { r, g, b }) => {
+                u32::from(r) + u32::from(g) + u32::from(b)
+            }
+            other => panic!("a fading row must carry a truecolor foreground, got {other:?}"),
+        };
+
+        assert!(
+            brightness(Duration::ZERO) > 0,
+            "a message just posted is drawn at full brightness",
+        );
+        assert_eq!(
+            brightness(STATUS_LIFETIME),
+            0,
+            "the fade must reach black exactly as the message is removed",
+        );
+
+        // Monotone the whole way down, so no repaint ever brightens a message
+        // that is on its way out.
+        let mut previous = brightness(Duration::ZERO);
+        for second in 1..=STATUS_LIFETIME.as_secs() {
+            let now = brightness(Duration::from_secs(second));
+            assert!(
+                now <= previous,
+                "the fade brightened at {second}s: {previous} then {now}",
+            );
+            previous = now;
+        }
+    }
+
+    #[test]
+    fn an_ageing_message_dims_once_where_there_is_no_truecolor() {
+        // The 8-color fallback the commit-log gradient already has. Two steps
+        // is all there is to spend, so the message is drawn plain while the
+        // news is current and dim for the rest of its life.
+        use colored::Styles;
+        let fresh = colorize_status(TEXT, Duration::ZERO, false);
+        assert!(
+            !fresh.style.contains(Styles::Dimmed) && fresh.fgcolor.is_none(),
+            "a message just posted is drawn exactly as it was before",
+        );
+        assert!(
+            colorize_status(TEXT, STATUS_LIFETIME - STATUS_CADENCE, false)
+                .style
+                .contains(Styles::Dimmed),
+            "an old message must be dimmed even with no gradient to fade along",
+        );
+    }
+
+    /// Stand-in row for the styling tests, which are about the color a status
+    /// row is drawn in and not about what it says.
+    const TEXT: &str = "Pushed 3 commits to origin/gsw-push (5s ago)";
+
+    #[test]
+    fn an_ageing_message_wakes_the_loop_every_second() {
+        // The loop sleeps until the soonest deadline any source imposes, and
+        // with `--refresh-interval 0` on a repository whose newest commit is
+        // hours old there is no other source at all. Without a deadline of its
+        // own the message would age only when something else happened to
+        // happen, and expire only when the user pressed a key — which is what
+        // it is here to stop doing.
+        let start = t0();
+        let mut ui = pushed_at(start);
+        ui.overlay(tall_pane(80), start);
+        assert_eq!(ui.next_tick(), Some(STATUS_CADENCE));
+
+        // And it stops asking once there is nothing left to move.
+        ui.overlay(tall_pane(80), start + STATUS_LIFETIME);
+        assert_eq!(
+            ui.next_tick(),
+            None,
+            "an expired message must not go on waking the loop",
+        );
+    }
+
+    #[test]
+    fn nothing_that_does_not_age_asks_the_loop_to_wake() {
+        // A wake-up costs a repaint of the whole pane, so only a message that
+        // actually changes with the clock may ask for one.
+        let start = t0();
+
+        assert_eq!(PushUi::new(false).next_tick(), None, "an idle UI");
+        assert_eq!(
+            asking().next_tick(),
+            None,
+            "a question waiting for an answer"
+        );
+
+        let mut running = asking();
+        running.confirm();
+        assert_eq!(running.next_tick(), None, "a push in flight");
+
+        let mut failed = asking();
+        failed.confirm();
+        failed.finished(
+            PushOutcome {
+                success: false,
+                output: "error: failed to push some refs\n".to_string(),
+            },
+            start,
+        );
+        assert_eq!(failed.next_tick(), None, "an error that never expires");
+    }
+
+    #[test]
+    fn the_age_is_part_of_what_the_pane_has_to_fit() {
+        // The age is appended before the row is truncated, not after, or a
+        // narrow pane gets a row that wraps — and a wrapped row scrolls the
+        // alternate screen gsw was measured to fill exactly.
+        let start = t0();
+        let mut ui = pushed_at(start);
+        for width in 1..60 {
+            let text = ui
+                .overlay(
+                    Dimensions {
+                        width,
+                        height: MAX_STATUS_ROWS + 10,
+                    },
+                    start + Duration::from_secs(42),
+                )
+                .text();
+            for line in text.lines() {
+                assert!(
+                    visible_width(line) <= width,
+                    "line {line:?} exceeds width {width}",
+                );
+            }
+        }
     }
 }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 
 use colored::{ColoredString, Colorize};
 
+use crate::age::{format_age_detailed, scale_rgb};
 use crate::render::{truncate_right, Snapshot, UpstreamStatus};
 use crate::repo::DETACHED_HEAD;
 use crate::watch::{Dimensions, InputMode};
@@ -525,13 +526,13 @@ pub(crate) struct PushUi {
 enum State {
     /// Nothing on screen and nothing pending.
     Idle,
-    /// A message under the frame, staying until the user presses a key.
+    /// A message under the frame.
     Status {
         /// Lines to show, already trimmed to [`MAX_STATUS_ROWS`]. How many of
         /// them a given pane has room for is [`PushUi::overlay`]'s call.
         lines: Vec<String>,
-        /// Whether this reports a failure, which the display colors red.
-        failed: bool,
+        /// How long this message stays, and how it is drawn while it does.
+        life: Life,
     },
     /// A confirmation is on screen, waiting for an answer. "On screen" is the
     /// load-bearing half, and two rules keep it true: [`PushUi::request`] does
@@ -546,6 +547,51 @@ enum State {
     },
     /// `git push` is running.
     Running { success_message: String },
+}
+
+/// How long a [`State::Status`] message stays under the frame, and how it is
+/// drawn while it does.
+///
+/// The split is between what gsw said and what git said, and it is one decision
+/// rather than two because the two halves are the same fact. Everything gsw
+/// composes itself — a push that worked, a push it would not run — is a
+/// *report*: the user pressed a key, the answer came back, and a monitor that
+/// holds it on screen for the rest of the session is spending a row on news.
+/// git's error text is a *remedy*: the user has to read it and act on it, so
+/// gsw must not take it away while they are looking at another pane.
+///
+/// The age and the fade ride on this enum rather than on a flag beside it,
+/// because a message that goes away on its own has to say how old it is — or it
+/// is a sentence that quietly stops being true — and a message that stays has
+/// no countdown to report. There is no third combination to represent.
+enum Life {
+    /// Stays until the user presses a key. git's own words about a push that
+    /// failed, drawn red, and the one message gsw will not remove by itself.
+    UntilDismissed,
+    /// Says how long ago it was posted, fades toward black across
+    /// [`STATUS_LIFETIME`], and then takes itself off the screen.
+    Fading {
+        /// When the message was posted, against the watch loop's injected
+        /// clock — the same clock [`PushUi::overlay`] is later given.
+        posted_at: Instant,
+    },
+}
+
+impl Life {
+    /// How long ago a fading message was posted, as of `now`, or `None` for one
+    /// that does not age.
+    ///
+    /// Saturating on purpose. `now` is read when the overlay is drawn and
+    /// `posted_at` when the news arrived, which is earlier in every path
+    /// through the loop — but a clock a test drives backwards, or a future
+    /// caller that renders with a stale instant, would otherwise underflow
+    /// rather than report the zero age it plainly has.
+    fn elapsed(&self, now: Instant) -> Option<Duration> {
+        match self {
+            Self::UntilDismissed => None,
+            Self::Fading { posted_at } => Some(now.saturating_duration_since(*posted_at)),
+        }
+    }
 }
 
 impl PushUi {
@@ -568,8 +614,20 @@ impl PushUi {
     /// repository whose newest commit is hours old leaves the loop blocked on
     /// the channel indefinitely, and a message that expires only when something
     /// else happens does not expire.
+    ///
+    /// A question, a push in flight, and an error that never expires all say
+    /// `None`: none of them changes with the clock, and a wake-up costs a
+    /// repaint of the whole pane.
     pub(crate) fn next_tick(&self) -> Option<Duration> {
-        None
+        match &self.state {
+            State::Status {
+                life: Life::Fading { .. },
+                ..
+            } => Some(STATUS_CADENCE),
+            State::Idle | State::Status { .. } | State::Asking { .. } | State::Running { .. } => {
+                None
+            }
+        }
     }
 
     /// What keys mean right now.
@@ -612,7 +670,6 @@ impl PushUi {
     /// but that now covers only the pane resized down while a question is
     /// already up: the render path is the only thing that sees the new size.
     pub(crate) fn request(&mut self, snapshot: &Snapshot, dims: Dimensions, now: Instant) {
-        let _ = now;
         self.state = match prompt_for(
             &snapshot.branch,
             snapshot.push_remote.as_deref(),
@@ -632,9 +689,12 @@ impl PushUi {
                 command,
                 success_message,
             },
+            // A refusal describes the repository as it stood when `p` was
+            // pressed, so it goes stale exactly the way a success does — and
+            // costs the frame the same row until it does.
             PushPrompt::Refuse { message } => State::Status {
                 lines: vec![message],
-                failed: false,
+                life: Life::Fading { posted_at: now },
             },
         };
     }
@@ -658,6 +718,25 @@ impl PushUi {
         Some(command)
     }
 
+    /// Drop a message that has outlived [`STATUS_LIFETIME`].
+    ///
+    /// The counterpart to [`PushUi::dismiss`], and deliberately the only other
+    /// way a status leaves the screen: one of them is the user saying they have
+    /// read it and the other is the clock saying they have had the chance to.
+    /// Everything else on screen — a question, a push in flight, git's error
+    /// text — is left exactly where it is.
+    fn expire(&mut self, now: Instant) {
+        let State::Status { life, .. } = &self.state else {
+            return;
+        };
+        if life
+            .elapsed(now)
+            .is_some_and(|elapsed| elapsed >= STATUS_LIFETIME)
+        {
+            self.state = State::Idle;
+        }
+    }
+
     /// Handle `n`: drop the confirmation. The prompt disappearing is the whole
     /// feedback — a "cancelled" notice would itself need dismissing.
     pub(crate) fn cancel(&mut self) {
@@ -672,8 +751,11 @@ impl PushUi {
     /// git's output, so a create reports itself as a create. On failure it is
     /// git's own words — a gsw paraphrase of a push error would drop exactly
     /// the detail the user needs.
+    ///
+    /// The same split decides how long the message stays: `now` starts the
+    /// countdown on a success, and a failure gets no countdown at all. See
+    /// [`Life`] for why those are one decision.
     pub(crate) fn finished(&mut self, outcome: PushOutcome, now: Instant) {
-        let _ = now;
         let success_message = match std::mem::replace(&mut self.state, State::Idle) {
             State::Running { success_message } => success_message,
             // A finish with no push running: nothing to report against, so
@@ -684,15 +766,12 @@ impl PushUi {
             }
         };
 
-        let lines = if outcome.success {
-            vec![success_message]
+        let (lines, life) = if outcome.success {
+            (vec![success_message], Life::Fading { posted_at: now })
         } else {
-            failure_lines(&outcome.output)
+            (failure_lines(&outcome.output), Life::UntilDismissed)
         };
-        self.state = State::Status {
-            lines,
-            failed: !outcome.success,
-        };
+        self.state = State::Status { lines, life };
     }
 
     /// Handle a key with no other meaning: clear a status message if one is up.
@@ -746,8 +825,16 @@ impl PushUi {
     /// fitted when it was asked, a resize took its row, and this is the only
     /// place that sees the new size. Nothing is lost but the question either
     /// way: `p` in a pane with a row to spare asks it again.
+    ///
+    /// A message that has outlived [`STATUS_LIFETIME`] is dropped here rather
+    /// than by a key or a timer of its own, for the same reason the question
+    /// above is: this is the one place that runs on every frame, so expiring
+    /// the message and giving its row back to the frame happen in the same
+    /// breath. Which is also why the loop is given [`PushUi::next_tick`] — a
+    /// message can only expire on a frame that is drawn, so there has to be a
+    /// frame drawn.
     pub(crate) fn overlay(&mut self, dims: Dimensions, now: Instant) -> Overlay {
-        let _ = now;
+        self.expire(now);
         let width = dims.width;
         let lines: Vec<String> = match &self.state {
             State::Idle => Vec::new(),
@@ -767,17 +854,33 @@ impl PushUi {
                 }]
             }
             State::Running { .. } => vec![truncate_right(RUNNING_NOTICE, width)],
-            State::Status { lines, failed } => lines
-                .iter()
-                .map(|line| {
-                    let line = truncate_right(line, width);
-                    if *failed {
-                        line.red().to_string()
-                    } else {
-                        line
-                    }
-                })
-                .collect(),
+            State::Status { lines, life } => {
+                let elapsed = life.elapsed(now);
+                // The age goes on the last row, which for every message that
+                // has one is the only row: a success and a refusal are one
+                // sentence each, and git's several-line error text is the one
+                // kind that never ages.
+                let last = lines.len().saturating_sub(1);
+                lines
+                    .iter()
+                    .enumerate()
+                    .map(|(row, line)| match elapsed {
+                        // Appended *before* the truncation, so the age is part
+                        // of what the pane has to fit rather than something
+                        // added to a row already measured against its width.
+                        Some(elapsed) => {
+                            let line = if row == last {
+                                format!("{line} ({} ago)", format_age_detailed(elapsed))
+                            } else {
+                                line.clone()
+                            };
+                            colorize_status(&truncate_right(&line, width), elapsed, self.truecolor)
+                                .to_string()
+                        }
+                        None => truncate_right(line, width).red().to_string(),
+                    })
+                    .collect()
+            }
         };
         // The frame never gives up its last row. A pane painted entirely by the
         // push feature would leave the user watching an error with nothing
@@ -907,10 +1010,58 @@ const STATUS_LIFETIME: Duration = Duration::from_secs(60);
 /// decay tick that advances the commit ages in the frame above.
 const STATUS_CADENCE: Duration = Duration::from_secs(1);
 
+/// The color an ageing status message is drawn in at age zero, on a terminal
+/// that takes 24-bit color.
+///
+/// A light neutral gray rather than white: it is what an unstyled row already
+/// looks like on the dark terminals gsw draws for, so the message starts where
+/// it used to start and only then begins to leave.
+const STATUS_RGB: (u8, u8, u8) = (208, 208, 208);
+
+/// Fraction of [`STATUS_LIFETIME`] an ageing message keeps full brightness for
+/// when there is no truecolor to fade along.
+///
+/// Without a gradient the fade has exactly two steps, so the step goes at the
+/// half-way mark: full brightness while the news is current, dim for the rest,
+/// gone at the end. Coarse, and honest about it — the alternative is a message
+/// that hangs at full brightness and then vanishes.
+const COARSE_FADE_AT: f32 = 0.5;
+
 /// Color one row of an ageing status message, `elapsed` after it was posted.
+///
+/// The fade runs the whole length of [`STATUS_LIFETIME`] and ends at black, so
+/// the row reaches the background exactly as it is removed — a message on its
+/// way out looks like one, and nothing ever blinks out at full brightness. It
+/// is the same shape as the commit-log gradient above it, with one difference
+/// that follows from what the two are for: the log fades to a floor, because a
+/// commit that has stopped being fresh is still a commit worth reading, and
+/// this fades past it, because a status message that has stopped being fresh is
+/// leaving.
+///
+/// Returns a [`ColoredString`] rather than a `String` so tests can read the
+/// color off the value. `colored` decides whether to emit escapes at all from
+/// process-global state, which other tests in this binary toggle.
 fn colorize_status(line: &str, elapsed: Duration, truecolor: bool) -> ColoredString {
-    let _ = (elapsed, truecolor);
-    line.normal()
+    // Cast is exact for the values involved: `STATUS_LIFETIME` is a small
+    // constant and `elapsed` is clamped to it by the division below.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "seconds counts here are far below f32's exact-integer range"
+    )]
+    let spent = (elapsed.as_secs_f32() / STATUS_LIFETIME.as_secs_f32()).clamp(0.0, 1.0);
+
+    if truecolor {
+        let (r, g, b) = scale_rgb(STATUS_RGB, 1.0 - spent);
+        return line.truecolor(r, g, b);
+    }
+    // No gradient to fade along: one step, at the half-way mark. `normal()`
+    // leaves the row exactly as it was drawn before this feature — `colored`
+    // emits nothing at all for a string with no color and no style.
+    if spent >= COARSE_FADE_AT {
+        line.dimmed()
+    } else {
+        line.normal()
+    }
 }
 
 /// What a failed push says when git said nothing gsw could show.

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -775,6 +775,7 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
         cache,
         initial_freshest,
         schedule,
+        PushUi::new(cfg.truecolor),
         LoopHooks {
             collect: || walk(&mut handle, &ignore, cfg),
             render: |snap: &Snapshot, dims: Dimensions, timing: FrameTiming| {
@@ -983,6 +984,12 @@ enum Flow {
 /// times is a rule that will be updated twice. Every event goes through here,
 /// so a variant added later cannot be handled in two of the three places.
 ///
+/// `clock` is the loop's injected clock, and it is passed rather than an
+/// instant so it is read only by the two events that need one: a self-expiring
+/// status message counts its age from the moment the news arrived, and no other
+/// event has a moment to record. Reading it up front instead would put a clock
+/// call on every filesystem event in a burst, for the two that use it.
+///
 /// A key arrives unclassified and is resolved here against `ui`'s *current*
 /// mode, which is what makes a burst read correctly: within one drain, the `p`
 /// ahead of a `y` has already switched the mode by the time the `y` is looked
@@ -997,15 +1004,17 @@ enum Flow {
 /// behind that `p` is read as the ordinary key it is. `dims` is the pane the
 /// last render measured, which is the pane the user was looking at when they
 /// pressed the key — the loop re-measures after this drain, not during it.
-fn absorb<StartPush>(
+fn absorb<Clock, StartPush>(
     event: Event,
     pending: &mut Pending,
     ui: &mut PushUi,
     snapshot: &Snapshot,
     dims: Dimensions,
+    clock: &Clock,
     start_push: &mut StartPush,
 ) -> Flow
 where
+    Clock: Fn() -> Instant,
     StartPush: FnMut(PushCommand),
 {
     match event {
@@ -1015,10 +1024,10 @@ where
         Event::ForceRefresh => pending.force = true,
         Event::Key(key) => {
             if let Some(action) = classify_input(key, ui.mode()) {
-                return absorb(action, pending, ui, snapshot, dims, start_push);
+                return absorb(action, pending, ui, snapshot, dims, clock, start_push);
             }
         }
-        Event::PushRequested => ui.request(snapshot, dims),
+        Event::PushRequested => ui.request(snapshot, dims, clock()),
         // `confirm` yields the command only once, so a second `y` that raced
         // the mode change starts nothing.
         Event::PushConfirmed => {
@@ -1030,7 +1039,7 @@ where
         Event::Dismiss => ui.dismiss(),
         Event::PushFinished(outcome) => {
             let succeeded = outcome.success;
-            ui.finished(outcome);
+            ui.finished(outcome, clock());
             // A successful push moved the upstream, so the header's arrows and
             // tracking segment are stale the moment it lands — walk now rather
             // than leaving a wrong count on screen until the next refresh. A
@@ -1056,10 +1065,17 @@ where
 ///
 /// No timer needs a thread of its own: every deadline is folded into the
 /// `recv_timeout` window by [`wait_window`], so a timeout *is* the tick, and the
-/// window is recomputed after every render. Three sources feed it — the decay
-/// cadence from `next_tick` (in `hooks`), the walk the schedule owes, and, while
-/// a countdown is on screen, [`CLOCK_CADENCE`]. With all three absent the loop
+/// window is recomputed after every render. Four sources feed it — the decay
+/// cadence from `next_tick` (in `hooks`), the walk the schedule owes, while
+/// a countdown is on screen [`CLOCK_CADENCE`], and, while a status message is
+/// ageing under the frame, [`PushUi::next_tick`]. With all four absent the loop
 /// blocks indefinitely on events.
+///
+/// `ui` is everything the push feature puts on screen, plus the input mode that
+/// goes with it. It is taken by value rather than built here because it carries
+/// the terminal's color depth, which is the caller's to resolve — and owned for
+/// the rest of the loop because this is the only place that knows what is
+/// displayed (see [`Event::Key`] for why the reader thread must not).
 ///
 /// `hooks` bundles the side effects (collect, render, terminal-size query, paint,
 /// clock, tick cadence) so the loop is one function testable without a TTY or
@@ -1100,6 +1116,7 @@ fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>(
     mut cache: SnapshotCache,
     initial_freshest: Option<Duration>,
     mut schedule: WalkSchedule,
+    mut ui: PushUi,
     mut hooks: LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>,
 ) -> Result<()>
 where
@@ -1112,10 +1129,6 @@ where
     StartPush: FnMut(PushCommand),
 {
     let mut freshest = initial_freshest;
-    // Everything the push feature puts on screen, plus the input mode that goes
-    // with it. Owned here because this is the only place that knows what is
-    // displayed — see [`Event::Key`] for why the reader thread must not.
-    let mut ui = PushUi::new();
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
         // after `interval` of quiet for a tick.
@@ -1135,6 +1148,7 @@ where
             (hooks.next_tick)(freshest),
             walk_wait,
             schedule.interval.map(|_| CLOCK_CADENCE),
+            ui.next_tick(),
         ]);
         let woke_for_timeout = match wait {
             Some(interval) => match rx.recv_timeout(interval) {
@@ -1145,6 +1159,7 @@ where
                         &mut ui,
                         &cache.snapshot,
                         cache.dims,
+                        &hooks.clock,
                         &mut hooks.start_push,
                     ) == Flow::Quit
                     {
@@ -1163,6 +1178,7 @@ where
                         &mut ui,
                         &cache.snapshot,
                         cache.dims,
+                        &hooks.clock,
                         &mut hooks.start_push,
                     ) == Flow::Quit
                     {
@@ -1187,6 +1203,7 @@ where
                             &mut ui,
                             &cache.snapshot,
                             cache.dims,
+                            &hooks.clock,
                             &mut hooks.start_push,
                         ) == Flow::Quit
                         {
@@ -1268,7 +1285,7 @@ where
         // absorbed and before the next wake reads one, so the key a user
         // presses in reaction to what this paints is classified against the
         // mode this pane actually showed them.
-        let overlay = ui.overlay(cache.dims);
+        let overlay = ui.overlay(cache.dims, now);
         let frame_dims = Dimensions {
             height: overlay.frame_rows(),
             ..cache.dims
@@ -2714,6 +2731,7 @@ mod tests {
             seeded_cache(base),
             Some(Duration::ZERO),
             WalkSchedule::new(Some(interval), base, Duration::ZERO),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2760,6 +2778,7 @@ mod tests {
             seeded_cache(collected_at),
             Some(Duration::ZERO),
             WalkSchedule::new(Some(Duration::from_secs(60)), collected_at, Duration::ZERO),
+            PushUi::new(false),
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, timing: FrameTiming| {
@@ -2803,6 +2822,7 @@ mod tests {
             seeded_cache(base),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2852,6 +2872,7 @@ mod tests {
             seeded_cache(now),
             None,
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2894,6 +2915,7 @@ mod tests {
             seeded_cache(now),
             None,
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2937,6 +2959,7 @@ mod tests {
             seeded_cache(now),
             None,
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2976,6 +2999,7 @@ mod tests {
             seeded_cache(now),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {
@@ -3022,6 +3046,7 @@ mod tests {
             seeded_cache(now),
             Some(Duration::from_secs(30)),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {
@@ -3065,6 +3090,7 @@ mod tests {
             seeded_cache(collected_at),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3117,6 +3143,7 @@ mod tests {
             seeded_cache(now),
             None,
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3169,6 +3196,7 @@ mod tests {
             seeded_cache(base),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, timing: FrameTiming| {
@@ -3244,6 +3272,7 @@ mod tests {
             seeded_cache(base),
             None, // decay timer off: isolate the throttle from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3318,6 +3347,7 @@ mod tests {
             seeded_cache(base),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3389,6 +3419,7 @@ mod tests {
             seeded_cache(base),
             Some(Duration::ZERO),
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3461,6 +3492,7 @@ mod tests {
             seeded_cache(base),
             None, // decay timer off: isolate the throttle from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3533,6 +3565,7 @@ mod tests {
             seeded_cache(base),
             None, // decay timer off: isolate the throttle from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3594,6 +3627,7 @@ mod tests {
             seeded_cache(base),
             None, // decay timer off: isolate the forced walk from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3658,6 +3692,7 @@ mod tests {
             cache,
             None, // decay timer off: isolate the failed walk from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3739,6 +3774,7 @@ mod tests {
             seeded_cache(base),
             None, // decay timer off: isolate the throttle from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3830,6 +3866,7 @@ mod tests {
             cache,
             None, // decay timer off: isolate recovery from tick behavior
             no_timed_refresh(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -4009,6 +4046,22 @@ mod push_loop_tests {
         Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
     }
 
+    /// A [`PushUi`] holding the message a push that succeeded at `at` leaves
+    /// behind — the state the loop has to take back off the screen by itself.
+    fn pushed_ui(at: Instant) -> PushUi {
+        let mut ui = PushUi::new(false);
+        ui.request(&pushable_snapshot(), TEST_DIMS, at);
+        ui.confirm();
+        ui.finished(
+            crate::push::PushOutcome {
+                success: true,
+                output: String::new(),
+            },
+            at,
+        );
+        ui
+    }
+
     /// What one loop run observed. The loop takes its hooks by value, so the
     /// counters live behind `RefCell` and are read after it returns.
     #[derive(Default)]
@@ -4066,6 +4119,7 @@ mod push_loop_tests {
             cache_in(base, dims),
             None,
             no_timed_refresh_for_push(),
+            PushUi::new(false),
             LoopHooks {
                 collect: || {
                     seen.borrow_mut().collects += 1;
@@ -4090,6 +4144,99 @@ mod push_loop_tests {
     /// Purely event-driven: no timed refresh, so any walk came from an event.
     fn no_timed_refresh_for_push() -> WalkSchedule {
         WalkSchedule::unscheduled()
+    }
+
+    /// Longer than any status message lives, so a clock jump of this size is
+    /// past the point one has to be off the screen. Deliberately not the push
+    /// module's own constant: this test is about the loop waking itself, and
+    /// borrowing the exact lifetime would tie it to a number it does not care
+    /// about.
+    const PAST_ANY_LIFETIME: Duration = Duration::from_secs(600);
+
+    /// How long the rescue quit waits before it ends a loop that should have
+    /// ended on its own. Generous enough that a slow machine cannot trip it,
+    /// and short enough to keep the suite quick — it only elapses when the
+    /// test is already failing.
+    const RESCUE_AFTER: Duration = Duration::from_secs(3);
+
+    #[test]
+    fn the_loop_wakes_itself_to_take_an_expired_message_off_the_screen() {
+        // A status message expires against the clock, and on a quiet
+        // repository nothing else is due to wake the loop: no filesystem
+        // event, no timed refresh under `--refresh-interval 0`, and no decay
+        // tick once the newest commit is past the fade. Without a deadline of
+        // its own the message would come off the screen only when something
+        // unrelated happened — which is the "stays forever" this feature
+        // exists to answer.
+        let (tx, rx) = mpsc::channel();
+        // One event, so the first frame is painted straight away rather than a
+        // cadence later. After it the queue is empty and only a timeout can
+        // wake the loop again.
+        tx.send(Event::Resize).expect("queue the first wake");
+
+        // A quit from outside, long after the loop should have acted on its
+        // own, so a missing deadline fails this test instead of hanging it.
+        let rescue = tx.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(RESCUE_AFTER);
+            let _ = rescue.send(Event::Quit);
+        });
+
+        let base = Instant::now();
+        let jumped = std::cell::Cell::new(false);
+        let painted = RefCell::new(Vec::<String>::new());
+        let mut displayed = String::new();
+
+        event_loop(
+            &rx,
+            TEST_DEBOUNCE,
+            &mut displayed,
+            cache_at(base),
+            None, // decay timer off: the message is the only thing that ages
+            no_timed_refresh_for_push(),
+            pushed_ui(base),
+            LoopHooks {
+                collect: || Ok(pushable_snapshot()),
+                render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| frame("FRAME"),
+                dimensions: || TEST_DIMS,
+                paint: |output: &str| {
+                    painted.borrow_mut().push(output.to_string());
+                    // Every paint moves the clock past the message's lifetime,
+                    // so the wake after the first one finds it expired.
+                    jumped.set(true);
+                    if painted.borrow().len() >= 2 {
+                        let _ = tx.send(Event::Quit);
+                    }
+                    Ok(())
+                },
+                clock: || {
+                    if jumped.get() {
+                        base + PAST_ANY_LIFETIME
+                    } else {
+                        base
+                    }
+                },
+                next_tick: timer_off,
+                start_push: |_command: PushCommand| {},
+            },
+        )
+        .expect("loop");
+
+        let painted = painted.into_inner();
+        assert!(
+            painted[0].contains("Created origin/gsw-push"),
+            "the first frame must carry the message, got {:?}",
+            painted[0],
+        );
+        assert_eq!(
+            painted.len(),
+            2,
+            "the loop must wake itself once more to clear the message, painted {painted:?}",
+        );
+        assert_eq!(
+            painted[1], "FRAME",
+            "the expired message must leave the frame exactly as it was before it",
+        );
     }
 
     #[test]
@@ -4380,6 +4527,7 @@ mod push_loop_tests {
                 cache_at(base),
                 None,
                 no_timed_refresh_for_push(),
+                PushUi::new(false),
                 LoopHooks {
                     collect: || Ok(pushable_snapshot()),
                     render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {

--- a/src/gsw/src/watch.rs
+++ b/src/gsw/src/watch.rs
@@ -772,10 +772,12 @@ pub(crate) fn run(mut handle: RepoHandle, cfg: &RenderConfig) -> Result<()> {
         &rx,
         DEBOUNCE,
         &mut displayed,
-        cache,
-        initial_freshest,
-        schedule,
-        PushUi::new(cfg.truecolor),
+        LoopStart {
+            cache,
+            freshest: initial_freshest,
+            schedule,
+            ui: PushUi::new(cfg.truecolor),
+        },
         LoopHooks {
             collect: || walk(&mut handle, &ignore, cfg),
             render: |snap: &Snapshot, dims: Dimensions, timing: FrameTiming| {
@@ -927,6 +929,31 @@ struct SnapshotCache {
     /// The dimensions `snapshot` was last rendered at, so a resize can re-render
     /// the cached snapshot at the new size without collecting.
     dims: Dimensions,
+}
+
+/// Everything the watch loop starts from — as opposed to [`LoopHooks`], which
+/// is everything it drives.
+///
+/// Bundled for the same reason the hooks are: four values that are all "where
+/// this run begins" read better as one argument than as four, and the next one
+/// added goes here rather than onto the loop's signature. Each is built by the
+/// caller because each is anchored to the seed walk that filled it — the cache
+/// to the snapshot it collected, the freshest age to the frame that snapshot
+/// rendered, the schedule to the cost that walk measured, and the push UI to
+/// the terminal's color depth, which is resolved from the CLI and nowhere else.
+struct LoopStart {
+    /// The snapshot a re-render can use without walking git again.
+    cache: SnapshotCache,
+    /// The freshest displayed age of the frame already painted, which seeds
+    /// the decay-tick cadence for the loop's first wait.
+    freshest: Option<Duration>,
+    /// The walk schedule, already anchored to the seed walk.
+    schedule: WalkSchedule,
+    /// Everything the push feature puts on screen, plus the input mode that
+    /// goes with it. Owned by the loop for the rest of the run, because the
+    /// loop is the only place that knows what is displayed — see
+    /// [`Event::Key`] for why the reader thread must not.
+    ui: PushUi,
 }
 
 /// The side-effecting hooks the watch loop drives, bundled so the loop stays one
@@ -1113,10 +1140,7 @@ fn event_loop<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>(
     rx: &Receiver<Event>,
     debounce: Duration,
     displayed: &mut String,
-    mut cache: SnapshotCache,
-    initial_freshest: Option<Duration>,
-    mut schedule: WalkSchedule,
-    mut ui: PushUi,
+    start: LoopStart,
     mut hooks: LoopHooks<Collect, RenderFn, Dims, Paint, Clock, Tick, StartPush>,
 ) -> Result<()>
 where
@@ -1128,7 +1152,12 @@ where
     Tick: Fn(Option<Duration>) -> Option<Duration>,
     StartPush: FnMut(PushCommand),
 {
-    let mut freshest = initial_freshest;
+    let LoopStart {
+        mut cache,
+        mut freshest,
+        mut schedule,
+        mut ui,
+    } = start;
     loop {
         // Wait for the first event, or — when the decay timer is enabled — wake
         // after `interval` of quiet for a tick.
@@ -2728,10 +2757,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            Some(Duration::ZERO),
-            WalkSchedule::new(Some(interval), base, Duration::ZERO),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: Some(Duration::ZERO),
+                schedule: WalkSchedule::new(Some(interval), base, Duration::ZERO),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2775,10 +2806,16 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(collected_at),
-            Some(Duration::ZERO),
-            WalkSchedule::new(Some(Duration::from_secs(60)), collected_at, Duration::ZERO),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(collected_at),
+                freshest: Some(Duration::ZERO),
+                schedule: WalkSchedule::new(
+                    Some(Duration::from_secs(60)),
+                    collected_at,
+                    Duration::ZERO,
+                ),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, timing: FrameTiming| {
@@ -2819,10 +2856,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2869,10 +2908,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            None,
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: None,
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2912,10 +2953,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            None,
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: None,
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2956,10 +2999,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            None,
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: None,
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -2996,10 +3041,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {
@@ -3043,10 +3090,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            Some(Duration::from_secs(30)),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: Some(Duration::from_secs(30)),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {
@@ -3087,10 +3136,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(collected_at),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(collected_at),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3140,10 +3191,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(now),
-            None,
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(now),
+                freshest: None,
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3193,10 +3246,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || Ok(empty_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, timing: FrameTiming| {
@@ -3269,10 +3324,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            None, // decay timer off: isolate the throttle from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: None, // decay timer off: isolate the throttle from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3344,10 +3401,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3416,10 +3475,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            Some(Duration::ZERO),
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: Some(Duration::ZERO),
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3489,10 +3550,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            None, // decay timer off: isolate the throttle from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: None, // decay timer off: isolate the throttle from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3562,10 +3625,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            None, // decay timer off: isolate the throttle from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: None, // decay timer off: isolate the throttle from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3624,10 +3689,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            None, // decay timer off: isolate the forced walk from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: None, // decay timer off: isolate the forced walk from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3689,10 +3756,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            cache,
-            None, // decay timer off: isolate the failed walk from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache,
+                freshest: None, // decay timer off: isolate the failed walk from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3771,10 +3840,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            seeded_cache(base),
-            None, // decay timer off: isolate the throttle from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache: seeded_cache(base),
+                freshest: None, // decay timer off: isolate the throttle from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -3863,10 +3934,12 @@ mod tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            cache,
-            None, // decay timer off: isolate recovery from tick behavior
-            no_timed_refresh(),
-            PushUi::new(false),
+            LoopStart {
+                cache,
+                freshest: None, // decay timer off: isolate recovery from tick behavior
+                schedule: no_timed_refresh(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     collects += 1;
@@ -4116,10 +4189,12 @@ mod push_loop_tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            cache_in(base, dims),
-            None,
-            no_timed_refresh_for_push(),
-            PushUi::new(false),
+            LoopStart {
+                cache: cache_in(base, dims),
+                freshest: None,
+                schedule: no_timed_refresh_for_push(),
+                ui: PushUi::new(false),
+            },
             LoopHooks {
                 collect: || {
                     seen.borrow_mut().collects += 1;
@@ -4191,10 +4266,12 @@ mod push_loop_tests {
             &rx,
             TEST_DEBOUNCE,
             &mut displayed,
-            cache_at(base),
-            None, // decay timer off: the message is the only thing that ages
-            no_timed_refresh_for_push(),
-            pushed_ui(base),
+            LoopStart {
+                cache: cache_at(base),
+                freshest: None, // decay timer off: the message is the only thing that ages
+                schedule: no_timed_refresh_for_push(),
+                ui: pushed_ui(base),
+            },
             LoopHooks {
                 collect: || Ok(pushable_snapshot()),
                 render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| frame("FRAME"),
@@ -4524,10 +4601,12 @@ mod push_loop_tests {
                 &rx,
                 TEST_DEBOUNCE,
                 &mut displayed,
-                cache_at(base),
-                None,
-                no_timed_refresh_for_push(),
-                PushUi::new(false),
+                LoopStart {
+                    cache: cache_at(base),
+                    freshest: None,
+                    schedule: no_timed_refresh_for_push(),
+                    ui: PushUi::new(false),
+                },
                 LoopHooks {
                     collect: || Ok(pushable_snapshot()),
                     render: |_snap: &Snapshot, _dims: Dimensions, _timing: FrameTiming| {


### PR DESCRIPTION
## Summary

A status message that `gsw` writes for itself now ages, fades, and removes itself.

Before this change, the `Pushed N commits to origin/branch` notice stayed under the frame until a key was pressed. On a monitor that nobody types at, that means forever. The message also never said how long ago the push happened.

Now the message shows its age, fades from a light gray toward black across the minute it lives, and takes itself off the screen at the end. The row goes back to the frame with no key pressed. A refusal ages the same way, because it describes the repository as it stood when `p` was pressed. The error text from `git` is the exception. It is a remedy and not news, so it still waits for a key.

## Design

- `Life` carries the split between a message that counts down and a message that does not. Thus the age, the fade, and the expiry cannot disagree about the kind of message that they look at.
- `PushUi::next_tick` gives the loop a deadline of its own. A message can only expire on a frame that the loop draws, and a quiet repository under `--refresh-interval 0` draws none.
- The fade uses the gradient of the commit log and the `--truecolor` gate of that log. It runs past the floor of the log to black, because a status message that stopped being fresh is leaving and not only ageing.

## Tests

Written test-first, in a red commit and then a green commit. The tests state that the age is shown and advances, that the message reaches black and removes itself after a minute, that a refusal expires the same way, that the error text from `git` does not expire, and that the loop wakes itself to do the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
