### PR TITLE
test(gsw): prove --truecolor reaches the push status message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,3 +167,8 @@ allow_attributes_without_reason = "warn"
 redundant_clone = "warn"
 # Warn on byte-level string indexing (&s[..n]) which can panic on multi-byte UTF-8
 string_slice = "warn"
+# A banned method is a hard error, not a warning. The ban is how a crate makes
+# its own helper mandatory, and a warning is something a plain `cargo clippy`
+# run prints and a reader skips. Each crate lists the methods it bans in its own
+# clippy.toml, so a crate with no such file has nothing to trip on.
+disallowed_methods = "deny"

--- a/src/gsw/clippy.toml
+++ b/src/gsw/clippy.toml
@@ -3,8 +3,15 @@
 # changes what an unrelated test sees, which makes failures that appear and
 # disappear between runs. `testcolor::with_forced_ansi` holds the one lock on
 # that global state and puts the override back, so it is the only entrance.
-# These two entries make the bypass fail the build instead of failing a test
+# These entries make the bypass fail the build instead of failing a test
 # once a week.
+#
+# The override arrives in two spellings. The two free functions in
+# `colored::control` are the usual one, but each of them only forwards to a
+# method on the `SHOULD_COLORIZE` singleton, and that method is public too. A
+# ban on the free functions alone therefore leaves the singleton open, and one
+# call through it changes the same global state. All four spellings are banned
+# for that reason.
 #
 # This file sits beside gsw's Cargo.toml, so the ban covers the gsw crate only.
 # Other crates in the workspace, such as seescc, call the same API in
@@ -12,4 +19,6 @@
 disallowed-methods = [
     { path = "colored::control::set_override", reason = "call testcolor::with_forced_ansi instead; it holds the one lock on this process-global override" },
     { path = "colored::control::unset_override", reason = "testcolor::with_forced_ansi puts the override back on its own, on the panic path as well" },
+    { path = "colored::control::ShouldColorize::set_override", reason = "the singleton reaches the same global state as the free function; call testcolor::with_forced_ansi instead" },
+    { path = "colored::control::ShouldColorize::unset_override", reason = "the singleton reaches the same global state as the free function; testcolor::with_forced_ansi puts the override back on its own" },
 ]

--- a/src/gsw/clippy.toml
+++ b/src/gsw/clippy.toml
@@ -1,0 +1,15 @@
+# The `colored` crate's override is process-global, and `cargo test` runs the
+# tests of one binary on many threads. A test that sets the override directly
+# changes what an unrelated test sees, which makes failures that appear and
+# disappear between runs. `testcolor::with_forced_ansi` holds the one lock on
+# that global state and puts the override back, so it is the only entrance.
+# These two entries make the bypass fail the build instead of failing a test
+# once a week.
+#
+# This file sits beside gsw's Cargo.toml, so the ban covers the gsw crate only.
+# Other crates in the workspace, such as seescc, call the same API in
+# production and must keep it.
+disallowed-methods = [
+    { path = "colored::control::set_override", reason = "call testcolor::with_forced_ansi instead; it holds the one lock on this process-global override" },
+    { path = "colored::control::unset_override", reason = "testcolor::with_forced_ansi puts the override back on its own, on the panic path as well" },
+]

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -21,6 +21,11 @@ mod push;
 mod render;
 mod repo;
 mod snapshot;
+/// The one lock on `colored`'s process-global override, shared by every test
+/// module that needs real ANSI bytes. Test-only: the shipped binary never
+/// forces the override.
+#[cfg(test)]
+mod testcolor;
 /// Shared git fixtures for the unit tests. Test-only: it shells out to `git` to
 /// build throwaway repositories, which the shipped binary never does.
 #[cfg(test)]

--- a/src/gsw/src/main.rs
+++ b/src/gsw/src/main.rs
@@ -277,11 +277,19 @@ fn main() -> Result<()> {
     );
 
     if cli.no_color {
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "this process decides its own color output at startup; the ban covers the tests, which must go through testcolor::with_forced_ansi"
+        )]
         colored::control::set_override(false);
     } else if should_force_colors(stdout_is_tty, columns_env.is_some(), no_color_env) {
         // A watch-like wrapper (e.g. viddy) is rendering our output inside
         // its own TTY-backed UI. The colored crate would otherwise strip
         // colors because our stdout is a pipe.
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "this process decides its own color output at startup; the ban covers the tests, which must go through testcolor::with_forced_ansi"
+        )]
         colored::control::set_override(true);
     }
 

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -1412,7 +1412,7 @@ mod tests {
 mod ui_tests {
     use super::*;
     use crate::render::Snapshot;
-    use crate::testcolor;
+    use crate::testcolor::{self, max_red_channel, TRUECOLOR_FG};
 
     /// A snapshot on `gsw-push` with `origin` available and the given tracking
     /// status. Only the four fields the push feature reads matter here.
@@ -2363,10 +2363,6 @@ mod ui_tests {
     /// row is drawn in and not about what it says.
     const TEXT: &str = "Pushed 3 commits to origin/gsw-push (5s ago)";
 
-    /// The start of a 24-bit foreground SGR sequence. The red, green, and blue
-    /// values follow it.
-    const TRUECOLOR_FG: &str = "\x1b[38;2;";
-
     #[test]
     fn the_status_message_fades_in_24_bit_color_only_where_the_terminal_takes_it() {
         // The two tests above read a typed `ColoredString` from
@@ -2450,47 +2446,6 @@ mod ui_tests {
             aged_max < fresh_max,
             "an older message must be painted darker: fresh={fresh_max} aged={aged_max}",
         );
-    }
-
-    /// The largest red channel of any 24-bit foreground sequence in `text`.
-    ///
-    /// The fade scales all three channels by one factor, so one channel reports
-    /// the brightness of the whole row.
-    ///
-    /// This copies the `max_r` closure in `render.rs`, which reads the same
-    /// bytes for the same purpose. The original is a closure inside the body of
-    /// one test. To share it, `render.rs` must open its whole test module to
-    /// this one, which gives every test module a route into every other one for
-    /// the sake of twenty lines. A copy keeps each module's test helpers its
-    /// own.
-    ///
-    /// # Panics
-    ///
-    /// Panics when `text` carries no 24-bit foreground sequence. A caller here
-    /// paints a truecolor row on purpose, so an absent sequence is a failure of
-    /// the test rather than an empty result.
-    fn max_red_channel(text: &str) -> u8 {
-        let bytes = text.as_bytes();
-        let needle = TRUECOLOR_FG.as_bytes();
-        let mut best: Option<u8> = None;
-        let mut at = 0;
-        while let Some(found) = bytes[at..].windows(needle.len()).position(|w| w == needle) {
-            let start = at + found + needle.len();
-            let mut end = start;
-            while end < bytes.len() && bytes[end].is_ascii_digit() {
-                end += 1;
-            }
-            if let Ok(red) = std::str::from_utf8(&bytes[start..end])
-                .expect("ASCII digits are valid UTF-8")
-                .parse::<u8>()
-            {
-                best = Some(best.map_or(red, |seen: u8| seen.max(red)));
-            }
-            // `end` is past the needle even when it read no digits, so the scan
-            // always moves on.
-            at = end;
-        }
-        best.expect("a truecolor row must carry a 24-bit foreground sequence")
     }
 
     #[test]

--- a/src/gsw/src/push.rs
+++ b/src/gsw/src/push.rs
@@ -1412,6 +1412,7 @@ mod tests {
 mod ui_tests {
     use super::*;
     use crate::render::Snapshot;
+    use crate::testcolor;
 
     /// A snapshot on `gsw-push` with `origin` available and the given tracking
     /// status. Only the four fields the push feature reads matter here.
@@ -2153,7 +2154,21 @@ mod ui_tests {
     /// A UI holding the message a finished update push leaves behind, posted at
     /// `at`. The state every test below about ageing starts from.
     fn pushed_at(at: Instant) -> PushUi {
-        let mut ui = PushUi::new(false);
+        pushed_with(false, at)
+    }
+
+    /// The same message, on a UI built for a terminal whose color depth is
+    /// `truecolor`.
+    ///
+    /// The color depth is a parameter because it is the value under test. A
+    /// `PushUi` keeps the depth [`PushUi::new`] receives, and gives it to the
+    /// fade at the one point in [`PushUi::overlay`] that colors a row. A test
+    /// that proves the depth arrives there must therefore choose it here: this
+    /// function is the only route from the test suite to `PushUi::new(true)`.
+    /// [`pushed_at`] keeps the 8-color default, which is what every other test
+    /// about ageing reads.
+    fn pushed_with(truecolor: bool, at: Instant) -> PushUi {
+        let mut ui = PushUi::new(truecolor);
         ui.request(&snapshot(tracked(3)), tall_pane(80), at);
         ui.confirm();
         ui.finished(
@@ -2347,6 +2362,136 @@ mod ui_tests {
     /// Stand-in row for the styling tests, which are about the color a status
     /// row is drawn in and not about what it says.
     const TEXT: &str = "Pushed 3 commits to origin/gsw-push (5s ago)";
+
+    /// The start of a 24-bit foreground SGR sequence. The red, green, and blue
+    /// values follow it.
+    const TRUECOLOR_FG: &str = "\x1b[38;2;";
+
+    #[test]
+    fn the_status_message_fades_in_24_bit_color_only_where_the_terminal_takes_it() {
+        // The two tests above read a typed `ColoredString` from
+        // `colorize_status`, and the comment on the first one says why: the
+        // `colored` crate decides from process-global state whether it writes
+        // escape bytes at all. That reason holds for those tests, which supply
+        // the color depth themselves. It does not hold for this one. Here the
+        // color depth is the subject — the question is whether the value
+        // `PushUi::new` received arrives at the one call in `PushUi::overlay`
+        // that colors a row — and the painted bytes are the only place that
+        // answer appears. `testcolor::with_forced_ansi` makes those bytes
+        // stable: it holds the one lock on that global state for both halves of
+        // the comparison.
+        //
+        // Both halves are necessary. The first half alone passes if any other
+        // part of the row writes a 24-bit color. The second half is what shows
+        // that the color depth is the thing that decides.
+        //
+        // The age is half of `STATUS_LIFETIME` for two reasons. The message is
+        // still on screen at that age, well before it expires and leaves an
+        // empty overlay that satisfies the second half for the wrong reason.
+        // And the age is at `COARSE_FADE_AT`, so the 8-color half paints a dim
+        // row and writes an escape sequence of its own. The second half
+        // therefore proves that the row carries no 24-bit color, not merely
+        // that it carries no escapes.
+        let start = t0();
+        let age = STATUS_LIFETIME / 2;
+
+        let (deep, coarse) = testcolor::with_forced_ansi(|| {
+            let deep = pushed_with(true, start)
+                .overlay(tall_pane(80), start + age)
+                .text();
+            let coarse = pushed_with(false, start)
+                .overlay(tall_pane(80), start + age)
+                .text();
+            (deep, coarse)
+        });
+
+        assert!(
+            deep.contains(TRUECOLOR_FG),
+            "a truecolor terminal must get the 24-bit fade, got {deep:?}",
+        );
+        assert!(
+            !coarse.contains(TRUECOLOR_FG),
+            "an 8-color terminal must get no 24-bit color, got {coarse:?}",
+        );
+    }
+
+    #[test]
+    fn the_status_message_is_painted_darker_the_later_the_overlay_is_drawn() {
+        // The age the fade uses comes out of the UI, and `PushUi::overlay` is
+        // what takes it out. The two fade tests above miss a call that passes a
+        // constant age instead, because they call `colorize_status` directly
+        // and hand it the age themselves. This test reads the brightness of a
+        // row the overlay painted, at two ages, which is what the watch loop
+        // does on every repaint.
+        //
+        // The exception recorded in the test above applies here for the same
+        // reason: the brightness is in the escape bytes, so the row must carry
+        // real ones, and `testcolor::with_forced_ansi` is what makes it do so.
+        //
+        // One cadence before the end of `STATUS_LIFETIME` is the oldest age at
+        // which the message is still on screen, so the two ages are the largest
+        // difference in brightness the overlay can show.
+        let start = t0();
+        let old = STATUS_LIFETIME - STATUS_CADENCE;
+
+        let (fresh, aged) = testcolor::with_forced_ansi(|| {
+            let fresh = pushed_with(true, start)
+                .overlay(tall_pane(80), start)
+                .text();
+            let aged = pushed_with(true, start)
+                .overlay(tall_pane(80), start + old)
+                .text();
+            (fresh, aged)
+        });
+
+        let fresh_max = max_red_channel(&fresh);
+        let aged_max = max_red_channel(&aged);
+        assert!(
+            aged_max < fresh_max,
+            "an older message must be painted darker: fresh={fresh_max} aged={aged_max}",
+        );
+    }
+
+    /// The largest red channel of any 24-bit foreground sequence in `text`.
+    ///
+    /// The fade scales all three channels by one factor, so one channel reports
+    /// the brightness of the whole row.
+    ///
+    /// This copies the `max_r` closure in `render.rs`, which reads the same
+    /// bytes for the same purpose. The original is a closure inside the body of
+    /// one test. To share it, `render.rs` must open its whole test module to
+    /// this one, which gives every test module a route into every other one for
+    /// the sake of twenty lines. A copy keeps each module's test helpers its
+    /// own.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `text` carries no 24-bit foreground sequence. A caller here
+    /// paints a truecolor row on purpose, so an absent sequence is a failure of
+    /// the test rather than an empty result.
+    fn max_red_channel(text: &str) -> u8 {
+        let bytes = text.as_bytes();
+        let needle = TRUECOLOR_FG.as_bytes();
+        let mut best: Option<u8> = None;
+        let mut at = 0;
+        while let Some(found) = bytes[at..].windows(needle.len()).position(|w| w == needle) {
+            let start = at + found + needle.len();
+            let mut end = start;
+            while end < bytes.len() && bytes[end].is_ascii_digit() {
+                end += 1;
+            }
+            if let Ok(red) = std::str::from_utf8(&bytes[start..end])
+                .expect("ASCII digits are valid UTF-8")
+                .parse::<u8>()
+            {
+                best = Some(best.map_or(red, |seen: u8| seen.max(red)));
+            }
+            // `end` is past the needle even when it read no digits, so the scan
+            // always moves on.
+            at = end;
+        }
+        best.expect("a truecolor row must carry a 24-bit foreground sequence")
+    }
 
     #[test]
     fn an_ageing_message_wakes_the_loop_every_second() {

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1256,7 +1256,7 @@ pub(crate) fn strip_ansi(s: &str) -> String {
 mod tests {
     use super::*;
 
-    use crate::testcolor;
+    use crate::testcolor::{self, max_red_channel};
 
     fn opts() -> RenderOptions {
         RenderOptions {
@@ -3219,31 +3219,8 @@ mod tests {
             (fresh_out, aged_out)
         });
 
-        let max_r = |s: &str| {
-            // Extract the largest r-channel from any 38;2;r;g;b foreground sequence.
-            let mut best: Option<u8> = None;
-            let bytes = s.as_bytes();
-            let needle = b"\x1b[38;2;";
-            let mut i = 0;
-            while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
-                let start = i + pos + needle.len();
-                // Read r digits.
-                let mut j = start;
-                while j < bytes.len() && bytes[j].is_ascii_digit() {
-                    j += 1;
-                }
-                if j > start {
-                    if let Ok(r) = std::str::from_utf8(&bytes[start..j]).unwrap().parse::<u8>() {
-                        best = Some(best.map_or(r, |b| b.max(r)));
-                    }
-                }
-                i = j;
-            }
-            best.expect("at least one truecolor sequence")
-        };
-
-        let fresh_max = max_r(&fresh_out);
-        let aged_max = max_r(&aged_out);
+        let fresh_max = max_red_channel(&fresh_out);
+        let aged_max = max_red_channel(&aged_out);
         assert!(
             aged_max < fresh_max,
             "aged row's brightest channel should be lower than fresh row's: fresh={fresh_max} aged={aged_max}",

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1256,7 +1256,7 @@ pub(crate) fn strip_ansi(s: &str) -> String {
 mod tests {
     use super::*;
 
-    use crate::testcolor::{self, max_red_channel};
+    use crate::testcolor::{self, max_red_channel, TRUECOLOR_FG};
 
     fn opts() -> RenderOptions {
         RenderOptions {
@@ -3183,7 +3183,7 @@ mod tests {
         });
         // Truecolor foreground sequences start with `\x1b[38;2;`.
         assert!(
-            out.contains("\x1b[38;2;"),
+            out.contains(TRUECOLOR_FG),
             "rendered file row should contain a truecolor ANSI sequence when truecolor=true",
         );
     }
@@ -3195,7 +3195,7 @@ mod tests {
             render(&snap, &opts())
         });
         assert!(
-            !out.contains("\x1b[38;2;"),
+            !out.contains(TRUECOLOR_FG),
             "8-color mode must not emit any truecolor sequences for file rows",
         );
     }
@@ -3253,33 +3253,13 @@ mod tests {
         )]
         let upper = ((255.0_f32 * FADE_FLOOR).round() as u8).saturating_add(2);
 
-        // Parse every r-channel and assert all are <= upper.
-        let bytes = out.as_bytes();
-        let needle = b"\x1b[38;2;";
-        let mut i = 0;
-        let mut saw_any = false;
-        while let Some(pos) = bytes[i..].windows(needle.len()).position(|w| w == needle) {
-            let start = i + pos + needle.len();
-            let mut j = start;
-            while j < bytes.len() && bytes[j].is_ascii_digit() {
-                j += 1;
-            }
-            if j > start {
-                let r: u8 = std::str::from_utf8(&bytes[start..j])
-                    .unwrap()
-                    .parse()
-                    .unwrap();
-                assert!(
-                    r <= upper,
-                    "every channel on a no-age row should sit at or below the floor (got {r}, upper {upper})",
-                );
-                saw_any = true;
-            }
-            i = j;
-        }
+        // The brightest r-channel bounds every r-channel, so one comparison
+        // covers them all. `max_red_channel` panics when the row carries no
+        // truecolor sequence, which also proves that the row was painted.
+        let brightest = max_red_channel(&out);
         assert!(
-            saw_any,
-            "should have emitted at least one truecolor sequence"
+            brightest <= upper,
+            "every channel on a no-age row should sit at or below the floor (brightest {brightest}, upper {upper})",
         );
     }
 

--- a/src/gsw/src/render.rs
+++ b/src/gsw/src/render.rs
@@ -1256,16 +1256,7 @@ pub(crate) fn strip_ansi(s: &str) -> String {
 mod tests {
     use super::*;
 
-    /// Serializes any test that toggles `colored::control::set_override` —
-    /// the override is process-global, so concurrent toggles race and
-    /// cause intermittent failures. Tests that need ANSI bytes (rather
-    /// than typed `ColoredString::fgcolor` inspection) hold this for the
-    /// duration of their body.
-    ///
-    /// `.unwrap_or_else(|p| p.into_inner())` handles a poisoned mutex
-    /// from a previous panicking test so it doesn't cascade-fail the
-    /// rest of the suite.
-    static COLORED_OVERRIDE_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use crate::testcolor;
 
     fn opts() -> RenderOptions {
         RenderOptions {
@@ -2153,18 +2144,16 @@ mod tests {
         // empty cells to its right. Paint a matching dim background under
         // just the partial cell to bridge that gap.
         //
-        // Force `colored` on so the test inspects the actual ANSI we would
-        // emit on a real terminal; without this the crate strips all codes
-        // in non-TTY test runs.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let e = entry("foo.rs", FileStatus::Modified, true, 9, 1);
-        let with_partial = colorize_bar("█████▍", &e, 0.0, false);
-        let all_full = colorize_bar("██████", &e, 0.0, false);
-        let all_empty = colorize_bar("░░░░░░", &e, 0.0, false);
-        colored::control::unset_override();
+        // `with_forced_ansi` makes `colored` emit codes, so the test inspects
+        // the actual ANSI of a real terminal. Without it the crate removes all
+        // codes in a non-TTY test run.
+        let (with_partial, all_full, all_empty) = testcolor::with_forced_ansi(|| {
+            let e = entry("foo.rs", FileStatus::Modified, true, 9, 1);
+            let with_partial = colorize_bar("█████▍", &e, 0.0, false);
+            let all_full = colorize_bar("██████", &e, 0.0, false);
+            let all_empty = colorize_bar("░░░░░░", &e, 0.0, false);
+            (with_partial, all_full, all_empty)
+        });
 
         assert!(
             with_partial.contains("\x1b[48"),
@@ -2553,9 +2542,9 @@ mod tests {
     fn stale_age_renders_differently_from_aging() {
         // AgeDim has four buckets; if Stale and Aging both render `.dimmed()`
         // the bucket distinction is invisible to the user. Compare the Style
-        // bitsets on the returned ColoredStrings directly — avoids touching
-        // `colored::control::set_override`, which is process-global and would
-        // race with other tests in parallel.
+        // bitsets on the returned ColoredStrings directly. This test needs no
+        // ANSI bytes, so it does not force the process-global `colored`
+        // override and does not wait for the lock in `testcolor`.
         use colored::Styles;
         let aging = colorize_age("12h0m", Some(Duration::from_secs(2 * 3600)), 0.0, false);
         let stale = colorize_age("12h0m", Some(Duration::from_secs(2 * 86400)), 0.0, false);
@@ -3184,17 +3173,14 @@ mod tests {
 
     #[test]
     fn file_row_renders_with_truecolor_when_enabled() {
-        // Force the colored crate to actually emit ANSI in the test process so
-        // we can detect the truecolor codes from the rendered output.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
-        let mut o = opts();
-        o.truecolor = true;
-        let out = render(&snap, &o);
-        colored::control::unset_override();
+        // `with_forced_ansi` makes the `colored` crate emit ANSI in the test
+        // process, so the test finds the truecolor codes in the output.
+        let out = testcolor::with_forced_ansi(|| {
+            let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+            let mut o = opts();
+            o.truecolor = true;
+            render(&snap, &o)
+        });
         // Truecolor foreground sequences start with `\x1b[38;2;`.
         assert!(
             out.contains("\x1b[38;2;"),
@@ -3204,13 +3190,10 @@ mod tests {
 
     #[test]
     fn file_row_no_truecolor_in_8_color_mode() {
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
-        let out = render(&snap, &opts());
-        colored::control::unset_override();
+        let out = testcolor::with_forced_ansi(|| {
+            let snap = snap_with(vec![entry("src/foo.rs", FileStatus::Modified, false, 5, 2)]);
+            render(&snap, &opts())
+        });
         assert!(
             !out.contains("\x1b[38;2;"),
             "8-color mode must not emit any truecolor sequences for file rows",
@@ -3221,22 +3204,20 @@ mod tests {
     fn file_row_darkens_with_mtime_under_truecolor() {
         // End-to-end: an older file's row should contain a darker (lower-channel)
         // truecolor sequence than a fresher row of the same status.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let mut fresh_entry = entry("src/foo.rs", FileStatus::Modified, false, 5, 2);
-        fresh_entry.age = Some(Duration::from_secs(0));
-        let mut aged_entry = entry("src/bar.rs", FileStatus::Modified, false, 5, 2);
-        aged_entry.age = Some(Duration::from_secs(60 * 60));
+        let (fresh_out, aged_out) = testcolor::with_forced_ansi(|| {
+            let mut fresh_entry = entry("src/foo.rs", FileStatus::Modified, false, 5, 2);
+            fresh_entry.age = Some(Duration::from_secs(0));
+            let mut aged_entry = entry("src/bar.rs", FileStatus::Modified, false, 5, 2);
+            aged_entry.age = Some(Duration::from_secs(60 * 60));
 
-        let fresh_snap = snap_with(vec![fresh_entry]);
-        let aged_snap = snap_with(vec![aged_entry]);
-        let mut o = opts();
-        o.truecolor = true;
-        let fresh_out = render(&fresh_snap, &o);
-        let aged_out = render(&aged_snap, &o);
-        colored::control::unset_override();
+            let fresh_snap = snap_with(vec![fresh_entry]);
+            let aged_snap = snap_with(vec![aged_entry]);
+            let mut o = opts();
+            o.truecolor = true;
+            let fresh_out = render(&fresh_snap, &o);
+            let aged_out = render(&aged_snap, &o);
+            (fresh_out, aged_out)
+        });
 
         let max_r = |s: &str| {
             // Extract the largest r-channel from any 38;2;r;g;b foreground sequence.
@@ -3274,17 +3255,14 @@ mod tests {
         // Deleted file (age=None) should produce only sequences with channels
         // at or below the FADE_FLOOR fraction of their base.
         use crate::age::FADE_FLOOR;
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
-        e.age = None;
-        let snap = snap_with(vec![e]);
-        let mut o = opts();
-        o.truecolor = true;
-        let out = render(&snap, &o);
-        colored::control::unset_override();
+        let out = testcolor::with_forced_ansi(|| {
+            let mut e = entry("deleted.rs", FileStatus::Deleted, true, 0, 5);
+            e.age = None;
+            let snap = snap_with(vec![e]);
+            let mut o = opts();
+            o.truecolor = true;
+            render(&snap, &o)
+        });
 
         // The brightest channel allowed at the floor is `255 × FADE_FLOOR`
         // (a base channel of 255 hits the highest floor). Use that as the
@@ -3444,15 +3422,13 @@ mod tests {
         // marker in one fg sequence + one reset — not pay 3× the ANSI overhead
         // by re-emitting the sequence for every char of "bin". Holds for both
         // 8-color and truecolor paths.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
-        e.binary = true;
-        let out_ansi = colorize_bar("bin", &e, 0.0, false);
-        let out_tc = colorize_bar("bin", &e, 0.0, true);
-        colored::control::unset_override();
+        let (out_ansi, out_tc) = testcolor::with_forced_ansi(|| {
+            let mut e = entry("assets/logo.png", FileStatus::Modified, true, 0, 0);
+            e.binary = true;
+            let out_ansi = colorize_bar("bin", &e, 0.0, false);
+            let out_tc = colorize_bar("bin", &e, 0.0, true);
+            (out_ansi, out_tc)
+        });
         assert_eq!(
             out_ansi.matches("\x1b[").count(),
             2,
@@ -3495,24 +3471,21 @@ mod tests {
 
     #[test]
     fn behind_segment_is_yellow_and_sits_before_the_suffix() {
-        // The behind segment is warning-colored (yellow + bold). Force
-        // `colored` on so the rendered header carries the real ANSI we'd
-        // emit on a terminal, then assert: (1) a yellow SGR appears, (2) the
+        // The behind segment is warning-colored (yellow + bold).
+        // `with_forced_ansi` makes the rendered header carry the real ANSI of
+        // a terminal. The test then asserts: (1) a yellow SGR appears, (2) the
         // plain text is `…ahead of main, 87 behind • ↑2 ↓0 …` with the
         // segment wedged between the base name and the upstream field.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let mut snap = snap_with(vec![]);
-        snap.commits_behind = 87;
-        snap.upstream = Some(UpstreamStatus {
-            name: "origin/gsv".into(),
-            ahead: 2,
-            behind: 0,
+        let rendered = testcolor::with_forced_ansi(|| {
+            let mut snap = snap_with(vec![]);
+            snap.commits_behind = 87;
+            snap.upstream = Some(UpstreamStatus {
+                name: "origin/gsv".into(),
+                ahead: 2,
+                behind: 0,
+            });
+            render(&snap, &opts())
         });
-        let rendered = render(&snap, &opts());
-        colored::control::unset_override();
 
         let header_line = rendered.lines().next().unwrap_or("");
         assert!(
@@ -3564,26 +3537,24 @@ mod tests {
         // formatted age and no fade color byte changes. One-shot mode and the
         // seed walk render at ZERO and rely on this exactness.
         //
-        // Force `colored` on under the shared override guard so the
-        // comparison exercises the actual ANSI bytes and a concurrent test
-        // toggling the process-global override can't flip it between our two
-        // render calls and make identical frames compare unequal.
-        let _guard = COLORED_OVERRIDE_GUARD
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        colored::control::set_override(true);
-        let mut snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
-        snap.files[0].age = Some(Duration::from_secs(20));
-        snap.log = vec![LogEntry {
-            hash: "abc1234".into(),
-            subject: "test".into(),
-            age: Some(Duration::from_secs(100)),
-        }];
-        let mut o = opts();
-        o.log_lines = 5;
-        let with_offset = render_with_offset(&snap, &o, Duration::ZERO);
-        let baseline = render(&snap, &o);
-        colored::control::unset_override();
+        // `with_forced_ansi` holds the one shared lock on the process-global
+        // override, so the comparison sees the actual ANSI bytes and no
+        // concurrent test changes the override between the two render calls
+        // and makes identical frames compare unequal.
+        let (with_offset, baseline) = testcolor::with_forced_ansi(|| {
+            let mut snap = snap_with(vec![entry("a.rs", FileStatus::Modified, true, 1, 0)]);
+            snap.files[0].age = Some(Duration::from_secs(20));
+            snap.log = vec![LogEntry {
+                hash: "abc1234".into(),
+                subject: "test".into(),
+                age: Some(Duration::from_secs(100)),
+            }];
+            let mut o = opts();
+            o.log_lines = 5;
+            let with_offset = render_with_offset(&snap, &o, Duration::ZERO);
+            let baseline = render(&snap, &o);
+            (with_offset, baseline)
+        });
         assert_eq!(with_offset, baseline);
     }
 }

--- a/src/gsw/src/testcolor.rs
+++ b/src/gsw/src/testcolor.rs
@@ -59,6 +59,10 @@ pub(crate) fn with_forced_ansi<T>(body: impl FnOnce() -> T) -> T {
 /// would deadlock. Such a test calls `force` instead and holds the lock itself.
 /// No other caller has a reason to use this function.
 fn force<T>(body: impl FnOnce() -> T) -> T {
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "this is the helper the ban points every other caller at; the one call that sets the override lives here"
+    )]
     colored::control::set_override(true);
     // Build the guard before the body runs. A call to
     // `colored::control::unset_override()` after `body()` runs only when `body`
@@ -77,6 +81,10 @@ struct Restore;
 
 impl Drop for Restore {
     fn drop(&mut self) {
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "this is the helper the ban points every other caller at; the one call that puts the override back lives here"
+        )]
         colored::control::unset_override();
     }
 }

--- a/src/gsw/src/testcolor.rs
+++ b/src/gsw/src/testcolor.rs
@@ -1,0 +1,99 @@
+//! Test-only control of the `colored` crate's global override: one lock, one
+//! entrance.
+//!
+//! Some tests must see real ANSI bytes. The `colored` crate emits no escape
+//! codes when it writes to something that is not a terminal, and a test run is
+//! never a terminal, so those tests turn the codes on with
+//! `colored::control::set_override(true)`. That override is process-global, and
+//! `cargo test` runs the tests of one binary on many threads at the same time.
+//! One test that turns the override on therefore changes what a different test
+//! sees, and one test that turns it off again removes the escapes a different
+//! test is in the middle of reading. The result is a failure that appears and
+//! disappears between runs.
+//!
+//! The cure is a lock that every such test holds. A lock only serializes the
+//! tests that share the same lock, so a second copy of this mutex in a second
+//! module gives no protection at all: two mutexes let two tests hold one each
+//! and both run. For that reason this module keeps the only mutex, and it keeps
+//! it private. [`with_forced_ansi`] is the sole way to reach it, from every test
+//! module in the crate.
+
+use std::sync::{Mutex, PoisonError};
+
+/// The one lock on the `colored` crate's global override.
+///
+/// It is private on purpose. A caller that could lock it directly could also
+/// hold it across an unrelated body, or forget to put the override back, which
+/// is the exact failure this module removes. [`with_forced_ansi`] holds it for
+/// one body and gives it up at the end of that body.
+static OVERRIDE: Mutex<()> = Mutex::new(());
+
+/// Run `body` with the `colored` crate forced to emit ANSI escape codes, and
+/// give the process-global override back to its earlier state at the end.
+///
+/// The lock is held for the whole call, so two tests that both want real ANSI
+/// bytes run one after the other. The override goes back even when `body`
+/// panics, so one failed test leaves the next test a clean process.
+///
+/// A poisoned mutex is recovered, not propagated. Poison here records that some
+/// earlier test panicked while it held the lock. The data behind the lock is a
+/// unit value with no invariant to break, so the panic tells this module
+/// nothing, and a propagated poison turns one real failure into a cascade of
+/// unrelated ones.
+pub(crate) fn with_forced_ansi<T>(body: impl FnOnce() -> T) -> T {
+    let _lock = OVERRIDE.lock().unwrap_or_else(PoisonError::into_inner);
+    force(body)
+}
+
+/// The forcing half of [`with_forced_ansi`], without the lock.
+///
+/// This split exists for the tests of this module. [`OVERRIDE`] is a plain
+/// `Mutex`, which is not reentrant, so a test that holds the lock to read the
+/// override before and after the body cannot also call [`with_forced_ansi`] —
+/// that call would wait for a lock the same thread already holds, and the test
+/// would deadlock. Such a test calls `force` instead and holds the lock itself.
+/// No other caller has a reason to use this function.
+fn force<T>(body: impl FnOnce() -> T) -> T {
+    body()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{force, with_forced_ansi, OVERRIDE};
+
+    use std::sync::PoisonError;
+
+    use colored::control::SHOULD_COLORIZE;
+    use colored::Colorize;
+
+    /// The first byte of every ANSI escape sequence the `colored` crate writes.
+    const ESCAPE: &str = "\u{1b}[";
+
+    #[test]
+    fn forcing_makes_colored_emit_escapes() {
+        let painted = with_forced_ansi(|| "x".red().to_string());
+        assert!(
+            painted.contains(ESCAPE),
+            "expected ANSI escapes in {painted:?}"
+        );
+    }
+
+    #[test]
+    fn the_override_goes_back_when_the_body_ends() {
+        // Hold the lock for all three reads. No other test can change the
+        // override between them, so the before and after values are comparable.
+        // The test holds the lock itself and calls `force`, because the lock is
+        // not reentrant.
+        let _lock = OVERRIDE.lock().unwrap_or_else(PoisonError::into_inner);
+
+        let ambient = SHOULD_COLORIZE.should_colorize();
+        let inside = force(|| SHOULD_COLORIZE.should_colorize());
+
+        assert!(inside, "the body must run with the override on");
+        assert_eq!(
+            SHOULD_COLORIZE.should_colorize(),
+            ambient,
+            "the override must go back to what it was before the body"
+        );
+    }
+}

--- a/src/gsw/src/testcolor.rs
+++ b/src/gsw/src/testcolor.rs
@@ -1,5 +1,10 @@
-//! Test-only control of the `colored` crate's global override: one lock, one
-//! entrance.
+//! Test-only support for the ANSI escape codes the `colored` crate writes.
+//!
+//! The module has two jobs. It controls whether the `colored` crate writes
+//! escape codes at all, through one lock and one entrance. And it reads the
+//! codes that the crate wrote, through [`max_red_channel`]. A test that forces
+//! the codes on almost always goes on to read a color out of them, so the
+//! reader belongs beside the lock.
 //!
 //! Some tests must see real ANSI bytes. The `colored` crate emits no escape
 //! codes when it writes to something that is not a terminal, and a test run is
@@ -74,6 +79,46 @@ impl Drop for Restore {
     fn drop(&mut self) {
         colored::control::unset_override();
     }
+}
+
+/// The start of a 24-bit foreground SGR sequence. The red, green, and blue
+/// values follow it.
+pub(crate) const TRUECOLOR_FG: &str = "\x1b[38;2;";
+
+/// The largest red channel of any 24-bit foreground sequence in `text`.
+///
+/// The fade scales all three channels by one factor, so one channel reports the
+/// brightness of the whole row.
+///
+/// The scan finds every [`TRUECOLOR_FG`] prefix in `text` and reads the digits
+/// that follow it. A malformed sequence contributes nothing and breaks nothing:
+/// a prefix with no digits after it, and a red value above 255, both fail to
+/// parse and the scan drops them. The cursor moves past the prefix on every
+/// turn, even when the digits are absent, so the scan always ends.
+///
+/// # Panics
+///
+/// Panics when `text` carries no 24-bit foreground sequence. A caller paints a
+/// truecolor row on purpose, so an absent sequence is a failure of the test
+/// rather than an empty result.
+pub(crate) fn max_red_channel(text: &str) -> u8 {
+    let bytes = text.as_bytes();
+    let needle = TRUECOLOR_FG.as_bytes();
+    let mut best: Option<u8> = None;
+    let mut at = 0;
+    while let Some(found) = bytes[at..].windows(needle.len()).position(|w| w == needle) {
+        let start = at + found + needle.len();
+        let mut end = start;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        let digits = std::str::from_utf8(&bytes[start..end]).expect("ASCII digits are valid UTF-8");
+        if let Ok(red) = digits.parse::<u8>() {
+            best = Some(best.map_or(red, |seen: u8| seen.max(red)));
+        }
+        at = end;
+    }
+    best.expect("a truecolor row must carry a 24-bit foreground sequence")
 }
 
 #[cfg(test)]

--- a/src/gsw/src/testcolor.rs
+++ b/src/gsw/src/testcolor.rs
@@ -54,7 +54,26 @@ pub(crate) fn with_forced_ansi<T>(body: impl FnOnce() -> T) -> T {
 /// would deadlock. Such a test calls `force` instead and holds the lock itself.
 /// No other caller has a reason to use this function.
 fn force<T>(body: impl FnOnce() -> T) -> T {
+    colored::control::set_override(true);
+    // Build the guard before the body runs. A call to
+    // `colored::control::unset_override()` after `body()` runs only when `body`
+    // returns; a panic in `body` unwinds past it and leaves the override on for
+    // every later test. A guard restores the override on both paths, because
+    // unwinding drops it.
+    let _restore = Restore;
     body()
+}
+
+/// Puts the `colored` crate's global override back when it goes out of scope.
+///
+/// A test body panics as its normal way to fail, so the restore must survive a
+/// panic. Only a `Drop` implementation does that.
+struct Restore;
+
+impl Drop for Restore {
+    fn drop(&mut self) {
+        colored::control::unset_override();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #354.

## The gap

`src/gsw/src/push.rs` passes `self.truecolor` into `colorize_status`. No test held
that wiring. `PushUi::new(true)` appeared nowhere in the test suite, so a literal
`false` at that call site kept all 394 unit tests and 28 integration tests green.
The 24-bit fade on the push status message is a documented `--truecolor` contract,
and it could break in silence.

## What this branch does

- Adds `src/gsw/src/testcolor.rs`, a `#[cfg(test)]` helper that owns one shared
  `Mutex` over `colored`'s process-global override. `render::tests` and
  `push::ui_tests` now lock the same static. Two separate guards do not serialize
  against each other, so one shared guard is necessary.
- Adds a test that posts a fading message on `PushUi::new(true)` and asserts the
  overlay text carries a 24-bit SGR sequence. The same test asserts that
  `PushUi::new(false)` at the same elapsed time does not.
- Bans the raw `colored::control::set_override` API through clippy
  `disallowed-methods` in `src/gsw/clippy.toml`. The test helper is the only
  entrance. This makes the guard an enforced helper, not a convention.
- Replaces the hand-written truecolor channel parsers in `render.rs` with one
  shared scanner.

## Mutation test

I flipped `self.truecolor` to a literal `false` at the `colorize_status` call
site. The new test failed. I restored the code and the test passed again.

## Gates

`cargo fmt --check`, `cargo machete`, `cargo clippy --workspace --all-targets`,
and `cargo test --workspace` all pass. The last commit records that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
