### PR TITLE
feat(cwt): send wtm to master when the repository has no main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ dependencies = [
  "colored",
  "repowalker",
  "shellsetup",
+ "tempfile",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,7 @@ Navigate between git worktrees in a repository. Lists all worktrees, cycles thro
 cwt                           # Show list of worktrees with current highlighted
 cwt -f                        # Go to next worktree (wraps around)
 cwt -p                        # Go to previous worktree (wraps around)
+cwt -m                        # Go to the main worktree
 cwt main                      # Go to worktree by branch name
 cwt absurd-rock               # Go to worktree by directory name
 ```
@@ -1348,9 +1349,24 @@ cwt absurd-rock               # Go to worktree by directory name
 
 - `-f, --forward`: Go to the next worktree in the sorted list (wraps around)
 - `-p, --prev`: Go to the previous worktree (wraps around)
+- `-m, --main`: Go to the main worktree (see [The main worktree](#the-main-worktree))
 - `[TARGET]`: Worktree to switch to (directory name or branch name)
 - `--shell-setup`: Automatically add shell integration to your ~/.zshrc or ~/.bashrc
 - `-q, --quiet`: Suppress error messages
+
+### The main worktree
+
+`cwt -m` (and the `wtm` alias) goes to the worktree on branch `main`. If no worktree is on
+`main`, it goes to the worktree on branch `master`, so a repository that never renamed its
+first branch gets the same shortcut.
+
+The branch name must match exactly. This is what separates `cwt -m` from `cwt main`, which
+also substring-matches: in a `master` repository, `cwt main` lands on a branch such as
+`wt-main-master`, and `cwt -m` does not. A detached worktree has no branch, so it is never
+the main worktree.
+
+If neither branch is checked out anywhere, `cwt -m` lists the worktrees and exits with code
+3.
 
 ### Shell Integration
 
@@ -1387,7 +1403,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt main'  # Main worktree
+alias wtm='wt --main'  # Main worktree (branch main, or master)
 ```
 
 #### Fish (~/.config/fish/config.fish)
@@ -1407,7 +1423,7 @@ end
 # Quick navigation aliases
 alias wtf 'wt -f'  # Next worktree
 alias wtb 'wt -p'  # Previous worktree (back)
-alias wtm 'wt main'  # Main worktree
+alias wtm 'wt --main'  # Main worktree (branch main, or master)
 ```
 
 ### Examples
@@ -1430,7 +1446,7 @@ Jump to specific worktree:
 ```bash
 wt main           # By branch name
 wt absurd-rock    # By directory name
-wtm               # Quick alias for main worktree
+wtm               # Quick alias for the main worktree (branch main, or master)
 ```
 
 ### Exit Codes
@@ -1441,6 +1457,7 @@ wtm               # Quick alias for main worktree
 - `3`: Worktree not found
 - `4`: Could not determine current worktree (for -f/-p)
 - `5`: Shell setup failed
+- `6`: Multiple worktrees matched (be more specific)
 
 ## gitnuke (nuke a worktree)
 

--- a/src/cwt/Cargo.toml
+++ b/src/cwt/Cargo.toml
@@ -14,6 +14,9 @@ colored.workspace = true
 repowalker.workspace = true
 shellsetup.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints.rust]
 # Enforce stricter checks to catch issues early
 unsafe_code = "deny"

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -368,7 +368,11 @@ fn quoted_branch_alternatives(names: &[&str]) -> String {
 /// business and the line is not.
 ///
 /// The list follows an error, so it obeys quiet mode.
-fn print_worktree_line(_wt: &Worktree, _quiet: bool) {}
+fn print_worktree_line(wt: &Worktree, quiet: bool) {
+    let dir = wt.dir_name().unwrap_or("<unknown>");
+    let branch = wt.display_branch();
+    error!(quiet, "  {} [{}]", dir, branch);
+}
 
 /// Prints every worktree to stderr, one [`print_worktree_line`] each.
 ///

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -352,8 +352,12 @@ fn find_main_worktree(worktrees: &[Worktree]) -> Option<usize> {
 /// The missing-main-worktree error is built from [`MAIN_BRANCH_NAMES`] through
 /// this function, so a name added to the constant cannot leave the message
 /// naming a shorter list than the search actually tried.
-fn quoted_branch_alternatives(_names: &[&str]) -> String {
-    String::new()
+fn quoted_branch_alternatives(names: &[&str]) -> String {
+    names
+        .iter()
+        .map(|name| format!("'{name}'"))
+        .collect::<Vec<_>>()
+        .join(" or ")
 }
 
 /// Prints every worktree to stderr as `directory [branch]`.

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -85,18 +85,25 @@ macro_rules! error {
 #[allow(clippy::struct_excessive_bools)] // CLI flags are naturally bool-heavy
 struct Cli {
     /// Go to the next worktree (wraps around).
-    #[arg(short = 'f', long, conflicts_with_all = ["prev", "target", "shell_setup"])]
+    #[arg(short = 'f', long, conflicts_with_all = ["prev", "main", "target", "shell_setup"])]
     forward: bool,
 
     /// Go to the previous worktree (wraps around).
-    #[arg(short = 'p', long, conflicts_with_all = ["forward", "target", "shell_setup"])]
+    #[arg(short = 'p', long, conflicts_with_all = ["forward", "main", "target", "shell_setup"])]
     prev: bool,
+
+    /// Go to the main worktree.
+    ///
+    /// The main worktree is the one on branch `main`, or the one on branch `master` when
+    /// no worktree is on `main`. The branch name must match exactly.
+    #[arg(short = 'm', long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "target", "shell_setup"])]
+    main: bool,
 
     /// Worktree to switch to (directory name, branch name, or branch substring).
     ///
     /// Matches in order: exact directory name, exact branch name, then case-insensitive
     /// substring on branch names. If multiple branches match, lists them and exits.
-    #[arg(conflicts_with_all = ["forward", "prev", "shell_setup"], verbatim_doc_comment)]
+    #[arg(conflicts_with_all = ["forward", "prev", "main", "shell_setup"], verbatim_doc_comment)]
     target: Option<String>,
 
     /// Add shell integration to your shell config. Adds these commands:
@@ -105,7 +112,7 @@ struct Cli {
     ///   wtf          - Next worktree (forward)
     ///   wtb          - Previous worktree (back)
     ///   wtm          - Main worktree
-    #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "target"])]
+    #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "main", "target"])]
     shell_setup: bool,
 
     /// Suppress error messages.
@@ -313,6 +320,13 @@ fn find_worktree_by_name(worktrees: &[Worktree], name: &str) -> WorktreeMatch {
         1 => WorktreeMatch::Single(matches[0]),
         _ => WorktreeMatch::Multiple(matches),
     }
+}
+
+/// Finds the main worktree.
+///
+/// Not implemented yet.
+fn find_main_worktree(_worktrees: &[Worktree]) -> Option<usize> {
+    None
 }
 
 /// Displays the list of worktrees with the current one highlighted.
@@ -829,8 +843,107 @@ mod tests {
         assert_eq!(worktrees[0].branch, Some("main".to_string()));
     }
 
+    /// Builds a worktree fixture at `path` checked out on `branch`.
+    ///
+    /// Pass `None` as the branch for a detached HEAD.
+    fn worktree_on(path: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            path: PathBuf::from(path),
+            head: "abc1234567890".to_string(),
+            branch: branch.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn test_find_main_worktree_picks_main() {
+        let worktrees = vec![
+            worktree_on("/repo", Some("main")),
+            worktree_on("/repo-wt/wt1", Some("feature")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), Some(0));
+    }
+
+    #[test]
+    fn test_find_main_worktree_falls_back_to_master() {
+        // A repository that never renamed master still has a main worktree.
+        let worktrees = vec![
+            worktree_on("/repo-wt/wt1", Some("feature")),
+            worktree_on("/repo", Some("master")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), Some(1));
+    }
+
+    #[test]
+    fn test_find_main_worktree_prefers_main_over_master() {
+        // Both branches exist. main wins, whatever the order of the list.
+        let worktrees = vec![
+            worktree_on("/repo-wt/old", Some("master")),
+            worktree_on("/repo", Some("main")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), Some(1));
+    }
+
+    #[test]
+    fn test_find_main_worktree_ignores_substring_branches() {
+        // The branch name must match exactly. A branch that merely contains
+        // "main" must not capture the main worktree of a master repository.
+        let worktrees = vec![
+            worktree_on("/repo-wt/wt1", Some("wt-main-master")),
+            worktree_on("/repo", Some("master")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), Some(1));
+    }
+
+    #[test]
+    fn test_find_main_worktree_ignores_detached_head() {
+        let worktrees = vec![
+            worktree_on("/repo-wt/wt1", None),
+            worktree_on("/repo", Some("master")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), Some(1));
+    }
+
+    #[test]
+    fn test_find_main_worktree_none_without_main_or_master() {
+        let worktrees = vec![
+            worktree_on("/repo", Some("trunk")),
+            worktree_on("/repo-wt/wt1", Some("wt-main-master")),
+        ];
+        assert_eq!(find_main_worktree(&worktrees), None);
+    }
+
+    #[test]
+    fn test_main_flag_parses() {
+        let long = Cli::try_parse_from(["cwt", "--main"]).expect("--main must parse");
+        assert!(long.main);
+
+        let short = Cli::try_parse_from(["cwt", "-m"]).expect("-m must parse");
+        assert!(short.main);
+
+        let absent = Cli::try_parse_from(["cwt"]).expect("no arguments must parse");
+        assert!(!absent.main);
+    }
+
+    #[test]
+    fn test_main_flag_conflicts_with_other_modes() {
+        // --main selects a worktree, so it cannot combine with the other selectors.
+        for args in [
+            vec!["cwt", "--main", "feature"],
+            vec!["cwt", "--main", "-f"],
+            vec!["cwt", "--main", "-p"],
+            vec!["cwt", "--main", "--shell-setup"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&args).is_err(),
+                "{args:?} must be rejected"
+            );
+        }
+    }
+
     #[test]
     fn test_shell_code_contains_wtm() {
-        assert!(SHELL_CODE.contains("alias wtm='wt main'"));
+        // wtm goes through --main so that it finds master in a repository
+        // that has no main branch.
+        assert!(SHELL_CODE.contains("alias wtm='wt --main'"));
     }
 }

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -360,15 +360,23 @@ fn quoted_branch_alternatives(names: &[&str]) -> String {
         .join(" or ")
 }
 
-/// Prints every worktree to stderr as `directory [branch]`.
+/// Prints one worktree to stderr as `  directory [branch]`.
+///
+/// Both the "not found" and the "multiple matches" errors list worktrees in
+/// this format, so the format lives here and not at either call site. Those
+/// two list different sets of worktrees, which is why the set is the caller's
+/// business and the line is not.
+///
+/// The list follows an error, so it obeys quiet mode.
+fn print_worktree_line(_wt: &Worktree, _quiet: bool) {}
+
+/// Prints every worktree to stderr, one [`print_worktree_line`] each.
 ///
 /// This list follows a "not found" error, so it obeys quiet mode.
 fn print_available_worktrees(worktrees: &[Worktree], quiet: bool) {
     error!(quiet, "Available worktrees:");
     for wt in worktrees {
-        let dir = wt.dir_name().unwrap_or("<unknown>");
-        let branch = wt.display_branch();
-        error!(quiet, "  {} [{}]", dir, branch);
+        print_worktree_line(wt, quiet);
     }
 }
 
@@ -515,10 +523,7 @@ fn main() {
                     "Error: Multiple worktrees match '{}'. Be more specific:", name
                 );
                 for idx in indices {
-                    let wt = &worktrees[idx];
-                    let dir = wt.dir_name().unwrap_or("<unknown>");
-                    let branch = wt.display_branch();
-                    error!(cli.quiet, "  {} [{}]", dir, branch);
+                    print_worktree_line(&worktrees[idx], cli.quiet);
                 }
                 exit(exit_codes::MULTIPLE_MATCHES);
             }

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -347,6 +347,15 @@ fn find_main_worktree(worktrees: &[Worktree]) -> Option<usize> {
     })
 }
 
+/// Formats `names` as a quoted alternation: `'main' or 'master'`.
+///
+/// The missing-main-worktree error is built from [`MAIN_BRANCH_NAMES`] through
+/// this function, so a name added to the constant cannot leave the message
+/// naming a shorter list than the search actually tried.
+fn quoted_branch_alternatives(_names: &[&str]) -> String {
+    String::new()
+}
+
 /// Prints every worktree to stderr as `directory [branch]`.
 ///
 /// This list follows a "not found" error, so it obeys quiet mode.
@@ -483,9 +492,8 @@ fn main() {
         let Some(target_idx) = find_main_worktree(&worktrees) else {
             error!(
                 cli.quiet,
-                "Error: No worktree is on branch '{}' or '{}'",
-                MAIN_BRANCH_NAMES[0],
-                MAIN_BRANCH_NAMES[1]
+                "Error: No worktree is on branch {}",
+                quoted_branch_alternatives(&MAIN_BRANCH_NAMES)
             );
             print_available_worktrees(&worktrees, cli.quiet);
             exit(exit_codes::WORKTREE_NOT_FOUND);
@@ -948,6 +956,41 @@ mod tests {
             worktree_on("/repo-wt/wt1", Some("wt-main-master")),
         ];
         assert_eq!(find_main_worktree(&worktrees), None);
+    }
+
+    #[test]
+    fn test_quoted_branch_alternatives_quotes_a_single_name() {
+        assert_eq!(quoted_branch_alternatives(&["main"]), "'main'");
+    }
+
+    #[test]
+    fn test_quoted_branch_alternatives_joins_two_names() {
+        assert_eq!(
+            quoted_branch_alternatives(&["main", "master"]),
+            "'main' or 'master'"
+        );
+    }
+
+    #[test]
+    fn test_quoted_branch_alternatives_joins_three_names() {
+        // This is the assertion that proves the arity coupling is gone. The old
+        // message read MAIN_BRANCH_NAMES[0] and [1] by index, so a third name
+        // would be searched for and never named. The formatter must render
+        // every name it is given, whatever the length of the slice.
+        assert_eq!(
+            quoted_branch_alternatives(&["main", "master", "trunk"]),
+            "'main' or 'master' or 'trunk'"
+        );
+    }
+
+    #[test]
+    fn test_quoted_branch_alternatives_renders_the_branch_constant() {
+        // Ties the formatter to the constant the not-found message is built
+        // from, so the user-facing text stays what it has always been.
+        assert_eq!(
+            quoted_branch_alternatives(&MAIN_BRANCH_NAMES),
+            "'main' or 'master'"
+        );
     }
 
     #[test]

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -45,6 +45,7 @@ macro_rules! error {
 /// cwt           # Show list of worktrees with current highlighted
 /// cwt -f        # Go to next worktree (wraps around)
 /// cwt -p        # Go to previous worktree (wraps around)
+/// cwt -m        # Go to the main worktree (branch main, or master)
 /// cwt NAME      # Go to worktree by directory name or branch name
 /// cwt TEXT      # Go to worktree by case-insensitive substring match on branch
 /// ```
@@ -67,6 +68,7 @@ macro_rules! error {
 ///
 /// alias wtf='wt -f'  # Next worktree
 /// alias wtb='wt -p'  # Previous worktree (back)
+/// alias wtm='wt --main'  # Main worktree (branch main, or master)
 /// ```
 ///
 /// # Exit Codes
@@ -111,7 +113,7 @@ struct Cli {
     ///   wt [target]  - List worktrees or change to one
     ///   wtf          - Next worktree (forward)
     ///   wtb          - Previous worktree (back)
-    ///   wtm          - Main worktree
+    ///   wtm          - Main worktree (branch main, or master)
     #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "main", "target"])]
     shell_setup: bool,
 
@@ -322,11 +324,39 @@ fn find_worktree_by_name(worktrees: &[Worktree], name: &str) -> WorktreeMatch {
     }
 }
 
-/// Finds the main worktree.
+/// The branch names that identify the main worktree, in order of priority.
 ///
-/// Not implemented yet.
-fn find_main_worktree(_worktrees: &[Worktree]) -> Option<usize> {
-    None
+/// `main` comes first. `master` is the fallback for a repository that never
+/// renamed its first branch.
+const MAIN_BRANCH_NAMES: [&str; 2] = ["main", "master"];
+
+/// Finds the main worktree: the one on branch `main`, or the one on branch
+/// `master` when no worktree is on `main`.
+///
+/// The branch name must match exactly. The substring match that
+/// [`find_worktree_by_name`] does is wrong here: in a repository that has no
+/// `main` branch, a branch such as `wt-main-master` would capture the shortcut
+/// and send the user somewhere that is not the main worktree.
+///
+/// A detached worktree has no branch, so it is never the main worktree.
+fn find_main_worktree(worktrees: &[Worktree]) -> Option<usize> {
+    MAIN_BRANCH_NAMES.iter().find_map(|name| {
+        worktrees
+            .iter()
+            .position(|wt| wt.branch.as_deref() == Some(*name))
+    })
+}
+
+/// Prints every worktree to stderr as `directory [branch]`.
+///
+/// This list follows a "not found" error, so it obeys quiet mode.
+fn print_available_worktrees(worktrees: &[Worktree], quiet: bool) {
+    error!(quiet, "Available worktrees:");
+    for wt in worktrees {
+        let dir = wt.dir_name().unwrap_or("<unknown>");
+        let branch = wt.display_branch();
+        error!(quiet, "  {} [{}]", dir, branch);
+    }
 }
 
 /// Displays the list of worktrees with the current one highlighted.
@@ -372,7 +402,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt main'  # Main worktree
+alias wtm='wt --main'  # Main worktree (branch main, or master)
 "#;
 
 /// Sets up shell integration by adding the wt function to the user's shell config.
@@ -381,7 +411,7 @@ fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
         .with_command("wt", "List worktrees or change to one")
         .with_command("wtf", "Next worktree")
         .with_command("wtb", "Previous worktree (back)")
-        .with_command("wtm", "Main worktree")
+        .with_command("wtm", "Main worktree (branch main, or master)")
         // Old installations ended with this alias (before end marker was added)
         .with_old_end_marker("alias wtb='wt -p'");
 
@@ -448,6 +478,19 @@ fn main() {
             exit(exit_codes::CURRENT_UNKNOWN);
         };
         println!("{}", worktrees[target_idx].path.display());
+    } else if cli.main {
+        // Main worktree: branch main, or branch master when there is no main.
+        let Some(target_idx) = find_main_worktree(&worktrees) else {
+            error!(
+                cli.quiet,
+                "Error: No worktree is on branch '{}' or '{}'",
+                MAIN_BRANCH_NAMES[0],
+                MAIN_BRANCH_NAMES[1]
+            );
+            print_available_worktrees(&worktrees, cli.quiet);
+            exit(exit_codes::WORKTREE_NOT_FOUND);
+        };
+        println!("{}", worktrees[target_idx].path.display());
     } else if let Some(name) = &cli.target {
         // Find by name
         match find_worktree_by_name(&worktrees, name) {
@@ -469,12 +512,7 @@ fn main() {
             }
             WorktreeMatch::None => {
                 error!(cli.quiet, "Error: Worktree '{}' not found", name);
-                error!(cli.quiet, "Available worktrees:");
-                for wt in &worktrees {
-                    let dir = wt.dir_name().unwrap_or("<unknown>");
-                    let branch = wt.display_branch();
-                    error!(cli.quiet, "  {} [{}]", dir, branch);
-                }
+                print_available_worktrees(&worktrees, cli.quiet);
                 exit(exit_codes::WORKTREE_NOT_FOUND);
             }
         }

--- a/src/cwt/tests/common/mod.rs
+++ b/src/cwt/tests/common/mod.rs
@@ -1,0 +1,117 @@
+//! Fixtures shared by the `cwt` end-to-end tests.
+//!
+//! Every end-to-end test needs the same three things: a throwaway repository,
+//! a worktree beside it, and a way to run the binary somewhere inside them.
+//! They live here so that a second test target does not copy them.
+//!
+//! Cargo compiles this module separately into each test binary, so a helper
+//! that only one target calls looks unused to the other. That is what the
+//! blanket `dead_code` allow is for; it is not hiding a helper nobody calls.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+/// Exit code that `cwt` returns when it finds no matching worktree.
+pub const WORKTREE_NOT_FOUND: i32 = 3;
+
+/// Exit code that `cwt` returns when more than one worktree matches.
+pub const MULTIPLE_MATCHES: i32 = 6;
+
+/// Runs a git command in `dir` and returns whether it succeeded.
+///
+/// Output is nulled so that concurrent test runs do not interleave noise. The
+/// git environment of the parent is scrubbed because a run started from a git
+/// hook inherits `GIT_DIR` and friends, which would point every command here at
+/// the wrong repository.
+pub fn run_git(dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Creates a throwaway repository whose first branch is `branch`, with one commit.
+///
+/// The repository is a subdirectory of the [`TempDir`] (keep it alive) so that
+/// the worktrees added beside it are removed with it. gpg signing is disabled
+/// so that a globally configured signer cannot break the commit.
+pub fn init_repo(branch: &str) -> (TempDir, PathBuf) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let repo = temp.path().join(REPO_DIR_NAME);
+    std::fs::create_dir(&repo).expect("failed to create repo subdir");
+
+    assert!(run_git(&repo, &["init", "-b", branch]), "git init failed");
+    assert!(
+        run_git(&repo, &["config", "user.email", "test@example.com"]),
+        "git config user.email failed"
+    );
+    assert!(
+        run_git(&repo, &["config", "user.name", "Test User"]),
+        "git config user.name failed"
+    );
+
+    std::fs::write(repo.join("README.md"), "baseline\n").expect("failed to write baseline file");
+    assert!(run_git(&repo, &["add", "README.md"]), "git add failed");
+    assert!(
+        run_git(
+            &repo,
+            &["-c", "commit.gpgsign=false", "commit", "-m", "baseline"]
+        ),
+        "git commit failed"
+    );
+
+    (temp, repo)
+}
+
+/// Directory name that [`init_repo`] gives the repository it creates.
+///
+/// `cwt` lists a worktree by its directory name, so a test that asserts the
+/// rendered listing has to know what this one is called.
+pub const REPO_DIR_NAME: &str = "repo";
+
+/// Adds a worktree beside `repo` on a new branch, and returns its path.
+///
+/// The directory is named after the branch, so a listing renders the worktree
+/// as `branch [branch]`.
+pub fn add_worktree(temp: &TempDir, repo: &Path, branch: &str) -> PathBuf {
+    let worktree = temp.path().join(branch);
+    let path = worktree.to_str().expect("worktree path is not UTF-8");
+    assert!(
+        run_git(repo, &["worktree", "add", "-b", branch, path]),
+        "git worktree add failed"
+    );
+    worktree
+}
+
+/// Runs the `cwt` binary in `dir` with `args`.
+///
+/// The inherited git environment is scrubbed for the same reason [`run_git`]
+/// scrubs it: these tests can run from inside a pre-commit hook.
+pub fn cwt(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cwt"))
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .output()
+        .expect("failed to run cwt")
+}
+
+/// Runs `cwt --main` in `dir`.
+pub fn cwt_main(dir: &Path) -> Output {
+    cwt(dir, &["--main"])
+}

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -32,8 +32,7 @@ fn run_git(dir: &Path, args: &[&str]) -> bool {
         .env_remove("GIT_INDEX_FILE")
         .env_remove("GIT_PREFIX")
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Creates a throwaway repository whose first branch is `branch`, with one commit.

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -151,3 +151,16 @@ fn repository_without_main_or_master_reports_not_found() {
         "cwt must print no path when it finds no main worktree"
     );
 }
+
+#[test]
+fn not_found_message_names_every_branch_that_was_searched() {
+    let (temp, repo) = init_repo("trunk");
+    let feature = add_worktree(&temp, &repo, "feature");
+
+    let output = cwt_main(&feature);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("'main' or 'master'"),
+        "the not-found message must name every branch cwt searched for, got: {stderr}"
+    );
+}

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -1,0 +1,154 @@
+//! End-to-end coverage for `cwt --main`, the flag behind the `wtm` alias.
+//!
+//! The unit tests in `main.rs` prove how `find_main_worktree` ranks branch
+//! names. These tests prove that the binary applies that ranking to a real
+//! repository: a repository that never renamed `master` still gets a main
+//! worktree, `main` wins wherever both branches exist, and a branch that merely
+//! contains the text "main" never captures the shortcut.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+/// Exit code that `cwt` returns when it finds no matching worktree.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+/// Runs a git command in `dir` and returns whether it succeeded.
+///
+/// Output is nulled so that concurrent test runs do not interleave noise. The
+/// git environment of the parent is scrubbed because a run started from a git
+/// hook inherits `GIT_DIR` and friends, which would point every command here at
+/// the wrong repository.
+fn run_git(dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Creates a throwaway repository whose first branch is `branch`, with one commit.
+///
+/// The repository is a subdirectory of the [`TempDir`] (keep it alive) so that
+/// the worktrees added beside it are removed with it. gpg signing is disabled
+/// so that a globally configured signer cannot break the commit.
+fn init_repo(branch: &str) -> (TempDir, PathBuf) {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("failed to create repo subdir");
+
+    assert!(run_git(&repo, &["init", "-b", branch]), "git init failed");
+    assert!(
+        run_git(&repo, &["config", "user.email", "test@example.com"]),
+        "git config user.email failed"
+    );
+    assert!(
+        run_git(&repo, &["config", "user.name", "Test User"]),
+        "git config user.name failed"
+    );
+
+    std::fs::write(repo.join("README.md"), "baseline\n").expect("failed to write baseline file");
+    assert!(run_git(&repo, &["add", "README.md"]), "git add failed");
+    assert!(
+        run_git(
+            &repo,
+            &["-c", "commit.gpgsign=false", "commit", "-m", "baseline"]
+        ),
+        "git commit failed"
+    );
+
+    (temp, repo)
+}
+
+/// Adds a worktree beside `repo` on a new branch, and returns its path.
+fn add_worktree(temp: &TempDir, repo: &Path, branch: &str) -> PathBuf {
+    let worktree = temp.path().join(branch);
+    let path = worktree.to_str().expect("worktree path is not UTF-8");
+    assert!(
+        run_git(repo, &["worktree", "add", "-b", branch, path]),
+        "git worktree add failed"
+    );
+    worktree
+}
+
+/// Runs `cwt --main` in `dir`.
+fn cwt_main(dir: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_cwt"))
+        .arg("--main")
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+        .output()
+        .expect("failed to run cwt")
+}
+
+/// Asserts that `cwt --main`, run in `from`, printed the path of `expected`.
+///
+/// Both paths are canonicalized because macOS reports the temporary directory
+/// through the `/var` symlink.
+fn assert_main_worktree_is(from: &Path, expected: &Path) {
+    let output = cwt_main(from);
+    assert!(
+        output.status.success(),
+        "cwt --main failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let printed = String::from_utf8(output.stdout).expect("cwt printed invalid UTF-8");
+    let printed = printed.trim();
+    let actual = std::fs::canonicalize(printed)
+        .unwrap_or_else(|e| panic!("cwt printed {printed:?}, which is not a path: {e}"));
+    assert_eq!(
+        actual,
+        std::fs::canonicalize(expected).expect("the expected worktree does not exist"),
+    );
+}
+
+#[test]
+fn master_only_repository_resolves_to_master() {
+    let (temp, repo) = init_repo("master");
+    let feature = add_worktree(&temp, &repo, "feature");
+
+    assert_main_worktree_is(&feature, &repo);
+}
+
+#[test]
+fn main_wins_when_both_branches_have_worktrees() {
+    let (temp, repo) = init_repo("main");
+    let master = add_worktree(&temp, &repo, "master");
+
+    assert_main_worktree_is(&master, &repo);
+}
+
+#[test]
+fn branch_containing_main_does_not_capture_the_main_worktree() {
+    let (temp, repo) = init_repo("master");
+    let decoy = add_worktree(&temp, &repo, "wt-main-master");
+
+    assert_main_worktree_is(&decoy, &repo);
+}
+
+#[test]
+fn repository_without_main_or_master_reports_not_found() {
+    let (temp, repo) = init_repo("trunk");
+    let feature = add_worktree(&temp, &repo, "feature");
+
+    let output = cwt_main(&feature);
+    assert_eq!(output.status.code(), Some(WORKTREE_NOT_FOUND));
+    assert!(
+        output.stdout.is_empty(),
+        "cwt must print no path when it finds no main worktree"
+    );
+}

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -5,93 +5,16 @@
 //! repository: a repository that never renamed `master` still gets a main
 //! worktree, `main` wins wherever both branches exist, and a branch that merely
 //! contains the text "main" never captures the shortcut.
+//!
+//! The repository fixtures and the binary runner are shared with the other
+//! end-to-end targets and live in [`common`]. Only the `--main` assertions are
+//! here.
 
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
+mod common;
 
-use tempfile::TempDir;
+use std::path::Path;
 
-/// Exit code that `cwt` returns when it finds no matching worktree.
-const WORKTREE_NOT_FOUND: i32 = 3;
-
-/// Runs a git command in `dir` and returns whether it succeeded.
-///
-/// Output is nulled so that concurrent test runs do not interleave noise. The
-/// git environment of the parent is scrubbed because a run started from a git
-/// hook inherits `GIT_DIR` and friends, which would point every command here at
-/// the wrong repository.
-fn run_git(dir: &Path, args: &[&str]) -> bool {
-    Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_PREFIX")
-        .status()
-        .is_ok_and(|s| s.success())
-}
-
-/// Creates a throwaway repository whose first branch is `branch`, with one commit.
-///
-/// The repository is a subdirectory of the [`TempDir`] (keep it alive) so that
-/// the worktrees added beside it are removed with it. gpg signing is disabled
-/// so that a globally configured signer cannot break the commit.
-fn init_repo(branch: &str) -> (TempDir, PathBuf) {
-    let temp = TempDir::new().expect("failed to create temp dir");
-    let repo = temp.path().join("repo");
-    std::fs::create_dir(&repo).expect("failed to create repo subdir");
-
-    assert!(run_git(&repo, &["init", "-b", branch]), "git init failed");
-    assert!(
-        run_git(&repo, &["config", "user.email", "test@example.com"]),
-        "git config user.email failed"
-    );
-    assert!(
-        run_git(&repo, &["config", "user.name", "Test User"]),
-        "git config user.name failed"
-    );
-
-    std::fs::write(repo.join("README.md"), "baseline\n").expect("failed to write baseline file");
-    assert!(run_git(&repo, &["add", "README.md"]), "git add failed");
-    assert!(
-        run_git(
-            &repo,
-            &["-c", "commit.gpgsign=false", "commit", "-m", "baseline"]
-        ),
-        "git commit failed"
-    );
-
-    (temp, repo)
-}
-
-/// Adds a worktree beside `repo` on a new branch, and returns its path.
-fn add_worktree(temp: &TempDir, repo: &Path, branch: &str) -> PathBuf {
-    let worktree = temp.path().join(branch);
-    let path = worktree.to_str().expect("worktree path is not UTF-8");
-    assert!(
-        run_git(repo, &["worktree", "add", "-b", branch, path]),
-        "git worktree add failed"
-    );
-    worktree
-}
-
-/// Runs `cwt --main` in `dir`.
-fn cwt_main(dir: &Path) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_cwt"))
-        .arg("--main")
-        .current_dir(dir)
-        .stdin(Stdio::null())
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_PREFIX")
-        .output()
-        .expect("failed to run cwt")
-}
+use common::{add_worktree, cwt_main, init_repo, WORKTREE_NOT_FOUND};
 
 /// Asserts that `cwt --main`, run in `from`, printed the path of `expected`.
 ///

--- a/src/cwt/tests/worktree-listing.rs
+++ b/src/cwt/tests/worktree-listing.rs
@@ -1,0 +1,77 @@
+//! End-to-end coverage for the worktree list that `cwt` prints under an error.
+//!
+//! Two different failures list worktrees: "no main worktree" and "not found"
+//! list every worktree, and "multiple matches" lists only the ones that
+//! matched. The sets differ, the rendering does not, so these tests pin the
+//! rendered line at both sites and would catch the two drifting apart.
+
+mod common;
+
+use common::{
+    add_worktree, cwt, cwt_main, init_repo, MULTIPLE_MATCHES, REPO_DIR_NAME, WORKTREE_NOT_FOUND,
+};
+
+/// Renders the line `cwt` is expected to print for one worktree.
+///
+/// The indent is two spaces. It is part of the format under test, so it is
+/// spelled out here and the assertions compare whole lines rather than
+/// trimming it away.
+fn worktree_line(dir: &str, branch: &str) -> String {
+    format!("  {dir} [{branch}]")
+}
+
+/// Asserts that `stderr` has a line listing the worktree `dir` on `branch`.
+fn assert_lists(stderr: &str, dir: &str, branch: &str) {
+    let expected = worktree_line(dir, branch);
+    assert!(
+        stderr.lines().any(|line| line == expected),
+        "expected a line {expected:?} in stderr, got:\n{stderr}"
+    );
+}
+
+/// Asserts that `stderr` has no line listing the worktree `dir` on `branch`.
+fn assert_does_not_list(stderr: &str, dir: &str, branch: &str) {
+    let unwanted = worktree_line(dir, branch);
+    assert!(
+        !stderr.lines().any(|line| line == unwanted),
+        "did not expect a line {unwanted:?} in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn not_found_lists_every_worktree() {
+    let (temp, repo) = init_repo("trunk");
+    add_worktree(&temp, &repo, "feature");
+
+    let output = cwt_main(&repo);
+    assert_eq!(output.status.code(), Some(WORKTREE_NOT_FOUND));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Available worktrees:"),
+        "the not-found error must introduce the list, got:\n{stderr}"
+    );
+    assert_lists(&stderr, REPO_DIR_NAME, "trunk");
+    assert_lists(&stderr, "feature", "feature");
+}
+
+#[test]
+fn multiple_matches_lists_every_candidate() {
+    let (temp, repo) = init_repo("trunk");
+    add_worktree(&temp, &repo, "feature-alpha");
+    add_worktree(&temp, &repo, "feature-beta");
+
+    let output = cwt(&repo, &["feature"]);
+    assert_eq!(output.status.code(), Some(MULTIPLE_MATCHES));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Multiple worktrees match 'feature'"),
+        "the ambiguous-match error must name the search term, got:\n{stderr}"
+    );
+    assert_lists(&stderr, "feature-alpha", "feature-alpha");
+    assert_lists(&stderr, "feature-beta", "feature-beta");
+    // This arm lists the matches, not every worktree. That is the difference
+    // that kept it off the shared helper; the rendered line is still shared.
+    assert_does_not_list(&stderr, REPO_DIR_NAME, "trunk");
+}


### PR DESCRIPTION
## Problem

The `wtm` alias was `wt main`, a substring search for the text "main". In a repository that never renamed `master`, it found nothing. Worse, it could land on an unrelated branch whose name contains "main" — for example `wt-main-master`.

## Change

Add `cwt --main`, which resolves the main worktree by exact branch name: `main` first, then `master`. The `wtm` alias becomes `wt --main`.

Users must run `cwt --shell-setup` again to pick up the new alias.

## Tests

TDD red then green. Ten new tests cover the resolution order and the failure case:

- `src/cwt/tests/main-worktree.rs` — end-to-end tests over real repositories.
- Unit tests in `src/cwt/src/main.rs`.

The red commit added the tests against a `find_main_worktree` stub that returns `None`.

## Docs

`README.md` records what the main worktree is, why the match is exact where `cwt main` substring-matches, the new `wtm` alias in both manual-setup snippets, and the missing exit code 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
