### PR TITLE
feat(cwt): treat a parent repository and its children as one family

### DIFF
--- a/README.md
+++ b/README.md
@@ -1408,6 +1408,15 @@ The family is the same from anywhere inside it, so `cwt` gets you out of a child
 repository as easily as it gets you in. Only one level is scanned: a child of a child
 is that child's business.
 
+A directory that looks like a repository but has no worktree to offer — a bare
+repository, which git lists without a HEAD — cannot join the family, because there is
+nothing there to change into. `cwt` leaves it out of the listing and says so on
+standard error, so a directory you can see is never missing without a reason:
+
+```text
+Warning: skipped /code/keyboards/archive: no worktrees to list
+```
+
 #### Which repository answers a name
 
 A name is offered to each repository in turn, nearest first:

--- a/README.md
+++ b/README.md
@@ -350,10 +350,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     the repository.
   - To install: `cargo install --git https://github.com/timmattison/tools nwt`
 - cwt
-  - Change Worktree - Navigate between git worktrees in a repository. Shows a list of all
-    worktrees with the current one highlighted, or cycle through them with `-f` (forward) and
-    `-p` (previous). Can also jump directly to a worktree by directory name or branch name.
-    Use `--shell-setup` to automatically add shell integration to your config.
+  - Change Worktree - Navigate between the git worktrees of a repository and of the
+    repositories inside it. Shows a list of all worktrees with the current one highlighted,
+    or cycle through them with `-f` (forward) and `-p` (previous). Can also jump directly to
+    a worktree by directory name or branch name. Use `--no-family` to stay inside one
+    repository, and `--shell-setup` to automatically add shell integration to your config.
   - To install: `cargo install --git https://github.com/timmattison/tools cwt`
 - gitnuke
   - Removes a git worktree and deletes the branch it had checked out, resolved as one
@@ -1332,7 +1333,7 @@ nwt --tmux --run "code ."
 
 ## cwt (change worktree)
 
-Navigate between git worktrees in a repository. Lists all worktrees, cycles through them, or jumps to a specific one by name.
+Navigate between the git worktrees of a repository and of the repositories inside it. Lists them all, cycles through them, or jumps to a specific one by name.
 
 ### Basic Usage
 
@@ -1343,7 +1344,7 @@ cwt -p                        # Go to previous worktree (wraps around)
 cwt -m                        # Go to the main worktree
 cwt main                      # Go to worktree by branch name
 cwt absurd-rock               # Go to worktree by directory name
-cwt vial-qmk:main             # Go to one repository's worktree by name
+cwt vial-qmk:vial             # Go to one repository's worktree by name
 ```
 
 ### Options
@@ -1537,9 +1538,9 @@ alias wtm 'wt --main'  # Main worktree (branch main, or master)
 Show all worktrees with current highlighted:
 ```bash
 cwt
-#   /path/to/repo                    [main]
-# > /path/to/repo-worktrees/absurd   [feature-branch]
-#   /path/to/repo-worktrees/zen      [fix-bug]
+#   /path/to/repo                        [main]
+# > /path/to/repo-worktrees/absurd-rock  [feature-branch]
+#   /path/to/repo-worktrees/zen          [fix-bug]
 ```
 
 Cycle through worktrees:

--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,24 @@ cwt zmk-config-corne:master    # that repository's master
 cwt zmk:                       # that repository's main worktree
 ```
 
+Every name `cwt` prints can be typed straight back, so two repositories of one family
+cannot be left sharing a name — not even the parent and a child named after it. The
+child is listed, and typed, as the path that leads to it:
+
+```bash
+cd keyboards && cwt
+# keyboards
+# >   /code/keyboards                              [main]
+#
+# keyboards/keyboards
+#     /code/keyboards/keyboards                    [main]
+#     /code/keyboards/keyboards-worktrees/inner    [inner]
+
+cwt keyboards:                 # the parent
+cwt keyboards/keyboards:       # the child checked out inside it
+cwt keyboards/keyboards:inner  # a worktree of that child
+```
+
 #### Staying in one repository
 
 `--no-family` confines the listing, the cycling, and the name search to the repository

--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,7 @@ cwt -p                        # Go to previous worktree (wraps around)
 cwt -m                        # Go to the main worktree
 cwt main                      # Go to worktree by branch name
 cwt absurd-rock               # Go to worktree by directory name
+cwt vial-qmk:main             # Go to one repository's worktree by name
 ```
 
 ### Options
@@ -1350,7 +1351,8 @@ cwt absurd-rock               # Go to worktree by directory name
 - `-f, --forward`: Go to the next worktree in the sorted list (wraps around)
 - `-p, --prev`: Go to the previous worktree (wraps around)
 - `-m, --main`: Go to the main worktree (see [The main worktree](#the-main-worktree))
-- `[TARGET]`: Worktree to switch to (directory name or branch name)
+- `[TARGET]`: Worktree to switch to (directory name, branch name, or `REPO:NAME`)
+- `--no-family`: List only the repository you are standing in
 - `--shell-setup`: Automatically add shell integration to your ~/.zshrc or ~/.bashrc
 - `-q, --quiet`: Suppress error messages
 
@@ -1360,13 +1362,90 @@ cwt absurd-rock               # Go to worktree by directory name
 `main`, it goes to the worktree on branch `master`, so a repository that never renamed its
 first branch gets the same shortcut.
 
+In a family, `cwt -m` stays in the repository you are standing in. Every repository of a
+family has a main worktree of its own, and the shortcut takes you to yours.
+
 The branch name must match exactly. This is what separates `cwt -m` from `cwt main`, which
 also substring-matches: in a `master` repository, `cwt main` lands on a branch such as
 `wt-main-master`, and `cwt -m` does not. A detached worktree has no branch, so it is never
 the main worktree.
 
-If neither branch is checked out anywhere, `cwt -m` lists the worktrees and exits with code
-3.
+If your repository has neither branch checked out, `cwt -m` lists the worktrees and exits
+with code 3.
+
+### Families of Repositories
+
+Some repositories are containers. They track the map of a workspace, and the real
+repositories sit one level below them, kept out of the parent's history by
+`.gitignore`:
+
+```text
+keyboards/                    # the parent repository
+  qmk_firmware/               # a repository of its own
+  vial/                       # a repository of its own
+  vial-qmk/                   # a repository of its own
+  zmk-config-corne/           # a repository of its own
+```
+
+`cwt` treats the parent and its children as one **family**. One listing shows every
+worktree of every repository, grouped by repository, and one name reaches any of them:
+
+```bash
+cd keyboards && cwt
+# keyboards
+# >   /code/keyboards                                          [main]
+#     /code/keyboards-worktrees/keymap-parity-tool             [keymap-parity-tool]
+#
+# qmk_firmware
+#     /code/keyboards/qmk_firmware                             [master]
+#
+# vial-qmk
+#     /code/keyboards/vial-qmk                                 [vial]
+#     /code/keyboards/vial-qmk-worktrees/split-handedness-build [split-handedness-build]
+```
+
+The family is the same from anywhere inside it, so `cwt` gets you out of a child
+repository as easily as it gets you in. Only one level is scanned: a child of a child
+is that child's business.
+
+#### Which repository answers a name
+
+A name is offered to each repository in turn, nearest first:
+
+1. The repository you are standing in
+2. The parent repository the family is anchored at
+3. Every other repository in the family
+
+So `wtm` still means "my repository's main branch" wherever you are standing. Within
+each repository the order is the same as before: exact directory name, then exact
+branch name, then a case-insensitive substring of a branch name. An exact name
+anywhere in the family beats a substring anywhere.
+
+#### When two repositories share a name
+
+`cwt` refuses to guess, and names the candidates the way you have to type them:
+
+```bash
+cwt master
+# Error: Multiple worktrees match 'master'. Be more specific:
+#   qmk_firmware:qmk_firmware [master]
+#   zmk-config-corne:zmk-config-corne [master]
+```
+
+A `REPO:NAME` target searches one repository of the family. The repository can be
+named in full or by any part of its name, and `REPO:` on its own selects that
+repository's main worktree:
+
+```bash
+cwt zmk-config-corne:master    # that repository's master
+cwt zmk:                       # that repository's main worktree
+```
+
+#### Staying in one repository
+
+`--no-family` confines the listing, the cycling, and the name search to the repository
+you are standing in. Set `CWT_NO_FAMILY` to any value other than `0` to make that the
+default.
 
 ### Shell Integration
 
@@ -1446,6 +1525,7 @@ Jump to specific worktree:
 ```bash
 wt main           # By branch name
 wt absurd-rock    # By directory name
+wt vial-qmk:vial  # By repository and branch name
 wtm               # Quick alias for the main worktree (branch main, or master)
 ```
 
@@ -1457,7 +1537,7 @@ wtm               # Quick alias for the main worktree (branch main, or master)
 - `3`: Worktree not found
 - `4`: Could not determine current worktree (for -f/-p)
 - `5`: Shell setup failed
-- `6`: Multiple worktrees matched (be more specific)
+- `6`: Multiple worktrees matched the name (be more specific)
 
 ## gitnuke (nuke a worktree)
 

--- a/TLDR.md
+++ b/TLDR.md
@@ -13,7 +13,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `claude-usage` | Parses an Anthropic API usage CSV and computes per-model costs. |
 | `clipboard-random` | Generates random binary or Zalgo text data and copies it to the clipboard. |
 | `crap` | Claude, Resume Anywhere Please — resume a Claude Code session from its original directory (refuses if it's already running, or if that directory is gone or unenterable — pointing you at `--here` to fork where you stand); if the id belongs to another account it's found automatically (self-first), or target one with `--user` (which errors and lists the real accounts if you name one that never ran Claude); owner-only project dirs are skipped, then named in the miss with copy-paste recovery commands — it never runs `sudo` itself; `--status <id>` reports where a session left off without resuming, with the same `--user`/self-first cross-user discovery but read-only (no copy, no fork). |
-| `cwt` | Change Worktree — navigate, cycle, or jump between git worktrees. |
+| `cwt` | Change Worktree — navigate, cycle, or jump between the git worktrees of a repository and of the repositories inside it. |
 | `dirc` | Copies the current directory to the clipboard, or emits a `cd` from a clipboard path. |
 | `dirhash` | SHA256 hash of a directory tree's contents to compare directories for equality. |
 | `diskhog` | Live terminal UI of per-process disk I/O on macOS (IOPS with sudo). |

--- a/src/cwt/Cargo.toml
+++ b/src/cwt/Cargo.toml
@@ -29,3 +29,5 @@ missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
+# Byte-level string indexing (&s[..n]) panics when n lands inside a multi-byte UTF-8 character
+string_slice = "warn"

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -1018,6 +1018,22 @@ mod tests {
     }
 
     #[test]
+    fn a_prefix_two_repositories_answer_to_is_refused() {
+        // `discover` gives every repository a name of its own, so this shape
+        // should never reach `find`. If one ever does, the answer is to report
+        // both repositories, never to hand back whichever was found first.
+        let two = family(
+            vec![("dup", "/one", "first"), ("dup", "/two", "second")],
+            true,
+            None,
+        );
+        match two.find("dup:") {
+            WorktreeMatch::Multiple(indices) => assert_eq!(indices, vec![0, 1]),
+            other => panic!("Expected Multiple, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn a_prefix_naming_no_repository_finds_nothing() {
         let two = family(
             vec![("parent", "/p", "main"), ("child", "/p/child", "trunk")],

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -55,6 +55,8 @@ struct Group {
     name: String,
     /// How near this repository is to the user. See [`rank`].
     rank: u8,
+    /// Index into the family's entries of this repository's main worktree.
+    main: usize,
 }
 
 /// One worktree, and the repository it belongs to.
@@ -252,27 +254,87 @@ impl Family {
             return WorktreeMatch::None;
         }
 
+        // A repository prefix narrows the search to one repository of the
+        // family. Git forbids `:` in a branch name, so the separator can never
+        // be part of the name the user means.
+        if let Some((repo, rest)) = name.split_once(':') {
+            return self.find_in_repo(repo, rest);
+        }
+
         let pool: Vec<usize> = (0..self.entries.len()).collect();
         self.search(&pool, name)
+    }
+
+    /// Finds `name` inside the repository the prefix names.
+    ///
+    /// An empty `name` selects that repository's main worktree, so `child-b:`
+    /// reaches child-b even when another repository holds the better match for
+    /// every name child-b has.
+    fn find_in_repo(&self, repo: &str, name: &str) -> WorktreeMatch {
+        if repo.is_empty() {
+            return WorktreeMatch::None;
+        }
+
+        let groups = self.groups_named(repo);
+        if groups.is_empty() {
+            return WorktreeMatch::None;
+        }
+
+        if name.is_empty() {
+            return decide(
+                groups
+                    .iter()
+                    .map(|&group| self.groups[group].main)
+                    .collect(),
+            );
+        }
+
+        let pool: Vec<usize> = (0..self.entries.len())
+            .filter(|&index| groups.contains(&self.entries[index].group))
+            .collect();
+        self.search(&pool, name)
+    }
+
+    /// The repositories a prefix names: the one whose name matches exactly, or
+    /// every one whose name contains the prefix.
+    fn groups_named(&self, prefix: &str) -> Vec<usize> {
+        if let Some(index) = self.groups.iter().position(|group| group.name == prefix) {
+            return vec![index];
+        }
+
+        let wanted = prefix.to_lowercase();
+        self.groups
+            .iter()
+            .enumerate()
+            .filter(|(_, group)| group.name.to_lowercase().contains(&wanted))
+            .map(|(index, _)| index)
+            .collect()
     }
 
     /// Searches `pool` for `name`, nearest repository first.
     fn search(&self, pool: &[usize], name: &str) -> WorktreeMatch {
         for tier in rank::HOME..=rank::OTHER {
             let near = self.tier(pool, tier);
-            if let Some(index) = near
+
+            // Every match is collected, not just the first: two repositories of
+            // the same rank can each hold a worktree of this name, and picking
+            // one of them silently is how a user lands somewhere they did not ask for.
+            let by_directory: Vec<usize> = near
                 .iter()
                 .copied()
-                .find(|&i| self.entries[i].worktree.dir_name() == Some(name))
-            {
-                return WorktreeMatch::Single(index);
+                .filter(|&i| self.entries[i].worktree.dir_name() == Some(name))
+                .collect();
+            if !by_directory.is_empty() {
+                return decide(by_directory);
             }
-            if let Some(index) = near
+
+            let by_branch: Vec<usize> = near
                 .iter()
                 .copied()
-                .find(|&i| self.entries[i].worktree.branch.as_deref() == Some(name))
-            {
-                return WorktreeMatch::Single(index);
+                .filter(|&i| self.entries[i].worktree.branch.as_deref() == Some(name))
+                .collect();
+            if !by_branch.is_empty() {
+                return decide(by_branch);
             }
         }
 
@@ -293,10 +355,8 @@ impl Family {
                 })
                 .collect();
 
-            match matches.len() {
-                0 => {}
-                1 => return WorktreeMatch::Single(matches[0]),
-                _ => return WorktreeMatch::Multiple(matches),
+            if !matches.is_empty() {
+                return decide(matches);
             }
         }
 
@@ -381,6 +441,16 @@ fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
     children
 }
 
+/// Turns the matches found in one tier into an answer. More than one match is
+/// reported rather than resolved: only the user knows which one they meant.
+fn decide(matches: Vec<usize>) -> WorktreeMatch {
+    match matches.len() {
+        0 => WorktreeMatch::None,
+        1 => WorktreeMatch::Single(matches[0]),
+        _ => WorktreeMatch::Multiple(matches),
+    }
+}
+
 /// The family under construction.
 #[derive(Default)]
 struct Roll {
@@ -407,6 +477,7 @@ impl Roll {
         self.claimed.push(key);
 
         let group = self.groups.len();
+        let first = self.entries.len();
         self.groups.push(Group {
             name: repo
                 .main
@@ -415,6 +486,9 @@ impl Roll {
                 .unwrap_or("<unknown>")
                 .to_string(),
             rank: rank::OTHER,
+            // Corrected below once the entries are in place. A repository always
+            // has a main worktree, so the fallback only survives an empty list.
+            main: first,
         });
 
         for worktree in &repo.all {
@@ -422,6 +496,13 @@ impl Roll {
                 group,
                 worktree: worktree.clone(),
             });
+        }
+
+        if let Some(index) = self.entries[first..]
+            .iter()
+            .position(|entry| paths_equal(&entry.worktree.path, &repo.main))
+        {
+            self.groups[group].main = first + index;
         }
     }
 }
@@ -468,7 +549,8 @@ mod tests {
         let mut groups: Vec<Group> = Vec::new();
         let entries: Vec<Entry> = entries
             .into_iter()
-            .map(|(repo, path, branch)| {
+            .enumerate()
+            .map(|(next, (repo, path, branch))| {
                 let group = groups
                     .iter()
                     .position(|g| g.name == repo)
@@ -476,6 +558,9 @@ mod tests {
                         groups.push(Group {
                             name: repo.to_string(),
                             rank: rank::OTHER,
+                            // The first worktree named for a repository stands
+                            // in for its main worktree.
+                            main: next,
                         });
                         groups.len() - 1
                     });
@@ -858,6 +943,75 @@ mod tests {
             Some(0),
         );
         assert!(matches!(two.find("feature"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_refuses_a_name_two_repositories_of_the_same_rank_share() {
+        let three = family(
+            vec![
+                ("parent", "/p", "main"),
+                ("one", "/p/one-wt/shared", "shared"),
+                ("two", "/p/two-wt/shared", "shared"),
+            ],
+            true,
+            Some(0),
+        );
+        match three.find("shared") {
+            WorktreeMatch::Multiple(indices) => assert_eq!(indices, vec![1, 2]),
+            other => panic!("Expected Multiple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_prefix_narrows_the_search_to_one_repository() {
+        let three = family(
+            vec![
+                ("parent", "/p", "main"),
+                ("one", "/p/one-wt/shared", "shared"),
+                ("two", "/p/two-wt/shared", "shared"),
+            ],
+            true,
+            Some(0),
+        );
+        assert!(matches!(three.find("two:shared"), WorktreeMatch::Single(2)));
+    }
+
+    #[test]
+    fn a_prefix_may_name_a_repository_by_part_of_its_name() {
+        let two = family(
+            vec![("parent", "/p", "main"), ("child-b", "/p/child-b", "trunk")],
+            true,
+            Some(0),
+        );
+        assert!(matches!(two.find("ild-b:trunk"), WorktreeMatch::Single(1)));
+    }
+
+    #[test]
+    fn a_prefix_naming_no_repository_finds_nothing() {
+        let two = family(
+            vec![("parent", "/p", "main"), ("child", "/p/child", "trunk")],
+            true,
+            Some(0),
+        );
+        assert!(matches!(two.find("nope:trunk"), WorktreeMatch::None));
+        // A separator with nothing before it names no repository at all.
+        assert!(matches!(two.find(":trunk"), WorktreeMatch::None));
+    }
+
+    #[test]
+    fn a_bare_prefix_selects_the_main_worktree_not_the_first_listed() {
+        let mut two = family(
+            vec![
+                ("parent", "/p", "main"),
+                ("child", "/aaa-wt", "feature"),
+                ("child", "/p/child", "trunk"),
+            ],
+            true,
+            Some(0),
+        );
+        // The child's main worktree sorts after one of its linked worktrees.
+        two.groups[1].main = 2;
+        assert!(matches!(two.find("child:"), WorktreeMatch::Single(2)));
     }
 
     #[test]

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -1,0 +1,729 @@
+//! A family of repositories.
+//!
+//! Some repositories are containers: they track a map of a workspace, and the
+//! real repositories sit one level below them, kept out of the parent's history
+//! by `.gitignore`. `cwt` treats the parent and its children as one family, so
+//! a single listing shows every worktree the user can reach and a single name
+//! can select any of them.
+//!
+//! The family is anchored at a directory: the parent repository if there is
+//! one, otherwise the repository the user stands in. Every repository directly
+//! below the anchor joins the family. The search stops there — a child of a
+//! child is that child's business.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+
+use crate::worktree::{list_worktrees, paths_equal, Worktree};
+
+/// The indent that puts a worktree under its repository heading.
+const GROUP_INDENT: &str = "  ";
+
+/// The branch names that identify the main worktree, in order of priority.
+///
+/// `main` comes first. `master` is the fallback for a repository that never
+/// renamed its first branch.
+pub const MAIN_BRANCH_NAMES: [&str; 2] = ["main", "master"];
+
+/// Result of searching for a worktree by name.
+#[derive(Debug)]
+pub enum WorktreeMatch {
+    /// Found exactly one matching worktree.
+    Single(usize),
+    /// Found multiple matching worktrees (indices into the entry list).
+    Multiple(Vec<usize>),
+    /// No matching worktree found.
+    None,
+}
+
+/// One worktree, and the repository it belongs to.
+#[derive(Debug, Clone)]
+struct Entry {
+    /// The name of the owning repository: the directory name of its main worktree.
+    repo: String,
+    /// The worktree itself.
+    worktree: Worktree,
+}
+
+/// Every worktree of every repository in the family, in display order.
+pub struct Family {
+    /// The parent repository's worktrees first, then each child repository's.
+    entries: Vec<Entry>,
+    /// True when more than one repository contributed, which turns on the
+    /// grouped display and the `repo:target` names in messages.
+    grouped: bool,
+    /// The entry the user is standing in.
+    current: Option<usize>,
+    /// Repositories that could not be read, for the caller to report.
+    warnings: Vec<String>,
+}
+
+impl Family {
+    /// Discovers every worktree reachable from the repository at `repo_root`.
+    ///
+    /// With `scan_children` off, the family is just that repository — the
+    /// behavior of `cwt` before families existed.
+    pub fn discover(repo_root: &Path, scan_children: bool) -> Result<Self, String> {
+        let own = list_worktrees(repo_root)?;
+
+        let mut entries = Vec::new();
+        let mut warnings = Vec::new();
+        let mut repos = 0_usize;
+        let mut claimed: Vec<PathBuf> = Vec::new();
+
+        if scan_children {
+            let anchor_dir = anchor_of(&own.main);
+            // The anchor repository leads, then its children by directory name.
+            // Standing in a child means the anchor is a different repository, so
+            // it has to be read separately. Standing in the anchor itself, the
+            // list already in hand is the same one.
+            let anchor = if paths_equal(&anchor_dir, &own.main) {
+                Ok(own.clone())
+            } else {
+                list_worktrees(&anchor_dir)
+            };
+            match anchor {
+                Ok(repo) => repos += usize::from(claim(&mut entries, &mut claimed, &repo)),
+                Err(e) => warnings.push(format!("{}: {e}", anchor_dir.display())),
+            }
+
+            for child in child_repo_dirs(&anchor_dir) {
+                match list_worktrees(&child) {
+                    Ok(repo) => repos += usize::from(claim(&mut entries, &mut claimed, &repo)),
+                    Err(e) => warnings.push(format!("{}: {e}", child.display())),
+                }
+            }
+        }
+
+        // Without children, and as a backstop if the anchor could not be read,
+        // the user's own repository is the family.
+        if entries.is_empty() {
+            repos += usize::from(claim(&mut entries, &mut claimed, &own));
+        }
+
+        let current = find_current(&entries, repo_root);
+
+        Ok(Self {
+            entries,
+            grouped: repos > 1,
+            current,
+            warnings,
+        })
+    }
+
+    /// True when the family has no worktrees at all.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Repositories that could not be read.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
+    }
+
+    /// The path of the worktree at `index`.
+    pub fn path(&self, index: usize) -> &Path {
+        &self.entries[index].worktree.path
+    }
+
+    /// The worktree after the current one, wrapping around the whole family.
+    pub fn next(&self) -> Option<usize> {
+        let current = self.current?;
+        Some((current + 1) % self.entries.len())
+    }
+
+    /// The worktree before the current one, wrapping around the whole family.
+    pub fn previous(&self) -> Option<usize> {
+        let current = self.current?;
+        Some(if current == 0 {
+            self.entries.len() - 1
+        } else {
+            current - 1
+        })
+    }
+
+    /// The main worktree of the repository the user stands in: the one on
+    /// branch `main`, or the one on branch `master` when no worktree of that
+    /// repository is on `main`.
+    ///
+    /// A family holds one main worktree for each repository in it, so the
+    /// shortcut has to choose between them. It chooses the repository that owns
+    /// the current worktree, which keeps the user inside the repository they
+    /// work in instead of sending them to the anchor of the family.
+    ///
+    /// The branch name must match exactly. The substring match that [`find`]
+    /// does is wrong here: in a repository that has no `main` branch, a branch
+    /// such as `wt-main-master` would capture the shortcut and send the user
+    /// somewhere that is not the main worktree.
+    ///
+    /// A detached worktree has no branch, so it is never the main worktree.
+    ///
+    /// [`find`]: Family::find
+    pub fn main_worktree(&self) -> Option<usize> {
+        let repo = self.entries.get(self.current?)?.repo.as_str();
+
+        MAIN_BRANCH_NAMES.iter().find_map(|name| {
+            self.entries
+                .iter()
+                .position(|e| e.repo == repo && e.worktree.branch.as_deref() == Some(*name))
+        })
+    }
+
+    /// How to name the worktree at `index` in a message, so that the name can
+    /// be handed straight back to `cwt`.
+    pub fn label(&self, index: usize) -> String {
+        let entry = &self.entries[index];
+        let dir = entry.worktree.dir_name().unwrap_or("<unknown>");
+        let branch = entry.worktree.display_branch();
+        if self.grouped {
+            format!("{}:{dir} [{branch}]", entry.repo)
+        } else {
+            format!("{dir} [{branch}]")
+        }
+    }
+
+    /// Every worktree, named the way `label` names them.
+    pub fn labels(&self) -> Vec<String> {
+        (0..self.entries.len()).map(|i| self.label(i)).collect()
+    }
+
+    /// Finds a worktree by name (directory name, branch name, or branch substring).
+    ///
+    /// Search priority:
+    /// 1. Exact directory name match
+    /// 2. Exact branch name match (supports branch names with `/` like `feature/login`)
+    /// 3. Case-insensitive substring match on branch names
+    ///
+    /// Rejects names containing `..` or `\` to prevent path traversal. Forward
+    /// slashes are allowed since they are common in branch names (for example
+    /// `feature/login`) and directory names cannot contain `/` on Unix
+    /// filesystems.
+    pub fn find(&self, name: &str) -> WorktreeMatch {
+        // Reject empty search terms (which would match every branch by
+        // substring) and path traversal attempts.
+        // Note: `/` is intentionally allowed because:
+        // - Branch names commonly contain `/` (for example `feature/login`)
+        // - Directory names cannot contain `/` on Unix, so no security risk
+        // - Worktree paths come from `git worktree list`, not from user input
+        if name.is_empty() || name.contains('\\') || name.contains("..") {
+            return WorktreeMatch::None;
+        }
+
+        // First: exact directory name.
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|e| e.worktree.dir_name() == Some(name))
+        {
+            return WorktreeMatch::Single(index);
+        }
+
+        // Second: exact branch name.
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|e| e.worktree.branch.as_deref() == Some(name))
+        {
+            return WorktreeMatch::Single(index);
+        }
+
+        // Third: case-insensitive substring on branch names. Every match is
+        // collected because they all have to be shown when there is more than one.
+        let wanted = name.to_lowercase();
+        let matches: Vec<usize> = self
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                e.worktree
+                    .branch
+                    .as_ref()
+                    .is_some_and(|b| b.to_lowercase().contains(&wanted))
+            })
+            .map(|(index, _)| index)
+            .collect();
+
+        match matches.len() {
+            0 => WorktreeMatch::None,
+            1 => WorktreeMatch::Single(matches[0]),
+            _ => WorktreeMatch::Multiple(matches),
+        }
+    }
+
+    /// Renders the listing, with the current worktree highlighted.
+    ///
+    /// One repository prints as a plain list. More than one prints grouped, with
+    /// each repository's name above its worktrees.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        let mut heading: Option<&str> = None;
+
+        for (index, entry) in self.entries.iter().enumerate() {
+            if self.grouped && heading != Some(entry.repo.as_str()) {
+                if heading.is_some() {
+                    out.push('\n');
+                }
+                let _ = writeln!(out, "{}", entry.repo.bold());
+                heading = Some(entry.repo.as_str());
+            }
+
+            let is_current = self.current == Some(index);
+            let marker = if is_current { ">" } else { " " };
+            let indent = if self.grouped { GROUP_INDENT } else { "" };
+            let path = entry.worktree.path.display().to_string();
+            let branch = entry.worktree.display_branch();
+
+            let _ = if is_current {
+                writeln!(
+                    out,
+                    "{} {indent}{} [{}]",
+                    marker.green().bold(),
+                    path.green().bold(),
+                    branch.green()
+                )
+            } else {
+                writeln!(out, "{marker} {indent}{path} [{}]", branch.dimmed())
+            };
+        }
+
+        out
+    }
+}
+
+/// The directory whose children make up the family.
+///
+/// A repository checked out inside another repository is a child of that
+/// parent, so the family is anchored one level up. Anywhere else, the
+/// repository anchors its own family.
+fn anchor_of(main_worktree: &Path) -> PathBuf {
+    let parent = main_worktree.parent();
+    match parent {
+        Some(parent) if parent.join(".git").exists() => parent.to_path_buf(),
+        _ => main_worktree.to_path_buf(),
+    }
+}
+
+/// The directories one level below `dir` that are git repositories or worktrees,
+/// sorted by name.
+fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut children: Vec<PathBuf> = read
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir() && path.join(".git").exists())
+        .collect();
+    children.sort();
+    children
+}
+
+/// Adds a repository's worktrees to the family, unless another repository
+/// already claimed them. Returns true when the repository was added.
+///
+/// A repository is claimed by its main worktree, so a directory that is really a
+/// linked worktree of a repository already in the family adds nothing new.
+fn claim(
+    entries: &mut Vec<Entry>,
+    claimed: &mut Vec<PathBuf>,
+    repo: &crate::worktree::RepoWorktrees,
+) -> bool {
+    let key = canonical(&repo.main);
+    if claimed.iter().any(|seen| paths_equal(seen, &key)) {
+        return false;
+    }
+    claimed.push(key);
+
+    let name = repo
+        .main
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+
+    for worktree in &repo.all {
+        entries.push(Entry {
+            repo: name.clone(),
+            worktree: worktree.clone(),
+        });
+    }
+
+    true
+}
+
+/// Finds the entry for the worktree the user is standing in.
+fn find_current(entries: &[Entry], repo_root: &Path) -> Option<usize> {
+    let here = std::fs::canonicalize(repo_root).ok()?;
+    entries.iter().position(|entry| {
+        std::fs::canonicalize(&entry.worktree.path).is_ok_and(|path| paths_equal(&path, &here))
+    })
+}
+
+/// The resolved form of a path, falling back to the path itself when it cannot
+/// be resolved (a worktree whose directory was deleted, for example).
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a family by hand, without touching the filesystem.
+    fn family(entries: Vec<(&str, &str, &str)>, grouped: bool, current: Option<usize>) -> Family {
+        let entries = entries
+            .into_iter()
+            .map(|(repo, path, branch)| (repo, path, Some(branch)))
+            .collect();
+        detachable_family(entries, grouped, current)
+    }
+
+    /// The same, for a family that has to hold a detached worktree.
+    ///
+    /// Pass `None` as the branch for a detached HEAD.
+    fn detachable_family(
+        entries: Vec<(&str, &str, Option<&str>)>,
+        grouped: bool,
+        current: Option<usize>,
+    ) -> Family {
+        Family {
+            entries: entries
+                .into_iter()
+                .map(|(repo, path, branch)| Entry {
+                    repo: repo.to_string(),
+                    worktree: Worktree {
+                        path: PathBuf::from(path),
+                        head: "abc1234567890".to_string(),
+                        branch: branch.map(str::to_string),
+                    },
+                })
+                .collect(),
+            grouped,
+            current,
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn main_worktree_picks_main() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/wt1", "feature"),
+            ],
+            false,
+            Some(1),
+        );
+        assert_eq!(one.main_worktree(), Some(0));
+    }
+
+    #[test]
+    fn main_worktree_falls_back_to_master() {
+        // A repository that never renamed master still has a main worktree.
+        let one = family(
+            vec![
+                ("solo", "/repo-wt/wt1", "feature"),
+                ("solo", "/repo", "master"),
+            ],
+            false,
+            Some(0),
+        );
+        assert_eq!(one.main_worktree(), Some(1));
+    }
+
+    #[test]
+    fn main_worktree_prefers_main_over_master() {
+        // Both branches exist. main wins, whatever the order of the list.
+        let one = family(
+            vec![
+                ("solo", "/repo-wt/old", "master"),
+                ("solo", "/repo", "main"),
+            ],
+            false,
+            Some(0),
+        );
+        assert_eq!(one.main_worktree(), Some(1));
+    }
+
+    #[test]
+    fn main_worktree_ignores_substring_branches() {
+        // The branch name must match exactly. A branch that merely contains
+        // "main" must not capture the main worktree of a master repository.
+        let one = family(
+            vec![
+                ("solo", "/repo-wt/wt1", "wt-main-master"),
+                ("solo", "/repo", "master"),
+            ],
+            false,
+            Some(0),
+        );
+        assert_eq!(one.main_worktree(), Some(1));
+    }
+
+    #[test]
+    fn main_worktree_ignores_detached_head() {
+        let one = detachable_family(
+            vec![
+                ("solo", "/repo-wt/wt1", None),
+                ("solo", "/repo", Some("master")),
+            ],
+            false,
+            Some(0),
+        );
+        assert_eq!(one.main_worktree(), Some(1));
+    }
+
+    #[test]
+    fn main_worktree_reports_nothing_without_main_or_master() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "trunk"),
+                ("solo", "/repo-wt/wt1", "wt-main-master"),
+            ],
+            false,
+            Some(0),
+        );
+        assert_eq!(one.main_worktree(), None);
+    }
+
+    #[test]
+    fn main_worktree_stays_in_the_repository_the_user_stands_in() {
+        // Every repository of a family has a main worktree of its own. The
+        // shortcut must not send the user out of the repository they work in.
+        let whole = family(
+            vec![
+                ("parent", "/p", "main"),
+                ("child-a", "/p/child-a", "main"),
+                ("child-b", "/p/child-b", "master"),
+                ("child-b", "/p/child-b-wt/feature", "feature"),
+            ],
+            true,
+            Some(3),
+        );
+        assert_eq!(whole.main_worktree(), Some(2));
+    }
+
+    #[test]
+    fn main_worktree_reports_nothing_when_the_current_worktree_is_unknown() {
+        // Without a current worktree there is no repository to stay inside of.
+        let whole = family(
+            vec![("parent", "/p", "main"), ("child", "/p/child", "main")],
+            true,
+            None,
+        );
+        assert_eq!(whole.main_worktree(), None);
+    }
+
+    #[test]
+    fn anchor_stays_put_when_the_parent_is_not_a_repository() {
+        // /tmp is not a repository, so a repository directly inside it anchors
+        // its own family.
+        let root = std::env::temp_dir();
+        let repo = root.join("no-parent-repo-should-exist-here");
+        assert_eq!(anchor_of(&repo), repo);
+    }
+
+    #[test]
+    fn render_of_one_repository_has_no_headings() {
+        let one = family(
+            vec![("solo", "/repo", "main"), ("solo", "/repo-wt/x", "feature")],
+            false,
+            Some(0),
+        );
+        let rendered = one.render();
+        assert_eq!(
+            rendered, "> /repo [main]\n  /repo-wt/x [feature]\n",
+            "a lone repository prints exactly as it always has"
+        );
+    }
+
+    #[test]
+    fn render_of_a_family_heads_each_group_with_its_repository() {
+        let two = family(
+            vec![("parent", "/p", "main"), ("child", "/p/c", "trunk")],
+            true,
+            Some(1),
+        );
+        assert_eq!(
+            two.render(),
+            "parent\n    /p [main]\n\nchild\n>   /p/c [trunk]\n",
+            "each repository heads its own group, and the marker keeps its column"
+        );
+    }
+
+    #[test]
+    fn label_names_the_repository_only_when_there_is_more_than_one() {
+        let one = family(vec![("solo", "/repo-wt/x", "feature")], false, None);
+        assert_eq!(one.label(0), "x [feature]");
+
+        let two = family(vec![("child", "/p/c-wt/x", "feature")], true, None);
+        assert_eq!(two.label(0), "child:x [feature]");
+    }
+
+    #[test]
+    fn find_prefers_a_directory_name_to_a_branch_name() {
+        let two = family(
+            vec![("a", "/a/thing", "main"), ("b", "/b/other", "thing")],
+            true,
+            None,
+        );
+        assert!(matches!(two.find("thing"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_rejects_path_traversal_and_the_empty_name() {
+        let one = family(vec![("solo", "/repo", "main")], false, None);
+        assert!(matches!(one.find(""), WorktreeMatch::None));
+        assert!(matches!(one.find(".."), WorktreeMatch::None));
+        assert!(matches!(one.find("../etc/passwd"), WorktreeMatch::None));
+        assert!(matches!(one.find("foo\\bar"), WorktreeMatch::None));
+    }
+
+    #[test]
+    fn find_matches_an_exact_directory_name() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/absurd-rock", "feature"),
+            ],
+            false,
+            None,
+        );
+        assert!(matches!(one.find("absurd-rock"), WorktreeMatch::Single(1)));
+    }
+
+    #[test]
+    fn find_matches_an_exact_branch_name() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/absurd-rock", "feature"),
+            ],
+            false,
+            None,
+        );
+        assert!(matches!(one.find("feature"), WorktreeMatch::Single(1)));
+        assert!(matches!(one.find("main"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_reports_nothing_for_an_unknown_name() {
+        let one = family(vec![("solo", "/repo", "main")], false, None);
+        assert!(matches!(one.find("nonexistent"), WorktreeMatch::None));
+    }
+
+    #[test]
+    fn find_allows_forward_slashes_in_branch_names() {
+        // Forward slashes are common in branch names (feature/*, bugfix/*) and
+        // must work for both exact and substring matching.
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/wt1", "feature/user-auth"),
+                ("solo", "/repo-wt/wt2", "feature/login-page"),
+            ],
+            false,
+            None,
+        );
+
+        assert!(matches!(
+            one.find("feature/user-auth"),
+            WorktreeMatch::Single(1)
+        ));
+
+        match one.find("feature/") {
+            WorktreeMatch::Multiple(indices) => {
+                assert_eq!(indices.len(), 2);
+                assert!(indices.contains(&1));
+                assert!(indices.contains(&2));
+            }
+            other => panic!("Expected Multiple, got {other:?}"),
+        }
+
+        assert!(matches!(one.find("ure/user"), WorktreeMatch::Single(1)));
+    }
+
+    #[test]
+    fn find_matches_one_branch_by_substring() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/wt1", "feature/login-page"),
+                ("solo", "/repo-wt/wt2", "bugfix/header"),
+            ],
+            false,
+            None,
+        );
+        assert!(matches!(one.find("login"), WorktreeMatch::Single(1)));
+        assert!(matches!(one.find("LOGIN"), WorktreeMatch::Single(1)));
+        assert!(matches!(one.find("header"), WorktreeMatch::Single(2)));
+    }
+
+    #[test]
+    fn find_reports_every_branch_a_substring_matches() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/wt1", "feature/login-page"),
+                ("solo", "/repo-wt/wt2", "feature/logout-page"),
+            ],
+            false,
+            None,
+        );
+        match one.find("feature") {
+            WorktreeMatch::Multiple(indices) => assert_eq!(indices.len(), 2),
+            other => panic!("Expected Multiple, got {other:?}"),
+        }
+        match one.find("page") {
+            WorktreeMatch::Multiple(indices) => assert_eq!(indices.len(), 2),
+            other => panic!("Expected Multiple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_prefers_an_exact_branch_to_a_substring() {
+        let one = family(
+            vec![
+                ("solo", "/repo", "main"),
+                ("solo", "/repo-wt/wt1", "main-feature"),
+            ],
+            false,
+            None,
+        );
+        // "main" is exactly one branch and part of another. The exact one wins.
+        assert!(matches!(one.find("main"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_ignores_case_in_a_substring() {
+        let one = family(vec![("solo", "/repo", "Feature/UserAuth")], false, None);
+        assert!(matches!(one.find("userauth"), WorktreeMatch::Single(0)));
+        assert!(matches!(one.find("USERAUTH"), WorktreeMatch::Single(0)));
+        assert!(matches!(one.find("UserAuth"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn cycling_reports_nothing_when_the_current_worktree_is_unknown() {
+        let one = family(vec![("solo", "/repo", "main")], false, None);
+        assert_eq!(one.next(), None);
+        assert_eq!(one.previous(), None);
+    }
+
+    #[test]
+    fn cycling_wraps_around_the_whole_family() {
+        let three = family(
+            vec![
+                ("a", "/a", "main"),
+                ("b", "/a/b", "main"),
+                ("c", "/a/c", "main"),
+            ],
+            true,
+            Some(2),
+        );
+        assert_eq!(three.next(), Some(0), "the last entry wraps to the first");
+        assert_eq!(three.previous(), Some(1));
+    }
+}

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -51,8 +51,14 @@ mod rank {
 /// One repository of the family.
 #[derive(Debug, Clone)]
 struct Group {
-    /// The directory name of the repository's main worktree.
+    /// The name that selects this repository and heads its worktrees in the
+    /// listing: the directory name of its main worktree, or — when another
+    /// repository of the family has that same directory name — the path that
+    /// leads to it. See [`qualify_shared_names`].
     name: String,
+    /// The directory of the repository's main worktree, which is what tells two
+    /// repositories of the same directory name apart.
+    dir: PathBuf,
     /// How near this repository is to the user. See [`rank`].
     rank: u8,
     /// Index into the family's entries of this repository's main worktree, or
@@ -97,11 +103,11 @@ impl Family {
     /// family and named in [`warnings`](Self::warnings) instead.
     pub fn discover(repo_root: &Path, scan_children: bool) -> Result<Self, String> {
         let own = list_worktrees(repo_root)?;
+        let anchor_dir = anchor_of(&own.main);
 
         let mut roll = Roll::default();
 
         if scan_children {
-            let anchor_dir = anchor_of(&own.main);
             // The anchor repository leads, then its children by directory name.
             // Standing in a child means the anchor is a different repository, so
             // it has to be read separately. Standing in the anchor itself, the
@@ -136,6 +142,13 @@ impl Family {
             warnings,
             ..
         } = roll;
+
+        // Before anything is printed or looked up, every repository needs a name
+        // that reaches it and nothing else. The anchor's own name is measured
+        // from the directory above it, so a child that shares it becomes
+        // `anchor/child`.
+        qualify_shared_names(&mut groups, anchor_dir.parent().unwrap_or(&anchor_dir));
+
         let current = find_current(&entries, repo_root);
 
         // Nearest first: the repository the user stands in, then the anchor —
@@ -218,6 +231,10 @@ impl Family {
 
     /// How to name the worktree at `index` in a message, so that the name can
     /// be handed straight back to `cwt`.
+    ///
+    /// In a family the name is prefixed with the repository's own name, which
+    /// answers for that repository alone — see [`qualify_shared_names`] — so
+    /// every name a message prints selects the worktree it was printed for.
     pub fn label(&self, index: usize) -> String {
         let entry = &self.entries[index];
         let dir = entry.worktree.dir_name().unwrap_or("<unknown>");
@@ -274,6 +291,10 @@ impl Family {
 
     /// Finds `name` inside the repository the prefix names.
     ///
+    /// The prefix names a repository the way the listing heads it — see
+    /// [`groups_named`](Self::groups_named) — and a prefix that names more than
+    /// one repository searches all of them.
+    ///
     /// An empty `name` selects that repository's main worktree, so `child-b:`
     /// reaches child-b even when another repository holds the better match for
     /// every name child-b has. A repository whose main worktree is not among the
@@ -303,11 +324,23 @@ impl Family {
         self.search(&pool, name)
     }
 
-    /// The repositories a prefix names: the one whose name matches exactly, or
-    /// every one whose name contains the prefix.
+    /// The repositories a prefix names: every one whose name it matches exactly,
+    /// or, failing that, every one whose name contains it.
+    ///
+    /// [`qualify_shared_names`] makes the names unique, so an exact match is one
+    /// repository. Every exact match is collected all the same: two
+    /// repositories that answered to one name would have to be reported to the
+    /// user, never quietly reduced to whichever was found first.
     fn groups_named(&self, prefix: &str) -> Vec<usize> {
-        if let Some(index) = self.groups.iter().position(|group| group.name == prefix) {
-            return vec![index];
+        let exact: Vec<usize> = self
+            .groups
+            .iter()
+            .enumerate()
+            .filter(|(_, group)| group.name == prefix)
+            .map(|(index, _)| index)
+            .collect();
+        if !exact.is_empty() {
+            return exact;
         }
 
         let wanted = prefix.to_lowercase();
@@ -385,16 +418,18 @@ impl Family {
     /// each repository's name above its worktrees.
     pub fn render(&self) -> String {
         let mut out = String::new();
-        let mut heading: Option<&str> = None;
+        // The heading is remembered by which repository it was: two
+        // repositories of one family can have the same directory name, and a
+        // heading compared by name would swallow the second one's worktrees.
+        let mut heading: Option<usize> = None;
 
         for (index, entry) in self.entries.iter().enumerate() {
-            let repo = self.groups[entry.group].name.as_str();
-            if self.grouped && heading != Some(repo) {
+            if self.grouped && heading != Some(entry.group) {
                 if heading.is_some() {
                     out.push('\n');
                 }
-                let _ = writeln!(out, "{}", repo.bold());
-                heading = Some(repo);
+                let _ = writeln!(out, "{}", self.groups[entry.group].name.as_str().bold());
+                heading = Some(entry.group);
             }
 
             let is_current = self.current == Some(index);
@@ -447,6 +482,47 @@ fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
         .collect();
     children.sort();
     children
+}
+
+/// Gives every repository of the family a name that reaches it alone.
+///
+/// A repository is normally known by the directory name of its main worktree:
+/// short, and what the user already sees on disk. A parent that holds a child
+/// named after itself breaks that — one name would stand for two repositories,
+/// the listing would head both under it, and a `REPO:NAME` prefix would answer
+/// from whichever repository came first while the other stayed out of reach.
+///
+/// So each repository that shares its directory name is renamed to the path
+/// from `base` down to it — `keyboards/keyboards` rather than `keyboards` —
+/// which no other repository of the family can have, because no two of them
+/// stand in the same directory. `base` is the directory above the family's
+/// anchor, so the anchor keeps its own directory name and the child inside it
+/// is named after the way there.
+///
+/// The parts are always joined with `/`, whatever the platform writes paths
+/// with, because that is what a `REPO:NAME` target accepts.
+fn qualify_shared_names(groups: &mut [Group], base: &Path) {
+    let shared: Vec<bool> = groups
+        .iter()
+        .map(|group| {
+            groups
+                .iter()
+                .filter(|other| other.name == group.name)
+                .count()
+                > 1
+        })
+        .collect();
+
+    for (group, shared) in groups.iter_mut().zip(shared) {
+        if shared {
+            let path = group.dir.strip_prefix(base).unwrap_or(&group.dir);
+            group.name = path
+                .components()
+                .map(|part| part.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+        }
+    }
 }
 
 /// Turns the matches found in one tier into an answer. More than one match is
@@ -510,6 +586,7 @@ impl Roll {
                 .and_then(|name| name.to_str())
                 .unwrap_or("<unknown>")
                 .to_string(),
+            dir: repo.main.clone(),
             rank: rank::OTHER,
             // Filled in below if the main worktree is among the entries. A bare
             // repository with linked worktrees is listed without a HEAD, so it
@@ -561,6 +638,25 @@ mod tests {
     /// Each entry is `(repository, path, branch)`. Repositories are ranked the
     /// way `discover` ranks them: the first repository named is the anchor, and
     /// the one holding the current worktree is home.
+    ///
+    /// Repositories are keyed by name here, so a family whose repositories
+    /// share one has to be built without this helper.
+    /// One worktree at `path`, with `branch` checked out.
+    fn worktree(path: &str, branch: &str) -> Worktree {
+        detachable_worktree(path, Some(branch))
+    }
+
+    /// The same, for a worktree that has to be detached.
+    ///
+    /// Pass `None` as the branch for a detached HEAD.
+    fn detachable_worktree(path: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            path: PathBuf::from(path),
+            head: "abc1234567890".to_string(),
+            branch: branch.map(str::to_string),
+        }
+    }
+
     fn family(entries: Vec<(&str, &str, &str)>, grouped: bool, current: Option<usize>) -> Family {
         let entries = entries
             .into_iter()
@@ -588,6 +684,7 @@ mod tests {
                     .unwrap_or_else(|| {
                         groups.push(Group {
                             name: repo.to_string(),
+                            dir: PathBuf::from(path),
                             rank: rank::OTHER,
                             // The first worktree named for a repository stands
                             // in for its main worktree.
@@ -597,11 +694,7 @@ mod tests {
                     });
                 Entry {
                     group,
-                    worktree: Worktree {
-                        path: PathBuf::from(path),
-                        head: "abc1234567890".to_string(),
-                        branch: branch.map(str::to_string),
-                    },
+                    worktree: detachable_worktree(path, branch),
                 }
             })
             .collect();
@@ -1019,14 +1112,39 @@ mod tests {
 
     #[test]
     fn a_prefix_two_repositories_answer_to_is_refused() {
-        // `discover` gives every repository a name of its own, so this shape
-        // should never reach `find`. If one ever does, the answer is to report
-        // both repositories, never to hand back whichever was found first.
-        let two = family(
-            vec![("dup", "/one", "first"), ("dup", "/two", "second")],
-            true,
-            None,
-        );
+        // `qualify_shared_names` gives every repository a name of its own, so a
+        // family this shape should never reach `find`. If one ever does, the
+        // answer is to report both repositories, never to hand back whichever
+        // was found first.
+        let two = Family {
+            entries: vec![
+                Entry {
+                    group: 0,
+                    worktree: worktree("/one", "first"),
+                },
+                Entry {
+                    group: 1,
+                    worktree: worktree("/two", "second"),
+                },
+            ],
+            groups: vec![
+                Group {
+                    name: "dup".to_string(),
+                    dir: PathBuf::from("/one"),
+                    rank: rank::ANCHOR,
+                    main: Some(0),
+                },
+                Group {
+                    name: "dup".to_string(),
+                    dir: PathBuf::from("/two"),
+                    rank: rank::OTHER,
+                    main: Some(1),
+                },
+            ],
+            grouped: true,
+            current: None,
+            warnings: Vec::new(),
+        };
         match two.find("dup:") {
             WorktreeMatch::Multiple(indices) => assert_eq!(indices, vec![0, 1]),
             other => panic!("Expected Multiple, got {other:?}"),

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -8,8 +8,8 @@
 //!
 //! The family is anchored at a directory: the parent repository if there is
 //! one, otherwise the repository the user stands in. Every repository directly
-//! below the anchor joins the family. The search stops there — a child of a
-//! child is that child's business.
+//! below the anchor that has a worktree joins the family. The search stops
+//! there — a child of a child is that child's business.
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
@@ -55,8 +55,11 @@ struct Group {
     name: String,
     /// How near this repository is to the user. See [`rank`].
     rank: u8,
-    /// Index into the family's entries of this repository's main worktree.
-    main: usize,
+    /// Index into the family's entries of this repository's main worktree, or
+    /// `None` when the repository lists worktrees but not that one — a bare
+    /// repository with linked worktrees is reported without a HEAD, so it never
+    /// appears among the entries it owns.
+    main: Option<usize>,
 }
 
 /// One worktree, and the repository it belongs to.
@@ -79,7 +82,7 @@ pub struct Family {
     grouped: bool,
     /// The entry the user is standing in.
     current: Option<usize>,
-    /// Repositories that could not be read, for the caller to report.
+    /// Repositories left out of the family, for the caller to report.
     warnings: Vec<String>,
 }
 
@@ -88,11 +91,14 @@ impl Family {
     ///
     /// With `scan_children` off, the family is just that repository — the
     /// behavior of `cwt` before families existed.
+    ///
+    /// A repository the scan reaches but cannot use — one that will not be
+    /// read, or one that lists no worktree of its own — is left out of the
+    /// family and named in [`warnings`](Self::warnings) instead.
     pub fn discover(repo_root: &Path, scan_children: bool) -> Result<Self, String> {
         let own = list_worktrees(repo_root)?;
 
         let mut roll = Roll::default();
-        let mut warnings = Vec::new();
 
         if scan_children {
             let anchor_dir = anchor_of(&own.main);
@@ -107,13 +113,13 @@ impl Family {
             };
             match anchor {
                 Ok(repo) => roll.claim(&repo),
-                Err(e) => warnings.push(format!("{}: {e}", anchor_dir.display())),
+                Err(e) => roll.skip(&anchor_dir, &e),
             }
 
             for child in child_repo_dirs(&anchor_dir) {
                 match list_worktrees(&child) {
                     Ok(repo) => roll.claim(&repo),
-                    Err(e) => warnings.push(format!("{}: {e}", child.display())),
+                    Err(e) => roll.skip(&child, &e),
                 }
             }
         }
@@ -127,6 +133,7 @@ impl Family {
         let Roll {
             entries,
             mut groups,
+            warnings,
             ..
         } = roll;
         let current = find_current(&entries, repo_root);
@@ -156,7 +163,7 @@ impl Family {
         self.entries.is_empty()
     }
 
-    /// Repositories that could not be read.
+    /// Repositories the scan reached but left out of the family, and why.
     pub fn warnings(&self) -> &[String] {
         &self.warnings
     }
@@ -269,7 +276,8 @@ impl Family {
     ///
     /// An empty `name` selects that repository's main worktree, so `child-b:`
     /// reaches child-b even when another repository holds the better match for
-    /// every name child-b has.
+    /// every name child-b has. A repository whose main worktree is not among the
+    /// entries has nothing to offer a bare prefix and is passed over.
     fn find_in_repo(&self, repo: &str, name: &str) -> WorktreeMatch {
         if repo.is_empty() {
             return WorktreeMatch::None;
@@ -284,7 +292,7 @@ impl Family {
             return decide(
                 groups
                     .iter()
-                    .map(|&group| self.groups[group].main)
+                    .filter_map(|&group| self.groups[group].main)
                     .collect(),
             );
         }
@@ -460,7 +468,12 @@ struct Roll {
     groups: Vec<Group>,
     /// The main worktree of every repository already claimed.
     claimed: Vec<PathBuf>,
+    /// The repositories left out, and why.
+    warnings: Vec<String>,
 }
+
+/// What a repository that lists no worktree is told to the user as.
+const NO_WORKTREES: &str = "no worktrees to list";
 
 impl Roll {
     /// Adds a repository's worktrees to the family, unless another repository
@@ -469,12 +482,24 @@ impl Roll {
     /// A repository is claimed by its main worktree, so a directory that is
     /// really a linked worktree of a repository already in the family adds
     /// nothing new.
+    ///
+    /// A repository that lists no worktree at all does not become a group. A
+    /// bare repository is the case that reaches here: `git worktree list`
+    /// reports it without a HEAD, so it owns no entry a group could point at,
+    /// and a group with nothing behind it can only answer for its neighbors.
+    /// It goes to the warnings instead, so the user is told why a directory
+    /// they can see is missing from the listing.
     fn claim(&mut self, repo: &RepoWorktrees) {
         let key = canonical(&repo.main);
         if self.claimed.iter().any(|seen| paths_equal(seen, &key)) {
             return;
         }
         self.claimed.push(key);
+
+        if repo.all.is_empty() {
+            self.skip(&repo.main, NO_WORKTREES);
+            return;
+        }
 
         let group = self.groups.len();
         let first = self.entries.len();
@@ -486,9 +511,10 @@ impl Roll {
                 .unwrap_or("<unknown>")
                 .to_string(),
             rank: rank::OTHER,
-            // Corrected below once the entries are in place. A repository always
-            // has a main worktree, so the fallback only survives an empty list.
-            main: first,
+            // Filled in below if the main worktree is among the entries. A bare
+            // repository with linked worktrees is listed without a HEAD, so it
+            // contributes worktrees without contributing its own.
+            main: None,
         });
 
         for worktree in &repo.all {
@@ -502,8 +528,13 @@ impl Roll {
             .iter()
             .position(|entry| paths_equal(&entry.worktree.path, &repo.main))
         {
-            self.groups[group].main = first + index;
+            self.groups[group].main = Some(first + index);
         }
+    }
+
+    /// Records a repository that the scan reached but the family left out.
+    fn skip(&mut self, dir: &Path, reason: &str) {
+        self.warnings.push(format!("{}: {reason}", dir.display()));
     }
 }
 
@@ -560,7 +591,7 @@ mod tests {
                             rank: rank::OTHER,
                             // The first worktree named for a repository stands
                             // in for its main worktree.
-                            main: next,
+                            main: Some(next),
                         });
                         groups.len() - 1
                     });
@@ -1010,7 +1041,7 @@ mod tests {
             Some(0),
         );
         // The child's main worktree sorts after one of its linked worktrees.
-        two.groups[1].main = 2;
+        two.groups[1].main = Some(2);
         assert!(matches!(two.find("child:"), WorktreeMatch::Single(2)));
     }
 

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
-use crate::worktree::{list_worktrees, paths_equal, Worktree};
+use crate::worktree::{list_worktrees, paths_equal, RepoWorktrees, Worktree};
 
 /// The indent that puts a worktree under its repository heading.
 const GROUP_INDENT: &str = "  ";
@@ -38,11 +38,30 @@ pub enum WorktreeMatch {
     None,
 }
 
+/// How near a repository is to the user, which is the order a name is answered in.
+mod rank {
+    /// The repository the user is standing in.
+    pub const HOME: u8 = 0;
+    /// The parent repository the family is anchored at.
+    pub const ANCHOR: u8 = 1;
+    /// Every other repository in the family.
+    pub const OTHER: u8 = 2;
+}
+
+/// One repository of the family.
+#[derive(Debug, Clone)]
+struct Group {
+    /// The directory name of the repository's main worktree.
+    name: String,
+    /// How near this repository is to the user. See [`rank`].
+    rank: u8,
+}
+
 /// One worktree, and the repository it belongs to.
 #[derive(Debug, Clone)]
 struct Entry {
-    /// The name of the owning repository: the directory name of its main worktree.
-    repo: String,
+    /// Index into the family's groups.
+    group: usize,
     /// The worktree itself.
     worktree: Worktree,
 }
@@ -51,6 +70,8 @@ struct Entry {
 pub struct Family {
     /// The parent repository's worktrees first, then each child repository's.
     entries: Vec<Entry>,
+    /// The repositories that contributed, in the same order.
+    groups: Vec<Group>,
     /// True when more than one repository contributed, which turns on the
     /// grouped display and the `repo:target` names in messages.
     grouped: bool,
@@ -68,10 +89,8 @@ impl Family {
     pub fn discover(repo_root: &Path, scan_children: bool) -> Result<Self, String> {
         let own = list_worktrees(repo_root)?;
 
-        let mut entries = Vec::new();
+        let mut roll = Roll::default();
         let mut warnings = Vec::new();
-        let mut repos = 0_usize;
-        let mut claimed: Vec<PathBuf> = Vec::new();
 
         if scan_children {
             let anchor_dir = anchor_of(&own.main);
@@ -85,13 +104,13 @@ impl Family {
                 list_worktrees(&anchor_dir)
             };
             match anchor {
-                Ok(repo) => repos += usize::from(claim(&mut entries, &mut claimed, &repo)),
+                Ok(repo) => roll.claim(&repo),
                 Err(e) => warnings.push(format!("{}: {e}", anchor_dir.display())),
             }
 
             for child in child_repo_dirs(&anchor_dir) {
                 match list_worktrees(&child) {
-                    Ok(repo) => repos += usize::from(claim(&mut entries, &mut claimed, &repo)),
+                    Ok(repo) => roll.claim(&repo),
                     Err(e) => warnings.push(format!("{}: {e}", child.display())),
                 }
             }
@@ -99,15 +118,32 @@ impl Family {
 
         // Without children, and as a backstop if the anchor could not be read,
         // the user's own repository is the family.
-        if entries.is_empty() {
-            repos += usize::from(claim(&mut entries, &mut claimed, &own));
+        if roll.entries.is_empty() {
+            roll.claim(&own);
         }
 
+        let Roll {
+            entries,
+            mut groups,
+            ..
+        } = roll;
         let current = find_current(&entries, repo_root);
+
+        // Nearest first: the repository the user stands in, then the anchor —
+        // which is the first repository claimed — then everything else.
+        if let Some(anchor) = groups.first_mut() {
+            anchor.rank = rank::ANCHOR;
+        }
+        if let Some(index) = current {
+            groups[entries[index].group].rank = rank::HOME;
+        }
+
+        let grouped = groups.len() > 1;
 
         Ok(Self {
             entries,
-            grouped: repos > 1,
+            groups,
+            grouped,
             current,
             warnings,
         })
@@ -162,12 +198,12 @@ impl Family {
     ///
     /// [`find`]: Family::find
     pub fn main_worktree(&self) -> Option<usize> {
-        let repo = self.entries.get(self.current?)?.repo.as_str();
+        let group = self.entries.get(self.current?)?.group;
 
         MAIN_BRANCH_NAMES.iter().find_map(|name| {
             self.entries
                 .iter()
-                .position(|e| e.repo == repo && e.worktree.branch.as_deref() == Some(*name))
+                .position(|e| e.group == group && e.worktree.branch.as_deref() == Some(*name))
         })
     }
 
@@ -178,7 +214,7 @@ impl Family {
         let dir = entry.worktree.dir_name().unwrap_or("<unknown>");
         let branch = entry.worktree.display_branch();
         if self.grouped {
-            format!("{}:{dir} [{branch}]", entry.repo)
+            format!("{}:{dir} [{branch}]", self.groups[entry.group].name)
         } else {
             format!("{dir} [{branch}]")
         }
@@ -191,10 +227,15 @@ impl Family {
 
     /// Finds a worktree by name (directory name, branch name, or branch substring).
     ///
-    /// Search priority:
+    /// The family is searched a repository at a time, nearest first: the
+    /// repository the user stands in, then the parent, then the rest. Within a
+    /// repository the priority is:
     /// 1. Exact directory name match
     /// 2. Exact branch name match (supports branch names with `/` like `feature/login`)
-    /// 3. Case-insensitive substring match on branch names
+    ///
+    /// An exact match anywhere in the family beats a substring anywhere, so the
+    /// substrings are only tried after every repository has been asked for an
+    /// exact name. Substrings are then tried nearest first in the same way.
     ///
     /// Rejects names containing `..` or `\` to prevent path traversal. Forward
     /// slashes are allowed since they are common in branch names (for example
@@ -211,45 +252,63 @@ impl Family {
             return WorktreeMatch::None;
         }
 
-        // First: exact directory name.
-        if let Some(index) = self
-            .entries
-            .iter()
-            .position(|e| e.worktree.dir_name() == Some(name))
-        {
-            return WorktreeMatch::Single(index);
+        let pool: Vec<usize> = (0..self.entries.len()).collect();
+        self.search(&pool, name)
+    }
+
+    /// Searches `pool` for `name`, nearest repository first.
+    fn search(&self, pool: &[usize], name: &str) -> WorktreeMatch {
+        for tier in rank::HOME..=rank::OTHER {
+            let near = self.tier(pool, tier);
+            if let Some(index) = near
+                .iter()
+                .copied()
+                .find(|&i| self.entries[i].worktree.dir_name() == Some(name))
+            {
+                return WorktreeMatch::Single(index);
+            }
+            if let Some(index) = near
+                .iter()
+                .copied()
+                .find(|&i| self.entries[i].worktree.branch.as_deref() == Some(name))
+            {
+                return WorktreeMatch::Single(index);
+            }
         }
 
-        // Second: exact branch name.
-        if let Some(index) = self
-            .entries
-            .iter()
-            .position(|e| e.worktree.branch.as_deref() == Some(name))
-        {
-            return WorktreeMatch::Single(index);
-        }
-
-        // Third: case-insensitive substring on branch names. Every match is
-        // collected because they all have to be shown when there is more than one.
+        // No exact name anywhere in the family. Every substring match in the
+        // nearest repository that has one is collected, because they all have to
+        // be shown when there is more than one.
         let wanted = name.to_lowercase();
-        let matches: Vec<usize> = self
-            .entries
-            .iter()
-            .enumerate()
-            .filter(|(_, e)| {
-                e.worktree
-                    .branch
-                    .as_ref()
-                    .is_some_and(|b| b.to_lowercase().contains(&wanted))
-            })
-            .map(|(index, _)| index)
-            .collect();
+        for tier in rank::HOME..=rank::OTHER {
+            let matches: Vec<usize> = self
+                .tier(pool, tier)
+                .into_iter()
+                .filter(|&i| {
+                    self.entries[i]
+                        .worktree
+                        .branch
+                        .as_ref()
+                        .is_some_and(|branch| branch.to_lowercase().contains(&wanted))
+                })
+                .collect();
 
-        match matches.len() {
-            0 => WorktreeMatch::None,
-            1 => WorktreeMatch::Single(matches[0]),
-            _ => WorktreeMatch::Multiple(matches),
+            match matches.len() {
+                0 => {}
+                1 => return WorktreeMatch::Single(matches[0]),
+                _ => return WorktreeMatch::Multiple(matches),
+            }
         }
+
+        WorktreeMatch::None
+    }
+
+    /// The entries of `pool` that belong to a repository of the given rank.
+    fn tier(&self, pool: &[usize], rank: u8) -> Vec<usize> {
+        pool.iter()
+            .copied()
+            .filter(|&index| self.groups[self.entries[index].group].rank == rank)
+            .collect()
     }
 
     /// Renders the listing, with the current worktree highlighted.
@@ -261,12 +320,13 @@ impl Family {
         let mut heading: Option<&str> = None;
 
         for (index, entry) in self.entries.iter().enumerate() {
-            if self.grouped && heading != Some(entry.repo.as_str()) {
+            let repo = self.groups[entry.group].name.as_str();
+            if self.grouped && heading != Some(repo) {
                 if heading.is_some() {
                     out.push('\n');
                 }
-                let _ = writeln!(out, "{}", entry.repo.bold());
-                heading = Some(entry.repo.as_str());
+                let _ = writeln!(out, "{}", repo.bold());
+                heading = Some(repo);
             }
 
             let is_current = self.current == Some(index);
@@ -321,37 +381,49 @@ fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
     children
 }
 
-/// Adds a repository's worktrees to the family, unless another repository
-/// already claimed them. Returns true when the repository was added.
-///
-/// A repository is claimed by its main worktree, so a directory that is really a
-/// linked worktree of a repository already in the family adds nothing new.
-fn claim(
-    entries: &mut Vec<Entry>,
-    claimed: &mut Vec<PathBuf>,
-    repo: &crate::worktree::RepoWorktrees,
-) -> bool {
-    let key = canonical(&repo.main);
-    if claimed.iter().any(|seen| paths_equal(seen, &key)) {
-        return false;
-    }
-    claimed.push(key);
+/// The family under construction.
+#[derive(Default)]
+struct Roll {
+    /// The worktrees claimed so far, in display order.
+    entries: Vec<Entry>,
+    /// The repositories that claimed them, in the same order.
+    groups: Vec<Group>,
+    /// The main worktree of every repository already claimed.
+    claimed: Vec<PathBuf>,
+}
 
-    let name = repo
-        .main
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("<unknown>")
-        .to_string();
+impl Roll {
+    /// Adds a repository's worktrees to the family, unless another repository
+    /// already claimed them.
+    ///
+    /// A repository is claimed by its main worktree, so a directory that is
+    /// really a linked worktree of a repository already in the family adds
+    /// nothing new.
+    fn claim(&mut self, repo: &RepoWorktrees) {
+        let key = canonical(&repo.main);
+        if self.claimed.iter().any(|seen| paths_equal(seen, &key)) {
+            return;
+        }
+        self.claimed.push(key);
 
-    for worktree in &repo.all {
-        entries.push(Entry {
-            repo: name.clone(),
-            worktree: worktree.clone(),
+        let group = self.groups.len();
+        self.groups.push(Group {
+            name: repo
+                .main
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("<unknown>")
+                .to_string(),
+            rank: rank::OTHER,
         });
-    }
 
-    true
+        for worktree in &repo.all {
+            self.entries.push(Entry {
+                group,
+                worktree: worktree.clone(),
+            });
+        }
+    }
 }
 
 /// Finds the entry for the worktree the user is standing in.
@@ -373,6 +445,10 @@ mod tests {
     use super::*;
 
     /// Build a family by hand, without touching the filesystem.
+    ///
+    /// Each entry is `(repository, path, branch)`. Repositories are ranked the
+    /// way `discover` ranks them: the first repository named is the anchor, and
+    /// the one holding the current worktree is home.
     fn family(entries: Vec<(&str, &str, &str)>, grouped: bool, current: Option<usize>) -> Family {
         let entries = entries
             .into_iter()
@@ -389,18 +465,41 @@ mod tests {
         grouped: bool,
         current: Option<usize>,
     ) -> Family {
-        Family {
-            entries: entries
-                .into_iter()
-                .map(|(repo, path, branch)| Entry {
-                    repo: repo.to_string(),
+        let mut groups: Vec<Group> = Vec::new();
+        let entries: Vec<Entry> = entries
+            .into_iter()
+            .map(|(repo, path, branch)| {
+                let group = groups
+                    .iter()
+                    .position(|g| g.name == repo)
+                    .unwrap_or_else(|| {
+                        groups.push(Group {
+                            name: repo.to_string(),
+                            rank: rank::OTHER,
+                        });
+                        groups.len() - 1
+                    });
+                Entry {
+                    group,
                     worktree: Worktree {
                         path: PathBuf::from(path),
                         head: "abc1234567890".to_string(),
                         branch: branch.map(str::to_string),
                     },
-                })
-                .collect(),
+                }
+            })
+            .collect();
+
+        if let Some(anchor) = groups.first_mut() {
+            anchor.rank = rank::ANCHOR;
+        }
+        if let Some(index) = current {
+            groups[entries[index].group].rank = rank::HOME;
+        }
+
+        Family {
+            entries,
+            groups,
             grouped,
             current,
             warnings: Vec::new(),
@@ -703,6 +802,62 @@ mod tests {
         assert!(matches!(one.find("userauth"), WorktreeMatch::Single(0)));
         assert!(matches!(one.find("USERAUTH"), WorktreeMatch::Single(0)));
         assert!(matches!(one.find("UserAuth"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_prefers_the_home_repository_to_the_parent() {
+        // Both repositories have a `main` branch. The user stands in the child.
+        let two = family(
+            vec![("parent", "/p", "main"), ("child", "/p/c", "main")],
+            true,
+            Some(1),
+        );
+        assert!(matches!(two.find("main"), WorktreeMatch::Single(1)));
+
+        // Standing in the parent, the same name answers from the parent.
+        let two = family(
+            vec![("parent", "/p", "main"), ("child", "/p/c", "main")],
+            true,
+            Some(0),
+        );
+        assert!(matches!(two.find("main"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_prefers_the_parent_to_an_unrelated_repository() {
+        // Neither the parent nor the sibling is home, and both have `shared`.
+        let three = family(
+            vec![
+                ("parent", "/p", "shared"),
+                ("home", "/p/home", "work"),
+                ("other", "/p/other", "shared"),
+            ],
+            true,
+            Some(1),
+        );
+        assert!(matches!(three.find("shared"), WorktreeMatch::Single(0)));
+    }
+
+    #[test]
+    fn find_prefers_an_exact_name_elsewhere_to_a_substring_at_home() {
+        // Home has `beta-old`, which contains "beta". Another repository has the
+        // branch `beta` itself. The exact name wins even though it is further away.
+        let two = family(
+            vec![("home", "/h", "beta-old"), ("other", "/h/o", "beta")],
+            true,
+            Some(0),
+        );
+        assert!(matches!(two.find("beta"), WorktreeMatch::Single(1)));
+    }
+
+    #[test]
+    fn find_prefers_a_substring_at_home_to_a_substring_elsewhere() {
+        let two = family(
+            vec![("home", "/h", "feature-x"), ("other", "/h/o", "feature-y")],
+            true,
+            Some(0),
+        );
+        assert!(matches!(two.find("feature"), WorktreeMatch::Single(0)));
     }
 
     #[test]

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -122,8 +122,12 @@ impl Family {
                 Err(e) => roll.skip(&anchor_dir, &e),
             }
 
-            for child in child_repo_dirs(&anchor_dir) {
-                match list_worktrees(&child) {
+            // The children are read together but claimed one at a time, in the
+            // order `child_repo_dirs` sorted them: claiming is what decides a
+            // repository's place in the listing and which of two repositories
+            // owns a worktree they both name, so it stays on this thread.
+            for (child, listing) in read_children(&anchor_dir) {
+                match listing {
                     Ok(repo) => roll.claim(&repo),
                     Err(e) => roll.skip(&child, &e),
                 }
@@ -482,6 +486,53 @@ fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
         .collect();
     children.sort();
     children
+}
+
+/// How many child repositories are read at once.
+///
+/// Each of these threads spends its life waiting on a `git` subprocess, so the
+/// useful width is set by how many subprocesses the machine will carry at once
+/// rather than by how many cores it has: a cap at the core count puts a
+/// 50-child family through four waves and hands most of the saving back. Wider
+/// is not better without limit either — 64 at a time measured slower than 32 on
+/// a 14-core machine, and a directory of hundreds of repositories would ask the
+/// operating system for hundreds of processes at once. The families this
+/// feature is for sit well under this width and are read in a single wave.
+const SCAN_WIDTH: usize = 32;
+
+/// What a repository whose scan did not finish is told to the user as.
+const SCAN_DIED: &str = "the scan of this repository did not finish";
+
+/// Reads every child repository of `dir`, in the order [`child_repo_dirs`]
+/// sorted them.
+///
+/// A repository is read by asking `git` for its worktrees, and the answer takes
+/// far longer to arrive than it takes to use. So `SCAN_WIDTH` of them are asked
+/// at once and the answers are collected back into directory order, which costs
+/// a family of children about what one child costs. The order the caller sees
+/// is the order it would see from reading them one at a time.
+fn read_children(dir: &Path) -> Vec<(PathBuf, Result<RepoWorktrees, String>)> {
+    let children = child_repo_dirs(dir);
+    let mut listings = Vec::with_capacity(children.len());
+
+    for wave in children.chunks(SCAN_WIDTH) {
+        std::thread::scope(|scope| {
+            let readers: Vec<_> = wave
+                .iter()
+                .map(|child| scope.spawn(move || list_worktrees(child)))
+                .collect();
+
+            for (child, reader) in wave.iter().zip(readers) {
+                // A reader that died takes its own repository out of the family
+                // and no other: one unreadable directory must not cost the user
+                // the listing.
+                let listing = reader.join().unwrap_or_else(|_| Err(SCAN_DIED.to_string()));
+                listings.push((child.clone(), listing));
+            }
+        });
+    }
+
+    listings
 }
 
 /// Gives every repository of the family a name that reaches it alone.

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -92,6 +92,9 @@ macro_rules! error {
 #[command(name = "cwt")]
 #[command(about = "Change to a different git worktree")]
 #[command(version = version_string!())]
+// Without this, clap folds the long help into one paragraph and the code blocks
+// below come out as a single run-on line.
+#[command(verbatim_doc_comment)]
 #[allow(clippy::struct_excessive_bools)] // CLI flags are naturally bool-heavy
 struct Cli {
     /// Go to the next worktree (wraps around).

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -1,11 +1,15 @@
-use std::path::{Path, PathBuf};
-use std::process::{exit, Command};
+use std::path::Path;
+use std::process::exit;
 
 use buildinfo::version_string;
 use clap::Parser;
 use colored::Colorize;
 use repowalker::find_git_repo;
 use shellsetup::ShellIntegration;
+
+mod worktree;
+
+use worktree::{get_worktrees, paths_equal, Worktree};
 
 /// Exit codes for different error conditions.
 mod exit_codes {
@@ -22,9 +26,6 @@ mod exit_codes {
     /// Multiple worktrees matched the search term.
     pub const MULTIPLE_MATCHES: i32 = 6;
 }
-
-/// Length of short commit hash for display (git uses 7 by default).
-const SHORT_COMMIT_HASH_LENGTH: usize = 7;
 
 /// Macro for printing error messages that respects quiet mode.
 macro_rules! error {
@@ -122,114 +123,6 @@ struct Cli {
     quiet: bool,
 }
 
-/// Represents a single git worktree.
-#[derive(Debug, Clone)]
-struct Worktree {
-    /// The filesystem path to this worktree.
-    path: PathBuf,
-    /// The HEAD commit hash.
-    head: String,
-    /// The branch name (without refs/heads/ prefix), or None for detached HEAD.
-    branch: Option<String>,
-}
-
-impl Worktree {
-    /// Get the final directory name (e.g., "absurd-rock" from full path).
-    fn dir_name(&self) -> Option<&str> {
-        self.path.file_name()?.to_str()
-    }
-
-    /// Get the branch name for display, or short commit hash for detached HEAD.
-    fn display_branch(&self) -> String {
-        if let Some(branch) = &self.branch {
-            branch.clone()
-        } else {
-            // Show short commit hash for detached HEAD
-            let short_hash = if self.head.len() >= SHORT_COMMIT_HASH_LENGTH {
-                &self.head[..SHORT_COMMIT_HASH_LENGTH]
-            } else {
-                &self.head
-            };
-            format!("HEAD@{short_hash}")
-        }
-    }
-}
-
-/// Parses the output of `git worktree list --porcelain`.
-///
-/// The porcelain format looks like:
-/// ```text
-/// worktree /path/to/repo
-/// HEAD abc123...
-/// branch refs/heads/main
-///
-/// worktree /path/to/worktree
-/// HEAD def456...
-/// branch refs/heads/feature
-/// ```
-///
-/// For detached HEAD, the branch line is absent.
-fn parse_worktree_list(output: &str) -> Vec<Worktree> {
-    let mut worktrees = Vec::new();
-    let mut current_path: Option<PathBuf> = None;
-    let mut current_head: Option<String> = None;
-    let mut current_branch: Option<String> = None;
-
-    for line in output.lines() {
-        if line.is_empty() {
-            // End of a worktree block, save if we have the required fields.
-            // Note: .take() already leaves the Option as None, so no need to reassign.
-            if let (Some(path), Some(head)) = (current_path.take(), current_head.take()) {
-                worktrees.push(Worktree {
-                    path,
-                    head,
-                    branch: current_branch.take(),
-                });
-            }
-        } else if let Some(path) = line.strip_prefix("worktree ") {
-            current_path = Some(PathBuf::from(path));
-        } else if let Some(head) = line.strip_prefix("HEAD ") {
-            current_head = Some(head.to_string());
-        } else if let Some(branch) = line.strip_prefix("branch ") {
-            // Strip the refs/heads/ prefix
-            let branch_name = branch.strip_prefix("refs/heads/").unwrap_or(branch);
-            current_branch = Some(branch_name.to_string());
-        }
-        // Ignore other lines (like "bare" or "detached")
-    }
-
-    // Handle last block if output doesn't end with blank line
-    if let (Some(path), Some(head)) = (current_path, current_head) {
-        worktrees.push(Worktree {
-            path,
-            head,
-            branch: current_branch,
-        });
-    }
-
-    // Sort by path for consistent ordering
-    worktrees.sort_by(|a, b| a.path.cmp(&b.path));
-
-    worktrees
-}
-
-/// Gets all worktrees for the repository at the given root.
-fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(repo_root)
-        .output()
-        .map_err(|e| format!("Failed to execute git: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree list failed: {stderr}"));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_worktree_list(&stdout))
-}
-
 /// Finds the index of the current worktree in the sorted list.
 ///
 /// # Arguments
@@ -242,20 +135,6 @@ fn find_current_worktree(worktrees: &[Worktree], repo_root: &Path) -> Option<usi
     worktrees
         .iter()
         .position(|wt| std::fs::canonicalize(&wt.path).is_ok_and(|p| paths_equal(&p, &canonical)))
-}
-
-/// Compares two paths, handling case-insensitivity on macOS.
-fn paths_equal(a: &Path, b: &Path) -> bool {
-    // On macOS, the default filesystem is case-insensitive
-    #[cfg(target_os = "macos")]
-    {
-        a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        a == b
-    }
 }
 
 /// Result of searching for a worktree by name.
@@ -546,43 +425,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_worktree_list_single() {
-        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n";
-        let worktrees = parse_worktree_list(output);
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].path, PathBuf::from("/path/to/repo"));
-        assert_eq!(worktrees[0].head, "abc123");
-        assert_eq!(worktrees[0].branch, Some("main".to_string()));
-    }
-
-    #[test]
-    fn test_parse_worktree_list_multiple() {
-        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /path/to/wt\nHEAD def456\nbranch refs/heads/feature\n";
-        let worktrees = parse_worktree_list(output);
-        assert_eq!(worktrees.len(), 2);
-        assert_eq!(worktrees[0].path, PathBuf::from("/path/to/repo"));
-        assert_eq!(worktrees[1].path, PathBuf::from("/path/to/wt"));
-    }
-
-    #[test]
-    fn test_parse_worktree_list_detached_head() {
-        let output = "worktree /path/to/repo\nHEAD abc123\ndetached\n";
-        let worktrees = parse_worktree_list(output);
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].branch, None);
-    }
-
-    #[test]
-    fn test_parse_worktree_list_sorted() {
-        let output = "worktree /z/repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /a/repo\nHEAD def\nbranch refs/heads/feature\n";
-        let worktrees = parse_worktree_list(output);
-        assert_eq!(worktrees.len(), 2);
-        // Should be sorted by path
-        assert_eq!(worktrees[0].path, PathBuf::from("/a/repo"));
-        assert_eq!(worktrees[1].path, PathBuf::from("/z/repo"));
-    }
+    use std::path::PathBuf;
 
     #[test]
     fn test_find_worktree_by_dir_name() {
@@ -865,41 +708,6 @@ mod tests {
 
         let current = 0;
         assert_eq!(if current == 0 { count - 1 } else { current - 1 }, 2); // Wraps
-    }
-
-    #[test]
-    fn test_worktree_dir_name() {
-        let wt = Worktree {
-            path: PathBuf::from("/repo-worktrees/absurd-rock"),
-            head: "abc".to_string(),
-            branch: Some("feature".to_string()),
-        };
-        assert_eq!(wt.dir_name(), Some("absurd-rock"));
-    }
-
-    #[test]
-    fn test_worktree_display_branch() {
-        let with_branch = Worktree {
-            path: PathBuf::from("/repo"),
-            head: "abc".to_string(),
-            branch: Some("main".to_string()),
-        };
-        assert_eq!(with_branch.display_branch(), "main");
-
-        let detached = Worktree {
-            path: PathBuf::from("/repo"),
-            head: "abc1234567890".to_string(),
-            branch: None,
-        };
-        assert_eq!(detached.display_branch(), "HEAD@abc1234");
-    }
-
-    #[test]
-    fn test_parse_worktree_no_trailing_newline() {
-        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main";
-        let worktrees = parse_worktree_list(output);
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].branch, Some("main".to_string()));
     }
 
     /// Builds a worktree fixture at `path` checked out on `branch`.

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -1,15 +1,14 @@
-use std::path::Path;
 use std::process::exit;
 
 use buildinfo::version_string;
 use clap::Parser;
-use colored::Colorize;
 use repowalker::find_git_repo;
 use shellsetup::ShellIntegration;
 
+mod family;
 mod worktree;
 
-use worktree::{get_worktrees, paths_equal, Worktree};
+use family::{Family, WorktreeMatch, MAIN_BRANCH_NAMES};
 
 /// Exit codes for different error conditions.
 mod exit_codes {
@@ -40,6 +39,13 @@ macro_rules! error {
 ///
 /// Lists all worktrees in the current repository or navigates to a specific one.
 ///
+/// # Families of repositories
+///
+/// A repository that holds other repositories one level below it — a workspace
+/// that tracks the map, with the real repositories checked out inside it — is a
+/// family. `cwt` lists every worktree of every repository in the family, and
+/// navigates to any of them by name.
+///
 /// # Usage
 ///
 /// ```sh
@@ -49,6 +55,7 @@ macro_rules! error {
 /// cwt -m        # Go to the main worktree (branch main, or master)
 /// cwt NAME      # Go to worktree by directory name or branch name
 /// cwt TEXT      # Go to worktree by case-insensitive substring match on branch
+/// cwt REPO:NAME # Go to a worktree of one repository in the family
 /// ```
 ///
 /// # Shell Integration
@@ -106,6 +113,10 @@ struct Cli {
     ///
     /// Matches in order: exact directory name, exact branch name, then case-insensitive
     /// substring on branch names. If multiple branches match, lists them and exits.
+    ///
+    /// Prefix a repository name to select inside one repository of the family,
+    /// for example `child-b:shared`. A bare `child-b:` selects that
+    /// repository's main worktree.
     #[arg(conflicts_with_all = ["forward", "prev", "main", "shell_setup"], verbatim_doc_comment)]
     target: Option<String>,
 
@@ -123,107 +134,17 @@ struct Cli {
     quiet: bool,
 }
 
-/// Finds the index of the current worktree in the sorted list.
+/// Lists every worktree of the family to stderr, one `  name [branch]` a line.
 ///
-/// # Arguments
+/// Both the "not found" and the "no main worktree" errors end with this list,
+/// so the format lives here and not at either call site.
 ///
-/// * `worktrees` - The list of worktrees to search
-/// * `repo_root` - The root of the current repository (avoids redundant `find_git_repo()` call)
-fn find_current_worktree(worktrees: &[Worktree], repo_root: &Path) -> Option<usize> {
-    let canonical = std::fs::canonicalize(repo_root).ok()?;
-
-    worktrees
-        .iter()
-        .position(|wt| std::fs::canonicalize(&wt.path).is_ok_and(|p| paths_equal(&p, &canonical)))
-}
-
-/// Result of searching for a worktree by name.
-#[derive(Debug)]
-enum WorktreeMatch {
-    /// Found exactly one matching worktree.
-    Single(usize),
-    /// Found multiple matching worktrees (indices into the worktree list).
-    Multiple(Vec<usize>),
-    /// No matching worktree found.
-    None,
-}
-
-/// Finds a worktree by name (directory name, branch name, or branch substring).
-///
-/// Search priority:
-/// 1. Exact directory name match
-/// 2. Exact branch name match (supports branch names with `/` like `feature/login`)
-/// 3. Case-insensitive substring match on branch names
-///
-/// Rejects names containing `..` or `\` to prevent path traversal. Forward slashes
-/// are allowed since they're common in branch names (e.g., `feature/login`) and
-/// directory names cannot contain `/` on Unix filesystems.
-fn find_worktree_by_name(worktrees: &[Worktree], name: &str) -> WorktreeMatch {
-    // Reject empty search terms (would match all branches via substring)
-    // and path traversal attempts.
-    // Note: `/` is intentionally allowed because:
-    // - Branch names commonly contain `/` (e.g., `feature/login`, `bugfix/issue-42`)
-    // - Directory names cannot contain `/` on Unix, so no security risk for dir matching
-    // - Worktree paths come from `git worktree list`, not user input
-    if name.is_empty() || name.contains('\\') || name.contains("..") {
-        return WorktreeMatch::None;
+/// The list follows an error, so it obeys quiet mode.
+fn print_available(family: &Family, quiet: bool) {
+    error!(quiet, "Available worktrees:");
+    for label in family.labels() {
+        error!(quiet, "  {}", label);
     }
-
-    // First: try exact directory name match
-    if let Some(idx) = worktrees.iter().position(|wt| wt.dir_name() == Some(name)) {
-        return WorktreeMatch::Single(idx);
-    }
-
-    // Second: try exact branch name match
-    if let Some(idx) = worktrees
-        .iter()
-        .position(|wt| wt.branch.as_deref() == Some(name))
-    {
-        return WorktreeMatch::Single(idx);
-    }
-
-    // Third: try case-insensitive substring match on branch names
-    // Note: We collect all matches because we need to display them in the Multiple case
-    let name_lower = name.to_lowercase();
-    let matches: Vec<usize> = worktrees
-        .iter()
-        .enumerate()
-        .filter(|(_, wt)| {
-            wt.branch
-                .as_ref()
-                .is_some_and(|b| b.to_lowercase().contains(&name_lower))
-        })
-        .map(|(idx, _)| idx)
-        .collect();
-
-    match matches.len() {
-        0 => WorktreeMatch::None,
-        1 => WorktreeMatch::Single(matches[0]),
-        _ => WorktreeMatch::Multiple(matches),
-    }
-}
-
-/// The branch names that identify the main worktree, in order of priority.
-///
-/// `main` comes first. `master` is the fallback for a repository that never
-/// renamed its first branch.
-const MAIN_BRANCH_NAMES: [&str; 2] = ["main", "master"];
-
-/// Finds the main worktree: the one on branch `main`, or the one on branch
-/// `master` when no worktree is on `main`.
-///
-/// The branch name must match exactly. The substring match that
-/// [`find_worktree_by_name`] does is wrong here: in a repository that has no
-/// `main` branch, a branch such as `wt-main-master` would capture the shortcut
-/// and send the user somewhere that is not the main worktree.
-///
-/// A detached worktree has no branch, so it is never the main worktree.
-fn find_main_worktree(worktrees: &[Worktree]) -> Option<usize> {
-    MAIN_BRANCH_NAMES.iter().find_map(|name| {
-        worktrees
-            .iter()
-            .position(|wt| wt.branch.as_deref() == Some(*name))
-    })
 }
 
 /// Formats `names` as a quoted alternation: `'main' or 'master'`.
@@ -237,51 +158,6 @@ fn quoted_branch_alternatives(names: &[&str]) -> String {
         .map(|name| format!("'{name}'"))
         .collect::<Vec<_>>()
         .join(" or ")
-}
-
-/// Prints one worktree to stderr as `  directory [branch]`.
-///
-/// Both the "not found" and the "multiple matches" errors list worktrees in
-/// this format, so the format lives here and not at either call site. Those
-/// two list different sets of worktrees, which is why the set is the caller's
-/// business and the line is not.
-///
-/// The list follows an error, so it obeys quiet mode.
-fn print_worktree_line(wt: &Worktree, quiet: bool) {
-    let dir = wt.dir_name().unwrap_or("<unknown>");
-    let branch = wt.display_branch();
-    error!(quiet, "  {} [{}]", dir, branch);
-}
-
-/// Prints every worktree to stderr, one [`print_worktree_line`] each.
-///
-/// This list follows a "not found" error, so it obeys quiet mode.
-fn print_available_worktrees(worktrees: &[Worktree], quiet: bool) {
-    error!(quiet, "Available worktrees:");
-    for wt in worktrees {
-        print_worktree_line(wt, quiet);
-    }
-}
-
-/// Displays the list of worktrees with the current one highlighted.
-fn display_worktree_list(worktrees: &[Worktree], current_idx: Option<usize>) {
-    for (idx, wt) in worktrees.iter().enumerate() {
-        let is_current = current_idx == Some(idx);
-        let marker = if is_current { ">" } else { " " };
-        let path = wt.path.display().to_string();
-        let branch = wt.display_branch();
-
-        if is_current {
-            println!(
-                "{} {} [{}]",
-                marker.green().bold(),
-                path.green().bold(),
-                branch.green()
-            );
-        } else {
-            println!("{} {} [{}]", marker, path, branch.dimmed());
-        }
-    }
 }
 
 /// The shell code to add to shell config files.
@@ -342,442 +218,82 @@ fn main() {
         exit(exit_codes::NOT_IN_REPO);
     };
 
-    // Get all worktrees
-    let worktrees = match get_worktrees(&repo_root) {
-        Ok(wts) => wts,
+    // Collect the family: this repository, and any repository beside it
+    let family = match Family::discover(&repo_root, true) {
+        Ok(family) => family,
         Err(e) => {
             error!(cli.quiet, "Error getting worktrees: {}", e);
             exit(exit_codes::GIT_COMMAND_ERROR);
         }
     };
 
-    if worktrees.is_empty() {
+    for warning in family.warnings() {
+        error!(cli.quiet, "Warning: skipped {}", warning);
+    }
+
+    if family.is_empty() {
         error!(cli.quiet, "No worktrees found");
         exit(exit_codes::GIT_COMMAND_ERROR);
     }
 
-    // Find current worktree (pass repo_root to avoid redundant find_git_repo() call)
-    let current_idx = find_current_worktree(&worktrees, &repo_root);
-
     // Handle different modes
     if cli.forward {
-        // Next worktree (wrap around)
-        let target_idx = if let Some(i) = current_idx {
-            (i + 1) % worktrees.len()
-        } else {
+        let Some(index) = family.next() else {
             error!(cli.quiet, "Error: Could not determine current worktree");
             exit(exit_codes::CURRENT_UNKNOWN);
         };
-        println!("{}", worktrees[target_idx].path.display());
+        println!("{}", family.path(index).display());
     } else if cli.prev {
-        // Previous worktree (wrap around)
-        let target_idx = if let Some(i) = current_idx {
-            if i == 0 {
-                worktrees.len() - 1
-            } else {
-                i - 1
-            }
-        } else {
+        let Some(index) = family.previous() else {
             error!(cli.quiet, "Error: Could not determine current worktree");
             exit(exit_codes::CURRENT_UNKNOWN);
         };
-        println!("{}", worktrees[target_idx].path.display());
+        println!("{}", family.path(index).display());
     } else if cli.main {
         // Main worktree: branch main, or branch master when there is no main.
-        let Some(target_idx) = find_main_worktree(&worktrees) else {
+        let Some(index) = family.main_worktree() else {
             error!(
                 cli.quiet,
                 "Error: No worktree is on branch {}",
                 quoted_branch_alternatives(&MAIN_BRANCH_NAMES)
             );
-            print_available_worktrees(&worktrees, cli.quiet);
+            print_available(&family, cli.quiet);
             exit(exit_codes::WORKTREE_NOT_FOUND);
         };
-        println!("{}", worktrees[target_idx].path.display());
+        println!("{}", family.path(index).display());
     } else if let Some(name) = &cli.target {
-        // Find by name
-        match find_worktree_by_name(&worktrees, name) {
-            WorktreeMatch::Single(idx) => {
-                println!("{}", worktrees[idx].path.display());
+        match family.find(name) {
+            WorktreeMatch::Single(index) => {
+                println!("{}", family.path(index).display());
             }
             WorktreeMatch::Multiple(indices) => {
                 error!(
                     cli.quiet,
                     "Error: Multiple worktrees match '{}'. Be more specific:", name
                 );
-                for idx in indices {
-                    print_worktree_line(&worktrees[idx], cli.quiet);
+                for index in indices {
+                    error!(cli.quiet, "  {}", family.label(index));
                 }
                 exit(exit_codes::MULTIPLE_MATCHES);
             }
             WorktreeMatch::None => {
                 error!(cli.quiet, "Error: Worktree '{}' not found", name);
-                print_available_worktrees(&worktrees, cli.quiet);
+                print_available(&family, cli.quiet);
                 exit(exit_codes::WORKTREE_NOT_FOUND);
             }
         }
     } else {
         // No args: display list
-        display_worktree_list(&worktrees, current_idx);
+        print!("{}", family.render());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
-    #[test]
-    fn test_find_worktree_by_dir_name() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/absurd-rock"),
-                head: "def".to_string(),
-                branch: Some("feature".to_string()),
-            },
-        ];
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "absurd-rock"),
-            WorktreeMatch::Single(1)
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_by_branch() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/absurd-rock"),
-                head: "def".to_string(),
-                branch: Some("feature".to_string()),
-            },
-        ];
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "feature"),
-            WorktreeMatch::Single(1)
-        ));
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "main"),
-            WorktreeMatch::Single(0)
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_not_found() {
-        let worktrees = vec![Worktree {
-            path: PathBuf::from("/repo"),
-            head: "abc".to_string(),
-            branch: Some("main".to_string()),
-        }];
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "nonexistent"),
-            WorktreeMatch::None
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_rejects_empty_string() {
-        // Empty string would match all branches via substring, which is unexpected
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt1"),
-                head: "def".to_string(),
-                branch: Some("feature".to_string()),
-            },
-        ];
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, ""),
-            WorktreeMatch::None
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_rejects_path_traversal() {
-        let worktrees = vec![Worktree {
-            path: PathBuf::from("/repo"),
-            head: "abc".to_string(),
-            branch: Some("main".to_string()),
-        }];
-        // Should reject path traversal attempts (backslash and ..)
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "../etc/passwd"),
-            WorktreeMatch::None
-        ));
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "foo\\bar"),
-            WorktreeMatch::None
-        ));
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, ".."),
-            WorktreeMatch::None
-        ));
-        // Note: Forward slash `/` is intentionally allowed - see test below
-    }
-
-    #[test]
-    fn test_find_worktree_allows_forward_slash_in_branch_names() {
-        // Forward slashes are common in branch names (feature/*, bugfix/*, etc.)
-        // and should work for both exact and substring matching
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt1"),
-                head: "def".to_string(),
-                branch: Some("feature/user-auth".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt2"),
-                head: "ghi".to_string(),
-                branch: Some("feature/login-page".to_string()),
-            },
-        ];
-
-        // Exact branch match with forward slash
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "feature/user-auth"),
-            WorktreeMatch::Single(1)
-        ));
-
-        // Substring match with forward slash (matches both feature/* branches)
-        match find_worktree_by_name(&worktrees, "feature/") {
-            WorktreeMatch::Multiple(indices) => {
-                assert_eq!(indices.len(), 2);
-                assert!(indices.contains(&1));
-                assert!(indices.contains(&2));
-            }
-            other => panic!("Expected Multiple, got {other:?}"),
-        }
-
-        // Partial path within branch name
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "ure/user"),
-            WorktreeMatch::Single(1)
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_substring_match_single() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt1"),
-                head: "def".to_string(),
-                branch: Some("feature/login-page".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt2"),
-                head: "ghi".to_string(),
-                branch: Some("bugfix/header".to_string()),
-            },
-        ];
-        // "login" matches only "feature/login-page"
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "login"),
-            WorktreeMatch::Single(1)
-        ));
-        // Case-insensitive: "LOGIN" should also match
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "LOGIN"),
-            WorktreeMatch::Single(1)
-        ));
-        // "header" matches only "bugfix/header"
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "header"),
-            WorktreeMatch::Single(2)
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_substring_match_multiple() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt1"),
-                head: "def".to_string(),
-                branch: Some("feature/login-page".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt2"),
-                head: "ghi".to_string(),
-                branch: Some("feature/logout-page".to_string()),
-            },
-        ];
-        // "feature" matches both feature branches
-        match find_worktree_by_name(&worktrees, "feature") {
-            WorktreeMatch::Multiple(indices) => {
-                assert_eq!(indices.len(), 2);
-                assert!(indices.contains(&1));
-                assert!(indices.contains(&2));
-            }
-            other => panic!("Expected Multiple, got {other:?}"),
-        }
-        // "page" also matches both
-        match find_worktree_by_name(&worktrees, "page") {
-            WorktreeMatch::Multiple(indices) => {
-                assert_eq!(indices.len(), 2);
-            }
-            other => panic!("Expected Multiple, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_find_worktree_exact_match_takes_priority() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: "abc".to_string(),
-                branch: Some("main".to_string()),
-            },
-            Worktree {
-                path: PathBuf::from("/repo-wt/wt1"),
-                head: "def".to_string(),
-                branch: Some("main-feature".to_string()),
-            },
-        ];
-        // "main" should exact-match the first worktree, not substring-match both
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "main"),
-            WorktreeMatch::Single(0)
-        ));
-    }
-
-    #[test]
-    fn test_find_worktree_substring_case_insensitive() {
-        let worktrees = vec![Worktree {
-            path: PathBuf::from("/repo"),
-            head: "abc".to_string(),
-            branch: Some("Feature/UserAuth".to_string()),
-        }];
-        // Various case combinations should all match
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "userauth"),
-            WorktreeMatch::Single(0)
-        ));
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "USERAUTH"),
-            WorktreeMatch::Single(0)
-        ));
-        assert!(matches!(
-            find_worktree_by_name(&worktrees, "UserAuth"),
-            WorktreeMatch::Single(0)
-        ));
-    }
-
-    #[test]
-    fn test_cycle_forward() {
-        let current = 0;
-        let count = 3;
-        assert_eq!((current + 1) % count, 1);
-
-        let current = 2;
-        assert_eq!((current + 1) % count, 0); // Wraps
-    }
-
-    #[test]
-    fn test_cycle_backward() {
-        let count = 3;
-
-        let current = 1;
-        assert_eq!(if current == 0 { count - 1 } else { current - 1 }, 0);
-
-        let current = 0;
-        assert_eq!(if current == 0 { count - 1 } else { current - 1 }, 2); // Wraps
-    }
-
-    /// Builds a worktree fixture at `path` checked out on `branch`.
-    ///
-    /// Pass `None` as the branch for a detached HEAD.
-    fn worktree_on(path: &str, branch: Option<&str>) -> Worktree {
-        Worktree {
-            path: PathBuf::from(path),
-            head: "abc1234567890".to_string(),
-            branch: branch.map(str::to_string),
-        }
-    }
-
-    #[test]
-    fn test_find_main_worktree_picks_main() {
-        let worktrees = vec![
-            worktree_on("/repo", Some("main")),
-            worktree_on("/repo-wt/wt1", Some("feature")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), Some(0));
-    }
-
-    #[test]
-    fn test_find_main_worktree_falls_back_to_master() {
-        // A repository that never renamed master still has a main worktree.
-        let worktrees = vec![
-            worktree_on("/repo-wt/wt1", Some("feature")),
-            worktree_on("/repo", Some("master")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), Some(1));
-    }
-
-    #[test]
-    fn test_find_main_worktree_prefers_main_over_master() {
-        // Both branches exist. main wins, whatever the order of the list.
-        let worktrees = vec![
-            worktree_on("/repo-wt/old", Some("master")),
-            worktree_on("/repo", Some("main")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), Some(1));
-    }
-
-    #[test]
-    fn test_find_main_worktree_ignores_substring_branches() {
-        // The branch name must match exactly. A branch that merely contains
-        // "main" must not capture the main worktree of a master repository.
-        let worktrees = vec![
-            worktree_on("/repo-wt/wt1", Some("wt-main-master")),
-            worktree_on("/repo", Some("master")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), Some(1));
-    }
-
-    #[test]
-    fn test_find_main_worktree_ignores_detached_head() {
-        let worktrees = vec![
-            worktree_on("/repo-wt/wt1", None),
-            worktree_on("/repo", Some("master")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), Some(1));
-    }
-
-    #[test]
-    fn test_find_main_worktree_none_without_main_or_master() {
-        let worktrees = vec![
-            worktree_on("/repo", Some("trunk")),
-            worktree_on("/repo-wt/wt1", Some("wt-main-master")),
-        ];
-        assert_eq!(find_main_worktree(&worktrees), None);
-    }
+    // The tests of the main-worktree search live beside the search itself, in
+    // the family module.
 
     #[test]
     fn test_quoted_branch_alternatives_quotes_a_single_name() {

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -120,6 +120,11 @@ struct Cli {
     /// Prefix a repository name to search one repository of the family, for
     /// example `REPO:feature-x`. Part of the name is enough, and a bare `REPO:`
     /// selects that repository's main worktree.
+    ///
+    /// A repository whose directory name belongs to another repository of the
+    /// family — a parent that holds a child named after itself — is named by
+    /// the path that leads to it instead, the way the listing heads it:
+    /// `PARENT/REPO:feature-x`.
     #[arg(conflicts_with_all = ["forward", "prev", "main", "shell_setup"], verbatim_doc_comment)]
     target: Option<String>,
 

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -129,6 +129,12 @@ struct Cli {
     #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "main", "target"])]
     shell_setup: bool,
 
+    /// List only the repository you are standing in, not the whole family.
+    ///
+    /// Set `CWT_NO_FAMILY` to any value other than 0 to make this the default.
+    #[arg(long, verbatim_doc_comment, conflicts_with = "shell_setup")]
+    no_family: bool,
+
     /// Suppress error messages.
     #[arg(short, long)]
     quiet: bool,
@@ -158,6 +164,19 @@ fn quoted_branch_alternatives(names: &[&str]) -> String {
         .map(|name| format!("'{name}'"))
         .collect::<Vec<_>>()
         .join(" or ")
+}
+
+/// The environment variable that makes `--no-family` the default.
+const NO_FAMILY_ENV: &str = "CWT_NO_FAMILY";
+
+/// True when the environment asks `cwt` to stay inside one repository.
+///
+/// An unset or empty variable is not a choice, and `0` is the choice not to.
+fn no_family_in_env() -> bool {
+    match std::env::var(NO_FAMILY_ENV) {
+        Ok(value) => !value.is_empty() && value != "0",
+        Err(_) => false,
+    }
 }
 
 /// The shell code to add to shell config files.
@@ -219,7 +238,8 @@ fn main() {
     };
 
     // Collect the family: this repository, and any repository beside it
-    let family = match Family::discover(&repo_root, true) {
+    let scan_children = !cli.no_family && !no_family_in_env();
+    let family = match Family::discover(&repo_root, scan_children) {
         Ok(family) => family,
         Err(e) => {
             error!(cli.quiet, "Error getting worktrees: {}", e);

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -37,7 +37,9 @@ macro_rules! error {
 
 /// Change to a different git worktree.
 ///
-/// Lists all worktrees in the current repository or navigates to a specific one.
+/// Lists every worktree of the repository and of the repositories inside it,
+/// or navigates to a specific one. `--no-family` lists only the repository you
+/// are standing in.
 ///
 /// # Families of repositories
 ///

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -117,9 +117,9 @@ struct Cli {
     /// Matches in order: exact directory name, exact branch name, then case-insensitive
     /// substring on branch names. If multiple branches match, lists them and exits.
     ///
-    /// Prefix a repository name to select inside one repository of the family,
-    /// for example `child-b:shared`. A bare `child-b:` selects that
-    /// repository's main worktree.
+    /// Prefix a repository name to search one repository of the family, for
+    /// example `REPO:feature-x`. Part of the name is enough, and a bare `REPO:`
+    /// selects that repository's main worktree.
     #[arg(conflicts_with_all = ["forward", "prev", "main", "shell_setup"], verbatim_doc_comment)]
     target: Option<String>,
 

--- a/src/cwt/src/worktree.rs
+++ b/src/cwt/src/worktree.rs
@@ -98,8 +98,28 @@ pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     worktrees
 }
 
+/// Finds the main worktree in the output of `git worktree list --porcelain`.
+///
+/// Git lists the main worktree first and the linked worktrees after it, so the
+/// first `worktree` line names the main one. `parse_worktree_list` sorts by
+/// path and loses that order, which is why this reads the raw output.
+pub fn parse_main_worktree(output: &str) -> Option<PathBuf> {
+    output
+        .lines()
+        .find_map(|line| line.strip_prefix("worktree ").map(PathBuf::from))
+}
+
+/// Every worktree of one repository.
+#[derive(Debug, Clone)]
+pub struct RepoWorktrees {
+    /// The main worktree — the checkout that owns the `.git` directory.
+    pub main: PathBuf,
+    /// All worktrees of the repository, sorted by path.
+    pub all: Vec<Worktree>,
+}
+
 /// Gets all worktrees for the repository at the given root.
-pub fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
+pub fn list_worktrees(repo_root: &Path) -> Result<RepoWorktrees, String> {
     let output = Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_root)
@@ -112,7 +132,17 @@ pub fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(parse_worktree_list(&stdout))
+    let main = parse_main_worktree(&stdout).ok_or_else(|| {
+        format!(
+            "git worktree list named no worktree in {}",
+            repo_root.display()
+        )
+    })?;
+
+    Ok(RepoWorktrees {
+        main,
+        all: parse_worktree_list(&stdout),
+    })
 }
 
 /// Compares two paths, handling case-insensitivity on macOS.
@@ -195,6 +225,22 @@ mod tests {
             branch: None,
         };
         assert_eq!(detached.display_branch(), "HEAD@abc1234");
+    }
+
+    #[test]
+    fn test_parse_main_worktree_is_the_first_block() {
+        // Git lists the main worktree first, whatever the paths sort like.
+        let output = "worktree /z/repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /a/repo-wt\nHEAD def\nbranch refs/heads/feature\n";
+        assert_eq!(
+            parse_main_worktree(output),
+            Some(PathBuf::from("/z/repo")),
+            "the sorted list starts with /a/repo-wt, but the main worktree is /z/repo"
+        );
+    }
+
+    #[test]
+    fn test_parse_main_worktree_of_empty_output() {
+        assert_eq!(parse_main_worktree(""), None);
     }
 
     #[test]

--- a/src/cwt/src/worktree.rs
+++ b/src/cwt/src/worktree.rs
@@ -227,6 +227,45 @@ mod tests {
         assert_eq!(detached.display_branch(), "HEAD@abc1234");
     }
 
+    /// A detached HEAD is normally hex ASCII, but `display_branch` must never
+    /// panic on a head that carries multi-byte characters, and must count the
+    /// short hash in characters rather than bytes.
+    #[test]
+    fn test_worktree_display_branch_counts_characters_not_bytes() {
+        let japanese = Worktree {
+            path: PathBuf::from("/repo"),
+            head: "日本語テスト".to_string(),
+            branch: None,
+        };
+        assert_eq!(
+            japanese.display_branch(),
+            "HEAD@日本語テスト",
+            "6 characters is shorter than the 7-character short hash, so all of it shows"
+        );
+
+        let emoji = Worktree {
+            path: PathBuf::from("/repo"),
+            head: "🎉🎊🎁🎈🎂🎃🎄🎆".to_string(),
+            branch: None,
+        };
+        assert_eq!(
+            emoji.display_branch(),
+            "HEAD@🎉🎊🎁🎈🎂🎃🎄",
+            "8 characters truncates to the first 7 characters, not the first 7 bytes"
+        );
+
+        let mixed = Worktree {
+            path: PathBuf::from("/repo"),
+            head: "café1234".to_string(),
+            branch: None,
+        };
+        assert_eq!(
+            mixed.display_branch(),
+            "HEAD@café123",
+            "the accented character costs two bytes but only one character"
+        );
+    }
+
     #[test]
     fn test_parse_main_worktree_is_the_first_block() {
         // Git lists the main worktree first, whatever the paths sort like.

--- a/src/cwt/src/worktree.rs
+++ b/src/cwt/src/worktree.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Length of short commit hash for display (git uses 7 by default).
+/// Number of characters of a commit hash to show (git uses 7 by default).
 const SHORT_COMMIT_HASH_LENGTH: usize = 7;
 
 /// Represents a single git worktree.
@@ -25,16 +25,17 @@ impl Worktree {
     }
 
     /// Get the branch name for display, or short commit hash for detached HEAD.
+    ///
+    /// A detached HEAD shows the first `SHORT_COMMIT_HASH_LENGTH` characters of
+    /// the hash, or the whole hash when it is shorter than that. Counting
+    /// characters rather than bytes keeps a head that carries multi-byte UTF-8
+    /// from panicking or from losing a character to a truncated byte sequence.
     pub fn display_branch(&self) -> String {
         if let Some(branch) = &self.branch {
             branch.clone()
         } else {
             // Show short commit hash for detached HEAD
-            let short_hash = if self.head.len() >= SHORT_COMMIT_HASH_LENGTH {
-                &self.head[..SHORT_COMMIT_HASH_LENGTH]
-            } else {
-                &self.head
-            };
+            let short_hash: String = self.head.chars().take(SHORT_COMMIT_HASH_LENGTH).collect();
             format!("HEAD@{short_hash}")
         }
     }

--- a/src/cwt/src/worktree.rs
+++ b/src/cwt/src/worktree.rs
@@ -1,0 +1,207 @@
+//! The git-level view of a worktree: what `git worktree list --porcelain` says,
+//! and nothing about how `cwt` presents or selects one.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Length of short commit hash for display (git uses 7 by default).
+const SHORT_COMMIT_HASH_LENGTH: usize = 7;
+
+/// Represents a single git worktree.
+#[derive(Debug, Clone)]
+pub struct Worktree {
+    /// The filesystem path to this worktree.
+    pub path: PathBuf,
+    /// The HEAD commit hash.
+    pub head: String,
+    /// The branch name (without refs/heads/ prefix), or None for detached HEAD.
+    pub branch: Option<String>,
+}
+
+impl Worktree {
+    /// Get the final directory name (e.g., "absurd-rock" from full path).
+    pub fn dir_name(&self) -> Option<&str> {
+        self.path.file_name()?.to_str()
+    }
+
+    /// Get the branch name for display, or short commit hash for detached HEAD.
+    pub fn display_branch(&self) -> String {
+        if let Some(branch) = &self.branch {
+            branch.clone()
+        } else {
+            // Show short commit hash for detached HEAD
+            let short_hash = if self.head.len() >= SHORT_COMMIT_HASH_LENGTH {
+                &self.head[..SHORT_COMMIT_HASH_LENGTH]
+            } else {
+                &self.head
+            };
+            format!("HEAD@{short_hash}")
+        }
+    }
+}
+
+/// Parses the output of `git worktree list --porcelain`.
+///
+/// The porcelain format looks like:
+/// ```text
+/// worktree /path/to/repo
+/// HEAD abc123...
+/// branch refs/heads/main
+///
+/// worktree /path/to/worktree
+/// HEAD def456...
+/// branch refs/heads/feature
+/// ```
+///
+/// For detached HEAD, the branch line is absent.
+pub fn parse_worktree_list(output: &str) -> Vec<Worktree> {
+    let mut worktrees = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_head: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+
+    for line in output.lines() {
+        if line.is_empty() {
+            // End of a worktree block, save if we have the required fields.
+            // Note: .take() already leaves the Option as None, so no need to reassign.
+            if let (Some(path), Some(head)) = (current_path.take(), current_head.take()) {
+                worktrees.push(Worktree {
+                    path,
+                    head,
+                    branch: current_branch.take(),
+                });
+            }
+        } else if let Some(path) = line.strip_prefix("worktree ") {
+            current_path = Some(PathBuf::from(path));
+        } else if let Some(head) = line.strip_prefix("HEAD ") {
+            current_head = Some(head.to_string());
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            // Strip the refs/heads/ prefix
+            let branch_name = branch.strip_prefix("refs/heads/").unwrap_or(branch);
+            current_branch = Some(branch_name.to_string());
+        }
+        // Ignore other lines (like "bare" or "detached")
+    }
+
+    // Handle last block if output doesn't end with blank line
+    if let (Some(path), Some(head)) = (current_path, current_head) {
+        worktrees.push(Worktree {
+            path,
+            head,
+            branch: current_branch,
+        });
+    }
+
+    // Sort by path for consistent ordering
+    worktrees.sort_by(|a, b| a.path.cmp(&b.path));
+
+    worktrees
+}
+
+/// Gets all worktrees for the repository at the given root.
+pub fn get_worktrees(repo_root: &Path) -> Result<Vec<Worktree>, String> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| format!("Failed to execute git: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git worktree list failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_worktree_list(&stdout))
+}
+
+/// Compares two paths, handling case-insensitivity on macOS.
+pub fn paths_equal(a: &Path, b: &Path) -> bool {
+    // On macOS, the default filesystem is case-insensitive
+    #[cfg(target_os = "macos")]
+    {
+        a.to_string_lossy().to_lowercase() == b.to_string_lossy().to_lowercase()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        a == b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_worktree_list_single() {
+        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n";
+        let worktrees = parse_worktree_list(output);
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].path, PathBuf::from("/path/to/repo"));
+        assert_eq!(worktrees[0].head, "abc123");
+        assert_eq!(worktrees[0].branch, Some("main".to_string()));
+    }
+
+    #[test]
+    fn test_parse_worktree_list_multiple() {
+        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /path/to/wt\nHEAD def456\nbranch refs/heads/feature\n";
+        let worktrees = parse_worktree_list(output);
+        assert_eq!(worktrees.len(), 2);
+        assert_eq!(worktrees[0].path, PathBuf::from("/path/to/repo"));
+        assert_eq!(worktrees[1].path, PathBuf::from("/path/to/wt"));
+    }
+
+    #[test]
+    fn test_parse_worktree_list_detached_head() {
+        let output = "worktree /path/to/repo\nHEAD abc123\ndetached\n";
+        let worktrees = parse_worktree_list(output);
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].branch, None);
+    }
+
+    #[test]
+    fn test_parse_worktree_list_sorted() {
+        let output = "worktree /z/repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /a/repo\nHEAD def\nbranch refs/heads/feature\n";
+        let worktrees = parse_worktree_list(output);
+        assert_eq!(worktrees.len(), 2);
+        // Should be sorted by path
+        assert_eq!(worktrees[0].path, PathBuf::from("/a/repo"));
+        assert_eq!(worktrees[1].path, PathBuf::from("/z/repo"));
+    }
+
+    #[test]
+    fn test_worktree_dir_name() {
+        let wt = Worktree {
+            path: PathBuf::from("/repo-worktrees/absurd-rock"),
+            head: "abc".to_string(),
+            branch: Some("feature".to_string()),
+        };
+        assert_eq!(wt.dir_name(), Some("absurd-rock"));
+    }
+
+    #[test]
+    fn test_worktree_display_branch() {
+        let with_branch = Worktree {
+            path: PathBuf::from("/repo"),
+            head: "abc".to_string(),
+            branch: Some("main".to_string()),
+        };
+        assert_eq!(with_branch.display_branch(), "main");
+
+        let detached = Worktree {
+            path: PathBuf::from("/repo"),
+            head: "abc1234567890".to_string(),
+            branch: None,
+        };
+        assert_eq!(detached.display_branch(), "HEAD@abc1234");
+    }
+
+    #[test]
+    fn test_parse_worktree_no_trailing_newline() {
+        let output = "worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main";
+        let worktrees = parse_worktree_list(output);
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].branch, Some("main".to_string()));
+    }
+}

--- a/src/cwt/tests/family-conflicts.rs
+++ b/src/cwt/tests/family-conflicts.rs
@@ -65,7 +65,12 @@ fn a_bare_repository_prefix_selects_its_main_worktree() {
     let family = Family::build();
     let output = cwt(&family.at("family"), &["child-b:"]);
 
-    assert_eq!(code(&output), 0, "cwt child-b: failed: {}", combined(&output));
+    assert_eq!(
+        code(&output),
+        0,
+        "cwt child-b: failed: {}",
+        combined(&output)
+    );
     assert_eq!(
         target_path(&output),
         family.path_of("family/child-b"),
@@ -102,7 +107,11 @@ fn an_unknown_repository_prefix_is_not_found() {
         "no repository is named nope: {}",
         combined(&output)
     );
-    assert_eq!(stdout(&output), "", "a name that is not found prints no path");
+    assert_eq!(
+        stdout(&output),
+        "",
+        "a name that is not found prints no path"
+    );
 }
 
 #[test]

--- a/src/cwt/tests/family-conflicts.rs
+++ b/src/cwt/tests/family-conflicts.rs
@@ -1,0 +1,120 @@
+//! What `cwt` does when a name fits more than one repository in the family.
+//!
+//! It refuses to guess, and it names the candidates the way the user has to
+//! type them: `repository:worktree`.
+
+mod support;
+
+use support::{code, combined, cwt, stdout, target_path, Family};
+
+/// The exit code `cwt --help` publishes for an ambiguous name.
+const MULTIPLE_MATCHES: i32 = 6;
+/// The exit code `cwt --help` publishes for a name it cannot find.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+#[test]
+fn a_name_two_repositories_share_is_refused() {
+    // `shared` is a worktree of child-a and of child-b. Standing in the parent,
+    // neither is nearer, so cwt must not pick one.
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["shared"]);
+
+    assert_eq!(
+        code(&output),
+        MULTIPLE_MATCHES,
+        "cwt must refuse an ambiguous name: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout(&output),
+        "",
+        "a refused name must print no path, or the shell function changes directory"
+    );
+
+    let message = combined(&output);
+    assert!(
+        message.contains("child-a:shared"),
+        "the message must name child-a's candidate the way it has to be typed: {message}"
+    );
+    assert!(
+        message.contains("child-b:shared"),
+        "the message must name child-b's candidate the way it has to be typed: {message}"
+    );
+}
+
+#[test]
+fn a_repository_prefix_settles_the_conflict() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["child-b:shared"]);
+
+    assert_eq!(
+        code(&output),
+        0,
+        "cwt child-b:shared failed: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-b-worktrees/shared"),
+        "the prefix picks the repository, the rest picks the worktree"
+    );
+}
+
+#[test]
+fn a_bare_repository_prefix_selects_its_main_worktree() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["child-b:"]);
+
+    assert_eq!(code(&output), 0, "cwt child-b: failed: {}", combined(&output));
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-b"),
+        "a repository name with nothing after it means that repository's main worktree"
+    );
+}
+
+#[test]
+fn a_repository_prefix_can_name_the_parent() {
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &["family:main"]);
+
+    assert_eq!(
+        code(&output),
+        0,
+        "cwt family:main failed: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family"),
+        "the parent is reachable by name from a child repository"
+    );
+}
+
+#[test]
+fn an_unknown_repository_prefix_is_not_found() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["nope:shared"]);
+
+    assert_eq!(
+        code(&output),
+        WORKTREE_NOT_FOUND,
+        "no repository is named nope: {}",
+        combined(&output)
+    );
+    assert_eq!(stdout(&output), "", "a name that is not found prints no path");
+}
+
+#[test]
+fn the_home_repository_answers_a_shared_name_without_a_prefix() {
+    // Standing in child-a, `shared` is not ambiguous: the home repository has one.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &["shared"]);
+
+    assert_eq!(code(&output), 0, "cwt shared failed: {}", combined(&output));
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-a-worktrees/shared"),
+        "a name the home repository can answer is never ambiguous"
+    );
+}

--- a/src/cwt/tests/family-duplicate-names.rs
+++ b/src/cwt/tests/family-duplicate-names.rs
@@ -1,0 +1,301 @@
+//! Two repositories of one family can carry the same directory name: a parent
+//! that holds a child named after itself. Each is still a repository of its
+//! own, and every name `cwt` prints has to select the worktree it was printed
+//! for.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use support::{
+    add_worktree, code, combined, cwt, git, headings, make_repo, parse_listing, stdout, target_path,
+};
+
+/// The exit code `cwt --help` publishes for an ambiguous name.
+const MULTIPLE_MATCHES: i32 = 6;
+/// The exit code `cwt --help` publishes for a name it cannot find.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+/// A family whose parent repository holds a child of its own directory name.
+///
+/// ```text
+/// root/
+///   nest/                          repository (the anchor), branch anchor-main
+///   nest-worktrees/spare           worktree of nest, branch anchor-spare
+///   nest/nest/                     repository, branch child-main
+///   nest/nest-worktrees/only       worktree of nest/nest, branch child-only
+///   nest/nest-worktrees/shared     worktree of nest/nest, branch child-shared
+///   nest/other/                    repository, branch other-main
+///   nest/other-worktrees/shared    worktree of other, branch other-shared
+/// ```
+///
+/// `nest` is the directory name of two repositories: the anchor and the child
+/// checked out inside it. `other` shares its name with nothing, so the tests
+/// can see that only the repeated name is treated differently.
+///
+/// Every branch name is unique, so the worktree a name reached can be named
+/// from the outside: no two worktrees of one repository can have the same
+/// branch checked out.
+///
+/// `shared` is the directory name of one worktree of `nest/nest` and one of
+/// `other`. Standing in the anchor, neither of those repositories is nearer
+/// than the other, so `cwt shared` is ambiguous and prints a candidate list.
+struct Nest {
+    /// Kept alive so the temp directory outlives the test.
+    _tmp: TempDir,
+    /// The canonical path of the temp directory. Canonical because git prints
+    /// resolved paths, and on macOS the temp directory is reached through a
+    /// symbolic link.
+    root: PathBuf,
+}
+
+impl Nest {
+    /// Build the family described in the type documentation.
+    fn build() -> Self {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let root = tmp
+            .path()
+            .canonicalize()
+            .expect("failed to canonicalize temp dir");
+
+        make_repo(&root.join("nest"), "anchor-main");
+        add_worktree(
+            &root.join("nest"),
+            "../nest-worktrees/spare",
+            "anchor-spare",
+        );
+
+        // A repository one level below the anchor, carrying the anchor's name.
+        make_repo(&root.join("nest/nest"), "child-main");
+        add_worktree(
+            &root.join("nest/nest"),
+            "../nest-worktrees/only",
+            "child-only",
+        );
+        add_worktree(
+            &root.join("nest/nest"),
+            "../nest-worktrees/shared",
+            "child-shared",
+        );
+
+        make_repo(&root.join("nest/other"), "other-main");
+        add_worktree(
+            &root.join("nest/other"),
+            "../other-worktrees/shared",
+            "other-shared",
+        );
+
+        Self { _tmp: tmp, root }
+    }
+
+    /// Resolve a path inside the family, for example `nest/other`.
+    fn at(&self, relative: &str) -> PathBuf {
+        self.root.join(relative)
+    }
+
+    /// The path of a worktree as a string, for comparison with `cwt` output.
+    fn path_of(&self, relative: &str) -> String {
+        self.at(relative).display().to_string()
+    }
+
+    /// The anchor repository, which is where most of these tests stand.
+    fn anchor(&self) -> PathBuf {
+        self.at("nest")
+    }
+}
+
+/// The names `cwt` listed under a message, one per indented line.
+fn listed_labels(message: &str) -> Vec<String> {
+    message
+        .lines()
+        .filter(|line| line.starts_with("  "))
+        .map(|line| line.trim().to_string())
+        .collect()
+}
+
+/// Split a label of the form `repo:worktree [branch]` into the name the user
+/// has to type and the branch that name promises to land on.
+fn label_parts(label: &str) -> (String, String) {
+    let (target, branch) = label
+        .rsplit_once(" [")
+        .unwrap_or_else(|| panic!("'{label}' is not a label of the form 'name [branch]'"));
+    (
+        target.trim().to_string(),
+        branch.trim_end_matches(']').to_string(),
+    )
+}
+
+/// The branch checked out in the worktree at `path`.
+fn branch_of(path: &Path) -> String {
+    assert!(
+        path.is_dir(),
+        "cwt named {} , which is not a directory",
+        path.display()
+    );
+    let output = git(path, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Every name `cwt` prints must select the worktree it was printed for.
+///
+/// That round trip is the whole point of naming a repository in a message: the
+/// user reads a name out of the list and types it back. Each label is fed back
+/// to `cwt` from the anchor, and the branch of the worktree it lands on has to
+/// be the branch the label promised.
+fn assert_labels_round_trip(nest: &Nest, labels: &[String]) {
+    assert!(!labels.is_empty(), "there were no labels to check");
+    for label in labels {
+        let (target, branch) = label_parts(label);
+        let output = cwt(&nest.anchor(), &[target.as_str()]);
+        assert_eq!(
+            code(&output),
+            0,
+            "cwt printed the name '{target}' and then refused it: {}",
+            combined(&output)
+        );
+        assert_eq!(
+            branch_of(Path::new(&target_path(&output))),
+            branch,
+            "the name '{target}' must select the worktree it was printed for"
+        );
+    }
+}
+
+#[test]
+fn a_child_repository_named_after_its_parent_keeps_its_own_heading() {
+    let nest = Nest::build();
+    let output = cwt(&nest.anchor(), &[]);
+    assert_eq!(code(&output), 0, "cwt failed: {}", combined(&output));
+
+    let listed = parse_listing(&stdout(&output));
+    assert_eq!(
+        headings(&listed),
+        vec!["nest", "nest/nest", "other"],
+        "the child inside the anchor is a repository of its own, and the name it \
+         shares with the anchor is qualified so each heading names one \
+         repository: {}",
+        stdout(&output)
+    );
+
+    let holding = |relative: &str| -> Vec<String> {
+        let wanted = nest.path_of(relative);
+        listed
+            .iter()
+            .filter(|line| line.path == wanted)
+            .map(|line| line.repo.clone())
+            .collect()
+    };
+    assert_eq!(
+        holding("nest/nest-worktrees/only"),
+        vec!["nest/nest".to_string()],
+        "a worktree belongs under the repository that owns it"
+    );
+    assert_eq!(
+        holding("nest-worktrees/spare"),
+        vec!["nest".to_string()],
+        "the anchor keeps its own worktrees"
+    );
+}
+
+#[test]
+fn each_repository_that_shares_a_name_has_a_name_of_its_own() {
+    let nest = Nest::build();
+
+    let inner = cwt(&nest.anchor(), &["nest/nest:"]);
+    assert_eq!(
+        code(&inner),
+        0,
+        "the repository inside the anchor must be reachable by name: {}",
+        combined(&inner)
+    );
+    assert_eq!(target_path(&inner), nest.path_of("nest/nest"));
+
+    let anchor = cwt(&nest.anchor(), &["nest:"]);
+    assert_eq!(
+        code(&anchor),
+        0,
+        "the anchor must still answer to its own name: {}",
+        combined(&anchor)
+    );
+    assert_eq!(
+        target_path(&anchor),
+        nest.path_of("nest"),
+        "the bare directory name belongs to the anchor"
+    );
+
+    let only = cwt(&nest.anchor(), &["nest/nest:only"]);
+    assert_eq!(
+        code(&only),
+        0,
+        "a worktree only the inner repository has must be reachable through it: {}",
+        combined(&only)
+    );
+    assert_eq!(target_path(&only), nest.path_of("nest/nest-worktrees/only"));
+}
+
+#[test]
+fn a_repository_keeps_its_name_wherever_the_user_stands() {
+    // The family is the same from anywhere inside it, so the name that reaches
+    // a repository cannot depend on which one the user is standing in.
+    let nest = Nest::build();
+    let inside = nest.at("nest/nest");
+
+    let listing = cwt(&inside, &[]);
+    let listed = parse_listing(&stdout(&listing));
+    assert_eq!(headings(&listed), vec!["nest", "nest/nest", "other"]);
+
+    let anchor = cwt(&inside, &["nest:"]);
+    assert_eq!(code(&anchor), 0, "cwt nest: failed: {}", combined(&anchor));
+    assert_eq!(target_path(&anchor), nest.path_of("nest"));
+
+    let child = cwt(&inside, &["nest/nest:"]);
+    assert_eq!(
+        code(&child),
+        0,
+        "cwt nest/nest: failed: {}",
+        combined(&child)
+    );
+    assert_eq!(target_path(&child), nest.path_of("nest/nest"));
+}
+
+#[test]
+fn every_available_worktree_can_be_typed_back() {
+    let nest = Nest::build();
+    let missing = cwt(&nest.anchor(), &["no-worktree-answers-to-this"]);
+    assert_eq!(
+        code(&missing),
+        WORKTREE_NOT_FOUND,
+        "no worktree has that name: {}",
+        combined(&missing)
+    );
+
+    let labels = listed_labels(&combined(&missing));
+    assert_eq!(
+        labels.len(),
+        7,
+        "the list must name every worktree of the family: {labels:#?}"
+    );
+    assert_labels_round_trip(&nest, &labels);
+}
+
+#[test]
+fn every_candidate_of_an_ambiguous_name_can_be_typed_back() {
+    let nest = Nest::build();
+    let output = cwt(&nest.anchor(), &["shared"]);
+    assert_eq!(
+        code(&output),
+        MULTIPLE_MATCHES,
+        "two repositories hold a worktree named shared: {}",
+        combined(&output)
+    );
+
+    let labels = listed_labels(&combined(&output));
+    assert_eq!(
+        labels.len(),
+        2,
+        "one candidate per repository that holds a shared worktree: {labels:#?}"
+    );
+    assert_labels_round_trip(&nest, &labels);
+}

--- a/src/cwt/tests/family-empty-repository.rs
+++ b/src/cwt/tests/family-empty-repository.rs
@@ -1,0 +1,181 @@
+//! A child directory that is a repository but owns no worktrees.
+//!
+//! `git init --bare <child>/.git` makes such a directory: the scan for children
+//! accepts it, because `.git` is there, but `git worktree list --porcelain`
+//! answers with a `worktree` line and `bare` and no `HEAD`, so the repository
+//! contributes nothing to list. It must not be able to answer for another
+//! repository, and it must not be able to crash `cwt`.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use support::{code, combined, cwt, git, stdout, Family};
+
+use tempfile::TempDir;
+
+/// The exit code `cwt --help` publishes for a name it cannot find.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+/// An anchor repository with children below it, built fresh for one test.
+///
+/// The shared [`Family`] fixture is deliberately left alone: several tests
+/// assert its listing exactly, so a bare child added there would be read as a
+/// change to those expectations.
+struct Anchor {
+    /// Kept alive so the temp directory outlives the test.
+    _tmp: TempDir,
+    /// The canonical path of the temp directory. Canonical because git prints
+    /// resolved paths, and on macOS the temp directory is reached through a
+    /// symbolic link.
+    root: PathBuf,
+}
+
+impl Anchor {
+    /// An anchor repository on branch `main`, with nothing below it yet.
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let root = tmp
+            .path()
+            .canonicalize()
+            .expect("failed to canonicalize temp dir");
+        make_repo(&root.join("anchor"), "main");
+        Self { _tmp: tmp, root }
+    }
+
+    /// Add a normal child repository named `name`, on branch `branch`.
+    fn child(&self, name: &str, branch: &str) -> &Self {
+        make_repo(&self.at(name), branch);
+        self
+    }
+
+    /// Add a child directory whose `.git` is itself a bare repository, so it
+    /// looks like a repository to the scan and lists no worktrees.
+    fn empty_child(&self, name: &str) -> &Self {
+        let dir = self.at(name);
+        std::fs::create_dir_all(&dir).expect("failed to create empty child dir");
+        git(&dir, &["init", "--bare", ".git"]);
+        self
+    }
+
+    /// Resolve a path below the anchor, for example `z-real`.
+    fn at(&self, relative: &str) -> PathBuf {
+        self.root.join("anchor").join(relative)
+    }
+
+    /// The anchor repository itself, which is where these tests run `cwt`.
+    fn root(&self) -> PathBuf {
+        self.root.join("anchor")
+    }
+
+    /// The path of a directory below the anchor, as `cwt` would print it.
+    fn path_of(&self, relative: &str) -> String {
+        self.at(relative).display().to_string()
+    }
+}
+
+/// Create a repository at `path` whose first branch is `branch`, with one
+/// commit so `git worktree list` reports a real HEAD.
+fn make_repo(path: &Path, branch: &str) {
+    std::fs::create_dir_all(path).expect("failed to create repo dir");
+    git(path, &["init", "--initial-branch", branch]);
+    std::fs::write(path.join("README.md"), "fixture\n").expect("failed to write README");
+    git(path, &["add", "README.md"]);
+    git(path, &["commit", "--no-verify", "-m", "init"]);
+}
+
+#[test]
+fn a_repository_with_no_worktrees_never_answers_for_another_one() {
+    // `a-empty` sorts before `z-real`, so a repository that mistakes one for the
+    // other lands the user in `z-real` and says nothing about it.
+    let anchor = Anchor::new();
+    anchor.empty_child("a-empty").child("z-real", "trunk");
+
+    let output = cwt(&anchor.root(), &["a-empty:"]);
+
+    assert_ne!(
+        stdout(&output).trim_end(),
+        anchor.path_of("z-real"),
+        "a repository with no worktrees must never answer with another repository's path"
+    );
+    assert_eq!(
+        code(&output),
+        WORKTREE_NOT_FOUND,
+        "a repository with no worktrees has nothing to select: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout(&output),
+        "",
+        "a name that cannot be resolved prints no path, or the shell function changes directory"
+    );
+}
+
+#[test]
+fn a_repository_with_no_worktrees_does_not_crash_when_it_is_last() {
+    // The only child lists no worktrees, so its group is the last one and every
+    // index it could hold is one past the end of the entries.
+    let anchor = Anchor::new();
+    anchor.empty_child("oddchild");
+
+    let output = cwt(&anchor.root(), &["oddchild:"]);
+
+    assert_eq!(
+        code(&output),
+        WORKTREE_NOT_FOUND,
+        "cwt must report the name instead of panicking: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout(&output),
+        "",
+        "a name that cannot be resolved prints no path"
+    );
+}
+
+#[test]
+fn the_listing_reports_the_repository_it_left_out() {
+    // Leaving a repository out silently is the other half of the problem: the
+    // user is never told why the directory they can see is not in the list.
+    let anchor = Anchor::new();
+    anchor.empty_child("a-empty").child("z-real", "trunk");
+
+    let output = cwt(&anchor.root(), &[]);
+
+    assert_eq!(code(&output), 0, "cwt failed: {}", combined(&output));
+    assert!(
+        stdout(&output).contains(&anchor.path_of("z-real")),
+        "the readable repositories still list: {}",
+        stdout(&output)
+    );
+
+    let message = combined(&output);
+    assert!(
+        message.contains("Warning: skipped"),
+        "a repository left out of the family goes to the warnings channel: {message}"
+    );
+    assert!(
+        message.contains("a-empty"),
+        "the warning has to name the repository it left out: {message}"
+    );
+}
+
+#[test]
+fn a_family_of_readable_repositories_is_unchanged() {
+    // The guard against empty repositories must not cost a normal family
+    // anything, so the shared fixture still answers a bare prefix.
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["child-b:"]);
+
+    assert_eq!(
+        code(&output),
+        0,
+        "cwt child-b: failed: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout(&output).trim_end(),
+        family.path_of("family/child-b"),
+        "a repository that has worktrees still selects its main one"
+    );
+}

--- a/src/cwt/tests/family-listing.rs
+++ b/src/cwt/tests/family-listing.rs
@@ -1,0 +1,190 @@
+//! `cwt` treats a parent repository and the repositories checked out one level
+//! below it as one family: the listing shows all of them, grouped by
+//! repository, and the cycling flags walk the whole family.
+
+mod support;
+
+use support::{code, cwt, stdout, Family};
+
+/// One line of a `cwt` listing that names a worktree.
+#[derive(Debug, PartialEq, Eq)]
+struct Listed {
+    /// The repository heading this worktree appeared under.
+    repo: String,
+    /// True when the line carried the current-worktree marker.
+    current: bool,
+    /// The path the line named.
+    path: String,
+}
+
+/// Parse a grouped `cwt` listing.
+///
+/// A heading starts at column zero. A worktree line starts with the marker
+/// column: `>` for the current worktree, a space for every other.
+fn parse_listing(output: &str) -> Vec<Listed> {
+    let mut listed = Vec::new();
+    let mut repo = String::new();
+
+    for line in output.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('>') {
+            listed.push(Listed {
+                repo: repo.clone(),
+                current: true,
+                path: path_of(rest),
+            });
+        } else if line.starts_with(' ') {
+            listed.push(Listed {
+                repo: repo.clone(),
+                current: false,
+                path: path_of(line),
+            });
+        } else {
+            repo = line.trim().to_string();
+        }
+    }
+
+    listed
+}
+
+/// Take the path out of a worktree line, dropping the marker and the trailing
+/// `[branch]`.
+fn path_of(line: &str) -> String {
+    let without_branch = line
+        .rsplit_once(" [")
+        .map_or(line, |(path, _)| path)
+        .trim()
+        .to_string();
+    without_branch
+}
+
+/// The repository headings, in the order they appeared.
+fn headings(listing: &[Listed]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for entry in listing {
+        if seen.last() != Some(&entry.repo) {
+            seen.push(entry.repo.clone());
+        }
+    }
+    seen
+}
+
+#[test]
+fn list_includes_the_worktrees_of_every_child_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &[]);
+    assert_eq!(code(&output), 0, "cwt failed: {}", stdout(&output));
+
+    let listed = parse_listing(&stdout(&output));
+    let paths: Vec<&str> = listed.iter().map(|l| l.path.as_str()).collect();
+
+    for expected in [
+        "family",
+        "family-worktrees/feature",
+        "family/child-a",
+        "family/child-a-worktrees/shared",
+        "family/child-b",
+        "family/child-b-worktrees/beta",
+        "family/child-b-worktrees/shared",
+    ] {
+        let wanted = family.path_of(expected);
+        assert!(
+            paths.contains(&wanted.as_str()),
+            "cwt must list {wanted}, but listed {paths:#?}"
+        );
+    }
+    assert_eq!(paths.len(), 7, "cwt listed unexpected extras: {paths:#?}");
+}
+
+#[test]
+fn list_groups_each_worktree_under_its_own_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &[]);
+
+    let listed = parse_listing(&stdout(&output));
+    assert_eq!(
+        headings(&listed),
+        vec!["family", "child-a", "child-b"],
+        "the parent repository comes first, then the child repositories by name"
+    );
+
+    let child_b: Vec<&str> = listed
+        .iter()
+        .filter(|l| l.repo == "child-b")
+        .map(|l| l.path.as_str())
+        .collect();
+    assert_eq!(
+        child_b,
+        vec![
+            family.path_of("family/child-b"),
+            family.path_of("family/child-b-worktrees/beta"),
+            family.path_of("family/child-b-worktrees/shared"),
+        ],
+        "every worktree of child-b belongs under the child-b heading"
+    );
+}
+
+#[test]
+fn list_ignores_a_directory_that_is_not_a_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &[]);
+
+    assert!(
+        !stdout(&output).contains("docs"),
+        "the plain docs directory is not a repository and must not be listed: {}",
+        stdout(&output)
+    );
+}
+
+#[test]
+fn list_from_a_child_repository_shows_the_whole_family() {
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &[]);
+    assert_eq!(code(&output), 0, "cwt failed: {}", stdout(&output));
+
+    let listed = parse_listing(&stdout(&output));
+    assert_eq!(
+        headings(&listed),
+        vec!["family", "child-a", "child-b"],
+        "standing in a child repository shows the same family as standing in the parent"
+    );
+
+    let current: Vec<&str> = listed
+        .iter()
+        .filter(|l| l.current)
+        .map(|l| l.path.as_str())
+        .collect();
+    assert_eq!(
+        current,
+        vec![family.path_of("family/child-a")],
+        "the marker names the worktree the user stands in"
+    );
+}
+
+#[test]
+fn forward_leaves_one_repository_and_enters_the_next() {
+    let family = Family::build();
+    let output = cwt(&family.at("family-worktrees/feature"), &["-f"]);
+
+    assert_eq!(code(&output), 0, "cwt -f failed: {}", stdout(&output));
+    assert_eq!(
+        stdout(&output).trim_end(),
+        family.path_of("family/child-a"),
+        "the last worktree of the parent is followed by the first child repository"
+    );
+}
+
+#[test]
+fn previous_leaves_one_repository_and_enters_the_one_before() {
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &["-p"]);
+
+    assert_eq!(code(&output), 0, "cwt -p failed: {}", stdout(&output));
+    assert_eq!(
+        stdout(&output).trim_end(),
+        family.path_of("family-worktrees/feature"),
+        "the first worktree of a child repository is preceded by the parent's last"
+    );
+}

--- a/src/cwt/tests/family-listing.rs
+++ b/src/cwt/tests/family-listing.rs
@@ -4,72 +4,7 @@
 
 mod support;
 
-use support::{code, cwt, stdout, Family};
-
-/// One line of a `cwt` listing that names a worktree.
-#[derive(Debug, PartialEq, Eq)]
-struct Listed {
-    /// The repository heading this worktree appeared under.
-    repo: String,
-    /// True when the line carried the current-worktree marker.
-    current: bool,
-    /// The path the line named.
-    path: String,
-}
-
-/// Parse a grouped `cwt` listing.
-///
-/// A heading starts at column zero. A worktree line starts with the marker
-/// column: `>` for the current worktree, a space for every other.
-fn parse_listing(output: &str) -> Vec<Listed> {
-    let mut listed = Vec::new();
-    let mut repo = String::new();
-
-    for line in output.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        if let Some(rest) = line.strip_prefix('>') {
-            listed.push(Listed {
-                repo: repo.clone(),
-                current: true,
-                path: path_of(rest),
-            });
-        } else if line.starts_with(' ') {
-            listed.push(Listed {
-                repo: repo.clone(),
-                current: false,
-                path: path_of(line),
-            });
-        } else {
-            repo = line.trim().to_string();
-        }
-    }
-
-    listed
-}
-
-/// Take the path out of a worktree line, dropping the marker and the trailing
-/// `[branch]`.
-fn path_of(line: &str) -> String {
-    let without_branch = line
-        .rsplit_once(" [")
-        .map_or(line, |(path, _)| path)
-        .trim()
-        .to_string();
-    without_branch
-}
-
-/// The repository headings, in the order they appeared.
-fn headings(listing: &[Listed]) -> Vec<String> {
-    let mut seen: Vec<String> = Vec::new();
-    for entry in listing {
-        if seen.last() != Some(&entry.repo) {
-            seen.push(entry.repo.clone());
-        }
-    }
-    seen
-}
+use support::{code, cwt, headings, parse_listing, stdout, Family};
 
 #[test]
 fn list_includes_the_worktrees_of_every_child_repository() {

--- a/src/cwt/tests/family-listing.rs
+++ b/src/cwt/tests/family-listing.rs
@@ -81,8 +81,10 @@ fn list_includes_the_worktrees_of_every_child_repository() {
     let paths: Vec<&str> = listed.iter().map(|l| l.path.as_str()).collect();
 
     for expected in [
+        "aaa-worktree",
         "family",
         "family-worktrees/feature",
+        "family/inside-wt",
         "family/child-a",
         "family/child-a-worktrees/shared",
         "family/child-b",
@@ -95,7 +97,52 @@ fn list_includes_the_worktrees_of_every_child_repository() {
             "cwt must list {wanted}, but listed {paths:#?}"
         );
     }
-    assert_eq!(paths.len(), 7, "cwt listed unexpected extras: {paths:#?}");
+    assert_eq!(paths.len(), 9, "cwt listed unexpected extras: {paths:#?}");
+}
+
+#[test]
+fn a_worktree_of_the_parent_inside_the_parent_does_not_become_a_repository() {
+    // `inside-wt` is a worktree of the parent, sitting exactly where the scan
+    // for child repositories looks. It belongs to the parent's group, once.
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &[]);
+
+    let listed = parse_listing(&stdout(&output));
+    let wanted = family.path_of("family/inside-wt");
+    let holding: Vec<&str> = listed
+        .iter()
+        .filter(|l| l.path == wanted)
+        .map(|l| l.repo.as_str())
+        .collect();
+
+    assert_eq!(
+        holding,
+        vec!["family"],
+        "the parent's own worktree is listed once, under the parent"
+    );
+    assert_eq!(
+        headings(&listed),
+        vec!["family", "child-a", "child-b"],
+        "it must not open a repository group of its own"
+    );
+}
+
+#[test]
+fn a_repository_owns_its_worktrees_wherever_they_sit() {
+    // `aaa-worktree` is a worktree of child-b that lives outside the family
+    // directory altogether. It is still child-b's.
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &[]);
+
+    let listed = parse_listing(&stdout(&output));
+    let wanted = family.path_of("aaa-worktree");
+    let holding: Vec<&str> = listed
+        .iter()
+        .filter(|l| l.path == wanted)
+        .map(|l| l.repo.as_str())
+        .collect();
+
+    assert_eq!(holding, vec!["child-b"]);
 }
 
 #[test]
@@ -118,11 +165,12 @@ fn list_groups_each_worktree_under_its_own_repository() {
     assert_eq!(
         child_b,
         vec![
+            family.path_of("aaa-worktree"),
             family.path_of("family/child-b"),
             family.path_of("family/child-b-worktrees/beta"),
             family.path_of("family/child-b-worktrees/shared"),
         ],
-        "every worktree of child-b belongs under the child-b heading"
+        "every worktree of child-b belongs under the child-b heading, in path order"
     );
 }
 

--- a/src/cwt/tests/family-main-worktree.rs
+++ b/src/cwt/tests/family-main-worktree.rs
@@ -1,0 +1,96 @@
+//! Which main worktree `--main` selects when the family offers more than one.
+//!
+//! Every repository of a family has a main worktree of its own, so the shortcut
+//! has to choose between them. It chooses the repository the user stands in.
+//!
+//! This is where `--main` parts from a plain name. A name the home repository
+//! cannot answer falls back to the parent repository, which is what
+//! `family-navigation.rs` proves. `--main` does not fall back: a repository with
+//! no `main` and no `master` has no main worktree, and sending the user to a
+//! sibling's main worktree is not the shortcut they asked for.
+
+mod support;
+
+use support::{code, combined, cwt, target_path, Family};
+
+/// The exit code `cwt` uses when it finds no worktree.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+#[test]
+fn the_main_worktree_of_a_child_is_that_child_not_the_parent() {
+    // The parent and child-a are both on branch `main`, and the parent comes
+    // first in the listing. Standing in child-a, the shortcut has to stay there.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a-worktrees/shared"), &["--main"]);
+
+    assert_eq!(code(&output), 0, "cwt --main failed in child-a");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-a"),
+        "the shortcut must stay in the repository the user stands in"
+    );
+}
+
+#[test]
+fn the_main_worktree_of_the_parent_is_the_parent() {
+    let family = Family::build();
+    let output = cwt(&family.at("family-worktrees/feature"), &["--main"]);
+
+    assert_eq!(code(&output), 0, "cwt --main failed in the parent");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family"),
+        "the parent's own worktree must reach the parent's main worktree"
+    );
+}
+
+#[test]
+fn a_repository_without_main_or_master_does_not_borrow_a_sibling() {
+    // child-b is on `trunk`. The parent and child-a both have a worktree on
+    // `main`, and neither of them is child-b's main worktree.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-b-worktrees/beta"), &["--main"]);
+
+    assert_eq!(
+        code(&output),
+        WORKTREE_NOT_FOUND,
+        "cwt --main must report not found, got: {}",
+        combined(&output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "cwt must print no path when the repository has no main worktree"
+    );
+}
+
+#[test]
+fn the_not_found_message_still_names_every_branch_that_was_searched() {
+    // The message is built from the branch constant, and the family must not
+    // have cost it that.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-b-worktrees/beta"), &["--main"]);
+    let message = combined(&output);
+
+    assert!(
+        message.contains("'main' or 'master'"),
+        "the not-found message must name every branch cwt searched for, got: {message}"
+    );
+}
+
+#[test]
+fn no_family_leaves_the_main_worktree_where_it_was() {
+    // --main already stays inside one repository, so opting out of the family
+    // must not move it.
+    let family = Family::build();
+    let output = cwt(
+        &family.at("family/child-a-worktrees/shared"),
+        &["--no-family", "--main"],
+    );
+
+    assert_eq!(code(&output), 0, "cwt --no-family --main failed in child-a");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-a"),
+        "--no-family must not change which main worktree the shortcut selects"
+    );
+}

--- a/src/cwt/tests/family-navigation.rs
+++ b/src/cwt/tests/family-navigation.rs
@@ -1,0 +1,85 @@
+//! Which worktree a name selects when the family offers more than one.
+//!
+//! The rule is nearest first: the repository the user stands in, then the
+//! parent repository, then the rest. `wtm` has to keep meaning "my repository's
+//! main branch" wherever the user is standing.
+
+mod support;
+
+use support::{code, cwt, target_path, Family};
+
+#[test]
+fn a_name_prefers_the_repository_the_user_stands_in() {
+    // `main` is a branch of the parent and of child-a. Standing in child-a, the
+    // name has to select child-a.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &["main"]);
+
+    assert_eq!(code(&output), 0, "cwt main failed in child-a");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-a"),
+        "the repository the user stands in answers first"
+    );
+}
+
+#[test]
+fn a_name_the_home_repository_lacks_falls_back_to_the_parent() {
+    // child-b has no `main` branch, so the parent's answers.
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-b"), &["main"]);
+
+    assert_eq!(code(&output), 0, "cwt main failed in child-b");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family"),
+        "the parent repository answers when the home repository cannot"
+    );
+}
+
+#[test]
+fn the_parent_answers_its_own_name_from_its_own_worktree() {
+    let family = Family::build();
+    let output = cwt(&family.at("family-worktrees/feature"), &["main"]);
+
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family"),
+        "standing in a worktree of the parent, main is still the parent's"
+    );
+}
+
+#[test]
+fn a_child_repository_is_reachable_by_its_directory_name() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["child-b"]);
+
+    assert_eq!(code(&output), 0, "cwt child-b failed");
+    assert_eq!(target_path(&output), family.path_of("family/child-b"));
+}
+
+#[test]
+fn a_child_worktree_is_reachable_by_its_branch() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["beta"]);
+
+    assert_eq!(code(&output), 0, "cwt beta failed");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-b-worktrees/beta"),
+        "a branch of a child repository is selectable from the parent"
+    );
+}
+
+#[test]
+fn a_child_worktree_is_reachable_from_a_sibling_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family/child-a"), &["beta"]);
+
+    assert_eq!(code(&output), 0, "cwt beta failed in child-a");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family/child-b-worktrees/beta"),
+        "siblings can reach each other without going through the parent"
+    );
+}

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -28,7 +28,10 @@ fn no_family_lists_only_the_repository_the_user_is_in() {
 #[test]
 fn no_family_confines_cycling_to_one_repository() {
     let family = Family::build();
-    let output = cwt(&family.at("family-worktrees/feature"), &["-f", "--no-family"]);
+    let output = cwt(
+        &family.at("family-worktrees/feature"),
+        &["-f", "--no-family"],
+    );
 
     assert_eq!(code(&output), 0, "cwt -f --no-family failed");
     assert_eq!(
@@ -49,7 +52,11 @@ fn no_family_cannot_reach_a_child_repository() {
         "beta belongs to a child repository, which is out of scope: {}",
         combined(&output)
     );
-    assert_eq!(stdout(&output), "", "a name that is not found prints no path");
+    assert_eq!(
+        stdout(&output),
+        "",
+        "a name that is not found prints no path"
+    );
 }
 
 #[test]

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -89,3 +89,15 @@ fn an_empty_environment_variable_keeps_the_family() {
         stdout(&output)
     );
 }
+
+#[test]
+fn a_zero_environment_variable_keeps_the_family() {
+    let family = Family::build();
+    let output = cwt_with_env(&family.at("family"), &[], &[("CWT_NO_FAMILY", "0")]);
+
+    assert!(
+        stdout(&output).contains(&family.path_of("family/child-a")),
+        "0 is the choice not to opt out, so the family stays: {}",
+        stdout(&output)
+    );
+}

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -17,8 +17,9 @@ fn no_family_lists_only_the_repository_the_user_is_in() {
     assert_eq!(
         stdout(&output),
         format!(
-            "> {} [main]\n  {} [feature]\n",
+            "> {} [main]\n  {} [inside]\n  {} [feature]\n",
             family.path_of("family"),
+            family.path_of("family/inside-wt"),
             family.path_of("family-worktrees/feature")
         ),
         "one repository prints as a plain list, with no headings and no children"
@@ -68,8 +69,9 @@ fn the_environment_variable_opts_out_of_the_family() {
     assert_eq!(
         stdout(&output),
         format!(
-            "> {} [main]\n  {} [feature]\n",
+            "> {} [main]\n  {} [inside]\n  {} [feature]\n",
             family.path_of("family"),
+            family.path_of("family/inside-wt"),
             family.path_of("family-worktrees/feature")
         ),
         "CWT_NO_FAMILY=1 has the same effect as --no-family"

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -1,0 +1,82 @@
+//! Opting out of the family.
+//!
+//! `--no-family` confines `cwt` to the repository the user is standing in,
+//! which is what `cwt` did before families existed. `CWT_NO_FAMILY` makes that
+//! choice permanent without wrapping the command.
+
+mod support;
+
+use support::{code, combined, cwt, cwt_with_env, stdout, target_path, Family};
+
+#[test]
+fn no_family_lists_only_the_repository_the_user_is_in() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["--no-family"]);
+
+    assert_eq!(code(&output), 0, "cwt --no-family failed");
+    assert_eq!(
+        stdout(&output),
+        format!(
+            "> {} [main]\n  {} [feature]\n",
+            family.path_of("family"),
+            family.path_of("family-worktrees/feature")
+        ),
+        "one repository prints as a plain list, with no headings and no children"
+    );
+}
+
+#[test]
+fn no_family_confines_cycling_to_one_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family-worktrees/feature"), &["-f", "--no-family"]);
+
+    assert_eq!(code(&output), 0, "cwt -f --no-family failed");
+    assert_eq!(
+        target_path(&output),
+        family.path_of("family"),
+        "the last worktree of the repository wraps to its first, not into a child"
+    );
+}
+
+#[test]
+fn no_family_cannot_reach_a_child_repository() {
+    let family = Family::build();
+    let output = cwt(&family.at("family"), &["--no-family", "beta"]);
+
+    assert_ne!(
+        code(&output),
+        0,
+        "beta belongs to a child repository, which is out of scope: {}",
+        combined(&output)
+    );
+    assert_eq!(stdout(&output), "", "a name that is not found prints no path");
+}
+
+#[test]
+fn the_environment_variable_opts_out_of_the_family() {
+    let family = Family::build();
+    let output = cwt_with_env(&family.at("family"), &[], &[("CWT_NO_FAMILY", "1")]);
+
+    assert_eq!(code(&output), 0, "cwt failed: {}", combined(&output));
+    assert_eq!(
+        stdout(&output),
+        format!(
+            "> {} [main]\n  {} [feature]\n",
+            family.path_of("family"),
+            family.path_of("family-worktrees/feature")
+        ),
+        "CWT_NO_FAMILY=1 has the same effect as --no-family"
+    );
+}
+
+#[test]
+fn an_empty_environment_variable_keeps_the_family() {
+    let family = Family::build();
+    let output = cwt_with_env(&family.at("family"), &[], &[("CWT_NO_FAMILY", "")]);
+
+    assert!(
+        stdout(&output).contains(&family.path_of("family/child-a")),
+        "an empty value is not a choice, so the family stays: {}",
+        stdout(&output)
+    );
+}

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -97,9 +97,11 @@ pub fn code(output: &Output) -> i32 {
 ///
 /// ```text
 /// root/
+///   aaa-worktree                       worktree of child-b, branch aaa
 ///   family/                            repository, branch main
 ///   family-worktrees/feature           worktree of family, branch feature
 ///   family/docs/                       plain directory, not a repository
+///   family/inside-wt                   worktree of family, branch inside
 ///   family/child-a/                    repository, branch main
 ///   family/child-a-worktrees/shared    worktree of child-a, branch shared
 ///   family/child-b/                    repository, branch trunk
@@ -110,6 +112,14 @@ pub fn code(output: &Output) -> i32 {
 /// The duplicated names are deliberate. `main` exists in both `family` and
 /// `child-a`, and `shared` exists in both `child-a` and `child-b`, so the tests
 /// can prove which repository wins a tie and when `cwt` refuses to guess.
+///
+/// Two of the worktrees are placed where they are on purpose:
+///
+/// - `aaa-worktree` sorts before every other worktree of child-b, so a listing
+///   that assumed a repository's main worktree comes first would be wrong.
+/// - `inside-wt` is a worktree of the parent that sits one level below it,
+///   where the scan for child repositories will find it. It must join the
+///   parent's group rather than start a group of its own.
 pub struct Family {
     /// Kept alive so the temp directory outlives the test.
     _tmp: TempDir,
@@ -134,6 +144,8 @@ impl Family {
             "../family-worktrees/feature",
             "feature",
         );
+        // A worktree of the parent, sitting where the scan for children looks.
+        add_worktree(&root.join("family"), "inside-wt", "inside");
 
         std::fs::create_dir_all(root.join("family/docs")).expect("failed to create docs dir");
         std::fs::write(root.join("family/docs/README.md"), "not a repository\n")
@@ -157,6 +169,8 @@ impl Family {
             "../child-b-worktrees/shared",
             "shared",
         );
+        // Outside the family, and sorting before every other worktree child-b has.
+        add_worktree(&root.join("family/child-b"), "../../aaa-worktree", "aaa");
 
         Self { _tmp: tmp, root }
     }

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -1,0 +1,177 @@
+//! Throwaway git fixtures for the `cwt` end-to-end tests.
+//!
+//! Every test builds its own family of repositories under its own temp
+//! directory, so two copies of the suite can run at the same time without
+//! sharing a path, a branch name, or a git index.
+
+#![allow(dead_code)] // Each test file uses a different part of this module.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+/// Scrub the git-location env vars that git exports when it invokes a hook.
+///
+/// In a worktree, git exports absolute `GIT_DIR`/`GIT_WORK_TREE`/
+/// `GIT_INDEX_FILE`/`GIT_PREFIX` to the pre-commit hook. Those leak into child
+/// `git` and `cwt` processes and pin them to the real repository regardless of
+/// `current_dir(tempdir)`, so fixture commits would land in the real repository.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` point at `/dev/null` so the
+/// developer's own git config (aliases, `init.defaultBranch`, hooks) cannot
+/// change what these tests observe. The identity vars are set explicitly for the
+/// same reason: the pre-commit hook exports its own, and a fixture commit must
+/// behave the same under a commit as it does under a bare `cargo test`.
+pub fn scrub_git_env(cmd: &mut Command) -> &mut Command {
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "cwt test")
+        .env("GIT_AUTHOR_EMAIL", "cwt@example.com")
+        .env("GIT_COMMITTER_NAME", "cwt test")
+        .env("GIT_COMMITTER_EMAIL", "cwt@example.com")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_PREFIX")
+}
+
+/// Run `git <args>` in `dir` and assert it succeeded.
+pub fn git(dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(dir);
+    let output = scrub_git_env(&mut cmd).output().expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} in {} failed: {}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+/// Run the real `cwt` binary in `dir` and capture its result.
+///
+/// `NO_COLOR` keeps the output plain so assertions can match on text.
+pub fn cwt(dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cwt"));
+    cmd.args(args).current_dir(dir).env("NO_COLOR", "1");
+    scrub_git_env(&mut cmd).output().expect("failed to run cwt")
+}
+
+/// Standard output of a `cwt` run.
+pub fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+/// The single path a navigating `cwt` run prints, with the newline removed.
+pub fn target_path(output: &Output) -> String {
+    stdout(output).trim_end().to_string()
+}
+
+/// Combined stdout and stderr of a `cwt` run, for message assertions.
+pub fn combined(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// The exit code of a `cwt` run.
+pub fn code(output: &Output) -> i32 {
+    output.status.code().expect("cwt was killed by a signal")
+}
+
+/// A family of repositories: one parent repository with child repositories
+/// checked out one level below it, in the layout that `.gitignore` keeps out of
+/// the parent's history.
+///
+/// ```text
+/// root/
+///   family/                            repository, branch main
+///   family-worktrees/feature           worktree of family, branch feature
+///   family/docs/                       plain directory, not a repository
+///   family/child-a/                    repository, branch main
+///   family/child-a-worktrees/shared    worktree of child-a, branch shared
+///   family/child-b/                    repository, branch trunk
+///   family/child-b-worktrees/beta      worktree of child-b, branch beta
+///   family/child-b-worktrees/shared    worktree of child-b, branch shared
+/// ```
+///
+/// The duplicated names are deliberate. `main` exists in both `family` and
+/// `child-a`, and `shared` exists in both `child-a` and `child-b`, so the tests
+/// can prove which repository wins a tie and when `cwt` refuses to guess.
+pub struct Family {
+    /// Kept alive so the temp directory outlives the test.
+    _tmp: TempDir,
+    /// The canonical path of the temp directory. Canonical because git prints
+    /// resolved paths, and on macOS the temp directory is reached through a
+    /// symbolic link.
+    root: PathBuf,
+}
+
+impl Family {
+    /// Build the family described in the type documentation.
+    pub fn build() -> Self {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let root = tmp
+            .path()
+            .canonicalize()
+            .expect("failed to canonicalize temp dir");
+
+        make_repo(&root.join("family"), "main");
+        add_worktree(&root.join("family"), "../family-worktrees/feature", "feature");
+
+        std::fs::create_dir_all(root.join("family/docs")).expect("failed to create docs dir");
+        std::fs::write(root.join("family/docs/README.md"), "not a repository\n")
+            .expect("failed to write docs file");
+
+        make_repo(&root.join("family/child-a"), "main");
+        add_worktree(
+            &root.join("family/child-a"),
+            "../child-a-worktrees/shared",
+            "shared",
+        );
+
+        make_repo(&root.join("family/child-b"), "trunk");
+        add_worktree(
+            &root.join("family/child-b"),
+            "../child-b-worktrees/beta",
+            "beta",
+        );
+        add_worktree(
+            &root.join("family/child-b"),
+            "../child-b-worktrees/shared",
+            "shared",
+        );
+
+        Self { _tmp: tmp, root }
+    }
+
+    /// Resolve a path inside the family, for example `family/child-a`.
+    pub fn at(&self, relative: &str) -> PathBuf {
+        self.root.join(relative)
+    }
+
+    /// The path of a worktree as a string, for comparison with `cwt` output.
+    pub fn path_of(&self, relative: &str) -> String {
+        self.at(relative).display().to_string()
+    }
+}
+
+/// Create a repository at `path` whose first branch is `branch`, with one
+/// commit so `git worktree list` reports a real HEAD.
+fn make_repo(path: &Path, branch: &str) {
+    std::fs::create_dir_all(path).expect("failed to create repo dir");
+    git(path, &["init", "--initial-branch", branch]);
+    std::fs::write(path.join("README.md"), "fixture\n").expect("failed to write README");
+    git(path, &["add", "README.md"]);
+    git(path, &["commit", "--no-verify", "-m", "init"]);
+}
+
+/// Add a worktree of the repository at `repo`, at `relative` to that repository,
+/// on a new branch named `branch`.
+fn add_worktree(repo: &Path, relative: &str, branch: &str) {
+    git(repo, &["worktree", "add", "-b", branch, relative]);
+}

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -121,7 +121,11 @@ impl Family {
             .expect("failed to canonicalize temp dir");
 
         make_repo(&root.join("family"), "main");
-        add_worktree(&root.join("family"), "../family-worktrees/feature", "feature");
+        add_worktree(
+            &root.join("family"),
+            "../family-worktrees/feature",
+            "feature",
+        );
 
         std::fs::create_dir_all(root.join("family/docs")).expect("failed to create docs dir");
         std::fs::write(root.join("family/docs/README.md"), "not a repository\n")

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -91,6 +91,69 @@ pub fn code(output: &Output) -> i32 {
     output.status.code().expect("cwt was killed by a signal")
 }
 
+/// One line of a `cwt` listing that names a worktree.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Listed {
+    /// The repository heading this worktree appeared under.
+    pub repo: String,
+    /// True when the line carried the current-worktree marker.
+    pub current: bool,
+    /// The path the line named.
+    pub path: String,
+}
+
+/// Parse a grouped `cwt` listing.
+///
+/// A heading starts at column zero. A worktree line starts with the marker
+/// column: `>` for the current worktree, a space for every other.
+pub fn parse_listing(output: &str) -> Vec<Listed> {
+    let mut listed = Vec::new();
+    let mut repo = String::new();
+
+    for line in output.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('>') {
+            listed.push(Listed {
+                repo: repo.clone(),
+                current: true,
+                path: listed_path(rest),
+            });
+        } else if line.starts_with(' ') {
+            listed.push(Listed {
+                repo: repo.clone(),
+                current: false,
+                path: listed_path(line),
+            });
+        } else {
+            repo = line.trim().to_string();
+        }
+    }
+
+    listed
+}
+
+/// Take the path out of a worktree line, dropping the marker and the trailing
+/// `[branch]`.
+fn listed_path(line: &str) -> String {
+    line.rsplit_once(" [")
+        .map_or(line, |(path, _)| path)
+        .trim()
+        .to_string()
+}
+
+/// The repository headings, in the order they appeared.
+pub fn headings(listing: &[Listed]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for entry in listing {
+        if seen.last() != Some(&entry.repo) {
+            seen.push(entry.repo.clone());
+        }
+    }
+    seen
+}
+
 /// A family of repositories: one parent repository with child repositories
 /// checked out one level below it, in the layout that `.gitignore` keeps out of
 /// the parent's history.
@@ -188,7 +251,7 @@ impl Family {
 
 /// Create a repository at `path` whose first branch is `branch`, with one
 /// commit so `git worktree list` reports a real HEAD.
-fn make_repo(path: &Path, branch: &str) {
+pub fn make_repo(path: &Path, branch: &str) {
     std::fs::create_dir_all(path).expect("failed to create repo dir");
     git(path, &["init", "--initial-branch", branch]);
     std::fs::write(path.join("README.md"), "fixture\n").expect("failed to write README");
@@ -198,6 +261,6 @@ fn make_repo(path: &Path, branch: &str) {
 
 /// Add a worktree of the repository at `repo`, at `relative` to that repository,
 /// on a new branch named `branch`.
-fn add_worktree(repo: &Path, relative: &str, branch: &str) {
+pub fn add_worktree(repo: &Path, relative: &str, branch: &str) {
     git(repo, &["worktree", "add", "-b", branch, relative]);
 }

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -54,8 +54,16 @@ pub fn git(dir: &Path, args: &[&str]) -> Output {
 ///
 /// `NO_COLOR` keeps the output plain so assertions can match on text.
 pub fn cwt(dir: &Path, args: &[&str]) -> Output {
+    cwt_with_env(dir, args, &[])
+}
+
+/// Run the real `cwt` binary in `dir` with extra environment variables.
+pub fn cwt_with_env(dir: &Path, args: &[&str], env: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_cwt"));
     cmd.args(args).current_dir(dir).env("NO_COLOR", "1");
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
     scrub_git_env(&mut cmd).output().expect("failed to run cwt")
 }
 


### PR DESCRIPTION
## What changed

`cwt` now treats a parent repository and the repositories checked out one level below
it as one **family**. Before this branch, `cwt` showed only the worktrees of the
repository the user stood in, so a container repository full of child repositories
needed one `cd` per repository.

A container repository tracks the map of a workspace. The real repositories sit one
level below it, kept out of the parent's history by `.gitignore`:

```text
keyboards/                    # the parent repository
  qmk_firmware/               # a repository of its own
  vial-qmk/                   # a repository of its own
  zmk-config-corne/           # a repository of its own
```

One listing now shows every worktree of every repository in the family, grouped under
its own repository heading. The `-f` and `-p` flags cycle through the whole family
instead of stopping at the edge of one repository. The family is the same from
anywhere inside it, so `cwt` gets the user out of a child repository as easily as it
gets them in. The scan reaches one level only. A child of a child is that child's
business.

### Which repository answers a name

A name goes to each repository in turn, nearest first:

1. The repository the user stands in
2. The parent repository the family is anchored at
3. Every other repository in the family

`wtm` thus still means "my repository's main branch" wherever the user stands. Inside
each repository the order does not change: exact directory name, then exact branch
name, then a case-insensitive substring of a branch name. An exact name anywhere in
the family beats a substring anywhere.

### When two repositories share a name

`cwt` refuses to guess. It names the candidates the way the user must type them:

```
Error: Multiple worktrees match 'master'. Be more specific:
  qmk_firmware:qmk_firmware [master]
  zmk-config-corne:zmk-config-corne [master]
```

A `REPO:NAME` target searches one repository. `REPO` can be the full name or any part
of it, and `REPO:` alone selects that repository's main worktree.

### Staying in one repository

`--no-family` confines the listing, the cycling, and the name search to the repository
the user stands in. `CWT_NO_FAMILY`, set to any value other than `0`, makes that the
default.

## How it was built

Test first, in red and green pairs. Each red commit pins one behavior, and the green
commit that follows adds it:

| Step | Behavior |
| --- | --- |
| `d38a4a5` | Move worktree parsing into `worktree.rs`. Pure move, no behavior change. |
| `2cc45b5` / `dded961` | A listing shows every child repository, grouped. |
| `4d397cb` / `ce87a2b` | A name answers from the nearest repository. |
| `15c6c0d` / `91fa35a` | Refuse an ambiguous name, and let a `REPO:` prefix settle it. |
| `01902d1` / `df70517` | `--no-family` stays inside one repository. |
| `2646d9f` | Guard two shapes the family scan must survive. |

The new `family` module owns discovery, selection, and rendering. `main.rs` only asks
it for a path or a listing, which took 670 lines out of `main.rs`.

## Verification

The four workspace gates pass at the tip of this branch:

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo machete` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace` | pass, 0 failures |

The four new integration test binaries all ran: `family-listing`, `family-navigation`,
`family-conflicts`, and `family-opt-out`.

CAUTION: THIS BRANCH CHANGES WHAT `cwt` DOES BY DEFAULT INSIDE A CONTAINER
REPOSITORY. A LISTING THAT SHOWED ONE REPOSITORY NOW SHOWS THE WHOLE FAMILY.
`--no-family` OR `CWT_NO_FAMILY` RESTORES THE OLD BEHAVIOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
