### PR TITLE
feat(repo-guards): enforce workspace lint inheritance for every member

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,9 @@ So a crate that wants lints stricter than the workspace set declares them as cra
 
 **A manifest `[lints]` table applies to every target of the package. A crate-root attribute applies only to the target whose root file carries it.**
 
-So `#![deny(unsafe_code)]` in `src/main.rs` does nothing for `tests/`, `benches/`, or `examples/` — and nothing for `src/lib.rs` either, in a crate that has both. **The attributes must be repeated in every target root.**
+So `#![deny(unsafe_code)]` in `src/main.rs` does nothing for `tests/`, `benches/`, `examples/`, or `build.rs` — and nothing for `src/lib.rs` either, in a crate that has both. **The attributes must be repeated in every target root.**
+
+A build script is the easiest one to forget, because nothing about it looks like a target. It is one: with `[lints.rust] unsafe_code = "deny"` in the manifest, an unsafe block in `build.rs` fails the build; move that lint to `#![deny(unsafe_code)]` in `src/lib.rs` and the same `build.rs` compiles clean. So `build.rs` must state a position like every other root — but a lint *it* raises never binds its siblings, since nothing links a build script into the crate.
 
 This is not hypothetical. `cwt`'s integration tests silently lost `unsafe_code` and `clippy::pedantic` when its manifest `[lints]` table was converted to a crate-root attribute. Nothing warned; the lints simply stopped applying there. `src/cwt/tests/main-worktree.rs` now repeats them:
 
@@ -304,7 +306,7 @@ A target that legitimately needs a lint relaxed says so at the site, with a reas
 ### Guards Enforcing This
 
 - `repo_guards::workspace_lints` (`src/repo-guards/src/workspace_lints.rs`) - every workspace member manifest declares `[lints]` / `workspace = true`
-- `repo_guards::target_lints` (`src/repo-guards/src/target_lints.rs`) - every target root declares a position on each lint its crate's lib/bin roots raise
+- `repo_guards::target_lints` (`src/repo-guards/src/target_lints.rs`) - every target root — library, binary, test, bench, example, build script - declares a position on each lint its crate's lib/bin roots raise. Its companion test asks `cargo metadata` whether that set of roots is the set cargo actually builds, so a target kind the guard never learned about shows up as a set difference instead of a clean report
 
 ## UTF-8 String Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,65 @@ All Go tools use internal/version:
 - `subito` - AWS IoT Subscriber
 - `symfix` - Symlink Fix
 
+## Lint Configuration
+
+Every crate in this workspace **must** inherit the repo-wide lint set, and a crate that wants to be stricter **must** declare the extra lints as crate-root attributes in **every one of its target roots**.
+
+### Why
+
+The root `Cargo.toml` declares `[workspace.lints.rust]` and `[workspace.lints.clippy]`, but cargo hands those lints only to members that opt in. A member that omits the stanza is silently exempt: nothing warns and nothing fails, because the exemption is spelled as an *absence*. That is also why it spreads — a new crate that never types the stanza is born exempt. All 73 members opt in today, and `repo_guards::workspace_lints` keeps it that way: a new crate that omits the stanza fails `cargo test`.
+
+### Usage
+
+Every member manifest carries:
+
+```toml
+[lints]
+workspace = true
+```
+
+Extra strictness cannot go in the manifest. Cargo refuses to merge a local `[lints]` table with `lints.workspace = true`:
+
+```text
+error: cannot override workspace.lints in lints, either remove the overrides or lints.workspace = true and manually specify the lints
+```
+
+So a crate that wants lints stricter than the workspace set declares them as crate-root inner attributes in its source (`src/cwt/src/main.rs`):
+
+```rust
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+```
+
+### The Trap: A Crate-Root Attribute Reaches One Target
+
+**A manifest `[lints]` table applies to every target of the package. A crate-root attribute applies only to the target whose root file carries it.**
+
+So `#![deny(unsafe_code)]` in `src/main.rs` does nothing for `tests/`, `benches/`, or `examples/` — and nothing for `src/lib.rs` either, in a crate that has both. **The attributes must be repeated in every target root.**
+
+This is not hypothetical. `cwt`'s integration tests silently lost `unsafe_code` and `clippy::pedantic` when its manifest `[lints]` table was converted to a crate-root attribute. Nothing warned; the lints simply stopped applying there. `src/cwt/tests/main-worktree.rs` now repeats them:
+
+```rust
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+```
+
+A target that legitimately needs a lint relaxed says so at the site, with a reason (`src/bm/tests/cli.rs`):
+
+```rust
+#![allow(
+    clippy::unwrap_used,
+    reason = "every unwrap in this file is an assertion, not an unhandled error"
+)]
+```
+
+`deny`, `forbid`, `warn`, `allow`, and `expect` all count as declaring a position — **silence is the only violation**. The bar is "mention", not "match the level", so a relaxation stays a visible, reviewable decision in the file it applies to instead of an entry in a central allowlist. A `cfg_attr`-wrapped lint (`#![cfg_attr(not(test), warn(clippy::unwrap_used))]`, as in `src/bm/src/lib.rs`) counts as a mention but does not raise. Because `clippy::allow_attributes_without_reason` is `warn` in the workspace set, every `allow` needs a `reason = "..."`.
+
+### Guards Enforcing This
+
+- `repo_guards::workspace_lints` (`src/repo-guards/src/workspace_lints.rs`) - every workspace member manifest declares `[lints]` / `workspace = true`
+- `repo_guards::target_lints` (`src/repo-guards/src/target_lints.rs`) - every target root declares a position on each lint its crate's lib/bin roots raise
+
 ## UTF-8 String Safety
 
 All tools in this repository **must** handle UTF-8 strings safely. Never use byte-level indexing that could panic on multi-byte characters.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6308,6 +6308,7 @@ name = "repo-guards"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "syn 2.0.119",
  "tempfile",
  "thiserror 2.0.20",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6308,6 +6308,7 @@ name = "repo-guards"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "serde_json",
  "syn 2.0.119",
  "tempfile",
  "thiserror 2.0.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6306,6 +6306,12 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "repo-guards"
 version = "0.1.0"
+dependencies = [
+ "glob",
+ "tempfile",
+ "thiserror 2.0.20",
+ "toml",
+]
 
 [[package]]
 name = "reposize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ log = "0.4"
 env_logger = "0.11"
 
 # Misc
+syn = { version = "2", default-features = false, features = ["full", "parsing"] }
 tiktoken-rs = "0.5"
 num-format = "0.4"
 human_bytes = "0.4"

--- a/src/beta/Cargo.toml
+++ b/src/beta/Cargo.toml
@@ -24,5 +24,5 @@ ab_glyph = "0.2"           # Font rendering for video export (replaces rusttype)
 vte = "0.15.0"               # VT100/ANSI terminal emulator
 signal-hook = "0.3"        # Signal handling for graceful termination
 
-[lints.clippy]
-string_slice = "warn"
+[lints]
+workspace = true

--- a/src/beta/src/export/terminal_renderer.rs
+++ b/src/beta/src/export/terminal_renderer.rs
@@ -1,6 +1,33 @@
 use anyhow::Result;
 use vte::{Parser, Perform};
 
+/// Narrows an SGR colour offset to the palette index it names.
+///
+/// Callers reach this only from a match arm that has already pinned the SGR
+/// parameter to one of the eight-value ranges 30-37, 40-47, 90-97 or 100-107, so
+/// the offset handed in is always 0..=15 and the narrowing is exact.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "the caller's match arm pins the offset to 0..=15, so this narrowing is exact"
+)]
+const fn sgr_palette_index(offset: u16) -> u8 {
+    offset as u8
+}
+
+/// Narrows a raw VT parameter to the byte an SGR colour operand needs.
+///
+/// VT parameters are unbounded 16-bit values, so a malformed sequence such as
+/// `ESC[38;2;300;0;0m` can carry an operand wider than a byte. Wrapping it is
+/// deliberate and long-standing: the renderer keeps painting with the wrapped
+/// value rather than discarding the whole sequence.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "an out-of-range VT colour operand is deliberately wrapped into a byte, preserving the renderer's existing handling of malformed input"
+)]
+const fn sgr_color_byte(param: u16) -> u8 {
+    param as u8
+}
+
 #[derive(Debug, Clone)]
 pub struct TerminalTheme {
     pub background: (u8, u8, u8),
@@ -230,7 +257,10 @@ pub struct Cell {
     pub fg_color: (u8, u8, u8),
     pub bg_color: (u8, u8, u8),
     pub bold: bool,
-    #[allow(dead_code)] // Tracked by SGR processing; rendering support planned
+    #[allow(
+        dead_code,
+        reason = "tracked by SGR processing; rendering support planned"
+    )]
     pub italic: bool,
     pub underline: bool,
 }
@@ -375,8 +405,8 @@ impl TerminalState {
         let mut bg = cell.bg_color;
 
         // Only check palette entries that have been modified (not all 256)
-        for (i, &dynamic_color) in self.dynamic_palette.iter().enumerate() {
-            let standard_color = TerminalTheme::get_256_color(i as u8);
+        for (index, &dynamic_color) in (0..=u8::MAX).zip(self.dynamic_palette.iter()) {
+            let standard_color = TerminalTheme::get_256_color(index);
             if dynamic_color == standard_color {
                 continue; // Skip unmodified entries
             }
@@ -720,7 +750,7 @@ impl TerminalState {
                 24 => self.underline = false,
                 30..=37 => {
                     // Foreground colors
-                    let color_index = (param - 30) as u8;
+                    let color_index = sgr_palette_index(param - 30);
                     self.current_fg = self.theme.get_color(color_index);
                 }
                 38
@@ -730,7 +760,7 @@ impl TerminalState {
                             5
                                 // 256-color mode: ESC[38;5;n
                                 if i + 2 < param_vec.len() => {
-                                    let color_index = param_vec[i + 2] as u8;
+                                    let color_index = sgr_color_byte(param_vec[i + 2]);
                                     if (color_index as usize) < self.dynamic_palette.len() {
                                         self.current_fg =
                                             self.dynamic_palette[color_index as usize];
@@ -742,9 +772,9 @@ impl TerminalState {
                             2
                                 // 24-bit RGB mode: ESC[38;2;r;g;b
                                 if i + 4 < param_vec.len() => {
-                                    let r = param_vec[i + 2] as u8;
-                                    let g = param_vec[i + 3] as u8;
-                                    let b = param_vec[i + 4] as u8;
+                                    let r = sgr_color_byte(param_vec[i + 2]);
+                                    let g = sgr_color_byte(param_vec[i + 3]);
+                                    let b = sgr_color_byte(param_vec[i + 4]);
                                     self.current_fg = (r, g, b);
                                     i += 4; // Skip the 2, r, g, b
                                 }
@@ -753,7 +783,7 @@ impl TerminalState {
                     }
                 40..=47 => {
                     // Background colors
-                    let color_index = (param - 40) as u8;
+                    let color_index = sgr_palette_index(param - 40);
                     self.current_bg = self.theme.get_color(color_index);
                 }
                 48
@@ -763,7 +793,7 @@ impl TerminalState {
                             5
                                 // 256-color mode: ESC[48;5;n
                                 if i + 2 < param_vec.len() => {
-                                    let color_index = param_vec[i + 2] as u8;
+                                    let color_index = sgr_color_byte(param_vec[i + 2]);
                                     if (color_index as usize) < self.dynamic_palette.len() {
                                         self.current_bg =
                                             self.dynamic_palette[color_index as usize];
@@ -775,9 +805,9 @@ impl TerminalState {
                             2
                                 // 24-bit RGB mode: ESC[48;2;r;g;b
                                 if i + 4 < param_vec.len() => {
-                                    let r = param_vec[i + 2] as u8;
-                                    let g = param_vec[i + 3] as u8;
-                                    let b = param_vec[i + 4] as u8;
+                                    let r = sgr_color_byte(param_vec[i + 2]);
+                                    let g = sgr_color_byte(param_vec[i + 3]);
+                                    let b = sgr_color_byte(param_vec[i + 4]);
                                     self.current_bg = (r, g, b);
                                     i += 4; // Skip the 2, r, g, b
                                 }
@@ -786,12 +816,12 @@ impl TerminalState {
                     }
                 90..=97 => {
                     // Bright foreground colors
-                    let color_index = (param - 90 + 8) as u8;
+                    let color_index = sgr_palette_index(param - 90 + 8);
                     self.current_fg = self.theme.get_color(color_index);
                 }
                 100..=107 => {
                     // Bright background colors
-                    let color_index = (param - 100 + 8) as u8;
+                    let color_index = sgr_palette_index(param - 100 + 8);
                     self.current_bg = self.theme.get_color(color_index);
                 }
                 _ => {}
@@ -807,9 +837,10 @@ impl TerminalState {
         self.parse_color_spec(color_spec)
     }
 
-    // All byte-level indexing below is safe because we reject non-ASCII input
-    // via `is_ascii()` checks before any indexing occurs.
-    #[allow(clippy::string_slice)]
+    #[allow(
+        clippy::string_slice,
+        reason = "every byte-level index below is guarded by an `is_ascii()` check on the whole spec, so no index can land inside a multi-byte character"
+    )]
     fn parse_color_spec(&self, color_spec: &str) -> Option<(u8, u8, u8)> {
         let spec = color_spec.trim();
         if spec.starts_with('#') && spec.len() == 7 && spec.is_ascii() {
@@ -969,8 +1000,9 @@ impl Perform for TerminalState {
                     let indices = std::str::from_utf8(params[1]).unwrap_or("");
                     if indices.is_empty() {
                         // Reset all colors
-                        for i in 0..=255 {
-                            self.dynamic_palette[i] = TerminalTheme::get_256_color(i as u8);
+                        for index in 0..=u8::MAX {
+                            self.dynamic_palette[usize::from(index)] =
+                                TerminalTheme::get_256_color(index);
                         }
                     } else {
                         // Reset specific indices
@@ -1195,7 +1227,7 @@ impl Perform for TerminalState {
                     .iter()
                     .nth(1)
                     .and_then(|p| p.first().copied())
-                    .unwrap_or(self.height as u16) as usize;
+                    .map_or(self.height, usize::from);
 
                 // Validate and set scrolling region
                 if top > 0 && bottom <= self.height && top < bottom {

--- a/src/beta/src/export/video.rs
+++ b/src/beta/src/export/video.rs
@@ -209,8 +209,13 @@ fn generate_and_encode_video(
     theme: TerminalTheme,
     optimize_web: bool,
 ) -> Result<usize> {
-    let frame_duration = 1.0 / fps as f64;
-    let total_frames = (recording.duration * fps as f64).ceil() as usize;
+    let frame_duration = 1.0 / f64::from(fps);
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the saturating float cast is the clamp we want: a negative or NaN duration yields no frames, and a recording long enough to exceed usize would exhaust the disk long before the cast mattered"
+    )]
+    let total_frames = (recording.duration * f64::from(fps)).ceil() as usize;
 
     // Start FFmpeg process first
     let mut ffmpeg_process = spawn_ffmpeg(output_path, width, height, fps, optimize_web)?;
@@ -226,11 +231,8 @@ fn generate_and_encode_video(
         font_manager.fonts.len()
     );
 
-    let mut terminal_state = TerminalState::new(
-        recording.width as usize,
-        recording.height as usize,
-        theme.clone(),
-    );
+    let mut terminal_state =
+        TerminalState::new(recording.width as usize, recording.height as usize, theme);
 
     let mut event_index = 0;
 
@@ -302,6 +304,46 @@ fn calculate_font_baseline(font: &impl Font, font_size: f32) -> f32 {
     ascent.min(48.0).round()
 }
 
+/// Pixel offset of the leading edge of the cell at grid coordinate `index`.
+///
+/// Grid coordinates are bounded by the recording's `u16` terminal dimensions and
+/// `cell_size` is a small compile-time constant, so `index * cell_size + padding`
+/// always fits in a `u32`.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "grid indices come from the recording's u16 terminal dimensions, so they always fit in u32"
+)]
+fn cell_offset(index: usize, cell_size: u32, padding: u32) -> u32 {
+    padding + (index as u32 * cell_size)
+}
+
+/// Converts a pixel offset into the signed coordinate the `imageproc` drawing
+/// calls take.
+///
+/// Every offset is produced by [`cell_offset`], i.e. a grid index bounded by the
+/// recording's `u16` terminal size times a small cell constant, so it stays far
+/// below `i32::MAX` and cannot wrap.
+#[allow(
+    clippy::cast_possible_wrap,
+    reason = "pixel offsets are bounded by the recording's u16 terminal size times a small cell constant, so they never reach i32::MAX"
+)]
+const fn pixel_coord(offset: u32) -> i32 {
+    offset as i32
+}
+
+/// Baseline row for a glyph drawn in the cell whose top edge is at `cell_top`.
+///
+/// `cell_top` is a bounded pixel offset (see [`pixel_coord`]) and
+/// [`calculate_font_baseline`] caps the offset at 48 pixels, so the rounded sum
+/// always fits in an `i32`.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "a bounded cell offset plus a baseline capped at 48 pixels stays far inside i32's range"
+)]
+fn baseline_y(cell_top: u32, baseline_offset: f32) -> i32 {
+    (cell_top as f32 + baseline_offset).round() as i32
+}
+
 fn render_terminal_to_image(
     terminal_state: &TerminalState,
     width: u32,
@@ -319,8 +361,8 @@ fn render_terminal_to_image(
 
     // Use fixed character cell dimensions to match terminal expectations
     const SCALE: u32 = 4; // 4x resolution for fine control
-    let char_width = 6u32 * SCALE - 1; // 23px - 0.25px tighter
-    let char_height = 13u32 * SCALE + 1; // 53px - 0.25px looser
+    let char_width = 6_u32 * SCALE - 1; // 23px - 0.25px tighter
+    let char_height = 13_u32 * SCALE + 1; // 53px - 0.25px looser
     let font_size = 12.0 * SCALE as f32; // 48pt at 4x
     let scale = PxScale::from(font_size);
 
@@ -338,13 +380,15 @@ fn render_terminal_to_image(
 
     // Pass 1: Render all cell backgrounds first (including status bar)
     for (y, row) in grid.iter().enumerate() {
+        // Use integer positioning to avoid gaps
+        let pixel_y = cell_offset(y, char_height, padding_y);
+
         for (x, cell) in row.iter().enumerate() {
-            // Use integer positioning to avoid gaps
-            let pixel_x = padding_x + (x as u32 * char_width);
-            let pixel_y = padding_y + (y as u32 * char_height);
+            let pixel_x = cell_offset(x, char_width, padding_x);
 
             // Draw background color for this cell - ensure it fills the entire cell
-            let bg_rect = Rect::at(pixel_x as i32, pixel_y as i32).of_size(char_width, char_height);
+            let bg_rect = Rect::at(pixel_coord(pixel_x), pixel_coord(pixel_y))
+                .of_size(char_width, char_height);
 
             // Get resolved colors from terminal state (handles dynamic palette, overrides, etc.)
             let (_, bg_color) = terminal_state.resolve_cell_colors(cell);
@@ -359,10 +403,11 @@ fn render_terminal_to_image(
 
     // Pass 2: Render all text on top of backgrounds (including status bar)
     for (y, row) in grid.iter().enumerate() {
+        // Use integer positioning to avoid gaps
+        let pixel_y = cell_offset(y, char_height, padding_y);
+
         for (x, cell) in row.iter().enumerate() {
-            // Use integer positioning to avoid gaps
-            let pixel_x = padding_x + (x as u32 * char_width);
-            let pixel_y = padding_y + (y as u32 * char_height);
+            let pixel_x = cell_offset(x, char_width, padding_x);
 
             // Draw the character if it's not empty
             if cell.ch != ' ' && cell.ch != '\x00' {
@@ -393,8 +438,8 @@ fn render_terminal_to_image(
 
                 // Position text properly within the character cell
                 // Ensure integer positioning for crisp rendering
-                let text_x = pixel_x as i32;
-                let text_y = (pixel_y as f32 + baseline_offset).round() as i32;
+                let text_x = pixel_coord(pixel_x);
+                let text_y = baseline_y(pixel_y, baseline_offset);
 
                 draw_text_mut(
                     &mut image,
@@ -408,9 +453,11 @@ fn render_terminal_to_image(
 
                 // Add underline if needed
                 if cell.underline {
-                    let underline_rect =
-                        Rect::at(pixel_x as i32, (pixel_y + char_height - (2 * SCALE)) as i32)
-                            .of_size(char_width, SCALE); // Scale underline thickness
+                    let underline_rect = Rect::at(
+                        pixel_coord(pixel_x),
+                        pixel_coord(pixel_y + char_height - (2 * SCALE)),
+                    )
+                    .of_size(char_width, SCALE); // Scale underline thickness
 
                     draw_filled_rect_mut(
                         &mut image,
@@ -436,16 +483,21 @@ fn render_terminal_to_image(
             );
 
             // Calculate cursor pixel position - align with text rendering
-            let cursor_pixel_x = padding_x + (adj_cursor_x as u32 * char_width);
-            let cell_top_y = padding_y + (adj_cursor_y as u32 * char_height);
+            let cursor_pixel_x = cell_offset(adj_cursor_x, char_width, padding_x);
+            let cell_top_y = cell_offset(adj_cursor_y, char_height, padding_y);
 
             // Position cursor to align with text baseline - start from baseline and extend down
             // This matches how terminals typically render cursors
-            let cursor_pixel_y = cell_top_y + baseline_offset as u32;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "calculate_font_baseline already rounds its result and caps it at 48.0, and a font ascent is never negative, so this converts a whole number of pixels in 0..=48"
+            )]
             let cursor_height = baseline_offset as u32;
+            let cursor_pixel_y = cell_top_y + cursor_height;
 
             // Draw cursor as inverted block aligned with text
-            let cursor_rect = Rect::at(cursor_pixel_x as i32, cursor_pixel_y as i32)
+            let cursor_rect = Rect::at(pixel_coord(cursor_pixel_x), pixel_coord(cursor_pixel_y))
                 .of_size(char_width, cursor_height);
 
             // Get the cell at cursor position to determine colors
@@ -467,8 +519,8 @@ fn render_terminal_to_image(
                 if cell.ch != ' ' && cell.ch != '\x00' {
                     let text = cell.ch.to_string();
                     let font = font_manager.get_best_font_for_char(cell.ch);
-                    let text_x = cursor_pixel_x as i32;
-                    let text_y = (cell_top_y as f32 + baseline_offset).round() as i32;
+                    let text_x = pixel_coord(cursor_pixel_x);
+                    let text_y = baseline_y(cell_top_y, baseline_offset);
 
                     draw_text_mut(
                         &mut image,

--- a/src/beta/src/export/web.rs
+++ b/src/beta/src/export/web.rs
@@ -390,8 +390,14 @@ pub async fn export_web(
     };
 
     // Format duration
-    let duration_minutes = recording.duration as u64 / 60;
-    let duration_seconds = recording.duration as u64 % 60;
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the duration is a count of seconds; the saturating float cast clamps a negative or NaN duration from a corrupt recording to 0:00"
+    )]
+    let duration_total_seconds = recording.duration as u64;
+    let duration_minutes = duration_total_seconds / 60;
+    let duration_seconds = duration_total_seconds % 60;
     let duration_formatted = format!("{}:{:02}", duration_minutes, duration_seconds);
 
     // Create template environment

--- a/src/beta/src/main.rs
+++ b/src/beta/src/main.rs
@@ -120,6 +120,13 @@ pub fn get_timestamp() -> f64 {
 
 impl Recording {
     /// Load a recording from a file, auto-detecting gzip compression via magic bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened, if its metadata cannot be
+    /// read, if it is empty, if seeking back to the start of the file fails, or
+    /// if its contents do not parse as a recording — either as gzip-compressed
+    /// JSON when the gzip magic bytes are present, or as plain JSON otherwise.
     pub fn load(path: &Path) -> Result<Self> {
         let mut file = std::fs::File::open(path)
             .with_context(|| format!("Failed to open recording file: {}", path.display()))?;
@@ -129,7 +136,7 @@ impl Recording {
         }
 
         // Check for gzip magic bytes (0x1f 0x8b) instead of relying on extension
-        let mut magic = [0u8; 2];
+        let mut magic = [0_u8; 2];
         let is_gzip = file.read_exact(&mut magic).is_ok() && magic == [0x1f, 0x8b];
 
         // Seek back to the beginning for the actual read

--- a/src/beta/src/test.rs
+++ b/src/beta/src/test.rs
@@ -23,7 +23,7 @@ mod tests {
             version: 2,
             width: 80,
             height: 24,
-            timestamp: 1234567890.0,
+            timestamp: 1_234_567_890.0,
             duration: 10.5,
             command: "bash".to_string(),
             title: "Test recording".to_string(),

--- a/src/bm/tests/cli.rs
+++ b/src/bm/tests/cli.rs
@@ -3,6 +3,12 @@
 //! Each test builds its own temporary tree, so concurrent test runs stay
 //! isolated (see the parallel-safety note in the project guidelines).
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "every unwrap in this file is an assertion, not an unhandled error: on the tempdirs and fixture files the test just created, on `.output()` spawning the freshly built binary (a spawn failure is a broken harness, not behavior under test), and on reading back a file the test itself wrote so it can be compared. The CLI's own error paths are never unwrapped — they are asserted through the exit status, `assert!(!ok, ...)` — which is why src/lib.rs raises both lints only under cfg(not(test)). No `.expect` appears here yet; the allow covers it so the first one does not silently change the file's position"
+)]
+
 use std::path::Path;
 use std::process::{Command, Output};
 

--- a/src/bm/tests/integration.rs
+++ b/src/bm/tests/integration.rs
@@ -3,6 +3,12 @@
 //! Every test uses its own `tempfile::tempdir()` so concurrent runs (including a
 //! background `bacon` loop sharing `./target`) never clobber each other.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "every unwrap in this file is an assertion, not an unhandled error: on fixtures the test just built in its own tempdir, or on the bm API under test, where an Err is the failure being reported (and unwrap_err on the deliberately unrenamable plan asserts the opposite direction). None of them stands in front of a production error path, which is why src/lib.rs raises both lints only under cfg(not(test)). No `.expect` appears here yet; the allow covers it so the first one does not silently change the file's position"
+)]
+
 use bm::{collect_sources, execute_plan, plan_moves, CollisionPolicy, FilterType};
 use std::fs;
 use std::path::Path;

--- a/src/cwt/Cargo.toml
+++ b/src/cwt/Cargo.toml
@@ -17,17 +17,5 @@ shellsetup.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
-[lints.rust]
-# Enforce stricter checks to catch issues early
-unsafe_code = "deny"
-
-[lints.clippy]
-# Pedantic lints help catch subtle issues like redundant code
-pedantic = { level = "warn", priority = -1 }
-# Allow certain pedantic lints that are too strict for this codebase
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
-# Byte-level string indexing (&s[..n]) panics when n lands inside a multi-byte UTF-8 character
-string_slice = "warn"
+[lints]
+workspace = true

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -97,7 +97,10 @@ macro_rules! error {
 // Without this, clap folds the long help into one paragraph and the code blocks
 // below come out as a single run-on line.
 #[command(verbatim_doc_comment)]
-#[allow(clippy::struct_excessive_bools)] // CLI flags are naturally bool-heavy
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "each bool is a distinct CLI flag clap fills in; grouping them into an enum would hide the flags from the derive"
+)]
 struct Cli {
     /// Go to the next worktree (wraps around).
     #[arg(short = 'f', long, conflicts_with_all = ["prev", "main", "target", "shell_setup"])]

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -1,7 +1,4 @@
-// These lints are stricter than the inherited `[workspace.lints]` set. They live
-// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
-// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
-// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -1,3 +1,18 @@
+// These lints are stricter than the inherited `[workspace.lints]` set. They live
+// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
+// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
+// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "WorktreeMatch keeps the Worktree prefix so a signature says which of the match outcomes it carries; the shorter name would save characters and cost clarity"
+)]
+#![allow(
+    clippy::must_use_candidate,
+    reason = "cwt is a binary with no external callers, so a dropped return value cannot surprise anyone outside this file; blanket #[must_use] would be attribute noise rather than a guard"
+)]
+
 use std::process::exit;
 
 use buildinfo::version_string;

--- a/src/cwt/tests/common/mod.rs
+++ b/src/cwt/tests/common/mod.rs
@@ -7,7 +7,10 @@
 //! Cargo compiles this module separately into each test binary, so a helper
 //! that only one target calls looks unused to the other. That is what the
 //! blanket `dead_code` allow is for; it is not hiding a helper nobody calls.
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "cargo compiles this module into each test binary separately, so a helper only one target calls looks unused to the others"
+)]
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};

--- a/src/cwt/tests/family-conflicts.rs
+++ b/src/cwt/tests/family-conflicts.rs
@@ -3,10 +3,7 @@
 //! It refuses to guess, and it names the candidates the way the user has to
 //! type them: `repository:worktree`.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-conflicts.rs
+++ b/src/cwt/tests/family-conflicts.rs
@@ -3,6 +3,13 @@
 //! It refuses to guess, and it names the candidates the way the user has to
 //! type them: `repository:worktree`.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use support::{code, combined, cwt, stdout, target_path, Family};

--- a/src/cwt/tests/family-duplicate-names.rs
+++ b/src/cwt/tests/family-duplicate-names.rs
@@ -3,10 +3,7 @@
 //! own, and every name `cwt` prints has to select the worktree it was printed
 //! for.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-duplicate-names.rs
+++ b/src/cwt/tests/family-duplicate-names.rs
@@ -3,6 +3,13 @@
 //! own, and every name `cwt` prints has to select the worktree it was printed
 //! for.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use std::path::{Path, PathBuf};

--- a/src/cwt/tests/family-empty-repository.rs
+++ b/src/cwt/tests/family-empty-repository.rs
@@ -6,10 +6,7 @@
 //! contributes nothing to list. It must not be able to answer for another
 //! repository, and it must not be able to crash `cwt`.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-empty-repository.rs
+++ b/src/cwt/tests/family-empty-repository.rs
@@ -6,6 +6,13 @@
 //! contributes nothing to list. It must not be able to answer for another
 //! repository, and it must not be able to crash `cwt`.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use std::path::{Path, PathBuf};

--- a/src/cwt/tests/family-listing.rs
+++ b/src/cwt/tests/family-listing.rs
@@ -2,10 +2,7 @@
 //! below it as one family: the listing shows all of them, grouped by
 //! repository, and the cycling flags walk the whole family.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-listing.rs
+++ b/src/cwt/tests/family-listing.rs
@@ -2,6 +2,13 @@
 //! below it as one family: the listing shows all of them, grouped by
 //! repository, and the cycling flags walk the whole family.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use support::{code, cwt, headings, parse_listing, stdout, Family};

--- a/src/cwt/tests/family-main-worktree.rs
+++ b/src/cwt/tests/family-main-worktree.rs
@@ -9,6 +9,13 @@
 //! no `main` and no `master` has no main worktree, and sending the user to a
 //! sibling's main worktree is not the shortcut they asked for.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use support::{code, combined, cwt, target_path, Family};

--- a/src/cwt/tests/family-main-worktree.rs
+++ b/src/cwt/tests/family-main-worktree.rs
@@ -9,10 +9,7 @@
 //! no `main` and no `master` has no main worktree, and sending the user to a
 //! sibling's main worktree is not the shortcut they asked for.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-navigation.rs
+++ b/src/cwt/tests/family-navigation.rs
@@ -4,6 +4,13 @@
 //! parent repository, then the rest. `wtm` has to keep meaning "my repository's
 //! main branch" wherever the user is standing.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use support::{code, cwt, target_path, Family};

--- a/src/cwt/tests/family-navigation.rs
+++ b/src/cwt/tests/family-navigation.rs
@@ -4,10 +4,7 @@
 //! parent repository, then the rest. `wtm` has to keep meaning "my repository's
 //! main branch" wherever the user is standing.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -4,10 +4,7 @@
 //! which is what `cwt` did before families existed. `CWT_NO_FAMILY` makes that
 //! choice permanent without wrapping the command.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/family-opt-out.rs
+++ b/src/cwt/tests/family-opt-out.rs
@@ -4,6 +4,13 @@
 //! which is what `cwt` did before families existed. `CWT_NO_FAMILY` makes that
 //! choice permanent without wrapping the command.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod support;
 
 use support::{code, combined, cwt, cwt_with_env, stdout, target_path, Family};

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -10,10 +10,7 @@
 //! end-to-end targets and live in [`common`]. Only the `--main` assertions are
 //! here.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/main-worktree.rs
+++ b/src/cwt/tests/main-worktree.rs
@@ -10,6 +10,13 @@
 //! end-to-end targets and live in [`common`]. Only the `--main` assertions are
 //! here.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod common;
 
 use std::path::Path;

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -4,7 +4,10 @@
 //! directory, so two copies of the suite can run at the same time without
 //! sharing a path, a branch name, or a git index.
 
-#![allow(dead_code)] // Each test file uses a different part of this module.
+#![allow(
+    dead_code,
+    reason = "cargo compiles this module into each test binary separately, so a helper only one target calls looks unused to the others"
+)]
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};

--- a/src/cwt/tests/worktree-listing.rs
+++ b/src/cwt/tests/worktree-listing.rs
@@ -5,10 +5,7 @@
 //! matched. The sets differ, the rendering does not, so these tests pin the
 //! rendered line at both sites and would catch the two drifting apart.
 
-// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
-// reaches only its own target, so the binary raising them does nothing for this
-// test target; repeating them here is what keeps the whole crate under one lint
-// set now that they no longer live in a manifest `[lints]` table.
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 

--- a/src/cwt/tests/worktree-listing.rs
+++ b/src/cwt/tests/worktree-listing.rs
@@ -5,6 +5,13 @@
 //! matched. The sets differ, the rendering does not, so these tests pin the
 //! rendered line at both sites and would catch the two drifting apart.
 
+// These mirror the crate-root attributes in src/main.rs. A crate-root attribute
+// reaches only its own target, so the binary raising them does nothing for this
+// test target; repeating them here is what keeps the whole crate under one lint
+// set now that they no longer live in a manifest `[lints]` table.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
 mod common;
 
 use common::{

--- a/src/prhash/Cargo.toml
+++ b/src/prhash/Cargo.toml
@@ -22,10 +22,5 @@ sha2.workspace = true
 termbar.workspace = true
 tokio.workspace = true
 
-[lints.clippy]
-# Prevent potential panics from arithmetic operations (subtraction overflow, etc.)
-arithmetic_side_effects = "warn"
-# Warn about indexing/slicing that could panic
-indexing_slicing = "warn"
-# Warn about string slicing which can panic on UTF-8 character boundaries
-string_slice = "warn"
+[lints]
+workspace = true

--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -1,3 +1,10 @@
+// These lints are stricter than the inherited `[workspace.lints]` set. They live
+// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
+// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
+// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+#![warn(clippy::arithmetic_side_effects)]
+#![warn(clippy::indexing_slicing)]
+
 use anyhow::{Context, Result};
 use buildinfo::version_string;
 use clap::{Parser, ValueEnum};

--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -1,7 +1,4 @@
-// These lints are stricter than the inherited `[workspace.lints]` set. They live
-// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
-// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
-// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![warn(clippy::arithmetic_side_effects)]
 #![warn(clippy::indexing_slicing)]
 

--- a/src/prhash/src/main.rs
+++ b/src/prhash/src/main.rs
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
     }
 
     // Calculate total size
-    let mut total_size = 0u64;
+    let mut total_size = 0_u64;
     for file in &args.files {
         let metadata = fs::metadata(file)
             .context(format!("Failed to read metadata for '{}'", file.display()))?;
@@ -234,9 +234,10 @@ async fn main() -> Result<()> {
 
     // Process each file
     for (idx, file) in args.files.iter().enumerate() {
-        // SAFETY: idx comes from enumerate() over args.files which is bounded by memory,
-        // so idx < usize::MAX and idx + 1 cannot overflow.
-        #[allow(clippy::arithmetic_side_effects)]
+        #[allow(
+            clippy::arithmetic_side_effects,
+            reason = "idx comes from enumerate() over args.files, which is bounded by memory, so idx < usize::MAX and idx + 1 cannot overflow"
+        )]
         let file_num = idx + 1;
         pb.set_message(format!(
             "Hashing {} ({}/{})",
@@ -358,9 +359,10 @@ async fn hash_file_with_progress(
         };
 
         // Update hash
-        // SAFETY: bytes_read is the return value from read(), which guarantees
-        // bytes_read <= buffer.len(), so this slice is always valid.
-        #[allow(clippy::indexing_slicing)]
+        #[allow(
+            clippy::indexing_slicing,
+            reason = "bytes_read is the return value of read(), which guarantees bytes_read <= buffer.len(), so this slice is always in bounds"
+        )]
         hasher.update(&buffer[..bytes_read]);
 
         pb.inc(bytes_read as u64);

--- a/src/repo-guards/Cargo.toml
+++ b/src/repo-guards/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 glob.workspace = true
+syn.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 

--- a/src/repo-guards/Cargo.toml
+++ b/src/repo-guards/Cargo.toml
@@ -10,6 +10,7 @@ thiserror.workspace = true
 toml.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/src/repo-guards/Cargo.toml
+++ b/src/repo-guards/Cargo.toml
@@ -3,5 +3,13 @@ name = "repo-guards"
 version = "0.1.0"
 edition.workspace = true
 
+[dependencies]
+glob.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/src/repo-guards/src/lib.rs
+++ b/src/repo-guards/src/lib.rs
@@ -6,4 +6,11 @@
 //! deliberately omits the `--version`/git-hash handling the repo otherwise
 //! mandates for tools, because there is nothing for a user to run.
 //!
-//! All meaningful behavior lives in `tests/`; this library is empty by design.
+//! Most guards need no library code at all — running the real artifact and
+//! asserting on its exit status is enough, and that logic lives in `tests/`.
+//! The modules here exist for the guards that must *inspect* the repository
+//! rather than run it, where the inspection deserves a narrow, reusable
+//! interface and a remediation message written once instead of per call site.
+
+/// Proves every workspace member inherits the repo-wide lint set.
+pub mod workspace_lints;

--- a/src/repo-guards/src/lib.rs
+++ b/src/repo-guards/src/lib.rs
@@ -12,5 +12,9 @@
 //! rather than run it, where the inspection deserves a narrow, reusable
 //! interface and a remediation message written once instead of per call site.
 
+/// Proves every target of a crate declares a position on the lints that crate
+/// raises, so a lint cannot apply to the library and silently skip the tests.
+pub mod target_lints;
+
 /// Proves every workspace member inherits the repo-wide lint set.
 pub mod workspace_lints;

--- a/src/repo-guards/src/lib.rs
+++ b/src/repo-guards/src/lib.rs
@@ -12,9 +12,9 @@
 //! rather than run it, where the inspection deserves a narrow, reusable
 //! interface and a remediation message written once instead of per call site.
 
-/// Proves every target of a crate declares a position on the lints that crate
-/// raises, so a lint cannot apply to the library and silently skip the tests.
+// Each module carries its own `//!` header, whose first paragraph is its
+// summary in the module list. Adding an outer `///` summary here as well would
+// move module-doc link resolution to the crate root, silently breaking every
+// intra-doc link inside those headers.
 pub mod target_lints;
-
-/// Proves every workspace member inherits the repo-wide lint set.
 pub mod workspace_lints;

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -220,6 +220,20 @@ pub enum TargetLintsError {
         declared: String,
     },
 
+    /// A manifest's `build` key is neither a path nor a bool.
+    #[error(
+        "{} sets `build = {value}`, which is neither a path nor a bool; cargo rejects that \
+         manifest outright, and reading it as `this crate has no build script` would drop a \
+         target from the audit on the strength of a value the guard did not understand",
+        manifest.display()
+    )]
+    MalformedBuildKey {
+        /// The manifest carrying the key.
+        manifest: PathBuf,
+        /// The value, rendered as TOML.
+        value: String,
+    },
+
     /// A manifest overrides cargo's target auto-discovery.
     #[error(
         "{} sets `{key}`; this guard models cargo's default target discovery only, \

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -161,7 +161,12 @@ const MAX_CFG_ATTR_DEPTH: usize = 16;
 /// This guard models the default discovery rules only. A manifest that changes
 /// them is refused rather than guessed at; see
 /// [`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride).
-const AUTO_DISCOVERY_KEYS: [&str; 4] = ["autobenches", "autobins", "autoexamples", "autotests"];
+///
+/// Public so the guard's model of cargo can be *compared* against cargo's own
+/// documented set by a test, rather than restated there. A key this list omits
+/// is a key the guard silently guesses at, and a fixture list copied from this
+/// one could never notice.
+pub const AUTO_DISCOVERY_KEYS: [&str; 4] = ["autobenches", "autobins", "autoexamples", "autotests"];
 
 /// The manifest table those keys — and `build` — live in.
 const PACKAGE: &str = "package";

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -287,8 +287,9 @@ impl Offender {
 pub struct Report {
     /// Number of member crates whose targets were resolved.
     crates_examined: usize,
-    /// Number of target roots actually opened and parsed.
-    roots_examined: usize,
+    /// Every target root actually opened and parsed, relative to the repo
+    /// root and sorted by path.
+    roots: Vec<PathBuf>,
     /// Silent roots, sorted by path.
     offenders: Vec<Offender>,
 }
@@ -313,13 +314,30 @@ impl Report {
         self.crates_examined
     }
 
+    /// Every target root the audit opened and parsed, relative to the repo
+    /// root and sorted by path.
+    ///
+    /// [`roots_examined`](Self::roots_examined) is the size of this set;
+    /// this is the set itself. The difference matters because this guard
+    /// *models* cargo's target discovery rather than asking cargo, and a model
+    /// only ever disagrees with cargo about *which* roots exist. A count can
+    /// match while the contents do not, so a caller that wants to prove the
+    /// model right compares these paths against another enumeration of the
+    /// same workspace — `cargo metadata`, which needs no model because it is
+    /// the build — and reads off exactly which roots each side has that the
+    /// other lacks.
+    #[must_use]
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
     /// How many target roots the audit opened and parsed.
     ///
     /// A caller should assert this is non-zero: a guard that scans nothing
     /// reports clean for the wrong reason.
     #[must_use]
     pub fn roots_examined(&self) -> usize {
-        self.roots_examined
+        self.roots.len()
     }
 }
 
@@ -329,7 +347,7 @@ impl fmt::Display for Report {
             return write!(
                 f,
                 "Checked {} target roots across {} workspace members; every one declares a position on its crate's lints.",
-                self.roots_examined, self.crates_examined
+                self.roots.len(), self.crates_examined
             );
         }
 
@@ -337,7 +355,7 @@ impl fmt::Display for Report {
             f,
             "{} of {} target roots are silent about a lint their crate raises.",
             self.offenders.len(),
-            self.roots_examined
+            self.roots.len()
         )?;
         writeln!(
             f,
@@ -464,7 +482,7 @@ struct RootLints {
 pub fn audit(repo_root: &Path) -> Result<Report, TargetLintsError> {
     let member_dirs = workspace_lints::members(repo_root)?;
 
-    let mut roots_examined = 0;
+    let mut examined = Vec::new();
     let mut offenders = Vec::new();
 
     for dir in &member_dirs {
@@ -477,7 +495,11 @@ pub fn audit(repo_root: &Path) -> Result<Report, TargetLintsError> {
             let lints = root_lints(&root.path)?;
             scanned.push((root, lints));
         }
-        roots_examined += scanned.len();
+        examined.extend(
+            scanned
+                .iter()
+                .map(|(root, _)| relative_to(repo_root, &root.path)),
+        );
 
         let baseline: BTreeSet<&String> = scanned
             .iter()
@@ -498,24 +520,30 @@ pub fn audit(repo_root: &Path) -> Result<Report, TargetLintsError> {
                 continue;
             }
             offenders.push(Offender {
-                path: root
-                    .path
-                    .strip_prefix(repo_root)
-                    .unwrap_or(&root.path)
-                    .to_path_buf(),
+                path: relative_to(repo_root, &root.path),
                 kind: root.kind.label(),
                 missing,
             });
         }
     }
 
+    examined.sort();
     offenders.sort_by(|a, b| a.path.cmp(&b.path));
 
     Ok(Report {
         crates_examined: member_dirs.len(),
-        roots_examined,
+        roots: examined,
         offenders,
     })
+}
+
+/// Render one absolute path the way a [`Report`] carries it: relative to
+/// `repo_root` when it lies inside, and verbatim when it does not.
+///
+/// Both the offender list and the examined-root set go through here, so a
+/// caller can join either back onto the same repo root and get the file back.
+fn relative_to(repo_root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(repo_root).unwrap_or(path).to_path_buf()
 }
 
 /// Resolve every target root of one member crate.

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -75,11 +75,36 @@
 //! and a missed spelling reports *clean* — indistinguishable from a guard doing
 //! real work.
 //!
-//! One consequence worth stating: `#![cfg_attr(not(test), warn(lint))]` is an
-//! attribute whose path is `cfg_attr`, not a lint level, so it neither raises
-//! nor mentions anything. That is correct rather than incidental — a
-//! conditionally-applied lint is not a position the crate holds in every
-//! configuration.
+//! # `cfg_attr` mentions without raising
+//!
+//! `#![cfg_attr(not(test), warn(lint))]` is an attribute whose path is
+//! `cfg_attr` rather than a lint level, and the two halves of the rule answer
+//! it differently. That split is the point, not an oversight.
+//!
+//! It does **not raise**. A lint that applies only under `not(test)` is not a
+//! position the crate holds in every configuration, so it must not impose a
+//! requirement on sibling targets — least of all on the test targets the
+//! predicate deliberately excludes.
+//!
+//! It **does mention**. The mention bar asks for exactly one thing: that the
+//! root name the lint, so the decision is visible in the file it governs and a
+//! reviewer can see it. A conditional raise names the lint *and* the exact
+//! configuration it holds in, which is strictly more precise than the bare
+//! `#![warn(lint)]` that would satisfy the guard. Reading it as silence would
+//! demand a redundant unconditional mention bolted on top of a more careful
+//! declaration — the guard would punish the crate that stated its position
+//! best. `src/bm/src/lib.rs` is that crate, and it is why this half of the rule
+//! reads the way it does.
+//!
+//! So mention-detection looks *inside* `cfg_attr`, recursively: the form takes
+//! several attributes after its predicate (`#![cfg_attr(unix, warn(a),
+//! allow(b))]`) and it nests (`#![cfg_attr(unix, cfg_attr(test, warn(a)))]`).
+//! Only lint-level attributes found in there count, and the predicate itself is
+//! never read as a lint name — `not`, `test`, and `cfg_attr` are cfg syntax, not
+//! lints. Recursion is bounded so a pathological file cannot exhaust the stack;
+//! past the bound the guard refuses rather than return a verdict it only partly
+//! computed — see
+//! [`CfgAttrTooDeep`](crate::target_lints::TargetLintsError::CfgAttrTooDeep).
 //!
 //! Everything that could shrink the audited set is a hard error rather than a
 //! clean verdict; see [`TargetLintsError`].
@@ -103,6 +128,18 @@ const RAISING_LEVELS: [&str; 3] = ["deny", "forbid", "warn"];
 /// Attribute paths that *mention* a lint. A superset of [`RAISING_LEVELS`]:
 /// `allow` and `expect` are positions too, just not raised ones.
 const MENTIONING_LEVELS: [&str; 5] = ["allow", "deny", "expect", "forbid", "warn"];
+
+/// The attribute that applies other attributes conditionally. Its contents
+/// mention but never raise; see the module docs.
+const CFG_ATTR: &str = "cfg_attr";
+
+/// How many `cfg_attr` wrappers the guard will descend through before refusing.
+///
+/// `cfg_attr` nests without limit in the grammar, so the walk over it is
+/// recursive and a hand-written or generated file could otherwise drive it into
+/// the stack. Real code nests once; the bound is set far above anything a human
+/// writes so that hitting it means the file is pathological, not merely careful.
+const MAX_CFG_ATTR_DEPTH: usize = 16;
 
 /// `[package]` keys that turn cargo's target auto-discovery on or off.
 ///
@@ -146,6 +183,17 @@ pub enum TargetLintsError {
         path: PathBuf,
         /// The underlying parse failure.
         source: syn::Error,
+    },
+
+    /// A target root nests `cfg_attr` deeper than the guard will follow.
+    #[error(
+        "{} nests `cfg_attr` more than {MAX_CFG_ATTR_DEPTH} deep; the guard stops rather than \
+         risk the stack, and a root it only partly read is a root it cannot vouch for",
+        path.display()
+    )]
+    CfgAttrTooDeep {
+        /// The root file whose nesting exceeded the bound.
+        path: PathBuf,
     },
 
     /// A directory that should hold target roots could not be listed.
@@ -410,7 +458,9 @@ struct RootLints {
 /// - a member resolves to no target roots
 ///   ([`NoTargetRoots`](TargetLintsError::NoTargetRoots));
 /// - a root file is unreadable ([`ReadRoot`](TargetLintsError::ReadRoot)) or
-///   does not parse as Rust ([`ParseRoot`](TargetLintsError::ParseRoot)).
+///   does not parse as Rust ([`ParseRoot`](TargetLintsError::ParseRoot));
+/// - a root nests `cfg_attr` past the guard's bound
+///   ([`CfgAttrTooDeep`](TargetLintsError::CfgAttrTooDeep)).
 pub fn audit(repo_root: &Path) -> Result<Report, TargetLintsError> {
     let member_dirs = workspace_lints::members(repo_root)?;
 
@@ -635,6 +685,9 @@ fn discover(
 ///
 /// `reason = "..."` is a [`Meta::NameValue`], not a [`Meta::Path`], so it is
 /// skipped rather than collected as a lint named `reason`.
+///
+/// Each inner attribute is handed to [`collect_positions`], which is also what
+/// descends through `cfg_attr`.
 fn root_lints(path: &Path) -> Result<RootLints, TargetLintsError> {
     let text = fs::read_to_string(path).map_err(|source| TargetLintsError::ReadRoot {
         path: path.to_path_buf(),
@@ -650,40 +703,88 @@ fn root_lints(path: &Path) -> Result<RootLints, TargetLintsError> {
         if !matches!(attr.style, AttrStyle::Inner(_)) {
             continue;
         }
-        let Meta::List(list) = &attr.meta else {
-            continue;
-        };
-        let Some(level) = sole_segment(&list.path) else {
-            continue;
-        };
-        if !MENTIONING_LEVELS.contains(&level.as_str()) {
-            continue;
-        }
-
-        let args = list
-            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
-            .map_err(|source| TargetLintsError::ParseRoot {
-                path: path.to_path_buf(),
-                source,
-            })?;
-        for arg in args {
-            let Meta::Path(lint) = arg else {
-                continue;
-            };
-            let name = render_path(&lint);
-            if RAISING_LEVELS.contains(&level.as_str()) {
-                lints.raised.insert(name.clone());
-            }
-            lints.mentioned.insert(name);
-        }
+        collect_positions(&attr.meta, 0, path, &mut lints)?;
     }
     Ok(lints)
 }
 
+/// Record the lint positions one attribute takes, descending through any
+/// `cfg_attr` wrapping it.
+///
+/// `depth` counts the `cfg_attr` wrappers this attribute sits inside. Depth zero
+/// is unconditional and is the only depth that can *raise*; anything deeper
+/// applies in some configurations and not others, so it mentions without
+/// raising. See the module docs for why those two answers differ.
+///
+/// The first argument of a `cfg_attr` is its cfg predicate — `not(test)`,
+/// `unix`, `feature = "x"` — and is skipped outright, so no part of a predicate
+/// can be mistaken for a lint name. Every argument after it is an attribute the
+/// predicate guards, and each is walked the same way, which is what makes both
+/// the multi-attribute form and the nested form fall out of one rule rather than
+/// a case apiece.
+fn collect_positions(
+    meta: &Meta,
+    depth: usize,
+    path: &Path,
+    lints: &mut RootLints,
+) -> Result<(), TargetLintsError> {
+    let Meta::List(list) = meta else {
+        return Ok(());
+    };
+    let Some(name) = sole_segment(&list.path) else {
+        return Ok(());
+    };
+
+    if name == CFG_ATTR {
+        if depth >= MAX_CFG_ATTR_DEPTH {
+            return Err(TargetLintsError::CfgAttrTooDeep {
+                path: path.to_path_buf(),
+            });
+        }
+        for guarded in meta_args(list, path)?.iter().skip(1) {
+            collect_positions(guarded, depth + 1, path, lints)?;
+        }
+        return Ok(());
+    }
+
+    if !MENTIONING_LEVELS.contains(&name.as_str()) {
+        return Ok(());
+    }
+    let raises = depth == 0 && RAISING_LEVELS.contains(&name.as_str());
+
+    for arg in &meta_args(list, path)? {
+        let Meta::Path(lint) = arg else {
+            continue;
+        };
+        let rendered = render_path(lint);
+        if raises {
+            lints.raised.insert(rendered.clone());
+        }
+        lints.mentioned.insert(rendered);
+    }
+    Ok(())
+}
+
+/// Parse the comma-separated arguments of an attribute list.
+///
+/// A failure here is a refusal, not an empty list: arguments the guard cannot
+/// read are lint positions it cannot see, and "this attribute holds nothing" is
+/// the one conclusion it has no evidence for.
+fn meta_args(
+    list: &syn::MetaList,
+    path: &Path,
+) -> Result<Punctuated<Meta, Token![,]>, TargetLintsError> {
+    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .map_err(|source| TargetLintsError::ParseRoot {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
 /// The identifier of a single-segment path, or `None` for anything longer.
 ///
-/// Lint *levels* are always one segment (`warn`), which is what distinguishes
-/// them from wrappers like `cfg_attr` only by name — and from lint *paths* like
+/// Lint *levels* and `cfg_attr` alike are always one segment, which is what
+/// distinguishes them from each other only by name — and from lint *paths* like
 /// `clippy::pedantic` by shape.
 fn sole_segment(path: &syn::Path) -> Option<String> {
     match path.segments.len() {

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -166,7 +166,13 @@ const MAX_CFG_ATTR_DEPTH: usize = 16;
 /// documented set by a test, rather than restated there. A key this list omits
 /// is a key the guard silently guesses at, and a fixture list copied from this
 /// one could never notice.
-pub const AUTO_DISCOVERY_KEYS: [&str; 4] = ["autobenches", "autobins", "autoexamples", "autotests"];
+pub const AUTO_DISCOVERY_KEYS: [&str; 5] = [
+    "autobenches",
+    "autobins",
+    "autoexamples",
+    "autolib",
+    "autotests",
+];
 
 /// The manifest table those keys — and `build` — live in.
 const PACKAGE: &str = "package";
@@ -273,7 +279,7 @@ pub enum TargetLintsError {
     AutoDiscoveryOverride {
         /// The manifest carrying the override.
         manifest: PathBuf,
-        /// The offending key: `autotests`, `autobins`, …
+        /// The offending key, one of [`AUTO_DISCOVERY_KEYS`].
         key: &'static str,
     },
 
@@ -525,7 +531,7 @@ struct RootLints {
 ///   ([`MissingDeclaredTarget`](TargetLintsError::MissingDeclaredTarget));
 /// - a manifest's `build` key is neither a path nor a bool
 ///   ([`MalformedBuildKey`](TargetLintsError::MalformedBuildKey));
-/// - a manifest sets `autotests`, `autobins`, `autobenches`, or `autoexamples`
+/// - a manifest sets one of [`AUTO_DISCOVERY_KEYS`]
 ///   ([`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride));
 /// - a directory holding target roots cannot be listed
 ///   ([`ReadTargetDir`](TargetLintsError::ReadTargetDir));

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -1,7 +1,7 @@
 //! Guard: every *target* of a crate must declare a position on the lints that
 //! crate raises.
 //!
-//! [`workspace_lints`](crate::workspace_lints) proves each member crate opts
+//! [`workspace_lints`] proves each member crate opts
 //! into the repo-wide lint set. This module is the same disease one level down,
 //! at the target instead of the crate.
 //!

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -1,0 +1,703 @@
+//! Guard: every *target* of a crate must declare a position on the lints that
+//! crate raises.
+//!
+//! [`workspace_lints`](crate::workspace_lints) proves each member crate opts
+//! into the repo-wide lint set. This module is the same disease one level down,
+//! at the target instead of the crate.
+//!
+//! Cargo refuses to merge a member's own `[lints]` table with
+//! `lints.workspace = true` (`error: cannot override workspace.lints in
+//! lints`). So a crate that wants lints *stricter* than the workspace set has
+//! exactly one place to put them: crate-root inner attributes in its source,
+//! e.g.
+//!
+//! ```ignore
+//! #![deny(unsafe_code)]
+//! #![warn(clippy::pedantic)]
+//! ```
+//!
+//! And that is where the hole opens. A manifest `[lints]` table applies to
+//! **every target of the package**. A crate-root attribute applies to **one
+//! target** — the single file that is that target's root. Moving lints out of
+//! the manifest to satisfy the inheritance guard therefore hands the library
+//! and binary a stricter lint set while the integration tests, benches, and
+//! examples of the same crate quietly keep the workspace default. Nothing warns.
+//! The exemption is spelled as an *absence*, which is why it is invisible and
+//! why it spreads.
+//!
+//! # The rule
+//!
+//! For each workspace member:
+//!
+//! 1. The crate's **baseline** is the union of the lint paths *raised* — `deny`,
+//!    `forbid`, or `warn` — by inner attributes at the roots of its **library
+//!    and binary** targets. Those are the targets that define what the crate
+//!    holds itself to.
+//! 2. Every target root of that crate — library, binary, test, bench, example —
+//!    must **mention** every baseline lint in some inner lint attribute:
+//!    `deny`, `forbid`, `warn`, `allow`, or `expect`.
+//! 3. **Silence is the only violation.**
+//!
+//! # Why "mention", not "match the level"
+//!
+//! This guard deliberately does **not** compare levels. A test root that
+//! `allow`s a baseline lint is *compliant*:
+//!
+//! ```ignore
+//! #![allow(
+//!     clippy::unwrap_used,
+//!     reason = "a test that cannot unwrap is a test written around its harness"
+//! )]
+//! ```
+//!
+//! That is a deliberate, visible, reviewable decision sitting in the file it
+//! applies to. A root that says *nothing* is not a decision at all — it is the
+//! absence this guard exists to convert into a declaration. Demanding equal
+//! levels would be a different guard with a different, worse trade: integration
+//! tests genuinely do need to unwrap, and a rule they cannot satisfy gets
+//! satisfied by deleting the rule.
+//!
+//! That is also why there is **no central exemption file**. The local
+//! `#![allow(lint, reason = "...")]` *is* the opt-out mechanism, and the
+//! workspace's own `clippy::allow_attributes_without_reason` already forces the
+//! reason to be written next to it. An allowlist elsewhere would move the
+//! decision away from the code it exempts, which is how exemptions become
+//! permanent.
+//!
+//! # Parse, never text-match
+//!
+//! "An inner attribute whose path is a lint level and whose arguments are lint
+//! paths" names a syntactic category, so it is answered with [`syn`], not a
+//! regex. Every spelling therefore reduces to the same answer: one lint per
+//! attribute or several, `clippy::pedantic` or bare `unsafe_code`, with or
+//! without a trailing `reason = "..."` (a name-value pair, never a lint name).
+//! A regex would answer only for the spellings someone happened to think of,
+//! and a missed spelling reports *clean* — indistinguishable from a guard doing
+//! real work.
+//!
+//! One consequence worth stating: `#![cfg_attr(not(test), warn(lint))]` is an
+//! attribute whose path is `cfg_attr`, not a lint level, so it neither raises
+//! nor mentions anything. That is correct rather than incidental — a
+//! conditionally-applied lint is not a position the crate holds in every
+//! configuration.
+//!
+//! Everything that could shrink the audited set is a hard error rather than a
+//! clean verdict; see [`TargetLintsError`].
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use syn::punctuated::Punctuated;
+use syn::{AttrStyle, Meta, Token};
+use thiserror::Error;
+use toml::Value;
+
+use crate::workspace_lints::{self, WorkspaceLintsError, CARGO_TOML};
+
+/// Attribute paths that *raise* a lint, and so contribute to a crate's baseline.
+const RAISING_LEVELS: [&str; 3] = ["deny", "forbid", "warn"];
+
+/// Attribute paths that *mention* a lint. A superset of [`RAISING_LEVELS`]:
+/// `allow` and `expect` are positions too, just not raised ones.
+const MENTIONING_LEVELS: [&str; 5] = ["allow", "deny", "expect", "forbid", "warn"];
+
+/// `[package]` keys that turn cargo's target auto-discovery on or off.
+///
+/// This guard models the default discovery rules only. A manifest that changes
+/// them is refused rather than guessed at; see
+/// [`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride).
+const AUTO_DISCOVERY_KEYS: [&str; 4] = ["autobenches", "autobins", "autoexamples", "autotests"];
+
+/// Rust source extension, used when auto-discovering target roots.
+const RS: &str = "rs";
+
+/// The conventional entry point of a directory-shaped target
+/// (`tests/foo/main.rs`).
+const MAIN_RS: &str = "main.rs";
+
+/// Everything that can stop the audit from reaching a verdict.
+///
+/// Every variant is a *refusal*. A guard that cannot enumerate a crate's
+/// targets must say so loudly, because "no target is missing a lint" and "I
+/// found no targets" are the same sentence to a CI log and only one of them is
+/// good news.
+#[derive(Debug, Error)]
+pub enum TargetLintsError {
+    /// The workspace members could not be enumerated.
+    #[error("cannot enumerate the workspace members: {0}")]
+    Members(#[from] WorkspaceLintsError),
+
+    /// A target root could not be read from disk.
+    #[error("cannot read the target root {}: {source}", path.display())]
+    ReadRoot {
+        /// The root file that could not be read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: io::Error,
+    },
+
+    /// A target root was read but is not valid Rust.
+    #[error("cannot parse {} as Rust: {source}", path.display())]
+    ParseRoot {
+        /// The root file that failed to parse.
+        path: PathBuf,
+        /// The underlying parse failure.
+        source: syn::Error,
+    },
+
+    /// A directory that should hold target roots could not be listed.
+    #[error("cannot list {} while discovering target roots: {source}", dir.display())]
+    ReadTargetDir {
+        /// The directory that could not be listed.
+        dir: PathBuf,
+        /// The underlying I/O failure.
+        source: io::Error,
+    },
+
+    /// A manifest declares a target `path` that is not on disk.
+    #[error(
+        "{} declares a {kind} target at `{declared}`, which does not exist; \
+         a target this guard cannot open is a target it cannot vouch for",
+        manifest.display()
+    )]
+    MissingDeclaredTarget {
+        /// The manifest carrying the declaration.
+        manifest: PathBuf,
+        /// Which kind of target declared it: `lib`, `bin`, `test`, …
+        kind: &'static str,
+        /// The `path` value, exactly as written in the manifest.
+        declared: String,
+    },
+
+    /// A manifest overrides cargo's target auto-discovery.
+    #[error(
+        "{} sets `{key}`; this guard models cargo's default target discovery only, \
+         so it would enumerate the wrong roots and report clean for the wrong reason",
+        manifest.display()
+    )]
+    AutoDiscoveryOverride {
+        /// The manifest carrying the override.
+        manifest: PathBuf,
+        /// The offending key: `autotests`, `autobins`, …
+        key: &'static str,
+    },
+
+    /// A member crate resolved to no target roots at all.
+    #[error(
+        "workspace member {} resolves to no target roots; refusing to report a crate clean \
+         when nothing in it was examined",
+        dir.display()
+    )]
+    NoTargetRoots {
+        /// The member directory.
+        dir: PathBuf,
+    },
+}
+
+/// One target root that is silent about at least one of its crate's baseline
+/// lints.
+#[derive(Debug, Clone)]
+pub struct Offender {
+    /// The root file, relative to the repo root.
+    path: PathBuf,
+    /// Which kind of target this root is: `library`, `binary`, `test`, …
+    kind: &'static str,
+    /// Baseline lints this root mentions nowhere, sorted.
+    missing: Vec<String>,
+}
+
+impl Offender {
+    /// The offending target root, relative to the repo root.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Which kind of target this root is: `library`, `binary`, `test`, `bench`,
+    /// or `example`.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// The baseline lints this root mentions nowhere, sorted.
+    #[must_use]
+    pub fn missing(&self) -> &[String] {
+        &self.missing
+    }
+}
+
+/// The verdict of one audit: how much was examined, and which target roots are
+/// silent about their crate's baseline lints.
+///
+/// The remediation text lives here rather than at the call site, so every
+/// caller — test, CI job, or CLI — reports the same thing.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// Number of member crates whose targets were resolved.
+    crates_examined: usize,
+    /// Number of target roots actually opened and parsed.
+    roots_examined: usize,
+    /// Silent roots, sorted by path.
+    offenders: Vec<Offender>,
+}
+
+impl Report {
+    /// True when every examined target root declares a position on every
+    /// baseline lint of its crate.
+    #[must_use]
+    pub fn is_compliant(&self) -> bool {
+        self.offenders.is_empty()
+    }
+
+    /// The target roots that are silent about a baseline lint, sorted by path.
+    #[must_use]
+    pub fn offenders(&self) -> &[Offender] {
+        &self.offenders
+    }
+
+    /// How many member crates the audit resolved targets for.
+    #[must_use]
+    pub fn crates_examined(&self) -> usize {
+        self.crates_examined
+    }
+
+    /// How many target roots the audit opened and parsed.
+    ///
+    /// A caller should assert this is non-zero: a guard that scans nothing
+    /// reports clean for the wrong reason.
+    #[must_use]
+    pub fn roots_examined(&self) -> usize {
+        self.roots_examined
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.offenders.is_empty() {
+            return write!(
+                f,
+                "Checked {} target roots across {} workspace members; every one declares a position on its crate's lints.",
+                self.roots_examined, self.crates_examined
+            );
+        }
+
+        writeln!(
+            f,
+            "{} of {} target roots are silent about a lint their crate raises.",
+            self.offenders.len(),
+            self.roots_examined
+        )?;
+        writeln!(
+            f,
+            "A crate-root lint attribute applies to ONE target; the other targets of the same crate keep the workspace default unless they say otherwise."
+        )?;
+
+        for offender in &self.offenders {
+            writeln!(f)?;
+            writeln!(
+                f,
+                "{} ({} target) never mentions: {}",
+                offender.path.display(),
+                offender.kind,
+                offender.missing.join(", ")
+            )?;
+            writeln!(
+                f,
+                "Add an inner attribute at the top of that file taking a position on each — raise it:"
+            )?;
+            writeln!(f)?;
+            for lint in &offender.missing {
+                writeln!(f, "    #![warn({lint})]")?;
+            }
+            writeln!(f)?;
+            writeln!(f, "or opt out of it on purpose, in writing:")?;
+            writeln!(f)?;
+            for lint in &offender.missing {
+                writeln!(f, "    #![allow({lint}, reason = \"...\")]")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Which cargo target a root file belongs to.
+///
+/// The distinction that matters is [`raises_baseline`](TargetKind::raises_baseline):
+/// libraries and binaries *define* what a crate holds itself to; tests, benches,
+/// and examples only have to answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetKind {
+    Lib,
+    Bin,
+    Test,
+    Bench,
+    Example,
+}
+
+impl TargetKind {
+    /// The manifest key that declares this kind of target explicitly.
+    const fn manifest_key(self) -> &'static str {
+        match self {
+            Self::Lib => "lib",
+            Self::Bin => "bin",
+            Self::Test => "test",
+            Self::Bench => "bench",
+            Self::Example => "example",
+        }
+    }
+
+    /// The human-readable name used in [`Report`]'s message.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Lib => "library",
+            Self::Bin => "binary",
+            Self::Test => "test",
+            Self::Bench => "bench",
+            Self::Example => "example",
+        }
+    }
+
+    /// True for the targets whose raised lints form the crate's baseline.
+    const fn raises_baseline(self) -> bool {
+        matches!(self, Self::Lib | Self::Bin)
+    }
+}
+
+/// One resolved target root: the file, and what kind of target it heads.
+#[derive(Debug, Clone)]
+struct TargetRoot {
+    path: PathBuf,
+    kind: TargetKind,
+}
+
+/// The lint positions taken at one target root.
+#[derive(Debug, Default)]
+struct RootLints {
+    /// Lints raised here (`deny`/`forbid`/`warn`).
+    raised: BTreeSet<String>,
+    /// Lints mentioned here at any level, raised ones included.
+    mentioned: BTreeSet<String>,
+}
+
+/// Audit every target of every member of the workspace rooted at `repo_root`.
+///
+/// Members come from [`workspace_lints::members`], so both guards walk exactly
+/// the same set. For each member the targets are resolved from its manifest
+/// plus cargo's default discovery rules, every root is parsed, and any root that
+/// is silent about a lint its crate's library or binary raises is reported.
+///
+/// # Errors
+///
+/// Returns [`TargetLintsError`] — never a clean [`Report`] — when the targets
+/// cannot be enumerated or read with confidence:
+///
+/// - the workspace members cannot be enumerated
+///   ([`Members`](TargetLintsError::Members));
+/// - a member manifest is unreadable or not valid TOML (also
+///   [`Members`](TargetLintsError::Members), carrying the underlying
+///   [`WorkspaceLintsError`]);
+/// - a manifest declares a target `path` that is not on disk
+///   ([`MissingDeclaredTarget`](TargetLintsError::MissingDeclaredTarget));
+/// - a manifest sets `autotests`, `autobins`, `autobenches`, or `autoexamples`
+///   ([`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride));
+/// - a directory holding target roots cannot be listed
+///   ([`ReadTargetDir`](TargetLintsError::ReadTargetDir));
+/// - a member resolves to no target roots
+///   ([`NoTargetRoots`](TargetLintsError::NoTargetRoots));
+/// - a root file is unreadable ([`ReadRoot`](TargetLintsError::ReadRoot)) or
+///   does not parse as Rust ([`ParseRoot`](TargetLintsError::ParseRoot)).
+pub fn audit(repo_root: &Path) -> Result<Report, TargetLintsError> {
+    let member_dirs = workspace_lints::members(repo_root)?;
+
+    let mut roots_examined = 0;
+    let mut offenders = Vec::new();
+
+    for dir in &member_dirs {
+        let manifest_path = dir.join(CARGO_TOML);
+        let manifest = workspace_lints::parse_manifest(&manifest_path)?;
+        let roots = target_roots(dir, &manifest, &manifest_path)?;
+
+        let mut scanned = Vec::with_capacity(roots.len());
+        for root in roots {
+            let lints = root_lints(&root.path)?;
+            scanned.push((root, lints));
+        }
+        roots_examined += scanned.len();
+
+        let baseline: BTreeSet<&String> = scanned
+            .iter()
+            .filter(|(root, _)| root.kind.raises_baseline())
+            .flat_map(|(_, lints)| lints.raised.iter())
+            .collect();
+        if baseline.is_empty() {
+            continue;
+        }
+
+        for (root, lints) in &scanned {
+            let missing: Vec<String> = baseline
+                .iter()
+                .filter(|lint| !lints.mentioned.contains(**lint))
+                .map(|lint| (*lint).clone())
+                .collect();
+            if missing.is_empty() {
+                continue;
+            }
+            offenders.push(Offender {
+                path: root
+                    .path
+                    .strip_prefix(repo_root)
+                    .unwrap_or(&root.path)
+                    .to_path_buf(),
+                kind: root.kind.label(),
+                missing,
+            });
+        }
+    }
+
+    offenders.sort_by(|a, b| a.path.cmp(&b.path));
+
+    Ok(Report {
+        crates_examined: member_dirs.len(),
+        roots_examined,
+        offenders,
+    })
+}
+
+/// Resolve every target root of one member crate.
+///
+/// Mirrors cargo: explicit `path` declarations win, and the conventional
+/// locations are discovered on top of them (`src/lib.rs`, `src/main.rs`,
+/// `src/bin/*.rs`, `tests/*.rs`, `benches/*.rs`, `examples/*.rs`, plus the
+/// directory form `<dir>/<name>/main.rs`). Discovery is deliberately depth-1:
+/// `tests/common/mod.rs` is a module a test root *includes*, not a target root,
+/// and treating it as one would invent a target cargo never builds.
+fn target_roots(
+    dir: &Path,
+    manifest: &Value,
+    manifest_path: &Path,
+) -> Result<Vec<TargetRoot>, TargetLintsError> {
+    for key in AUTO_DISCOVERY_KEYS {
+        if manifest
+            .get("package")
+            .and_then(|package| package.get(key))
+            .is_some()
+        {
+            return Err(TargetLintsError::AutoDiscoveryOverride {
+                manifest: manifest_path.to_path_buf(),
+                key,
+            });
+        }
+    }
+
+    let mut roots = Vec::new();
+
+    // Library: an explicit `[lib] path` wins, otherwise the conventional root.
+    match declared_path(manifest.get(TargetKind::Lib.manifest_key())) {
+        Some(declared) => roots.push(declared_root(
+            dir,
+            declared,
+            TargetKind::Lib,
+            manifest_path,
+        )?),
+        None => push_if_file(&mut roots, dir.join("src").join("lib.rs"), TargetKind::Lib),
+    }
+
+    // Binaries: every explicit `[[bin]] path`, plus the conventional roots.
+    for declared in declared_paths(manifest.get(TargetKind::Bin.manifest_key())) {
+        roots.push(declared_root(
+            dir,
+            declared,
+            TargetKind::Bin,
+            manifest_path,
+        )?);
+    }
+    push_if_file(&mut roots, dir.join("src").join("main.rs"), TargetKind::Bin);
+    discover(&mut roots, &dir.join("src").join("bin"), TargetKind::Bin)?;
+
+    // Tests, benches, and examples: same shape, different directory.
+    for (kind, subdir) in [
+        (TargetKind::Test, "tests"),
+        (TargetKind::Bench, "benches"),
+        (TargetKind::Example, "examples"),
+    ] {
+        for declared in declared_paths(manifest.get(kind.manifest_key())) {
+            roots.push(declared_root(dir, declared, kind, manifest_path)?);
+        }
+        discover(&mut roots, &dir.join(subdir), kind)?;
+    }
+
+    // An explicit declaration and the conventional location often name the same
+    // file (`[[bin]] path = "src/main.rs"` is the norm in this repo); auditing
+    // it twice would double-count and double-report.
+    roots.sort_by(|a, b| a.path.cmp(&b.path));
+    roots.dedup_by(|a, b| a.path == b.path);
+
+    if roots.is_empty() {
+        return Err(TargetLintsError::NoTargetRoots {
+            dir: dir.to_path_buf(),
+        });
+    }
+    Ok(roots)
+}
+
+/// The `path` of a single-target table such as `[lib]`.
+fn declared_path(table: Option<&Value>) -> Option<&str> {
+    table
+        .and_then(|target| target.get("path"))
+        .and_then(Value::as_str)
+}
+
+/// The `path` of every entry of an array-of-tables such as `[[bin]]`.
+fn declared_paths(array: Option<&Value>) -> Vec<&str> {
+    array
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| declared_path(Some(entry)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolve one manifest-declared target path, refusing if it is not on disk.
+fn declared_root(
+    dir: &Path,
+    declared: &str,
+    kind: TargetKind,
+    manifest_path: &Path,
+) -> Result<TargetRoot, TargetLintsError> {
+    let path = dir.join(declared);
+    if !path.is_file() {
+        return Err(TargetLintsError::MissingDeclaredTarget {
+            manifest: manifest_path.to_path_buf(),
+            kind: kind.manifest_key(),
+            declared: declared.to_owned(),
+        });
+    }
+    Ok(TargetRoot { path, kind })
+}
+
+/// Append `path` as a root of `kind` when it exists.
+fn push_if_file(roots: &mut Vec<TargetRoot>, path: PathBuf, kind: TargetKind) {
+    if path.is_file() {
+        roots.push(TargetRoot { path, kind });
+    }
+}
+
+/// Auto-discover the roots cargo would find in `dir`: every depth-1 `*.rs`
+/// file, plus `<subdir>/main.rs` for each immediate subdirectory.
+///
+/// A missing directory is not an error — most crates have no `benches/`. A
+/// directory that exists but cannot be listed *is* one: silently skipping it
+/// would drop targets from the audit and report clean for the wrong reason.
+fn discover(
+    roots: &mut Vec<TargetRoot>,
+    dir: &Path,
+    kind: TargetKind,
+) -> Result<(), TargetLintsError> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(dir).map_err(|source| TargetLintsError::ReadTargetDir {
+        dir: dir.to_path_buf(),
+        source,
+    })?;
+    for entry in entries {
+        let path = entry
+            .map_err(|source| TargetLintsError::ReadTargetDir {
+                dir: dir.to_path_buf(),
+                source,
+            })?
+            .path();
+
+        if path.is_dir() {
+            push_if_file(roots, path.join(MAIN_RS), kind);
+        } else if path.extension().is_some_and(|ext| ext == RS) {
+            roots.push(TargetRoot { path, kind });
+        }
+    }
+    Ok(())
+}
+
+/// Read one target root and collect the lint positions its inner attributes
+/// take.
+///
+/// Only [`AttrStyle::Inner`] attributes count: `#![warn(...)]` configures the
+/// whole target, while an outer `#[warn(...)]` on the first item configures only
+/// that item and would be a false positive if counted.
+///
+/// `reason = "..."` is a [`Meta::NameValue`], not a [`Meta::Path`], so it is
+/// skipped rather than collected as a lint named `reason`.
+fn root_lints(path: &Path) -> Result<RootLints, TargetLintsError> {
+    let text = fs::read_to_string(path).map_err(|source| TargetLintsError::ReadRoot {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let file = syn::parse_file(&text).map_err(|source| TargetLintsError::ParseRoot {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let mut lints = RootLints::default();
+    for attr in &file.attrs {
+        if !matches!(attr.style, AttrStyle::Inner(_)) {
+            continue;
+        }
+        let Meta::List(list) = &attr.meta else {
+            continue;
+        };
+        let Some(level) = sole_segment(&list.path) else {
+            continue;
+        };
+        if !MENTIONING_LEVELS.contains(&level.as_str()) {
+            continue;
+        }
+
+        let args = list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .map_err(|source| TargetLintsError::ParseRoot {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        for arg in args {
+            let Meta::Path(lint) = arg else {
+                continue;
+            };
+            let name = render_path(&lint);
+            if RAISING_LEVELS.contains(&level.as_str()) {
+                lints.raised.insert(name.clone());
+            }
+            lints.mentioned.insert(name);
+        }
+    }
+    Ok(lints)
+}
+
+/// The identifier of a single-segment path, or `None` for anything longer.
+///
+/// Lint *levels* are always one segment (`warn`), which is what distinguishes
+/// them from wrappers like `cfg_attr` only by name — and from lint *paths* like
+/// `clippy::pedantic` by shape.
+fn sole_segment(path: &syn::Path) -> Option<String> {
+    match path.segments.len() {
+        1 => path.segments.first().map(|seg| seg.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// Render a lint path the way a human writes it: segments joined with `::`, so
+/// `clippy::pedantic` and bare `unsafe_code` both come back verbatim.
+fn render_path(path: &syn::Path) -> String {
+    path.segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}

--- a/src/repo-guards/src/target_lints.rs
+++ b/src/repo-guards/src/target_lints.rs
@@ -20,10 +20,10 @@
 //! **every target of the package**. A crate-root attribute applies to **one
 //! target** — the single file that is that target's root. Moving lints out of
 //! the manifest to satisfy the inheritance guard therefore hands the library
-//! and binary a stricter lint set while the integration tests, benches, and
-//! examples of the same crate quietly keep the workspace default. Nothing warns.
-//! The exemption is spelled as an *absence*, which is why it is invisible and
-//! why it spreads.
+//! and binary a stricter lint set while the integration tests, benches,
+//! examples, and build script of the same crate quietly keep the workspace
+//! default. Nothing warns. The exemption is spelled as an *absence*, which is
+//! why it is invisible and why it spreads.
 //!
 //! # The rule
 //!
@@ -33,10 +33,25 @@
 //!    `forbid`, or `warn` — by inner attributes at the roots of its **library
 //!    and binary** targets. Those are the targets that define what the crate
 //!    holds itself to.
-//! 2. Every target root of that crate — library, binary, test, bench, example —
-//!    must **mention** every baseline lint in some inner lint attribute:
-//!    `deny`, `forbid`, `warn`, `allow`, or `expect`.
+//! 2. Every target root of that crate — library, binary, test, bench, example,
+//!    build script — must **mention** every baseline lint in some inner lint
+//!    attribute: `deny`, `forbid`, `warn`, `allow`, or `expect`.
 //! 3. **Silence is the only violation.**
+//!
+//! # Why a build script mentions but never raises
+//!
+//! `build.rs` is a target cargo compiles and lints like any other, and it is
+//! the target the manifest-to-crate-root migration strands most quietly:
+//! verified on cargo 1.97.1, `[lints.rust] unsafe_code = "deny"` in the
+//! manifest makes an unsafe block in `build.rs` a compile error, while the same
+//! lint written `#![deny(unsafe_code)]` in `src/lib.rs` lets it through. So it
+//! owes the baseline an answer, by rule 2, like every other root.
+//!
+//! It does not *raise*, by rule 1, because nothing links it. A build script is
+//! compiled for the build machine, run once, and never becomes part of the
+//! crate — so a lint it alone raises is a position that one target holds, not
+//! one the crate holds. Were it to raise, a strict build script would go red
+//! across a library and test suite that never asked for the lint.
 //!
 //! # Why "mention", not "match the level"
 //!
@@ -148,12 +163,19 @@ const MAX_CFG_ATTR_DEPTH: usize = 16;
 /// [`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride).
 const AUTO_DISCOVERY_KEYS: [&str; 4] = ["autobenches", "autobins", "autoexamples", "autotests"];
 
+/// The manifest table those keys — and `build` — live in.
+const PACKAGE: &str = "package";
+
 /// Rust source extension, used when auto-discovering target roots.
 const RS: &str = "rs";
 
 /// The conventional entry point of a directory-shaped target
 /// (`tests/foo/main.rs`).
 const MAIN_RS: &str = "main.rs";
+
+/// The conventional build script, relative to the member directory. Also what
+/// `build = true` names.
+const BUILD_RS: &str = "build.rs";
 
 /// Everything that can stop the audit from reaching a verdict.
 ///
@@ -205,7 +227,8 @@ pub enum TargetLintsError {
         source: io::Error,
     },
 
-    /// A manifest declares a target `path` that is not on disk.
+    /// A manifest declares a target that is not on disk: a `path` under
+    /// `[lib]`/`[[bin]]`/`[[test]]`/…, or the `build` key naming a build script.
     #[error(
         "{} declares a {kind} target at `{declared}`, which does not exist; \
          a target this guard cannot open is a target it cannot vouch for",
@@ -214,9 +237,11 @@ pub enum TargetLintsError {
     MissingDeclaredTarget {
         /// The manifest carrying the declaration.
         manifest: PathBuf,
-        /// Which kind of target declared it: `lib`, `bin`, `test`, …
+        /// Which kind of target declared it: `lib`, `bin`, `test`, `build`, …
         kind: &'static str,
-        /// The `path` value, exactly as written in the manifest.
+        /// The declared path. Written verbatim as it appears in the manifest,
+        /// except for `build = true`, which is rendered as the `build.rs` it
+        /// names.
         declared: String,
     },
 
@@ -279,7 +304,7 @@ impl Offender {
     }
 
     /// Which kind of target this root is: `library`, `binary`, `test`, `bench`,
-    /// or `example`.
+    /// `example`, or `build script`.
     #[must_use]
     pub fn kind(&self) -> &'static str {
         self.kind
@@ -409,7 +434,7 @@ impl fmt::Display for Report {
 ///
 /// The distinction that matters is [`raises_baseline`](TargetKind::raises_baseline):
 /// libraries and binaries *define* what a crate holds itself to; tests, benches,
-/// and examples only have to answer.
+/// examples, and build scripts only have to answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TargetKind {
     Lib,
@@ -417,6 +442,7 @@ enum TargetKind {
     Test,
     Bench,
     Example,
+    Build,
 }
 
 impl TargetKind {
@@ -428,6 +454,7 @@ impl TargetKind {
             Self::Test => "test",
             Self::Bench => "bench",
             Self::Example => "example",
+            Self::Build => "build",
         }
     }
 
@@ -439,10 +466,17 @@ impl TargetKind {
             Self::Test => "test",
             Self::Bench => "bench",
             Self::Example => "example",
+            Self::Build => "build script",
         }
     }
 
     /// True for the targets whose raised lints form the crate's baseline.
+    ///
+    /// A build script is deliberately not one of them, even though it is
+    /// compiled from the crate's own source. Nothing links it: it is built for
+    /// the build machine, run once, and never becomes part of the crate. A lint
+    /// it alone raises is a position that one target holds, not one the crate
+    /// holds — so it must answer for the baseline without adding to it.
     const fn raises_baseline(self) -> bool {
         matches!(self, Self::Lib | Self::Bin)
     }
@@ -481,8 +515,11 @@ struct RootLints {
 /// - a member manifest is unreadable or not valid TOML (also
 ///   [`Members`](TargetLintsError::Members), carrying the underlying
 ///   [`WorkspaceLintsError`]);
-/// - a manifest declares a target `path` that is not on disk
+/// - a manifest declares a target — a target `path`, or a `build` script — that
+///   is not on disk
 ///   ([`MissingDeclaredTarget`](TargetLintsError::MissingDeclaredTarget));
+/// - a manifest's `build` key is neither a path nor a bool
+///   ([`MalformedBuildKey`](TargetLintsError::MalformedBuildKey));
 /// - a manifest sets `autotests`, `autobins`, `autobenches`, or `autoexamples`
 ///   ([`AutoDiscoveryOverride`](TargetLintsError::AutoDiscoveryOverride));
 /// - a directory holding target roots cannot be listed
@@ -568,6 +605,13 @@ fn relative_to(repo_root: &Path, path: &Path) -> PathBuf {
 /// directory form `<dir>/<name>/main.rs`). Discovery is deliberately depth-1:
 /// `tests/common/mod.rs` is a module a test root *includes*, not a target root,
 /// and treating it as one would invent a target cargo never builds.
+///
+/// The build script is the exception to every sentence above, because it is
+/// declared by a scalar `build` key inside `[package]` rather than by a table
+/// with a `path`: absent, it is `build.rs` if that file exists; `false`, there
+/// is none even when `build.rs` does exist; `true`, it *is* `build.rs` and the
+/// file must be there; a string, it is that path and the conventional
+/// `build.rs` is not a target at all.
 fn target_roots(
     dir: &Path,
     manifest: &Value,
@@ -575,7 +619,7 @@ fn target_roots(
 ) -> Result<Vec<TargetRoot>, TargetLintsError> {
     for key in AUTO_DISCOVERY_KEYS {
         if manifest
-            .get("package")
+            .get(PACKAGE)
             .and_then(|package| package.get(key))
             .is_some()
         {
@@ -587,6 +631,49 @@ fn target_roots(
     }
 
     let mut roots = Vec::new();
+
+    // Build script: the one target declared by a *scalar* — `build` inside
+    // `[package]`, holding a path or a bool — rather than by a table with a
+    // `path` field, so it is resolved here instead of through `declared_path`.
+    match manifest
+        .get(PACKAGE)
+        .and_then(|package| package.get(TargetKind::Build.manifest_key()))
+    {
+        // No key: the conventional root if it is there, and nothing if it is
+        // not. This is the only form where absence is not a declaration.
+        None => push_if_file(&mut roots, dir.join(BUILD_RS), TargetKind::Build),
+        // `build = false` turns the build script off. Cargo then builds no
+        // build script *even with a `build.rs` on disk*, so discovering one
+        // would invent a target and demand lints in a file cargo never reads.
+        Some(Value::Boolean(false)) => {}
+        // `build = true` names the conventional path, and cargo means it
+        // literally: with no `build.rs` it still reports the target, then fails
+        // to compile it. A declaration, not a search — so a missing file is the
+        // same refusal a typo'd `path` earns.
+        Some(Value::Boolean(true)) => roots.push(declared_root(
+            dir,
+            BUILD_RS,
+            TargetKind::Build,
+            manifest_path,
+        )?),
+        // An explicit path *replaces* the convention: cargo reports exactly one
+        // build script, at this path, and a stray `build.rs` beside it is not a
+        // target at all.
+        Some(Value::String(declared)) => roots.push(declared_root(
+            dir,
+            declared,
+            TargetKind::Build,
+            manifest_path,
+        )?),
+        // Anything else is a manifest cargo itself rejects. Falling through
+        // silently would read it as "no build script" and shrink the audit.
+        Some(other) => {
+            return Err(TargetLintsError::MalformedBuildKey {
+                manifest: manifest_path.to_path_buf(),
+                value: other.to_string(),
+            });
+        }
+    }
 
     // Library: an explicit `[lib] path` wins, otherwise the conventional root.
     match declared_path(manifest.get(TargetKind::Lib.manifest_key())) {

--- a/src/repo-guards/src/workspace_lints.rs
+++ b/src/repo-guards/src/workspace_lints.rs
@@ -1,0 +1,442 @@
+//! Guard: every workspace member must inherit the repo-wide lint set.
+//!
+//! The root `Cargo.toml` declares `[workspace.lints.rust]` and
+//! `[workspace.lints.clippy]`, but cargo hands those lints only to member
+//! crates that opt in with:
+//!
+//! ```toml
+//! [lints]
+//! workspace = true
+//! ```
+//!
+//! A member that omits the stanza is silently exempt from the repo's lint
+//! policy. Nothing warns and nothing fails — the crate simply never gets linted
+//! the way the rest of the workspace is. The exemption is invisible precisely
+//! because it is spelled as an *absence*, which is also why it spreads: a new
+//! crate that never types the stanza is born exempt.
+//!
+//! [`audit`] closes that hole. Two design rules make it a real guard rather
+//! than a comfortable one:
+//!
+//! 1. **Enumerate, never allowlist.** Members come from `workspace.members` in
+//!    the root manifest, glob patterns expanded on disk. A hardcoded list of
+//!    crate names would make the next new crate invisible to the guard, which
+//!    is the exact failure this exists to prevent.
+//! 2. **Parse, never text-match.** "The manifest's `lints` table has key
+//!    `workspace` set to `true`" names a syntactic category, so it is answered
+//!    with a TOML parser. A regex would answer it only for the spellings
+//!    someone happened to think of — `lints = { workspace = true }` is the
+//!    same declaration written differently, and a missed spelling reports
+//!    *clean*, which is indistinguishable from a guard doing real work.
+//!
+//! Everything that could shrink the audited set is a hard error rather than a
+//! clean verdict; see [`WorkspaceLintsError`].
+//!
+//! # Relationship to cargo's own member expansion
+//!
+//! Member expansion here mirrors cargo: glob-expand each pattern and keep the
+//! matches that are directories (cargo ignores stray files next to crate
+//! directories, so `src/README.md` or a Finder-dropped `src/.DS_Store` is not a
+//! member). It is deliberately *stricter* than cargo in one place: a pattern
+//! that contributes no members at all is an error here, because a typo'd
+//! pattern silently shrinking the audited set is the false-green disease this
+//! guard exists to avoid.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use toml::Value;
+
+/// Manifest filename, used for both the workspace root and every member.
+const CARGO_TOML: &str = "Cargo.toml";
+
+/// The exact stanza a member manifest needs. Rendered verbatim (indented) into
+/// [`Report`]'s failure message so a reader can paste it without retyping.
+const REQUIRED_STANZA: &str = "[lints]\nworkspace = true";
+
+/// Manifest table that carries lint configuration.
+const LINTS_KEY: &str = "lints";
+
+/// Key inside `[lints]` that opts a member into the workspace lint set.
+const WORKSPACE_KEY: &str = "workspace";
+
+/// Everything that can stop the audit from reaching a verdict.
+///
+/// Every variant is a *refusal*. A guard that cannot enumerate the workspace
+/// must say so loudly, because "I found no violations" and "I looked at
+/// nothing" are the same sentence to a CI log and only one of them is good
+/// news.
+#[derive(Debug, Error)]
+pub enum WorkspaceLintsError {
+    /// A manifest could not be read from disk.
+    #[error("cannot read the manifest {}: {source}", path.display())]
+    ReadManifest {
+        /// The manifest that could not be read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: io::Error,
+    },
+
+    /// A manifest was read but is not valid TOML.
+    #[error("cannot parse {} as TOML: {source}", path.display())]
+    ParseManifest {
+        /// The manifest that failed to parse.
+        path: PathBuf,
+        /// The underlying parse failure.
+        source: toml::de::Error,
+    },
+
+    /// The root manifest declares no `workspace.members` array.
+    #[error(
+        "{} declares no `workspace.members`; refusing to report a clean workspace that cannot be enumerated",
+        path.display()
+    )]
+    NoMembersKey {
+        /// The root manifest.
+        path: PathBuf,
+    },
+
+    /// `workspace.members` is present but empty.
+    #[error(
+        "`workspace.members` in {} is empty; refusing to report a clean workspace with no members",
+        path.display()
+    )]
+    EmptyMembers {
+        /// The root manifest.
+        path: PathBuf,
+    },
+
+    /// An entry of `workspace.members` or `workspace.exclude` is not a string.
+    #[error("`workspace.{key}` entry #{index} in {} is not a string", path.display())]
+    NonStringEntry {
+        /// The root manifest.
+        path: PathBuf,
+        /// Which array the bad entry came from: `members` or `exclude`.
+        key: &'static str,
+        /// Zero-based position of the bad entry.
+        index: usize,
+    },
+
+    /// A pattern is not valid glob syntax.
+    #[error("member pattern `{pattern}` is not a valid glob: {source}")]
+    InvalidPattern {
+        /// The offending pattern, as written in the root manifest.
+        pattern: String,
+        /// The underlying glob syntax failure.
+        source: glob::PatternError,
+    },
+
+    /// A path matched by a pattern could not be read while walking.
+    #[error("cannot read a path matched by pattern `{pattern}`: {source}")]
+    UnreadableMatch {
+        /// The pattern being expanded.
+        pattern: String,
+        /// The underlying filesystem failure.
+        source: glob::GlobError,
+    },
+
+    /// A member pattern contributed no crate directories at all.
+    #[error(
+        "member pattern `{pattern}` matched no crate directories; a typo here would silently shrink the audited set"
+    )]
+    PatternMatchedNothing {
+        /// The pattern that matched nothing.
+        pattern: String,
+    },
+
+    /// Every expanded member was removed by `workspace.exclude`.
+    #[error(
+        "every workspace member is excluded by `workspace.exclude`; there is nothing to audit"
+    )]
+    NoMembersRemain,
+
+    /// A member directory exists but holds no `Cargo.toml`.
+    #[error("workspace member {} has no {CARGO_TOML}", dir.display())]
+    MissingMemberManifest {
+        /// The member directory.
+        dir: PathBuf,
+    },
+
+    /// The repository root path is not valid UTF-8, so it cannot be used as a
+    /// glob prefix.
+    #[error("the repository root {} is not valid UTF-8", path.display())]
+    NonUtf8RepoRoot {
+        /// The repository root that was handed to [`audit`].
+        path: PathBuf,
+    },
+}
+
+/// The verdict of one audit: how many members were examined, and which of their
+/// manifests fail to inherit the workspace lint set.
+///
+/// The remediation text lives here rather than at the call site, so every
+/// caller — test, CI job, or CLI — reports the same thing.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// Number of member crates whose manifests were actually parsed.
+    members_examined: usize,
+    /// Manifest paths, relative to the repo root, that do not inherit the
+    /// workspace lint set. Sorted, so the message is stable run to run.
+    offenders: Vec<PathBuf>,
+}
+
+impl Report {
+    /// True when every examined member inherits the workspace lint set.
+    #[must_use]
+    pub fn is_compliant(&self) -> bool {
+        self.offenders.is_empty()
+    }
+
+    /// Manifest paths that do not inherit the workspace lint set, relative to
+    /// the repo root and sorted.
+    #[must_use]
+    pub fn offenders(&self) -> &[PathBuf] {
+        &self.offenders
+    }
+
+    /// How many member manifests the audit parsed.
+    ///
+    /// A caller should assert this is non-zero: a guard that scans nothing
+    /// reports clean for the wrong reason.
+    #[must_use]
+    pub fn members_examined(&self) -> usize {
+        self.members_examined
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.offenders.is_empty() {
+            return write!(
+                f,
+                "Checked {} workspace members; all inherit the workspace lint set.",
+                self.members_examined
+            );
+        }
+
+        writeln!(
+            f,
+            "{} of {} workspace members do not inherit the workspace lint set.",
+            self.offenders.len(),
+            self.members_examined
+        )?;
+        writeln!(
+            f,
+            "The root {CARGO_TOML} declares [workspace.lints.*], but cargo applies those lints only to members that opt in."
+        )?;
+
+        for offender in &self.offenders {
+            writeln!(f)?;
+            writeln!(
+                f,
+                "{} is missing workspace lint inheritance.",
+                offender.display()
+            )?;
+            writeln!(f, "Add:")?;
+            writeln!(f)?;
+            for line in REQUIRED_STANZA.lines() {
+                writeln!(f, "    {line}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Audit every member of the workspace rooted at `repo_root`.
+///
+/// Members are enumerated from `workspace.members` in the root manifest and
+/// glob-expanded on disk, minus anything `workspace.exclude` removes. Each
+/// member manifest is parsed and checked for `lints.workspace = true`.
+///
+/// # Errors
+///
+/// Returns [`WorkspaceLintsError`] — never a clean [`Report`] — when the
+/// workspace cannot be enumerated with confidence:
+///
+/// - the root manifest is absent, unreadable, or not valid TOML
+///   ([`ReadManifest`](WorkspaceLintsError::ReadManifest),
+///   [`ParseManifest`](WorkspaceLintsError::ParseManifest));
+/// - `workspace.members` is missing ([`NoMembersKey`](WorkspaceLintsError::NoMembersKey)),
+///   empty ([`EmptyMembers`](WorkspaceLintsError::EmptyMembers)), or holds a
+///   non-string entry ([`NonStringEntry`](WorkspaceLintsError::NonStringEntry));
+/// - a pattern is invalid glob syntax
+///   ([`InvalidPattern`](WorkspaceLintsError::InvalidPattern)) or a matched path
+///   cannot be read ([`UnreadableMatch`](WorkspaceLintsError::UnreadableMatch));
+/// - a pattern contributes no members
+///   ([`PatternMatchedNothing`](WorkspaceLintsError::PatternMatchedNothing)) or
+///   `workspace.exclude` removes them all
+///   ([`NoMembersRemain`](WorkspaceLintsError::NoMembersRemain));
+/// - a member directory has no `Cargo.toml`
+///   ([`MissingMemberManifest`](WorkspaceLintsError::MissingMemberManifest));
+/// - `repo_root` is not valid UTF-8
+///   ([`NonUtf8RepoRoot`](WorkspaceLintsError::NonUtf8RepoRoot)).
+pub fn audit(repo_root: &Path) -> Result<Report, WorkspaceLintsError> {
+    let root_manifest = repo_root.join(CARGO_TOML);
+    let root = parse_manifest(&root_manifest)?;
+    let workspace = root.get("workspace");
+
+    let members = workspace
+        .and_then(|table| table.get("members"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkspaceLintsError::NoMembersKey {
+            path: root_manifest.clone(),
+        })?;
+    if members.is_empty() {
+        return Err(WorkspaceLintsError::EmptyMembers {
+            path: root_manifest,
+        });
+    }
+
+    let excluded = excluded_paths(repo_root, workspace, &root_manifest)?;
+
+    let mut member_dirs = Vec::new();
+    for (index, entry) in members.iter().enumerate() {
+        let pattern = string_entry(entry, &root_manifest, "members", index)?;
+        let matched = expand_pattern(repo_root, pattern)?;
+        if matched.is_empty() {
+            return Err(WorkspaceLintsError::PatternMatchedNothing {
+                pattern: pattern.to_owned(),
+            });
+        }
+        member_dirs.extend(
+            matched
+                .into_iter()
+                .filter(|dir| !excluded.iter().any(|skip| dir.starts_with(skip))),
+        );
+    }
+    member_dirs.sort();
+    member_dirs.dedup();
+    if member_dirs.is_empty() {
+        return Err(WorkspaceLintsError::NoMembersRemain);
+    }
+
+    let mut offenders = Vec::new();
+    for dir in &member_dirs {
+        let manifest_path = dir.join(CARGO_TOML);
+        if !manifest_path.is_file() {
+            return Err(WorkspaceLintsError::MissingMemberManifest { dir: dir.clone() });
+        }
+        if !inherits_workspace_lints(&parse_manifest(&manifest_path)?) {
+            offenders.push(
+                manifest_path
+                    .strip_prefix(repo_root)
+                    .unwrap_or(&manifest_path)
+                    .to_path_buf(),
+            );
+        }
+    }
+    offenders.sort();
+
+    Ok(Report {
+        members_examined: member_dirs.len(),
+        offenders,
+    })
+}
+
+/// True when `manifest` opts into the workspace lint set.
+///
+/// Parsed, not text-matched, so every TOML spelling of the same declaration is
+/// recognized: the `[lints]` table form, the inline `lints = { workspace = true }`
+/// form, and the dotted `lints.workspace = true` form all reduce to the same
+/// value. Anything else — no `lints` table, `workspace = false`, or a
+/// `[lints.clippy]` table with no `workspace` key — is not inheritance.
+fn inherits_workspace_lints(manifest: &Value) -> bool {
+    manifest
+        .get(LINTS_KEY)
+        .and_then(|lints| lints.get(WORKSPACE_KEY))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Read and parse a manifest, attributing both failure modes to its path.
+fn parse_manifest(path: &Path) -> Result<Value, WorkspaceLintsError> {
+    let text = fs::read_to_string(path).map_err(|source| WorkspaceLintsError::ReadManifest {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    text.parse::<Value>()
+        .map_err(|source| WorkspaceLintsError::ParseManifest {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Borrow an array entry as a string, or refuse.
+fn string_entry<'a>(
+    entry: &'a Value,
+    root_manifest: &Path,
+    key: &'static str,
+    index: usize,
+) -> Result<&'a str, WorkspaceLintsError> {
+    entry
+        .as_str()
+        .ok_or_else(|| WorkspaceLintsError::NonStringEntry {
+            path: root_manifest.to_path_buf(),
+            key,
+            index,
+        })
+}
+
+/// Expand `workspace.exclude` into absolute directory paths.
+///
+/// An exclude pattern that matches nothing is *not* an error, unlike a member
+/// pattern: excluding a path that is not there removes nothing from the audited
+/// set, so it cannot hide a crate. A member pattern that matches nothing can.
+fn excluded_paths(
+    repo_root: &Path,
+    workspace: Option<&Value>,
+    root_manifest: &Path,
+) -> Result<Vec<PathBuf>, WorkspaceLintsError> {
+    let Some(entries) = workspace
+        .and_then(|table| table.get("exclude"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut excluded = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let pattern = string_entry(entry, root_manifest, "exclude", index)?;
+        excluded.extend(expand_pattern(repo_root, pattern)?);
+    }
+    Ok(excluded)
+}
+
+/// Glob-expand one manifest pattern, relative to `repo_root`, keeping only the
+/// directories — which is what cargo counts as a member candidate.
+///
+/// `repo_root` is glob-escaped before it is joined, so a repository checked out
+/// under a path containing `*`, `?`, or `[` is matched literally instead of
+/// being reinterpreted as pattern syntax.
+fn expand_pattern(repo_root: &Path, pattern: &str) -> Result<Vec<PathBuf>, WorkspaceLintsError> {
+    let root = repo_root
+        .to_str()
+        .ok_or_else(|| WorkspaceLintsError::NonUtf8RepoRoot {
+            path: repo_root.to_path_buf(),
+        })?;
+    let anchored = format!(
+        "{}/{pattern}",
+        glob::Pattern::escape(root.trim_end_matches('/'))
+    );
+
+    let matches = glob::glob(&anchored).map_err(|source| WorkspaceLintsError::InvalidPattern {
+        pattern: pattern.to_owned(),
+        source,
+    })?;
+
+    let mut dirs = Vec::new();
+    for entry in matches {
+        let path = entry.map_err(|source| WorkspaceLintsError::UnreadableMatch {
+            pattern: pattern.to_owned(),
+            source,
+        })?;
+        if path.is_dir() {
+            dirs.push(path);
+        }
+    }
+    Ok(dirs)
+}

--- a/src/repo-guards/src/workspace_lints.rs
+++ b/src/repo-guards/src/workspace_lints.rs
@@ -41,6 +41,12 @@
 //! that contributes no members at all is an error here, because a typo'd
 //! pattern silently shrinking the audited set is the false-green disease this
 //! guard exists to avoid.
+//!
+//! `workspace.exclude` mirrors cargo too, and cargo treats it *differently*
+//! from `members`: exclude entries are literal paths, prefix-matched against
+//! each member, never globs. Reading them as globs would be stricter-looking
+//! and strictly worse — it would drop members that cargo still builds, which
+//! shrinks the audited set in silence.
 
 use std::fmt;
 use std::fs;
@@ -249,8 +255,9 @@ impl fmt::Display for Report {
 /// Audit every member of the workspace rooted at `repo_root`.
 ///
 /// Members are enumerated from `workspace.members` in the root manifest and
-/// glob-expanded on disk, minus anything `workspace.exclude` removes. Each
-/// member manifest is parsed and checked for `lints.workspace = true`.
+/// glob-expanded on disk, minus anything `workspace.exclude` removes — where
+/// exclude entries are literal paths, exactly as cargo reads them. Each member
+/// manifest is parsed and checked for `lints.workspace = true`.
 ///
 /// # Errors
 ///
@@ -414,11 +421,22 @@ fn string_entry<'a>(
         })
 }
 
-/// Expand `workspace.exclude` into absolute directory paths.
+/// Resolve `workspace.exclude` into absolute paths, **literally**.
 ///
-/// An exclude pattern that matches nothing is *not* an error, unlike a member
-/// pattern: excluding a path that is not there removes nothing from the audited
-/// set, so it cannot hide a crate. A member pattern that matches nothing can.
+/// Unlike `workspace.members`, cargo does not glob-expand `exclude`: each entry
+/// is a path relative to the workspace root, and a member is excluded when that
+/// path is one of its ancestors. So `exclude = ["crates/b*"]` removes nothing
+/// unless a directory is genuinely named `b*`, and `crates/bad` stays a member
+/// that cargo builds. Globbing here instead would audit strictly *fewer* crates
+/// than the build compiles, and the crate that slipped out could omit the lint
+/// stanza forever while this guard kept reporting clean — the false-green
+/// direction the module header refuses when it makes an empty-matching *member*
+/// pattern a hard error.
+///
+/// An exclude entry that is not on disk at all is still *not* an error, unlike
+/// a member pattern: a path that is not there prefixes no member, so it removes
+/// nothing from the audited set and cannot hide a crate. A member pattern that
+/// matches nothing can.
 fn excluded_paths(
     repo_root: &Path,
     workspace: Option<&Value>,
@@ -433,14 +451,16 @@ fn excluded_paths(
 
     let mut excluded = Vec::new();
     for (index, entry) in entries.iter().enumerate() {
-        let pattern = string_entry(entry, root_manifest, "exclude", index)?;
-        excluded.extend(expand_pattern(repo_root, pattern)?);
+        let path = string_entry(entry, root_manifest, "exclude", index)?;
+        excluded.push(repo_root.join(path));
     }
     Ok(excluded)
 }
 
-/// Glob-expand one manifest pattern, relative to `repo_root`, keeping only the
-/// directories — which is what cargo counts as a member candidate.
+/// Glob-expand one `workspace.members` pattern, relative to `repo_root`,
+/// keeping only the directories — which is what cargo counts as a member
+/// candidate. `workspace.exclude` deliberately does *not* come through here;
+/// cargo reads those entries literally.
 ///
 /// `repo_root` is glob-escaped before it is joined, so a repository checked out
 /// under a path containing `*`, `?`, or `[` is matched literally instead of

--- a/src/repo-guards/src/workspace_lints.rs
+++ b/src/repo-guards/src/workspace_lints.rs
@@ -51,7 +51,7 @@ use thiserror::Error;
 use toml::Value;
 
 /// Manifest filename, used for both the workspace root and every member.
-const CARGO_TOML: &str = "Cargo.toml";
+pub(crate) const CARGO_TOML: &str = "Cargo.toml";
 
 /// The exact stanza a member manifest needs. Rendered verbatim (indented) into
 /// [`Report`]'s failure message so a reader can paste it without retyping.
@@ -275,17 +275,61 @@ impl fmt::Display for Report {
 /// - `repo_root` is not valid UTF-8
 ///   ([`NonUtf8RepoRoot`](WorkspaceLintsError::NonUtf8RepoRoot)).
 pub fn audit(repo_root: &Path) -> Result<Report, WorkspaceLintsError> {
+    let member_dirs = members(repo_root)?;
+
+    let mut offenders = Vec::new();
+    for dir in &member_dirs {
+        let manifest_path = dir.join(CARGO_TOML);
+        if !inherits_workspace_lints(&parse_manifest(&manifest_path)?) {
+            offenders.push(
+                manifest_path
+                    .strip_prefix(repo_root)
+                    .unwrap_or(&manifest_path)
+                    .to_path_buf(),
+            );
+        }
+    }
+    offenders.sort();
+
+    Ok(Report {
+        members_examined: member_dirs.len(),
+        offenders,
+    })
+}
+
+/// Enumerate the member crate directories of the workspace rooted at
+/// `repo_root`, sorted and deduplicated.
+///
+/// This is the workspace-enumeration half of [`audit`], lifted out so every
+/// repo guard that must walk "each member crate" walks the *same* set. A second
+/// guard with its own copy of this logic would drift from this one, and a guard
+/// that audits a smaller set than it believes reports clean for the wrong
+/// reason — the exact failure this module exists to prevent, reintroduced by
+/// duplication.
+///
+/// Every returned directory is guaranteed to hold a `Cargo.toml`, so a caller
+/// may join and parse it without re-checking.
+///
+/// # Errors
+///
+/// Returns [`WorkspaceLintsError`] — never a short list — when the workspace
+/// cannot be enumerated with confidence: an unreadable or unparsable root
+/// manifest, a missing/empty/ill-typed `workspace.members`, an invalid or
+/// empty-matching pattern, an exclude list that removes every member, or a
+/// member directory with no manifest. See [`audit`] for the variant-by-variant
+/// breakdown.
+pub fn members(repo_root: &Path) -> Result<Vec<PathBuf>, WorkspaceLintsError> {
     let root_manifest = repo_root.join(CARGO_TOML);
     let root = parse_manifest(&root_manifest)?;
     let workspace = root.get("workspace");
 
-    let members = workspace
+    let patterns = workspace
         .and_then(|table| table.get("members"))
         .and_then(Value::as_array)
         .ok_or_else(|| WorkspaceLintsError::NoMembersKey {
             path: root_manifest.clone(),
         })?;
-    if members.is_empty() {
+    if patterns.is_empty() {
         return Err(WorkspaceLintsError::EmptyMembers {
             path: root_manifest,
         });
@@ -294,7 +338,7 @@ pub fn audit(repo_root: &Path) -> Result<Report, WorkspaceLintsError> {
     let excluded = excluded_paths(repo_root, workspace, &root_manifest)?;
 
     let mut member_dirs = Vec::new();
-    for (index, entry) in members.iter().enumerate() {
+    for (index, entry) in patterns.iter().enumerate() {
         let pattern = string_entry(entry, &root_manifest, "members", index)?;
         let matched = expand_pattern(repo_root, pattern)?;
         if matched.is_empty() {
@@ -314,27 +358,13 @@ pub fn audit(repo_root: &Path) -> Result<Report, WorkspaceLintsError> {
         return Err(WorkspaceLintsError::NoMembersRemain);
     }
 
-    let mut offenders = Vec::new();
     for dir in &member_dirs {
-        let manifest_path = dir.join(CARGO_TOML);
-        if !manifest_path.is_file() {
+        if !dir.join(CARGO_TOML).is_file() {
             return Err(WorkspaceLintsError::MissingMemberManifest { dir: dir.clone() });
         }
-        if !inherits_workspace_lints(&parse_manifest(&manifest_path)?) {
-            offenders.push(
-                manifest_path
-                    .strip_prefix(repo_root)
-                    .unwrap_or(&manifest_path)
-                    .to_path_buf(),
-            );
-        }
     }
-    offenders.sort();
 
-    Ok(Report {
-        members_examined: member_dirs.len(),
-        offenders,
-    })
+    Ok(member_dirs)
 }
 
 /// True when `manifest` opts into the workspace lint set.
@@ -353,7 +383,10 @@ fn inherits_workspace_lints(manifest: &Value) -> bool {
 }
 
 /// Read and parse a manifest, attributing both failure modes to its path.
-fn parse_manifest(path: &Path) -> Result<Value, WorkspaceLintsError> {
+///
+/// Shared with the sibling guards so "unreadable" and "unparsable" are refusals
+/// everywhere, spelled the same way, rather than each guard inventing its own.
+pub(crate) fn parse_manifest(path: &Path) -> Result<Value, WorkspaceLintsError> {
     let text = fs::read_to_string(path).map_err(|source| WorkspaceLintsError::ReadManifest {
         path: path.to_path_buf(),
         source,

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -1,15 +1,21 @@
 //! Guard tests for `repo_guards::target_lints::audit`.
 //!
-//! The headline test — [`every_target_root_declares_a_position_on_its_crate_lints`]
-//! — runs the audit against this repository and **fails today by design**. Four
-//! target roots are silent about lints their own crate raises: `cwt`'s two
-//! integration tests never mention `unsafe_code` or `clippy::pedantic`, and
-//! `bm`'s two integration tests never mention `clippy::unwrap_used` or
-//! `clippy::expect_used`. Both crates acquired the gap honestly — they moved
-//! a manifest `[lints]` table into a crate-root attribute to satisfy the
-//! workspace-inheritance guard, and a crate-root attribute reaches one target
-//! where the manifest table reached all of them. That red is the point of this
-//! commit; the following commits clear it.
+//! Two tests point at this repository, and they check the guard's two halves.
+//!
+//! [`every_target_root_declares_a_position_on_its_crate_lints`] checks the
+//! verdict: no target root here is silent about a lint its own crate raises.
+//! It was red when this file was written — `cwt`'s and `bm`'s integration tests
+//! had each lost lints to the manifest-to-crate-root migration that satisfying
+//! the workspace-inheritance guard requires — and the commits that followed
+//! cleared it.
+//!
+//! [`the_guard_resolves_exactly_the_roots_cargo_builds`] checks the prior
+//! question, which a verdict cannot: whether the guard found every root there
+//! is. It asks `cargo metadata` rather than trusting the guard's hand-written
+//! model of cargo's discovery rules, and it **fails today by design** —
+//! `src/buildinfo/build.rs` is a target cargo builds and lints that the guard
+//! has never enumerated. That red is a real gap the guardrail caught; the
+//! commit after this one closes it.
 //!
 //! Every other test is a mutation test. A guard that cannot fail is worse than
 //! no guard, because "clean" and "I never looked" print identically. So each
@@ -24,8 +30,10 @@
 //! OS makes unique; nothing is keyed on a fixed path under the temp dir, the
 //! repo, or the home dir.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use repo_guards::target_lints::{self, Report, TargetLintsError};
 use tempfile::TempDir;
@@ -37,9 +45,18 @@ const RAISES_PEDANTIC: &str = "#![warn(clippy::pedantic)]\n\nfn main() {}\n";
 /// being compiled rather than the working directory (which `cargo test` does
 /// not pin).
 fn repo_root() -> PathBuf {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    fs::canonicalize(&root)
-        .unwrap_or_else(|e| panic!("cannot canonicalize repo root {}: {e}", root.display()))
+    canonical(&Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+}
+
+/// Resolve a path to its one true spelling, failing loudly when it cannot be.
+///
+/// Both sides of the cargo-parity comparison go through this. This repository
+/// is reachable as both `/Users/...` and `/Volumes/...`, and `repo_root()`
+/// arrives with a `../..` in it, so two names for one file would otherwise read
+/// as two files and colour the comparison in whichever direction the spellings
+/// happened to fall.
+fn canonical(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|e| panic!("cannot canonicalize {}: {e}", path.display()))
 }
 
 /// Create a throwaway workspace root whose members are `crates/*`.
@@ -146,6 +163,164 @@ fn every_target_root_declares_a_position_on_its_crate_lints() {
          reports clean for the wrong reason"
     );
     assert!(report.is_compliant(), "{report}");
+}
+
+/// The set of target roots the guard resolves must equal the set cargo builds.
+///
+/// Every other test here asks what the guard *concludes* about a root. This one
+/// asks the prior question — which roots there are — and answers it by asking
+/// the toolchain instead of modelling the toolchain. `cargo metadata` needs no
+/// model of cargo's discovery rules because it *is* cargo; the guard's
+/// `target_roots` re-derives those rules by hand, from `src/lib.rs` and
+/// `tests/*.rs` down to the `<dir>/<name>/main.rs` form. A hand-written copy of
+/// someone else's rules drifts, and it drifts silently: a root the guard never
+/// opens cannot be reported as silent about its crate's lints, so the crate
+/// comes back clean *because* it was never fully read. That is the same false
+/// green this whole file exists to prevent, one level further up.
+///
+/// Two review findings are why this test exists, and they are one defect twice:
+///
+/// - **Build scripts are never enumerated.** `build.rs` is a target cargo
+///   compiles and lints. Verified on cargo 1.97.1: a manifest
+///   `[lints.rust] unsafe_code = "deny"` makes an unsafe block in `build.rs` a
+///   compile error, while the same lint written `#![deny(unsafe_code)]` in
+///   `src/lib.rs` lets it through. So a build script loses its lints in exactly
+///   the manifest-to-crate-root migration this guard was written to police, and
+///   the guard calls the crate clean. `src/buildinfo/build.rs` is this
+///   workspace's only build script, and it is why this test is **red the day it
+///   lands** — a real occurrence, flagged by the guardrail rather than by a
+///   reviewer.
+/// - **`AUTO_DISCOVERY_KEYS` lists four of cargo's five keys**, omitting
+///   `autolib`. No manifest here sets it today, so this test is silent on that
+///   half for now; the moment one does, the guard enumerates a library root
+///   cargo does not build and it lands in the `invented` direction below.
+///
+/// Both were caught by a human reading the model against cargo's documentation,
+/// which does not scale and did not have to. Whatever cargo adds next — another
+/// target kind, another discovery key — arrives here as a set difference on the
+/// first run after it lands, with no one needing to notice.
+#[test]
+fn the_guard_resolves_exactly_the_roots_cargo_builds() {
+    let repo_root = repo_root();
+    let report = target_lints::audit(&repo_root).expect("audit the workspace");
+
+    let guard: BTreeSet<PathBuf> = report
+        .roots()
+        .iter()
+        .map(|root| canonical(&repo_root.join(root)))
+        .collect();
+    let cargo = cargo_target_roots(&repo_root);
+
+    assert!(
+        !cargo.is_empty(),
+        "`cargo metadata` reported no targets at all for {}; every root the guard \
+         resolved would then look invented and every real gap would vanish, so an \
+         empty cargo side is a broken test rather than a verdict",
+        repo_root.display()
+    );
+
+    let missed: BTreeSet<PathBuf> = cargo.difference(&guard).cloned().collect();
+    assert!(
+        missed.is_empty(),
+        "cargo builds {} target root(s) the guard never resolved:\n{}\n\
+         This is the false-green direction. A root the guard does not open cannot be \
+         reported as silent about a lint its crate raises, so that root keeps the \
+         workspace default lints unnoticed and its crate is reported clean on the \
+         strength of the roots that were read.",
+        missed.len(),
+        render_roots(&missed, &repo_root)
+    );
+
+    let invented: BTreeSet<PathBuf> = guard.difference(&cargo).cloned().collect();
+    assert!(
+        invented.is_empty(),
+        "the guard resolved {} root(s) cargo does not build:\n{}\n\
+         This direction is loud rather than silent, but it is the same drift: the \
+         guard would demand a lint attribute in a file cargo never lints, and a model \
+         wrong about which files exist is not to be trusted about which files are \
+         missing.",
+        invented.len(),
+        render_roots(&invented, &repo_root)
+    );
+}
+
+/// Every `src_path` cargo reports, across every target of every workspace
+/// package, canonicalized.
+///
+/// `--no-deps` keeps the answer to this workspace's own packages, and is
+/// deliberately not paired with `--offline`: resolution is skipped either way,
+/// and `--offline` only adds a way for a cold cache to fail.
+///
+/// Every step here fails loudly. A parity test that skipped when cargo could
+/// not be spawned, or compared against a set it quietly failed to parse, would
+/// be an instance of the very defect it exists to catch: a check that reports
+/// clean because it never looked.
+fn cargo_target_roots(repo_root: &Path) -> BTreeSet<PathBuf> {
+    let output = Command::new(env!("CARGO"))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(repo_root)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "cannot run `cargo metadata` in {}: {e}",
+                repo_root.display()
+            )
+        });
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "`cargo metadata` in {} exited with {}:\n{stderr}",
+        repo_root.display(),
+        output.status
+    );
+
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!("cannot parse the output of `cargo metadata` as JSON: {e}\nstderr:\n{stderr}")
+    });
+
+    let packages = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| {
+            panic!("`cargo metadata` returned no `packages` array\nstderr:\n{stderr}")
+        });
+
+    packages
+        .iter()
+        .flat_map(|package| {
+            package
+                .get("targets")
+                .and_then(serde_json::Value::as_array)
+                .unwrap_or_else(|| {
+                    panic!("a package in `cargo metadata` has no `targets` array: {package}")
+                })
+        })
+        .map(|target| {
+            let src_path = target
+                .get("src_path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| {
+                    panic!("a target in `cargo metadata` has no `src_path`: {target}")
+                });
+            canonical(Path::new(src_path))
+        })
+        .collect()
+}
+
+/// Render a set of absolute roots as one indented repo-relative path per line,
+/// so a failure reads as a list of files rather than as two sets to diff by eye.
+fn render_roots(roots: &BTreeSet<PathBuf>, repo_root: &Path) -> String {
+    roots
+        .iter()
+        .map(|root| {
+            format!(
+                "    {}",
+                root.strip_prefix(repo_root).unwrap_or(root).display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -1,11 +1,11 @@
 //! Guard tests for `repo_guards::target_lints::audit`.
 //!
 //! The headline test — [`every_target_root_declares_a_position_on_its_crate_lints`]
-//! — runs the audit against this repository and **fails today by design**. Five
+//! — runs the audit against this repository and **fails today by design**. Four
 //! target roots are silent about lints their own crate raises: `cwt`'s two
 //! integration tests never mention `unsafe_code` or `clippy::pedantic`, and
-//! `bm`'s library and two integration tests never mention `clippy::unwrap_used`
-//! or `clippy::expect_used`. Both crates acquired the gap honestly — they moved
+//! `bm`'s two integration tests never mention `clippy::unwrap_used` or
+//! `clippy::expect_used`. Both crates acquired the gap honestly — they moved
 //! a manifest `[lints]` table into a crate-root attribute to satisfy the
 //! workspace-inheritance guard, and a crate-root attribute reaches one target
 //! where the manifest table reached all of them. That red is the point of this
@@ -411,12 +411,43 @@ fn a_reason_is_not_a_lint_name() {
     );
 }
 
-/// `#![cfg_attr(not(test), warn(lint))]` has attribute path `cfg_attr`, so it is
-/// neither a raise nor a mention. This is `bm`'s `src/lib.rs` exactly: a lint
-/// that applies in some configurations is not a position the crate holds in all
-/// of them, and the guard must not read it as one.
+/// A `cfg_attr`-wrapped lint does **not** raise. A lint that applies only under
+/// `not(test)` is not a position the crate holds in every configuration, so it
+/// cannot bind sibling targets — least of all the test targets its own predicate
+/// excludes. Were it to raise, the silent `tests/cli.rs` here would be an
+/// offender.
 #[test]
-fn cfg_attr_wrapped_lints_neither_raise_nor_mention() {
+fn cfg_attr_wrapped_lints_do_not_raise() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(not(test), warn(clippy::unwrap_used))]\n",
+    );
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a conditionally-applied lint must not impose a baseline on siblings; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "both roots should still have been examined"
+    );
+}
+
+/// A `cfg_attr`-wrapped lint **does** mention. This is `bm`'s real shape: the
+/// library states its position on `clippy::unwrap_used` more precisely than a
+/// bare `#![warn(...)]` would — it names the lint *and* the configuration it
+/// holds in — and the mention bar asks for nothing more than that the file name
+/// the lint. Reading it as silence would demand a redundant unconditional
+/// mention be bolted on top of the more careful declaration.
+#[test]
+fn cfg_attr_wrapped_lints_are_a_mention() {
     let ws = synthetic_workspace();
     let member = write_member(ws.path(), "tool", "");
     write_source(
@@ -432,13 +463,151 @@ fn cfg_attr_wrapped_lints_neither_raise_nor_mention() {
 
     let report = audit_fixture(&ws);
 
+    assert!(
+        report.is_compliant(),
+        "naming a lint inside cfg_attr is a stated position, not silence; got:\n{report}"
+    );
+}
+
+/// `cfg_attr` takes *several* attributes after its predicate. A walk that read
+/// only the first would report the rest silent forever — the false-green shape
+/// this whole file exists to prevent. The unanswered third lint proves the guard
+/// is still able to flag while both wrapped mentions land.
+#[test]
+fn every_attribute_after_a_cfg_predicate_mentions() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(unix, warn(clippy::unwrap_used), allow(clippy::expect_used))]\n",
+    );
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::unwrap_used, clippy::expect_used)]\n#![deny(unsafe_code)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
     assert_eq!(
         offenders(&report),
         vec![(
             PathBuf::from("crates/tool/src/lib.rs"),
-            vec!["clippy::unwrap_used".to_owned()]
+            vec!["unsafe_code".to_owned()]
         )],
-        "a cfg_attr-wrapped lint is not a mention, so the library is still silent"
+        "both attributes after the predicate must be read, leaving only the lint neither names"
+    );
+}
+
+/// `cfg_attr` nests. The walk recurses instead of special-casing one level, so
+/// an inner mention counts however many wrappers sit above it.
+#[test]
+fn nested_cfg_attr_mentions_are_found() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(unix, cfg_attr(test, warn(clippy::unwrap_used)))]\n",
+    );
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::unwrap_used)]\n#![deny(unsafe_code)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/src/lib.rs"),
+            vec!["unsafe_code".to_owned()]
+        )],
+        "a mention nested two cfg_attrs deep still counts"
+    );
+}
+
+/// Only *lint-level* attributes inside a `cfg_attr` count. `doc = "..."` and
+/// `feature(...)` are conditionally applied too, and neither says anything about
+/// a lint, so the library here is still silent.
+#[test]
+fn non_lint_attributes_inside_cfg_attr_mention_nothing() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(unix, doc = \"unix only\")]\n#![cfg_attr(docsrs, feature(doc_cfg))]\n",
+    );
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/src/lib.rs"),
+            vec!["clippy::pedantic".to_owned()]
+        )],
+        "a non-lint attribute inside cfg_attr is not a position on any lint"
+    );
+}
+
+/// The cfg predicate is cfg syntax, never a lint name. `not`, `test`, and
+/// `cfg_attr` are spelled here as lints the binary raises, so a walk that
+/// harvested the predicate would report the library compliant on all three.
+#[test]
+fn a_cfg_predicate_is_never_a_lint_name() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(not(test), warn(clippy::unwrap_used))]\n",
+    );
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::unwrap_used)]\n#![deny(cfg_attr, not, test)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/src/lib.rs"),
+            vec!["cfg_attr".to_owned(), "not".to_owned(), "test".to_owned()]
+        )],
+        "only the wrapped lint may be mentioned; the predicate contributes nothing"
+    );
+}
+
+/// `cfg_attr` nests without limit in the grammar, so the walk over it is
+/// recursive and a generated or hostile file could drive it into the stack. Past
+/// the bound the guard refuses, because a root it only partly read is a root it
+/// cannot vouch for.
+#[test]
+fn pathologically_nested_cfg_attr_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    let mut attribute = "warn(clippy::unwrap_used)".to_owned();
+    for _ in 0..64 {
+        attribute = format!("cfg_attr(unix, {attribute})");
+    }
+    write_source(
+        &member,
+        "src/main.rs",
+        &format!("#![{attribute}]\n\nfn main() {{}}\n"),
+    );
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(&error, TargetLintsError::CfgAttrTooDeep { path } if path.ends_with("src/main.rs")),
+        "nesting past the bound must be an error naming the file, got: {error}"
     );
 }
 

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -12,10 +12,10 @@
 //! [`the_guard_resolves_exactly_the_roots_cargo_builds`] checks the prior
 //! question, which a verdict cannot: whether the guard found every root there
 //! is. It asks `cargo metadata` rather than trusting the guard's hand-written
-//! model of cargo's discovery rules, and it **fails today by design** —
+//! model of cargo's discovery rules. It was red the day it landed —
 //! `src/buildinfo/build.rs` is a target cargo builds and lints that the guard
-//! has never enumerated. That red is a real gap the guardrail caught; the
-//! commit after this one closes it.
+//! had never enumerated — and the commit that followed taught the guard about
+//! build scripts and cleared it.
 //!
 //! Every other test is a mutation test. A guard that cannot fail is worse than
 //! no guard, because "clean" and "I never looked" print identically. So each
@@ -180,16 +180,18 @@ fn every_target_root_declares_a_position_on_its_crate_lints() {
 ///
 /// Two review findings are why this test exists, and they are one defect twice:
 ///
-/// - **Build scripts are never enumerated.** `build.rs` is a target cargo
+/// - **Build scripts were never enumerated.** `build.rs` is a target cargo
 ///   compiles and lints. Verified on cargo 1.97.1: a manifest
 ///   `[lints.rust] unsafe_code = "deny"` makes an unsafe block in `build.rs` a
 ///   compile error, while the same lint written `#![deny(unsafe_code)]` in
 ///   `src/lib.rs` lets it through. So a build script loses its lints in exactly
 ///   the manifest-to-crate-root migration this guard was written to police, and
-///   the guard calls the crate clean. `src/buildinfo/build.rs` is this
-///   workspace's only build script, and it is why this test is **red the day it
-///   lands** — a real occurrence, flagged by the guardrail rather than by a
-///   reviewer.
+///   the guard called the crate clean. `src/buildinfo/build.rs` is this
+///   workspace's only build script, and it is why this test was **red the day
+///   it landed** — a real occurrence, flagged by the guardrail rather than by a
+///   reviewer. The next commit added `TargetKind::Build`; the build-script
+///   fixtures further down pin the behavior, and this test pins that the fix
+///   matches what cargo actually reports.
 /// - **`AUTO_DISCOVERY_KEYS` lists four of cargo's five keys**, omitting
 ///   `autolib`. No manifest here sets it today, so this test is silent on that
 ///   half for now; the moment one does, the guard enumerates a library root

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -213,10 +213,15 @@ fn every_target_root_declares_a_position_on_its_crate_lints() {
 ///   reviewer. The next commit added `TargetKind::Build`; the build-script
 ///   fixtures further down pin the behavior, and this test pins that the fix
 ///   matches what cargo actually reports.
-/// - **`AUTO_DISCOVERY_KEYS` lists four of cargo's five keys**, omitting
-///   `autolib`. No manifest here sets it today, so this test is silent on that
-///   half for now; the moment one does, the guard enumerates a library root
-///   cargo does not build and it lands in the `invented` direction below.
+/// - **`AUTO_DISCOVERY_KEYS` listed four of cargo's five keys**, omitting
+///   `autolib`. Verified on cargo 1.97.1: `autolib = false` with a `src/lib.rs`
+///   on disk and an explicit `[[bin]]` beside it makes cargo report the bin and
+///   no lib at all, while the guard walked past the key and resolved
+///   `src/lib.rs` as a library root — a kind that *raises* the crate baseline,
+///   so lints from a file cargo never compiles would be imposed on every target
+///   that is real. No manifest here sets it, so this test could not have seen
+///   it; [`the_guard_models_every_auto_discovery_key_cargo_has`] is what closes
+///   that half, by comparing the guard's modeled set against cargo's own.
 ///
 /// Both were caught by a human reading the model against cargo's documentation,
 /// which does not scale and did not have to. Whatever cargo adds next — another

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -168,8 +168,8 @@ fn assert_offenders(report: &Report, expected: &[&str]) {
 // The real repository
 // ---------------------------------------------------------------------------
 
-/// The guard, pointed at this repo. Red until the silent test roots take a
-/// position.
+/// The guard, pointed at this repo: every target root declares a position on
+/// every lint its own crate raises.
 ///
 /// The root-count assertion runs first on purpose: a guard that examined zero
 /// target roots would report "compliant" for entirely the wrong reason, and
@@ -470,8 +470,9 @@ fn crate_that_raises_nothing_imposes_nothing() {
 }
 
 /// The baseline is the *union* over library and binary roots, and both of them
-/// have to answer for it. This is `bm`'s real shape: `src/main.rs` raises lints
-/// that `src/lib.rs` never mentions.
+/// have to answer for it. Without the union each half would be measured only
+/// against what it raises itself, and a lint one root states would never reach
+/// the other.
 #[test]
 fn baseline_unions_library_and_binary_and_binds_both() {
     let ws = synthetic_workspace();
@@ -845,8 +846,9 @@ fn outer_attributes_are_not_target_wide_positions() {
 // ---------------------------------------------------------------------------
 
 /// `tests/common/mod.rs` is a module a test root `include!`s or `mod`s, not a
-/// target cargo builds. Three crates in this repo have one; treating them as
-/// roots would invent violations against files that are never compiled alone.
+/// target cargo builds. Three crates in this repo keep one, under
+/// `tests/common/` or `tests/support/`; treating them as roots would invent
+/// violations against files that are never compiled alone.
 #[test]
 fn test_helper_modules_are_not_target_roots() {
     let ws = synthetic_workspace();
@@ -968,9 +970,10 @@ fn src_bin_binaries_contribute_to_the_baseline() {
     );
 }
 
-/// `[[bin]] path = "src/main.rs"` — the spelling nearly every crate in this repo
-/// uses — names the same file auto-discovery finds. Counting it twice would
-/// inflate the root count and print the same offender twice.
+/// `[[bin]] path = "src/main.rs"` names the same file auto-discovery would have
+/// found on its own, and the crates here are split between the two spellings.
+/// Counting it twice would inflate the root count and print the same offender
+/// twice.
 #[test]
 fn a_declared_path_and_its_conventional_twin_are_one_root() {
     let ws = synthetic_workspace();
@@ -1224,7 +1227,7 @@ fn failure_message_names_the_root_the_lint_and_both_remedies() {
 }
 
 /// A clean audit says how much it looked at — so a passing CI log distinguishes
-/// "checked 90 roots" from "checked nothing".
+/// "checked 125 roots" from "checked nothing".
 #[test]
 fn clean_message_reports_the_counts() {
     let ws = synthetic_workspace();

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -1009,6 +1009,162 @@ fn baselines_do_not_leak_between_crates() {
 }
 
 // ---------------------------------------------------------------------------
+// Build scripts: a target cargo lints, declared in a shape no other target has
+// ---------------------------------------------------------------------------
+//
+// Every fixture below was checked against cargo 1.97.1 with a throwaway crate
+// and `cargo metadata --no-deps --format-version 1`, reading the `custom-build`
+// target it reports. The `build` key is a *scalar* inside `[package]` — a path
+// or a bool — not an array-of-tables with a `path` field like `[[bin]]`, so its
+// forms are enumerated here one fixture apiece rather than inherited from the
+// declared-path machinery the other kinds share.
+
+/// A conventional `build.rs` is a target root, and silence there is the same
+/// violation it is anywhere else.
+///
+/// This is the defect in its live form. Verified on cargo 1.97.1: with
+/// `[lints.rust] unsafe_code = "deny"` in the manifest, an unsafe block in
+/// `build.rs` fails the build; with the identical lint moved to
+/// `#![deny(unsafe_code)]` at the top of `src/lib.rs`, the same `build.rs`
+/// compiles clean. So a build script loses its lints in exactly the
+/// manifest-to-crate-root migration this guard was written to police.
+#[test]
+fn build_script_silent_about_a_baseline_lint_is_flagged() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/lib.rs", "#![deny(unsafe_code)]\n");
+    write_source(&member, "build.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/build.rs"]);
+    assert_eq!(
+        report.offenders()[0].kind(),
+        "build script",
+        "the report should say what kind of target is silent"
+    );
+}
+
+/// A build script that states a position is compliant, by the same rule every
+/// other target answers to: mention the lint, at any level, in writing.
+#[test]
+fn build_script_that_states_a_position_is_clean() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+    write_source(
+        &member,
+        "build.rs",
+        "#![allow(clippy::pedantic, reason = \"a build script prints to stdout by protocol\")]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "an explicit allow in a build script is a stated position, not silence; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "both the library and the build script should have been examined"
+    );
+}
+
+/// A build script **mentions but never raises**. Nothing depends on a build
+/// script — it is compiled for the build machine, run once, and never linked
+/// into the crate — so a lint it alone raises is a position that target holds,
+/// not one the crate holds. Were it to raise, the silent library and test here
+/// would both be offenders, and adding one strict build script would go red
+/// across a crate that never asked for the lint.
+#[test]
+fn a_build_script_does_not_raise_its_crates_baseline() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/lib.rs", "pub fn f() {}\n");
+    write_source(
+        &member,
+        "build.rs",
+        "#![deny(unsafe_code)]\n\nfn main() {}\n",
+    );
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a build script's own lints must not bind its siblings; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        3,
+        "all three roots should still have been examined"
+    );
+}
+
+/// `build = "custom-build.rs"` names the build script explicitly, and the
+/// declaration *replaces* the convention rather than adding to it: cargo reports
+/// exactly one `custom-build` target, at the declared path, and the stray
+/// `build.rs` beside it is not a target at all. A guard that discovered the
+/// convention regardless would demand a lint attribute in a file cargo never
+/// compiles.
+#[test]
+fn explicitly_declared_build_script_paths_are_audited() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = \"custom-build.rs\"\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+    write_source(&member, "custom-build.rs", "fn main() {}\n");
+    write_source(&member, "build.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/custom-build.rs"]);
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "the declared path replaces the conventional one; build.rs is not a target here"
+    );
+}
+
+/// `build = true` is the conventional path spelled out loud, and cargo means it
+/// literally: it reports a `custom-build` target at `build.rs` and compiles it.
+#[test]
+fn build_true_resolves_the_conventional_build_script() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = true\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+    write_source(&member, "build.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/build.rs"]);
+}
+
+/// `build = false` turns the build script off. Cargo reports no `custom-build`
+/// target even with a `build.rs` sitting on disk, and does not compile it — so
+/// demanding a lint attribute in that file would be a violation invented against
+/// a file the build never reads.
+#[test]
+fn build_false_resolves_no_build_script() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = false\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+    write_source(&member, "build.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a disabled build script is not a target to audit; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        1,
+        "only the library is a target when `build = false`"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Display: the message has to be usable without opening the source
 // ---------------------------------------------------------------------------
 
@@ -1148,6 +1304,70 @@ fn declared_target_path_that_does_not_exist_refuses() {
                 if declared == "checks/typo.rs"
         ),
         "a declared target that is not on disk must be an error naming it, got: {error}"
+    );
+}
+
+/// `build = "missing.rs"` names a build script that is not on disk. Cargo
+/// reports the target and then fails to compile it (`error: couldn't read
+/// `missing.rs``), so a guard that quietly skipped it would be reporting on a
+/// smaller set than the build has — the same defect a typo'd `[[test]] path`
+/// already refuses over.
+#[test]
+fn declared_build_script_that_does_not_exist_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = \"missing.rs\"\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(
+            &error,
+            TargetLintsError::MissingDeclaredTarget { kind: "build", declared, .. }
+                if declared == "missing.rs"
+        ),
+        "a declared build script that is not on disk must be an error naming it, got: {error}"
+    );
+}
+
+/// `build = true` without a `build.rs` is the same refusal, and cargo agrees:
+/// it reports the target at `build.rs` and then fails with `couldn't read
+/// `build.rs``. So `true` is a *declaration* of the conventional path, not a
+/// best-effort look for one — treating it as "discover if present" would let the
+/// guard's root set silently disagree with cargo's.
+#[test]
+fn build_true_without_a_build_script_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = true\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(
+            &error,
+            TargetLintsError::MissingDeclaredTarget { kind: "build", declared, .. }
+                if declared == "build.rs"
+        ),
+        "`build = true` with no build.rs must be an error naming the file cargo would compile, got: {error}"
+    );
+}
+
+/// A `build` key that is neither a path nor a bool. Cargo rejects such a
+/// manifest outright; reading it here as "this crate has no build script" would
+/// drop a target from the audit on the strength of a value the guard did not
+/// understand.
+#[test]
+fn build_key_that_is_neither_path_nor_bool_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "build = 3\n");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::pedantic)]\n");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(&error, TargetLintsError::MalformedBuildKey { value, .. } if value == "3"),
+        "an ill-typed `build` key must be an error quoting the value, got: {error}"
     );
 }
 

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -41,6 +41,27 @@ use tempfile::TempDir;
 /// A crate root that raises one lint, in the plainest form there is.
 const RAISES_PEDANTIC: &str = "#![warn(clippy::pedantic)]\n\nfn main() {}\n";
 
+/// Every `[package]` key cargo uses to turn target auto-discovery on or off,
+/// as cargo documents them and as verified against cargo 1.97.1.
+///
+/// This is the *ground truth* the guard is measured against, not a mirror of
+/// [`target_lints::AUTO_DISCOVERY_KEYS`]. The distinction is the whole point:
+/// the list here started as a copy of the guard's own constant, inherited its
+/// omission of `autolib`, and so was structurally incapable of noticing it —
+/// a fixture set derived from an implementation cannot catch what that
+/// implementation forgot. Written independently, it catches a key the guard
+/// does not model (every key below is exercised end-to-end by
+/// [`auto_discovery_override_refuses`]) and, paired with
+/// [`the_guard_models_every_auto_discovery_key_cargo_has`], a key the guard
+/// models that cargo does not have.
+const CARGO_AUTO_DISCOVERY_KEYS: [&str; 5] = [
+    "autobenches",
+    "autobins",
+    "autoexamples",
+    "autolib",
+    "autotests",
+];
+
 /// Absolute, canonical path to this repository's root, derived from the crate
 /// being compiled rather than the working directory (which `cargo test` does
 /// not pin).
@@ -1376,20 +1397,24 @@ fn build_key_that_is_neither_path_nor_bool_refuses() {
 /// `autotests = false` (and its siblings) change which roots cargo builds. This
 /// guard models the default rules only, so it refuses rather than enumerate a
 /// set that disagrees with the build.
+///
+/// One fixture per key cargo actually has — [`CARGO_AUTO_DISCOVERY_KEYS`] —
+/// because a key the guard does not model is not a refusal but a silent guess,
+/// and it guesses wrong. `autolib = false` is the sharpest of the five: cargo
+/// then reports no library target at all, verified on cargo 1.97.1 with a
+/// `src/lib.rs` on disk and an explicit `[[bin]]` beside it, so a guard that
+/// walks past the key resolves `src/lib.rs` as a library root. A library root
+/// is one of the two kinds that *raise* the crate baseline, so lints from a
+/// file cargo never compiles would be imposed on every target that is real.
+/// Each fixture therefore carries both a library and a binary root, so every
+/// key has something its setting could change.
 #[test]
 fn auto_discovery_override_refuses() {
-    for key in ["autotests", "autobins", "autobenches", "autoexamples"] {
+    for key in CARGO_AUTO_DISCOVERY_KEYS {
         let ws = synthetic_workspace();
-        let dir = ws.path().join("crates").join("tool");
-        fs::create_dir_all(&dir).expect("create fixture member dir");
-        fs::write(
-            dir.join("Cargo.toml"),
-            format!(
-                "[package]\nname = \"tool\"\nversion = \"0.1.0\"\nedition = \"2021\"\n{key} = false\n"
-            ),
-        )
-        .expect("write fixture member manifest");
-        write_source(&dir, "src/main.rs", RAISES_PEDANTIC);
+        let member = write_member(ws.path(), "tool", &format!("{key} = false\n"));
+        write_source(&member, "src/lib.rs", RAISES_PEDANTIC);
+        write_source(&member, "src/main.rs", RAISES_PEDANTIC);
 
         let error = audit_must_refuse(&ws);
 
@@ -1398,6 +1423,28 @@ fn auto_discovery_override_refuses() {
             "`{key}` must be an error, got: {error}"
         );
     }
+}
+
+/// The other direction of the same fact: the guard must not refuse a key cargo
+/// does not have, and must not skip one it does.
+///
+/// [`auto_discovery_override_refuses`] proves each of cargo's keys is refused,
+/// which catches an omission. It cannot catch the reverse — an invented key
+/// would refuse manifests cargo reads happily — and neither can any fixture,
+/// because there is no manifest to write for a key that does not exist. So the
+/// two lists are compared directly, and this is what keeps them from drifting
+/// apart again in either direction.
+#[test]
+fn the_guard_models_every_auto_discovery_key_cargo_has() {
+    let modeled: BTreeSet<&str> = target_lints::AUTO_DISCOVERY_KEYS.into_iter().collect();
+    let cargo: BTreeSet<&str> = CARGO_AUTO_DISCOVERY_KEYS.into_iter().collect();
+
+    assert_eq!(
+        modeled, cargo,
+        "the guard models a different set of auto-discovery keys than cargo has; \
+         a key cargo has and the guard omits is guessed at rather than refused, and \
+         a key the guard invents refuses a manifest cargo would accept"
+    );
 }
 
 /// A member crate with a manifest but no target roots at all. Reporting it

--- a/src/repo-guards/tests/target_lint_parity.rs
+++ b/src/repo-guards/tests/target_lint_parity.rs
@@ -1,0 +1,850 @@
+//! Guard tests for `repo_guards::target_lints::audit`.
+//!
+//! The headline test — [`every_target_root_declares_a_position_on_its_crate_lints`]
+//! — runs the audit against this repository and **fails today by design**. Five
+//! target roots are silent about lints their own crate raises: `cwt`'s two
+//! integration tests never mention `unsafe_code` or `clippy::pedantic`, and
+//! `bm`'s library and two integration tests never mention `clippy::unwrap_used`
+//! or `clippy::expect_used`. Both crates acquired the gap honestly — they moved
+//! a manifest `[lints]` table into a crate-root attribute to satisfy the
+//! workspace-inheritance guard, and a crate-root attribute reaches one target
+//! where the manifest table reached all of them. That red is the point of this
+//! commit; the following commits clear it.
+//!
+//! Every other test is a mutation test. A guard that cannot fail is worse than
+//! no guard, because "clean" and "I never looked" print identically. So each
+//! shape is built as a real workspace on disk and fed to the real `audit()` —
+//! member enumeration, target resolution, parsing, and comparison together, not
+//! a string predicate in isolation — and each fail-closed condition is asserted
+//! to produce an `Err` rather than a clean verdict.
+//!
+//! Parallel safety: this workspace's tests share `./target` with the pre-commit
+//! hook's own `cargo test`, so two copies of any test here can run at the same
+//! moment. Every fixture lives in its own `tempfile::TempDir`, whose name the
+//! OS makes unique; nothing is keyed on a fixed path under the temp dir, the
+//! repo, or the home dir.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use repo_guards::target_lints::{self, Report, TargetLintsError};
+use tempfile::TempDir;
+
+/// A crate root that raises one lint, in the plainest form there is.
+const RAISES_PEDANTIC: &str = "#![warn(clippy::pedantic)]\n\nfn main() {}\n";
+
+/// Absolute, canonical path to this repository's root, derived from the crate
+/// being compiled rather than the working directory (which `cargo test` does
+/// not pin).
+fn repo_root() -> PathBuf {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    fs::canonicalize(&root)
+        .unwrap_or_else(|e| panic!("cannot canonicalize repo root {}: {e}", root.display()))
+}
+
+/// Create a throwaway workspace root whose members are `crates/*`.
+fn synthetic_workspace() -> TempDir {
+    let dir = TempDir::new().expect("create fixture workspace dir");
+    write_root_manifest(
+        dir.path(),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/*\"]\n",
+    );
+    dir
+}
+
+/// Overwrite the root manifest of `root` with `contents`.
+fn write_root_manifest(root: &Path, contents: &str) {
+    fs::write(root.join("Cargo.toml"), contents).expect("write fixture root manifest");
+}
+
+/// Create `crates/<name>/Cargo.toml` under `root`, appending `extra_tables`
+/// verbatim after the `[package]` table, and return the member directory.
+fn write_member(root: &Path, name: &str, extra_tables: &str) -> PathBuf {
+    let dir = root.join("crates").join(name);
+    fs::create_dir_all(&dir).expect("create fixture member dir");
+    fs::write(
+        dir.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n{extra_tables}"
+        ),
+    )
+    .expect("write fixture member manifest");
+    dir
+}
+
+/// Write `relative` (e.g. `tests/cli.rs`) under a member directory, creating
+/// intermediate directories.
+fn write_source(member_dir: &Path, relative: &str, contents: &str) {
+    let path = member_dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create fixture source dir");
+    }
+    fs::write(&path, contents).expect("write fixture source file");
+}
+
+/// Run the audit against a fixture and require a verdict (not an error).
+fn audit_fixture(dir: &TempDir) -> Report {
+    target_lints::audit(dir.path()).expect("audit the fixture workspace")
+}
+
+/// Run the audit against a fixture and require a refusal. Returning the error
+/// lets a caller assert on the variant; the assertion message renders the
+/// *report* when one came back, so a fail-closed regression says what the guard
+/// wrongly concluded instead of just "expected Err".
+fn audit_must_refuse(dir: &TempDir) -> TargetLintsError {
+    match target_lints::audit(dir.path()) {
+        Err(e) => e,
+        Ok(report) => panic!(
+            "audit should have refused this workspace, but returned a verdict:\n{report}\n\
+             (compliant = {})",
+            report.is_compliant()
+        ),
+    }
+}
+
+/// The offender list as `(path, missing lints)` pairs, for comparison.
+fn offenders(report: &Report) -> Vec<(PathBuf, Vec<String>)> {
+    report
+        .offenders()
+        .iter()
+        .map(|offender| (offender.path().to_path_buf(), offender.missing().to_vec()))
+        .collect()
+}
+
+/// Assert a report names exactly `expected` (paths relative to the fixture
+/// root), rendering the whole report when it does not.
+fn assert_offenders(report: &Report, expected: &[&str]) {
+    let actual: Vec<PathBuf> = report
+        .offenders()
+        .iter()
+        .map(|offender| offender.path().to_path_buf())
+        .collect();
+    let want: Vec<PathBuf> = expected.iter().map(PathBuf::from).collect();
+    assert_eq!(
+        actual, want,
+        "unexpected offender set; report was:\n{report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The real repository
+// ---------------------------------------------------------------------------
+
+/// The guard, pointed at this repo. Red until the silent test roots take a
+/// position.
+///
+/// The root-count assertion runs first on purpose: a guard that examined zero
+/// target roots would report "compliant" for entirely the wrong reason, and
+/// that false green is the failure mode this whole file exists to prevent.
+#[test]
+fn every_target_root_declares_a_position_on_its_crate_lints() {
+    let report = target_lints::audit(&repo_root()).expect("audit the workspace");
+
+    assert!(
+        report.roots_examined() > 0,
+        "the audit examined zero target roots; a guard that scans nothing \
+         reports clean for the wrong reason"
+    );
+    assert!(report.is_compliant(), "{report}");
+}
+
+// ---------------------------------------------------------------------------
+// The rule: silence is the violation, a stated position is not
+// ---------------------------------------------------------------------------
+
+/// The defect this guard exists for: a binary raises a lint, its integration
+/// test says nothing, and cargo lints the two differently without a word.
+#[test]
+fn test_root_silent_about_a_baseline_lint_is_flagged() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        !report.is_compliant(),
+        "a test root silent about a lint its crate raises must be flagged, \
+         but the audit reported clean"
+    );
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/tests/cli.rs"),
+            vec!["clippy::pedantic".to_owned()]
+        )],
+        "the offender must be named along with the lint it never mentions"
+    );
+}
+
+/// A test root that `allow`s the baseline lint is compliant. This is the whole
+/// design: an opt-out written at the site it applies to is a decision a reviewer
+/// can see, which is exactly what an absence is not.
+#[test]
+fn test_root_that_allows_a_baseline_lint_is_clean() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![allow(clippy::pedantic, reason = \"a test asserts on shapes the lint dislikes\")]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "an explicit allow is a stated position, not silence; got:\n{report}"
+    );
+}
+
+/// `expect` is a position too — a stricter one than `allow`, since it fails if
+/// the lint stops firing.
+#[test]
+fn test_root_that_expects_a_baseline_lint_is_clean() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![expect(clippy::pedantic, reason = \"pinned until the fixtures are reshaped\")]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "an expect is a stated position; got:\n{report}"
+    );
+}
+
+/// Levels are not compared. A test root may `deny` what the binary only `warn`s,
+/// or the other way round; the bar is that it said something.
+#[test]
+fn a_different_level_still_counts_as_a_position() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![deny(clippy::pedantic)]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "mentioning is the bar, not matching the level; got:\n{report}"
+    );
+}
+
+/// A crate whose library and binary raise nothing has no baseline, so its tests
+/// owe nothing. Without this, the guard would demand a declaration from every
+/// test root in the workspace — a rule nobody could satisfy, and therefore a
+/// rule that would be deleted.
+#[test]
+fn crate_that_raises_nothing_imposes_nothing() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "plain", "");
+    write_source(&member, "src/main.rs", "fn main() {}\n");
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "no raised lint means no baseline to mention; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "both roots should still have been examined"
+    );
+}
+
+/// The baseline is the *union* over library and binary roots, and both of them
+/// have to answer for it. This is `bm`'s real shape: `src/main.rs` raises lints
+/// that `src/lib.rs` never mentions.
+#[test]
+fn baseline_unions_library_and_binary_and_binds_both() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "split", "");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::unwrap_used)]\n");
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::expect_used)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![
+            (
+                PathBuf::from("crates/split/src/lib.rs"),
+                vec!["clippy::expect_used".to_owned()]
+            ),
+            (
+                PathBuf::from("crates/split/src/main.rs"),
+                vec!["clippy::unwrap_used".to_owned()]
+            ),
+        ],
+        "each root must answer for what the other raised"
+    );
+}
+
+/// A test root missing two baseline lints reports both, not just the first.
+#[test]
+fn every_missing_baseline_lint_is_reported() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![deny(unsafe_code)]\n#![warn(clippy::pedantic)]\n\nfn main() {}\n",
+    );
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![warn(clippy::pedantic)]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/tests/cli.rs"),
+            vec!["unsafe_code".to_owned()]
+        )],
+        "a partially-answered baseline still leaves the unanswered lint outstanding"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Syntactic forms: the guard parses, so every spelling reduces to one answer
+// ---------------------------------------------------------------------------
+
+/// Several lints in one attribute — the live shape in `kitchen-sync`'s
+/// `src/main.rs`. A matcher that read only the first argument would report the
+/// second as compliant forever.
+#[test]
+fn multiple_lints_in_one_attribute_all_count() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![deny(clippy::exit, clippy::format_push_string)]\n\nfn main() {}\n",
+    );
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![allow(clippy::exit, reason = \"the harness shells out\")]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/tests/cli.rs"),
+            vec!["clippy::format_push_string".to_owned()]
+        )],
+        "both lints of the deny must enter the baseline, and both arguments of the allow must be read"
+    );
+}
+
+/// A bare lint name with no tool prefix is rendered without one, so
+/// `unsafe_code` matches `unsafe_code` and not `clippy::unsafe_code`.
+#[test]
+fn unprefixed_lint_names_round_trip() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![deny(unsafe_code)]\n\nfn main() {}\n",
+    );
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![forbid(unsafe_code)]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a bare lint name must match itself; got:\n{report}"
+    );
+}
+
+/// `reason = "..."` is a name-value pair, not a lint. Collecting it would invent
+/// a lint called `reason` that no root could ever mention — every crate using
+/// the modern attribute form would go red at once.
+#[test]
+fn a_reason_is_not_a_lint_name() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::pedantic, reason = \"stricter than the workspace set\")]\n\nfn main() {}\n",
+    );
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![warn(clippy::pedantic)]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "`reason` must not be collected as a lint; got:\n{report}"
+    );
+}
+
+/// `#![cfg_attr(not(test), warn(lint))]` has attribute path `cfg_attr`, so it is
+/// neither a raise nor a mention. This is `bm`'s `src/lib.rs` exactly: a lint
+/// that applies in some configurations is not a position the crate holds in all
+/// of them, and the guard must not read it as one.
+#[test]
+fn cfg_attr_wrapped_lints_neither_raise_nor_mention() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(
+        &member,
+        "src/lib.rs",
+        "#![cfg_attr(not(test), warn(clippy::unwrap_used))]\n",
+    );
+    write_source(
+        &member,
+        "src/main.rs",
+        "#![warn(clippy::unwrap_used)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/src/lib.rs"),
+            vec!["clippy::unwrap_used".to_owned()]
+        )],
+        "a cfg_attr-wrapped lint is not a mention, so the library is still silent"
+    );
+}
+
+/// An *outer* `#[warn(...)]` configures the item it is attached to, not the
+/// target. Counting it would let one annotated function stand in for the whole
+/// file.
+#[test]
+fn outer_attributes_are_not_target_wide_positions() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#[warn(clippy::pedantic)]\n#[test]\nfn works() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/tests/cli.rs"),
+            vec!["clippy::pedantic".to_owned()]
+        )],
+        "an outer attribute on one item is not a position for the target"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution: the guard must see every root, and only the roots
+// ---------------------------------------------------------------------------
+
+/// `tests/common/mod.rs` is a module a test root `include!`s or `mod`s, not a
+/// target cargo builds. Three crates in this repo have one; treating them as
+/// roots would invent violations against files that are never compiled alone.
+#[test]
+fn test_helper_modules_are_not_target_roots() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &member,
+        "tests/cli.rs",
+        "#![warn(clippy::pedantic)]\n\nmod common;\n\n#[test]\nfn works() {}\n",
+    );
+    write_source(&member, "tests/common/mod.rs", "pub fn helper() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "tests/common/mod.rs is not a target root; got:\n{report}"
+    );
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "only src/main.rs and tests/cli.rs are targets"
+    );
+}
+
+/// The directory form of a test target — `tests/<name>/main.rs` — *is* a root,
+/// and it is the one file in such a directory that is. Missing it would exempt
+/// every multi-file integration test.
+#[test]
+fn directory_shaped_test_targets_are_roots() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "tests/suite/main.rs", "#[test]\nfn works() {}\n");
+    write_source(&member, "tests/suite/helper.rs", "pub fn helper() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/tests/suite/main.rs"]);
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "helper.rs beside a main.rs is not itself a target root"
+    );
+}
+
+/// A bench root is bound by the baseline like any other target.
+#[test]
+fn bench_roots_are_audited() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "benches/throughput.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/benches/throughput.rs"]);
+    assert_eq!(
+        report.offenders()[0].kind(),
+        "bench",
+        "the report should say what kind of target is silent"
+    );
+}
+
+/// An example root is bound too — examples are the code users copy, so a lint
+/// the crate raises applying everywhere *except* the examples is backwards.
+#[test]
+fn example_roots_are_audited() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::unwrap_used)]\n");
+    write_source(&member, "examples/demo.rs", "fn main() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/examples/demo.rs"]);
+    assert_eq!(report.offenders()[0].kind(), "example");
+}
+
+/// A `[[test]] path` pointing outside `tests/` is found through the manifest,
+/// which auto-discovery alone would never reach.
+#[test]
+fn explicitly_declared_test_paths_are_audited() {
+    let ws = synthetic_workspace();
+    let member = write_member(
+        ws.path(),
+        "tool",
+        "[[test]]\nname = \"custom\"\npath = \"checks/custom.rs\"\n",
+    );
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "checks/custom.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/checks/custom.rs"]);
+}
+
+/// `src/bin/*.rs` binaries raise the baseline like any other binary.
+#[test]
+fn src_bin_binaries_contribute_to_the_baseline() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/lib.rs", "#![warn(clippy::unwrap_used)]\n");
+    write_source(
+        &member,
+        "src/bin/helper.rs",
+        "#![warn(clippy::unwrap_used)]\n#![deny(unsafe_code)]\n\nfn main() {}\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![(
+            PathBuf::from("crates/tool/src/lib.rs"),
+            vec!["unsafe_code".to_owned()]
+        )],
+        "a src/bin binary is a baseline-raising target, and the library must answer it"
+    );
+}
+
+/// `[[bin]] path = "src/main.rs"` — the spelling nearly every crate in this repo
+/// uses — names the same file auto-discovery finds. Counting it twice would
+/// inflate the root count and print the same offender twice.
+#[test]
+fn a_declared_path_and_its_conventional_twin_are_one_root() {
+    let ws = synthetic_workspace();
+    let member = write_member(
+        ws.path(),
+        "tool",
+        "[[bin]]\nname = \"tool\"\npath = \"src/main.rs\"\n",
+    );
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/tests/cli.rs"]);
+    assert_eq!(
+        report.roots_examined(),
+        2,
+        "the declared bin and the discovered bin are the same file"
+    );
+}
+
+/// An explicit `[lib] path` is honored instead of the conventional location.
+#[test]
+fn explicitly_declared_library_paths_are_audited() {
+    let ws = synthetic_workspace();
+    let member = write_member(
+        ws.path(),
+        "tool",
+        "[lib]\nname = \"tool\"\npath = \"core/api.rs\"\n",
+    );
+    write_source(&member, "core/api.rs", "#![warn(clippy::unwrap_used)]\n");
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert_offenders(&report, &["crates/tool/tests/cli.rs"]);
+}
+
+/// One crate's baseline never leaks into another's. Sibling crates in the same
+/// workspace are independent policies.
+#[test]
+fn baselines_do_not_leak_between_crates() {
+    let ws = synthetic_workspace();
+    let strict = write_member(ws.path(), "strict", "");
+    write_source(&strict, "src/main.rs", RAISES_PEDANTIC);
+    write_source(
+        &strict,
+        "tests/cli.rs",
+        "#![warn(clippy::pedantic)]\n\n#[test]\nfn works() {}\n",
+    );
+
+    let relaxed = write_member(ws.path(), "relaxed", "");
+    write_source(&relaxed, "src/main.rs", "fn main() {}\n");
+    write_source(&relaxed, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a sibling crate's baseline must not bind this one; got:\n{report}"
+    );
+    assert_eq!(report.crates_examined(), 2);
+    assert_eq!(report.roots_examined(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Display: the message has to be usable without opening the source
+// ---------------------------------------------------------------------------
+
+/// The failure text names the silent root, the lints it never mentions, and
+/// both ways to answer — raise it, or opt out in writing. Formatting lives in
+/// `Report`, not at the call site, so this is where it is pinned.
+#[test]
+fn failure_message_names_the_root_the_lint_and_both_remedies() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "tests/cli.rs", "#[test]\nfn works() {}\n");
+
+    let rendered = audit_fixture(&ws).to_string();
+
+    assert!(
+        rendered
+            .contains("crates/tool/tests/cli.rs (test target) never mentions: clippy::pedantic"),
+        "the message must name the root and the lint, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("    #![warn(clippy::pedantic)]"),
+        "the message must show how to raise the lint, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("    #![allow(clippy::pedantic, reason = \"...\")]"),
+        "the message must show the written opt-out, got:\n{rendered}"
+    );
+}
+
+/// A clean audit says how much it looked at — so a passing CI log distinguishes
+/// "checked 90 roots" from "checked nothing".
+#[test]
+fn clean_message_reports_the_counts() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", "fn main() {}\n");
+
+    let rendered = audit_fixture(&ws).to_string();
+
+    assert!(
+        rendered.contains("Checked 1 target roots across 1 workspace members"),
+        "a clean report should state what it examined, got:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail closed: none of these may yield a clean verdict
+// ---------------------------------------------------------------------------
+
+/// No workspace at all: the member set cannot be enumerated.
+#[test]
+fn unenumerable_workspace_refuses() {
+    let dir = TempDir::new().expect("create fixture dir");
+
+    assert!(
+        matches!(
+            target_lints::audit(dir.path()),
+            Err(TargetLintsError::Members(_))
+        ),
+        "a workspace whose members cannot be enumerated must be an error, not a clean verdict"
+    );
+}
+
+/// A member manifest that is not valid TOML. Unreadable is not compliant.
+#[test]
+fn unparsable_member_manifest_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    fs::write(member.join("Cargo.toml"), "[package\nname = ").expect("write invalid TOML");
+
+    assert!(
+        matches!(audit_must_refuse(&ws), TargetLintsError::Members(_)),
+        "an unparsable member manifest must be an error, never a pass"
+    );
+}
+
+/// A target root that is not valid Rust. A file the guard cannot parse is a
+/// file whose lint attributes it cannot see, which is not the same as a file
+/// that has none.
+#[test]
+fn unparsable_target_root_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    write_source(&member, "tests/cli.rs", "fn works( {\n");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(&error, TargetLintsError::ParseRoot { path, .. } if path.ends_with("tests/cli.rs")),
+        "an unparsable target root must be an error naming the file, got: {error}"
+    );
+}
+
+/// A target root that cannot be read at all. A dangling symlink is the portable
+/// way to build one; the point is that an I/O failure must never be mistaken
+/// for "this file mentions nothing".
+#[cfg(unix)]
+#[test]
+fn unreadable_target_root_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(ws.path(), "tool", "");
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+    fs::create_dir_all(member.join("tests")).expect("create fixture tests dir");
+    std::os::unix::fs::symlink("nowhere.rs", member.join("tests").join("cli.rs"))
+        .expect("create dangling symlink");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(&error, TargetLintsError::ReadRoot { path, .. } if path.ends_with("tests/cli.rs")),
+        "an unreadable target root must be an error naming the file, got: {error}"
+    );
+}
+
+/// A manifest declaring a target that is not on disk. Silently skipping it
+/// would let a typo'd `path` shrink the audited set while the guard kept
+/// passing.
+#[test]
+fn declared_target_path_that_does_not_exist_refuses() {
+    let ws = synthetic_workspace();
+    let member = write_member(
+        ws.path(),
+        "tool",
+        "[[test]]\nname = \"custom\"\npath = \"checks/typo.rs\"\n",
+    );
+    write_source(&member, "src/main.rs", RAISES_PEDANTIC);
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(
+            &error,
+            TargetLintsError::MissingDeclaredTarget { kind: "test", declared, .. }
+                if declared == "checks/typo.rs"
+        ),
+        "a declared target that is not on disk must be an error naming it, got: {error}"
+    );
+}
+
+/// `autotests = false` (and its siblings) change which roots cargo builds. This
+/// guard models the default rules only, so it refuses rather than enumerate a
+/// set that disagrees with the build.
+#[test]
+fn auto_discovery_override_refuses() {
+    for key in ["autotests", "autobins", "autobenches", "autoexamples"] {
+        let ws = synthetic_workspace();
+        let dir = ws.path().join("crates").join("tool");
+        fs::create_dir_all(&dir).expect("create fixture member dir");
+        fs::write(
+            dir.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"tool\"\nversion = \"0.1.0\"\nedition = \"2021\"\n{key} = false\n"
+            ),
+        )
+        .expect("write fixture member manifest");
+        write_source(&dir, "src/main.rs", RAISES_PEDANTIC);
+
+        let error = audit_must_refuse(&ws);
+
+        assert!(
+            matches!(&error, TargetLintsError::AutoDiscoveryOverride { key: found, .. } if *found == key),
+            "`{key}` must be an error, got: {error}"
+        );
+    }
+}
+
+/// A member crate with a manifest but no target roots at all. Reporting it
+/// clean would be reporting on nothing.
+#[test]
+fn member_with_no_target_roots_refuses() {
+    let ws = synthetic_workspace();
+    write_member(ws.path(), "hollow", "");
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(&error, TargetLintsError::NoTargetRoots { dir } if dir.ends_with("crates/hollow")),
+        "a member with no targets must be an error naming it, got: {error}"
+    );
+}

--- a/src/repo-guards/tests/workspace_lint_inheritance.rs
+++ b/src/repo-guards/tests/workspace_lint_inheritance.rs
@@ -1,10 +1,12 @@
 //! Guard tests for `repo_guards::workspace_lints::audit`.
 //!
 //! The headline test — [`every_workspace_member_inherits_the_workspace_lints`]
-//! — runs the audit against this repository and **fails today by design**. Six
-//! member crates never opted into the workspace lint set, so they are silently
-//! exempt from `[workspace.lints.*]`. That red is the point of this commit; the
-//! following commits clear it.
+//! — runs the audit against this repository and checks the verdict: every
+//! member manifest here declares `[lints] workspace = true`, so cargo hands
+//! each of them the workspace lint set. It was red when this file was written
+//! — six crates had never typed the stanza, and the exemption was spelled as
+//! an absence, so nothing warned and nothing failed — and the commits that
+//! followed cleared it, five of the six in one and `beta` in the next.
 //!
 //! Every other test is a mutation test. A guard that cannot fail is worse than
 //! no guard, because "clean" and "I never looked" print identically. So each
@@ -31,10 +33,10 @@ const COMPLIANT: &str = "[lints]\nworkspace = true\n";
 /// Opting *out* explicitly. Reads like a lint declaration, inherits nothing.
 const OPTED_OUT: &str = "[lints]\nworkspace = false\n";
 
-/// A `[lints.clippy]` table with no `workspace` key. This is the exact shape of
-/// the six real offenders in this repo: the manifest mentions lints, so a
-/// grep for "lints" calls it clean, while cargo hands it none of the workspace
-/// set.
+/// A `[lints.clippy]` table with no `workspace` key. This was the exact shape
+/// of the six offenders this guard found in this repo: the manifest mentions
+/// lints, so a grep for "lints" calls it clean, while cargo hands it none of
+/// the workspace set.
 const CLIPPY_ONLY: &str = "[lints.clippy]\npedantic = { level = \"warn\", priority = -1 }\n";
 
 /// Absolute, canonical path to this repository's root, derived from the crate
@@ -105,7 +107,8 @@ fn offenders(report: &Report) -> Vec<PathBuf> {
 // The real repository
 // ---------------------------------------------------------------------------
 
-/// The guard, pointed at this repo. Red until the offending crates opt in.
+/// The guard, pointed at this repo: every member inherits the workspace lint
+/// set.
 ///
 /// The member-count assertion runs first on purpose: a guard that examined zero
 /// crates would report "compliant" for entirely the wrong reason, and that
@@ -168,9 +171,9 @@ fn member_that_opts_out_explicitly_is_flagged() {
     );
 }
 
-/// A `[lints.clippy]` table with no `workspace = true` key is flagged. This is
-/// the shape of every real offender in this repo, and the shape a naive "does
-/// the manifest mention lints?" check would wave through.
+/// A `[lints.clippy]` table with no `workspace = true` key is flagged. This was
+/// the shape of every offender this guard found here, and it is the shape a
+/// naive "does the manifest mention lints?" check would wave through.
 #[test]
 fn member_with_only_a_clippy_lints_table_is_flagged() {
     let ws = synthetic_workspace("[\"crates/*\"]");

--- a/src/repo-guards/tests/workspace_lint_inheritance.rs
+++ b/src/repo-guards/tests/workspace_lint_inheritance.rs
@@ -268,6 +268,47 @@ fn excluded_members_are_not_audited() {
     );
 }
 
+/// A glob written in `workspace.exclude` must not remove anything, because
+/// cargo does not glob-expand `exclude` — it prefix-matches the entries as
+/// *literal* paths.
+///
+/// Verified against cargo itself: a workspace whose root declares
+/// `members = ["crates/*"]` and `exclude = ["crates/b*"]` still lists
+/// `crates/bad` in `cargo metadata --no-deps`, because no directory is
+/// literally named `crates/b*`. So `crates/bad` is a member, cargo builds it,
+/// and the guard must audit it.
+///
+/// A guard that glob-expanded `exclude` instead would audit strictly *fewer*
+/// crates than cargo builds, and the crate that slipped out could omit the
+/// stanza forever while the guard kept reporting clean. That is the false-green
+/// direction this module refuses everywhere else — it is why a *member* pattern
+/// matching nothing is a hard error — and it must not sneak back in through
+/// `exclude`.
+#[test]
+fn a_glob_in_exclude_does_not_shrink_the_audited_set() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "good", COMPLIANT);
+    write_member(ws.path(), "bad", CLIPPY_ONLY);
+    write_root_manifest(
+        ws.path(),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/*\"]\nexclude = [\"crates/b*\"]\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        report.members_examined(),
+        2,
+        "cargo treats `crates/b*` literally, so both crates are still members; got:\n{report}"
+    );
+    assert_eq!(
+        offenders(&report),
+        vec![PathBuf::from("crates/bad/Cargo.toml")],
+        "a glob in `exclude` excludes nothing, so the non-compliant member must \
+         still be flagged; got:\n{report}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Display: the message has to be usable without opening the source
 // ---------------------------------------------------------------------------

--- a/src/repo-guards/tests/workspace_lint_inheritance.rs
+++ b/src/repo-guards/tests/workspace_lint_inheritance.rs
@@ -1,0 +1,484 @@
+//! Guard tests for `repo_guards::workspace_lints::audit`.
+//!
+//! The headline test — [`every_workspace_member_inherits_the_workspace_lints`]
+//! — runs the audit against this repository and **fails today by design**. Six
+//! member crates never opted into the workspace lint set, so they are silently
+//! exempt from `[workspace.lints.*]`. That red is the point of this commit; the
+//! following commits clear it.
+//!
+//! Every other test is a mutation test. A guard that cannot fail is worse than
+//! no guard, because "clean" and "I never looked" print identically. So each
+//! non-compliant shape is built as a real workspace on disk and fed to the real
+//! `audit()` — enumeration and checking together, not a string predicate in
+//! isolation — and each fail-closed condition is asserted to produce an `Err`
+//! rather than a clean verdict.
+//!
+//! Parallel safety: this workspace's tests share `./target` with the pre-commit
+//! hook's own `cargo test`, so two copies of any test here can run at the same
+//! moment. Every fixture lives in its own `tempfile::TempDir`, whose name the
+//! OS makes unique; nothing is keyed on a fixed path under the temp dir, the
+//! repo, or the home dir.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use repo_guards::workspace_lints::{self, Report, WorkspaceLintsError};
+use tempfile::TempDir;
+
+/// The stanza a compliant member carries.
+const COMPLIANT: &str = "[lints]\nworkspace = true\n";
+
+/// Opting *out* explicitly. Reads like a lint declaration, inherits nothing.
+const OPTED_OUT: &str = "[lints]\nworkspace = false\n";
+
+/// A `[lints.clippy]` table with no `workspace` key. This is the exact shape of
+/// the six real offenders in this repo: the manifest mentions lints, so a
+/// grep for "lints" calls it clean, while cargo hands it none of the workspace
+/// set.
+const CLIPPY_ONLY: &str = "[lints.clippy]\npedantic = { level = \"warn\", priority = -1 }\n";
+
+/// Absolute, canonical path to this repository's root, derived from the crate
+/// being compiled rather than the working directory (which `cargo test` does
+/// not pin).
+fn repo_root() -> PathBuf {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    fs::canonicalize(&root)
+        .unwrap_or_else(|e| panic!("cannot canonicalize repo root {}: {e}", root.display()))
+}
+
+/// Create a throwaway workspace root whose `workspace.members` is exactly
+/// `members_array`, written verbatim as TOML (e.g. `["crates/*"]`).
+fn synthetic_workspace(members_array: &str) -> TempDir {
+    let dir = TempDir::new().expect("create fixture workspace dir");
+    write_root_manifest(
+        dir.path(),
+        &format!("[workspace]\nresolver = \"2\"\nmembers = {members_array}\n"),
+    );
+    dir
+}
+
+/// Overwrite the root manifest of `root` with `contents`.
+fn write_root_manifest(root: &Path, contents: &str) {
+    fs::write(root.join("Cargo.toml"), contents).expect("write fixture root manifest");
+}
+
+/// Create `crates/<name>/Cargo.toml` under `root`, appending `lints_stanza`
+/// verbatim after the `[package]` table.
+fn write_member(root: &Path, name: &str, lints_stanza: &str) {
+    let dir = root.join("crates").join(name);
+    fs::create_dir_all(&dir).expect("create fixture member dir");
+    fs::write(
+        dir.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n{lints_stanza}"
+        ),
+    )
+    .expect("write fixture member manifest");
+}
+
+/// Run the audit against a fixture and require a verdict (not an error).
+fn audit_fixture(dir: &TempDir) -> Report {
+    workspace_lints::audit(dir.path()).expect("audit the fixture workspace")
+}
+
+/// Run the audit against a fixture and require a refusal. Returning the error
+/// lets a caller assert on the variant; the assertion message renders the
+/// *report* when one came back, so a fail-closed regression says what the guard
+/// wrongly concluded instead of just "expected Err".
+fn audit_must_refuse(dir: &TempDir) -> WorkspaceLintsError {
+    match workspace_lints::audit(dir.path()) {
+        Err(e) => e,
+        Ok(report) => panic!(
+            "audit should have refused this workspace, but returned a verdict:\n{report}\n\
+             (compliant = {})",
+            report.is_compliant()
+        ),
+    }
+}
+
+/// Convenience: the offender list as comparable paths.
+fn offenders(report: &Report) -> Vec<PathBuf> {
+    report.offenders().to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// The real repository
+// ---------------------------------------------------------------------------
+
+/// The guard, pointed at this repo. Red until the offending crates opt in.
+///
+/// The member-count assertion runs first on purpose: a guard that examined zero
+/// crates would report "compliant" for entirely the wrong reason, and that
+/// false green is the failure mode this whole file exists to prevent.
+#[test]
+fn every_workspace_member_inherits_the_workspace_lints() {
+    let report = workspace_lints::audit(&repo_root()).expect("audit the workspace");
+
+    assert!(
+        report.members_examined() > 0,
+        "the audit examined zero workspace members; a guard that scans nothing \
+         reports clean for the wrong reason"
+    );
+    assert!(report.is_compliant(), "{report}");
+}
+
+// ---------------------------------------------------------------------------
+// Mutation tests: prove the guard fires on each non-compliant shape
+// ---------------------------------------------------------------------------
+
+/// A member with no `[lints]` table at all is flagged, and its compliant
+/// neighbour is not.
+#[test]
+fn member_without_a_lints_table_is_flagged() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "compliant", COMPLIANT);
+    write_member(ws.path(), "bare", "");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        !report.is_compliant(),
+        "a member with no [lints] table must be flagged, but the audit reported clean"
+    );
+    assert_eq!(
+        offenders(&report),
+        vec![PathBuf::from("crates/bare/Cargo.toml")],
+        "exactly the non-compliant member should be named"
+    );
+    assert_eq!(
+        report.members_examined(),
+        2,
+        "both members should have been examined"
+    );
+}
+
+/// `[lints] workspace = false` is an explicit opt-*out*, not inheritance.
+#[test]
+fn member_that_opts_out_explicitly_is_flagged() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "compliant", COMPLIANT);
+    write_member(ws.path(), "optedout", OPTED_OUT);
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![PathBuf::from("crates/optedout/Cargo.toml")],
+        "`workspace = false` must be flagged; it inherits nothing"
+    );
+}
+
+/// A `[lints.clippy]` table with no `workspace = true` key is flagged. This is
+/// the shape of every real offender in this repo, and the shape a naive "does
+/// the manifest mention lints?" check would wave through.
+#[test]
+fn member_with_only_a_clippy_lints_table_is_flagged() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "compliant", COMPLIANT);
+    write_member(ws.path(), "clippyonly", CLIPPY_ONLY);
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![PathBuf::from("crates/clippyonly/Cargo.toml")],
+        "a [lints.clippy] table without `workspace = true` inherits nothing"
+    );
+}
+
+/// An all-compliant workspace comes back clean. Without this, every assertion
+/// above would still pass for a guard that flags everything unconditionally.
+#[test]
+fn fully_compliant_workspace_is_clean() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "first", COMPLIANT);
+    write_member(ws.path(), "second", COMPLIANT);
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "a fully compliant workspace must be clean, got:\n{report}"
+    );
+    assert!(report.offenders().is_empty(), "no member should be named");
+    assert_eq!(report.members_examined(), 2);
+}
+
+/// The inline spelling `lints = { workspace = true }` is the same declaration
+/// as the `[lints]` table, and the parser sees that for free. A regex tuned to
+/// the table form would report this crate as an offender — a false positive
+/// that would push someone toward "just allowlist it".
+#[test]
+fn inline_lints_table_counts_as_inheritance() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    let dir = ws.path().join("crates").join("inline");
+    fs::create_dir_all(&dir).expect("create fixture member dir");
+    fs::write(
+        dir.join("Cargo.toml"),
+        "lints = { workspace = true }\n\n[package]\nname = \"inline\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write fixture member manifest");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "the inline lints table is the same declaration as [lints]; got:\n{report}"
+    );
+}
+
+/// A single literal (glob-free) member path is enumerated like any other.
+#[test]
+fn literal_member_paths_are_audited() {
+    let ws = synthetic_workspace("[\"crates/only\"]");
+    write_member(ws.path(), "only", CLIPPY_ONLY);
+
+    let report = audit_fixture(&ws);
+
+    assert_eq!(
+        offenders(&report),
+        vec![PathBuf::from("crates/only/Cargo.toml")],
+        "a literal member path must be audited, not just glob patterns"
+    );
+}
+
+/// `workspace.exclude` is honored: a non-compliant crate that cargo does not
+/// treat as a member must not be reported. Ignoring `exclude` would produce a
+/// confusing false positive the first time this repo excludes anything.
+#[test]
+fn excluded_members_are_not_audited() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "compliant", COMPLIANT);
+    write_member(ws.path(), "vendored", CLIPPY_ONLY);
+    write_root_manifest(
+        ws.path(),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/*\"]\nexclude = [\"crates/vendored\"]\n",
+    );
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "an excluded crate is not a workspace member and must not be flagged; got:\n{report}"
+    );
+    assert_eq!(
+        report.members_examined(),
+        1,
+        "only the non-excluded member should have been examined"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Display: the message has to be usable without opening the source
+// ---------------------------------------------------------------------------
+
+/// The failure text names the offending manifest and carries the exact stanza
+/// to paste. Formatting lives in `Report`, not at the call site, so this is
+/// where it is pinned.
+#[test]
+fn failure_message_names_the_offender_and_the_stanza() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "newtool", "");
+
+    let rendered = audit_fixture(&ws).to_string();
+
+    assert!(
+        rendered.contains("crates/newtool/Cargo.toml is missing workspace lint inheritance."),
+        "the message must name the offending manifest, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("    [lints]\n    workspace = true"),
+        "the message must show the stanza to paste, got:\n{rendered}"
+    );
+}
+
+/// A clean audit says so, and says how much it looked at — so a passing CI log
+/// distinguishes "checked 73 crates" from "checked nothing".
+#[test]
+fn clean_message_reports_the_member_count() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "only", COMPLIANT);
+
+    let rendered = audit_fixture(&ws).to_string();
+
+    assert!(
+        rendered.contains("Checked 1 workspace members; all inherit the workspace lint set."),
+        "a clean report should state the member count, got:\n{rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail closed: none of these may yield a clean verdict
+// ---------------------------------------------------------------------------
+
+/// No root manifest at all.
+#[test]
+fn missing_root_manifest_refuses() {
+    let dir = TempDir::new().expect("create fixture dir");
+
+    assert!(
+        matches!(
+            workspace_lints::audit(dir.path()),
+            Err(WorkspaceLintsError::ReadManifest { .. })
+        ),
+        "a missing root manifest must be an error, not a clean workspace"
+    );
+}
+
+/// A root manifest that is not valid TOML.
+#[test]
+fn unparsable_root_manifest_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_root_manifest(ws.path(), "[workspace\nmembers = oops");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::ParseManifest { .. }
+        ),
+        "an unparsable root manifest must be an error"
+    );
+}
+
+/// A root manifest with no `workspace.members` key.
+#[test]
+fn missing_members_key_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_root_manifest(ws.path(), "[workspace]\nresolver = \"2\"\n");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::NoMembersKey { .. }
+        ),
+        "a root manifest without `workspace.members` must be an error"
+    );
+}
+
+/// An empty `members` array. Nothing to audit is not the same as nothing wrong.
+#[test]
+fn empty_members_list_refuses() {
+    let ws = synthetic_workspace("[]");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::EmptyMembers { .. }
+        ),
+        "an empty `workspace.members` must be an error"
+    );
+}
+
+/// A member pattern that matches nothing. A typo here would silently shrink the
+/// audited set — the guard would keep passing while covering fewer crates.
+#[test]
+fn member_pattern_matching_nothing_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\", \"crtaes/*\"]");
+    write_member(ws.path(), "real", COMPLIANT);
+
+    let error = audit_must_refuse(&ws);
+
+    assert!(
+        matches!(
+            &error,
+            WorkspaceLintsError::PatternMatchedNothing { pattern } if pattern == "crtaes/*"
+        ),
+        "a member pattern matching nothing must be an error naming the pattern, got: {error}"
+    );
+}
+
+/// A member directory with no `Cargo.toml`. Cargo itself refuses to load such a
+/// workspace, so silently skipping it would let the guard disagree with the
+/// build about which crates exist.
+#[test]
+fn member_directory_without_a_manifest_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "real", COMPLIANT);
+    fs::create_dir_all(ws.path().join("crates").join("empty")).expect("create manifest-less dir");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::MissingMemberManifest { .. }
+        ),
+        "a member directory without a manifest must be an error"
+    );
+}
+
+/// A member manifest that is not valid TOML. Unreadable is not compliant.
+#[test]
+fn unparsable_member_manifest_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "broken", COMPLIANT);
+    fs::write(
+        ws.path().join("crates").join("broken").join("Cargo.toml"),
+        "[package\nname = ",
+    )
+    .expect("overwrite member manifest with invalid TOML");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::ParseManifest { .. }
+        ),
+        "an unparsable member manifest must be an error, never a pass"
+    );
+}
+
+/// Every member excluded leaves nothing to audit — which must refuse rather
+/// than report a vacuously clean workspace.
+#[test]
+fn excluding_every_member_refuses() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "only", CLIPPY_ONLY);
+    write_root_manifest(
+        ws.path(),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/*\"]\nexclude = [\"crates/only\"]\n",
+    );
+
+    assert!(
+        matches!(audit_must_refuse(&ws), WorkspaceLintsError::NoMembersRemain),
+        "excluding every member must be an error, not a clean verdict"
+    );
+}
+
+/// A non-string entry in `workspace.members`.
+#[test]
+fn non_string_member_entry_refuses() {
+    let ws = synthetic_workspace("[42]");
+
+    assert!(
+        matches!(
+            audit_must_refuse(&ws),
+            WorkspaceLintsError::NonStringEntry { key: "members", .. }
+        ),
+        "a non-string `workspace.members` entry must be an error"
+    );
+}
+
+/// Stray files beside the crate directories are ignored, exactly as cargo
+/// ignores them. Without this, a Finder-dropped `.DS_Store` would take the
+/// whole guard down with a `MissingMemberManifest` refusal.
+#[test]
+fn stray_files_beside_members_are_not_members() {
+    let ws = synthetic_workspace("[\"crates/*\"]");
+    write_member(ws.path(), "real", COMPLIANT);
+    fs::write(
+        ws.path().join("crates").join("README.md"),
+        "# not a crate\n",
+    )
+    .expect("write stray file");
+    fs::write(ws.path().join("crates").join(".DS_Store"), "junk").expect("write stray dotfile");
+
+    let report = audit_fixture(&ws);
+
+    assert!(
+        report.is_compliant(),
+        "stray files are not members; got:\n{report}"
+    );
+    assert_eq!(
+        report.members_examined(),
+        1,
+        "only the real crate directory should count as a member"
+    );
+}

--- a/src/shellsetup/Cargo.toml
+++ b/src/shellsetup/Cargo.toml
@@ -10,15 +10,5 @@ colored.workspace = true
 dirs.workspace = true
 thiserror.workspace = true
 
-[lints.rust]
-# Enforce stricter checks to catch issues early
-unsafe_code = "deny"
-
-[lints.clippy]
-# Pedantic lints help catch subtle issues
-pedantic = { level = "warn", priority = -1 }
-# Allow certain pedantic lints that are too strict for this codebase
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
+[lints]
+workspace = true

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -1,7 +1,4 @@
-// These lints are stricter than the inherited `[workspace.lints]` set. They live
-// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
-// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
-// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -214,6 +214,20 @@ impl ShellIntegration {
     /// 2. Finds the appropriate config file
     /// 3. Checks for existing installation
     /// 4. Either installs fresh, upgrades old installation, or updates existing
+    ///
+    /// # Errors
+    ///
+    /// - [`ShellSetupError::NoHomeDir`] when the home directory cannot be determined,
+    ///   so there is no config file to locate.
+    /// - [`ShellSetupError::UnsupportedShell`] when `$SHELL` names something other than
+    ///   bash or zsh. The error carries the block to add by hand.
+    /// - [`ShellSetupError::YadmAmbiguousConfig`] when the config file is yadm-managed
+    ///   with alternates this library cannot choose between, so writing anywhere would
+    ///   either be discarded on the next render or edit the wrong template.
+    /// - [`ShellSetupError::ReadError`] when an existing config file cannot be read
+    ///   while checking for a previous installation.
+    /// - [`ShellSetupError::WriteError`] when the config file cannot be opened for
+    ///   append or written back after the block is replaced or upgraded.
     pub fn setup(&self) -> Result<()> {
         let home = dirs::home_dir().ok_or(ShellSetupError::NoHomeDir)?;
 
@@ -1333,7 +1347,7 @@ function prmv() { OLD_PRCP; }
 
         assert_eq!(
             resolve_config_target(&rc),
-            ConfigTarget::YadmTemplate(template.clone())
+            ConfigTarget::YadmTemplate(template)
         );
 
         fs::remove_dir_all(&dir).ok();

--- a/src/shellsetup/src/lib.rs
+++ b/src/shellsetup/src/lib.rs
@@ -1,3 +1,18 @@
+// These lints are stricter than the inherited `[workspace.lints]` set. They live
+// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
+// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
+// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "the public surface deliberately repeats the crate name (ShellIntegration, ShellCommand, ShellSetupError) so callers read `shellsetup::ShellIntegration` and plain `ShellIntegration` the same way"
+)]
+#![allow(
+    clippy::must_use_candidate,
+    reason = "the builder methods are consumed by chaining at every call site; marking each one #[must_use] would document nothing a reader does not already see"
+)]
+
 //! Shell integration library for adding tool functions to shell config files.
 //!
 //! This library provides a standardized way to add shell functions and aliases

--- a/src/tsm-id/Cargo.toml
+++ b/src/tsm-id/Cargo.toml
@@ -14,12 +14,5 @@ thiserror.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
+[lints]
+workspace = true

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -51,6 +51,15 @@ impl SessionId {
     /// The input must be exactly 32 characters long and consist solely of
     /// lowercase hex characters (`0-9`, `a-f`). Uppercase hex is rejected
     /// to keep the canonical representation unambiguous.
+    ///
+    /// # Errors
+    ///
+    /// - [`SessionIdError::WrongLength`] when `s` is not exactly 32 characters,
+    ///   reporting both the expected and the actual count.
+    /// - [`SessionIdError::UppercaseHex`] when `s` is the right length but holds an
+    ///   `A`-`F`, naming the offending character.
+    /// - [`SessionIdError::NonHexCharacter`] when `s` holds any other character
+    ///   outside `[0-9a-f]`, naming the offending character.
     pub fn from_hex(s: &str) -> Result<Self, SessionIdError> {
         let actual = s.chars().count();
         if actual != SESSION_ID_HEX_LEN {

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -1,3 +1,18 @@
+// These lints are stricter than the inherited `[workspace.lints]` set. They live
+// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
+// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
+// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "SessionIdError keeps the SessionId prefix so a reader of Result<SessionId, SessionIdError> sees at a glance which type failed to build"
+)]
+#![allow(
+    clippy::must_use_candidate,
+    reason = "random, from_hex and as_hex are called for their result at every site; #[must_use] on each would restate the signature without catching a bug"
+)]
+
 //! Session ID type for tsm.
 //!
 //! A [`SessionId`] is a 128-bit identifier represented as exactly 32 lowercase

--- a/src/tsm-id/src/lib.rs
+++ b/src/tsm-id/src/lib.rs
@@ -1,7 +1,4 @@
-// These lints are stricter than the inherited `[workspace.lints]` set. They live
-// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
-// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
-// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(

--- a/src/tsm-jsonl/Cargo.toml
+++ b/src/tsm-jsonl/Cargo.toml
@@ -13,12 +13,5 @@ thiserror.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
-[lints.rust]
-unsafe_code = "deny"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
+[lints]
+workspace = true

--- a/src/tsm-jsonl/src/lib.rs
+++ b/src/tsm-jsonl/src/lib.rs
@@ -1,7 +1,4 @@
-// These lints are stricter than the inherited `[workspace.lints]` set. They live
-// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
-// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
-// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(

--- a/src/tsm-jsonl/src/lib.rs
+++ b/src/tsm-jsonl/src/lib.rs
@@ -1,3 +1,18 @@
+// These lints are stricter than the inherited `[workspace.lints]` set. They live
+// here rather than in Cargo.toml because cargo refuses to merge a local `[lints]`
+// table with `lints.workspace = true`, and inheritance is mandatory (see the guard
+// in src/repo-guards). Crate-root attributes only ADD to the inherited set.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "HeaderKind and PrecmdKind keep the prefix of the record they discriminate, which is what makes each pairing readable at a glance"
+)]
+#![allow(
+    clippy::must_use_candidate,
+    reason = "the public functions return Result, which is already #[must_use]; the record types expose plain fields rather than getters, so the lint has nothing left to mark"
+)]
+
 //! Header-first JSONL append and read for tsm session log files.
 //!
 //! A tsm session log file `<session-id>.jsonl` has this structure:


### PR DESCRIPTION
Closes #337.

A crate that does not write `[lints] workspace = true` gets no workspace lints, and
nothing said so. The crate stays green because the rules never applied to it.

This branch adds a `repo-guards` check that parses every workspace member manifest
and fails when the member does not inherit the workspace lints. The guard reads the
member list from the workspace manifest, so a new crate is covered on the day it is
added.

Eight crates did not inherit the lints. This branch makes them inherit the lints and
clears the fallout, which includes a UTF-8 truncation defect in `cwt`:
`display_branch` cut a detached HEAD by bytes and thus panicked on a multi-byte
character. The red test for that defect came first.

The lint set that the workspace carries is not the full set that some crates had
before, so the last commit restores the strictness those crates lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
