### PR TITLE
feat(cwt): wtm climbs out of a main worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1374,6 +1374,29 @@ the main worktree.
 If your repository has neither branch checked out, `cwt -m` lists the worktrees and exits
 with code 3.
 
+#### Pressing it again climbs out
+
+When you already stand in the main worktree, you have asked to go up. So the next `wtm`
+takes you to the main worktree of the repository that **holds** yours, and the one after
+that goes up again, for as deep as the repositories are nested:
+
+```bash
+cd keyboards/zmk-config-corne-worktrees/guard-the-commit-hashes-in-prose
+wtm   # -> keyboards/zmk-config-corne        the repository's own main worktree
+wtm   # -> keyboards                         the repository that holds it
+wtm   # Error: No repository above /code/keyboards has a main worktree
+```
+
+The climb is measured from where your repository **sits on disk** — its own main worktree —
+never from the worktree you happen to stand in. That is what keeps the first `wtm` above
+from skipping `zmk-config-corne` and landing on `keyboards`.
+
+Only the directory directly above counts, the same one level the family scan looks down. A
+repository on the way with neither `main` nor `master` cannot be a destination, so the
+climb steps over it and asks the repository above it. When nothing above has a main
+worktree, `cwt -m` says so and exits with code 3. `--no-family` does not change any of
+this: it says which repositories the **listing** shows, and the climb is not a listing.
+
 ### Families of Repositories
 
 Some repositories are containers. They track the map of a workspace, and the real
@@ -1426,7 +1449,8 @@ A name is offered to each repository in turn, nearest first:
 2. The parent repository the family is anchored at
 3. Every other repository in the family
 
-So `wtm` still means "my repository's main branch" wherever you are standing. Within
+So `wtm` still means "my repository's main branch" wherever you are standing — and,
+once you are standing in it, the repository above that. Within
 each repository the order is the same as before: exact directory name, then exact
 branch name, then a case-insensitive substring of a branch name. An exact name
 anywhere in the family beats a substring anywhere.
@@ -1510,7 +1534,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt --main'  # Main worktree (branch main, or master)
+alias wtm='wt --main'  # Main worktree, or a level up when you are in it
 ```
 
 #### Fish (~/.config/fish/config.fish)
@@ -1530,7 +1554,7 @@ end
 # Quick navigation aliases
 alias wtf 'wt -f'  # Next worktree
 alias wtb 'wt -p'  # Previous worktree (back)
-alias wtm 'wt --main'  # Main worktree (branch main, or master)
+alias wtm 'wt --main'  # Main worktree, or a level up when you are in it
 ```
 
 ### Examples
@@ -1554,7 +1578,7 @@ Jump to specific worktree:
 wt main           # By branch name
 wt absurd-rock    # By directory name
 wt vial-qmk:vial  # By repository and branch name
-wtm               # Quick alias for the main worktree (branch main, or master)
+wtm               # The main worktree, or a level up when you are in it
 ```
 
 ### Exit Codes

--- a/README.md
+++ b/README.md
@@ -1376,15 +1376,26 @@ with code 3.
 
 #### Pressing it again climbs out
 
-When you already stand in the main worktree, you have asked to go up. So the next `wtm`
-takes you to the main worktree of the repository that **holds** yours, and the one after
-that goes up again, for as deep as the repositories are nested:
+When the directory you are in **is** the main worktree, you have asked to go up. So the
+next `wtm` takes you to the main worktree of the repository that **holds** yours, and the
+one after that goes up again, for as deep as the repositories are nested:
 
 ```bash
 cd keyboards/zmk-config-corne-worktrees/guard-the-commit-hashes-in-prose
 wtm   # -> keyboards/zmk-config-corne        the repository's own main worktree
 wtm   # -> keyboards                         the repository that holds it
 wtm   # Error: No repository above /code/keyboards has a main worktree
+```
+
+It is the directory you stand in that decides, not the worktree that holds you. From a
+subdirectory of the main worktree — `zmk-config-corne/config`, say — `wtm` takes you to the
+top of it, exactly as it does from a subdirectory of any other worktree. Only the top of
+the main worktree has anywhere left to go, so that is the only place the climb starts:
+
+```bash
+cd keyboards/zmk-config-corne/config
+wtm   # -> keyboards/zmk-config-corne        the top of the worktree you are in
+wtm   # -> keyboards                         now the climb starts
 ```
 
 The climb is measured from where your repository **sits on disk** — its own main worktree —
@@ -1534,7 +1545,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt --main'  # Main worktree, or a level up when you are in it
+alias wtm='wt --main'  # Main worktree, or a level up when you are at its root
 ```
 
 #### Fish (~/.config/fish/config.fish)
@@ -1554,7 +1565,7 @@ end
 # Quick navigation aliases
 alias wtf 'wt -f'  # Next worktree
 alias wtb 'wt -p'  # Previous worktree (back)
-alias wtm 'wt --main'  # Main worktree, or a level up when you are in it
+alias wtm 'wt --main'  # Main worktree, or a level up when you are at its root
 ```
 
 ### Examples
@@ -1578,7 +1589,7 @@ Jump to specific worktree:
 wt main           # By branch name
 wt absurd-rock    # By directory name
 wt vial-qmk:vial  # By repository and branch name
-wtm               # The main worktree, or a level up when you are in it
+wtm               # The main worktree, or a level up when you are at its root
 ```
 
 ### Exit Codes

--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,7 @@ Navigate between the git worktrees of a repository and of the repositories insid
 cwt                           # Show list of worktrees with current highlighted
 cwt -f                        # Go to next worktree (wraps around)
 cwt -p                        # Go to previous worktree (wraps around)
-cwt -m                        # Go to the main worktree
+cwt -m                        # Go to the main worktree, or up a level when you are at its root
 cwt main                      # Go to worktree by branch name
 cwt absurd-rock               # Go to worktree by directory name
 cwt vial-qmk:vial             # Go to one repository's worktree by name
@@ -1363,8 +1363,9 @@ cwt vial-qmk:vial             # Go to one repository's worktree by name
 `main`, it goes to the worktree on branch `master`, so a repository that never renamed its
 first branch gets the same shortcut.
 
-In a family, `cwt -m` stays in the repository you are standing in. Every repository of a
-family has a main worktree of its own, and the shortcut takes you to yours.
+In a family, `cwt -m` stays in the repository you are standing in until you are already at
+the top of its main worktree. Every repository of a family has a main worktree of its own,
+and the shortcut takes you to yours.
 
 The branch name must match exactly. This is what separates `cwt -m` from `cwt main`, which
 also substring-matches: in a `master` repository, `cwt main` lands on a branch such as

--- a/TLDR.md
+++ b/TLDR.md
@@ -13,7 +13,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `claude-usage` | Parses an Anthropic API usage CSV and computes per-model costs. |
 | `clipboard-random` | Generates random binary or Zalgo text data and copies it to the clipboard. |
 | `crap` | Claude, Resume Anywhere Please — resume a Claude Code session from its original directory (refuses if it's already running, or if that directory is gone or unenterable — pointing you at `--here` to fork where you stand); if the id belongs to another account it's found automatically (self-first), or target one with `--user` (which errors and lists the real accounts if you name one that never ran Claude); owner-only project dirs are skipped, then named in the miss with copy-paste recovery commands — it never runs `sudo` itself; `--status <id>` reports where a session left off without resuming, with the same `--user`/self-first cross-user discovery but read-only (no copy, no fork). |
-| `cwt` | Change Worktree — navigate, cycle, or jump between the git worktrees of a repository and of the repositories inside it. |
+| `cwt` | Change Worktree — navigate, cycle, or jump between the git worktrees of a repository and of the repositories inside it. `wtm` goes to your main worktree, and from there climbs to the repository that holds yours. |
 | `dirc` | Copies the current directory to the clipboard, or emits a `cd` from a clipboard path. |
 | `dirhash` | SHA256 hash of a directory tree's contents to compare directories for equality. |
 | `diskhog` | Live terminal UI of per-process disk I/O on macOS (IOPS with sudo). |

--- a/src/cwt/src/ascent.rs
+++ b/src/cwt/src/ascent.rs
@@ -110,6 +110,8 @@ fn climb_with(from: &Path, list: impl Fn(&Path) -> Option<RepoWorktrees>) -> Opt
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
 
     /// One worktree at `path`, with `branch` checked out.
@@ -118,6 +120,49 @@ mod tests {
             path: PathBuf::from(path),
             head: "abc1234567890".to_string(),
             branch: branch.map(str::to_string),
+        }
+    }
+
+    /// One rung of a synthetic ladder: the repository whose main worktree sits
+    /// at `main`, holding one worktree per entry of `worktrees`.
+    fn rung(main: &str, worktrees: &[(&str, Option<&str>)]) -> RepoWorktrees {
+        RepoWorktrees {
+            main: PathBuf::from(main),
+            all: worktrees
+                .iter()
+                .map(|(path, branch)| worktree(path, *branch))
+                .collect(),
+        }
+    }
+
+    /// How many listings a climb over a synthetic ladder may ask for before the
+    /// test calls it a runaway. Every ladder here is a few rungs long, so this
+    /// sits far above a healthy climb and far below a hang.
+    const LOOKUP_LIMIT: usize = 32;
+
+    /// A reader over the synthetic ladder `rungs`, which pairs a directory with
+    /// the repository checked out there. A directory no rung names is off the
+    /// ladder, and the climb ends there.
+    ///
+    /// It counts its calls and panics past [`LOOKUP_LIMIT`]. That bound is what
+    /// turns a broken cycle guard into a loud, fast test failure instead of a
+    /// hang that takes the whole suite with it.
+    fn ladder<'a>(
+        rungs: &'a [(&'a str, RepoWorktrees)],
+        lookups: &'a Cell<usize>,
+    ) -> impl Fn(&Path) -> Option<RepoWorktrees> + 'a {
+        move |dir| {
+            lookups.set(lookups.get() + 1);
+            assert!(
+                lookups.get() <= LOOKUP_LIMIT,
+                "the climb asked for {} listings over a ladder of {} rungs, so it is not terminating",
+                lookups.get(),
+                rungs.len()
+            );
+            rungs
+                .iter()
+                .find(|(at, _)| Path::new(at) == dir)
+                .map(|(_, repo)| repo.clone())
         }
     }
 
@@ -198,8 +243,143 @@ mod tests {
 
     #[test]
     fn the_climb_stops_at_a_directory_that_is_not_a_checkout() {
-        let root = std::env::temp_dir();
-        let repo = root.join("no-parent-checkout-should-exist-here");
+        // The directory above the one the climb starts from is one this test
+        // just made and owns, so the answer says something about the climb
+        // rather than about wherever the temporary directory happens to live.
+        let root = tempfile::TempDir::new().expect("a temporary directory to climb out of");
+        let repo = root.path().join("repo");
+        std::fs::create_dir(&repo).expect("a directory for the climb to start from");
         assert_eq!(climb(&repo), None);
+    }
+
+    #[test]
+    fn the_climb_answers_with_the_first_repository_above_that_has_a_main_worktree() {
+        let lookups = Cell::new(0);
+        let rungs = [(
+            "/nest",
+            rung(
+                "/nest/holder",
+                &[
+                    ("/nest/holder", Some("main")),
+                    ("/nest/holder-wt/feature", Some("feature")),
+                ],
+            ),
+        )];
+
+        assert_eq!(
+            climb_with(Path::new("/nest/held"), ladder(&rungs, &lookups)),
+            Some(PathBuf::from("/nest/holder")),
+            "the repository above is on main, so the climb ends at its main worktree"
+        );
+        assert_eq!(
+            lookups.get(),
+            1,
+            "one rung answered, so one listing was read"
+        );
+    }
+
+    #[test]
+    fn the_climb_steps_over_a_repository_with_no_main_branch() {
+        let lookups = Cell::new(0);
+        let rungs = [
+            ("/one/two", rung("/one/two", &[("/one/two", Some("trunk"))])),
+            ("/one", rung("/one", &[("/one", Some("main"))])),
+        ];
+
+        assert_eq!(
+            climb_with(Path::new("/one/two/repo"), ladder(&rungs, &lookups)),
+            Some(PathBuf::from("/one")),
+            "the rung in between is on trunk, so the climb passes through it"
+        );
+    }
+
+    #[test]
+    fn the_climb_stops_when_the_ladder_leads_back_to_where_it_started() {
+        // Two repositories that hold each other. Neither is on a main branch, so
+        // nothing but the record of what has been asked ends this.
+        let lookups = Cell::new(0);
+        let rungs = [
+            (
+                "/tangle/first",
+                rung(
+                    "/tangle/second/repo",
+                    &[("/tangle/second/repo", Some("trunk"))],
+                ),
+            ),
+            (
+                "/tangle/second",
+                rung(
+                    "/tangle/first/repo",
+                    &[("/tangle/first/repo", Some("trunk"))],
+                ),
+            ),
+        ];
+
+        assert_eq!(
+            climb_with(Path::new("/tangle/first/repo"), ladder(&rungs, &lookups)),
+            None,
+            "the second rung names the repository the climb started from"
+        );
+        assert_eq!(
+            lookups.get(),
+            2,
+            "the climb stopped at the rung that repeated, not one rung later"
+        );
+    }
+
+    #[test]
+    fn the_climb_stops_when_the_ladder_revisits_a_repository_it_already_asked() {
+        // The revisited repository is one the climb reached on the way, not the
+        // one it started from, so this is the record the loop itself keeps.
+        let lookups = Cell::new(0);
+        let rungs = [
+            (
+                "/tangle/start",
+                rung(
+                    "/tangle/first/repo",
+                    &[("/tangle/first/repo", Some("trunk"))],
+                ),
+            ),
+            (
+                "/tangle/first",
+                rung(
+                    "/tangle/second/repo",
+                    &[("/tangle/second/repo", Some("trunk"))],
+                ),
+            ),
+            (
+                "/tangle/second",
+                rung(
+                    "/tangle/first/repo",
+                    &[("/tangle/first/repo", Some("trunk"))],
+                ),
+            ),
+        ];
+
+        assert_eq!(
+            climb_with(Path::new("/tangle/start/repo"), ladder(&rungs, &lookups)),
+            None,
+            "the third rung names a repository the climb has already asked"
+        );
+        assert_eq!(
+            lookups.get(),
+            3,
+            "the climb stopped at the rung that repeated, not one rung later"
+        );
+    }
+
+    #[test]
+    fn the_climb_stops_where_the_ladder_ends() {
+        // A directory the reader will not answer for — one that is not a
+        // checkout, or a checkout whose worktrees will not list — ends the
+        // climb rather than being stepped over.
+        let lookups = Cell::new(0);
+        let rungs: [(&str, RepoWorktrees); 0] = [];
+
+        assert_eq!(
+            climb_with(Path::new("/off/the/ladder"), ladder(&rungs, &lookups)),
+            None
+        );
+        assert_eq!(lookups.get(), 1, "the climb asked once and took the answer");
     }
 }

--- a/src/cwt/src/ascent.rs
+++ b/src/cwt/src/ascent.rs
@@ -7,7 +7,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::worktree::{canonical, is_checkout, list_worktrees, paths_equal, Worktree};
+use crate::worktree::{
+    canonical, is_checkout, list_worktrees, paths_equal, RepoWorktrees, Worktree,
+};
 
 /// The branch names that identify the main worktree, in order of priority.
 ///
@@ -59,6 +61,27 @@ fn main_worktree_of(worktrees: &[Worktree]) -> Option<&Worktree> {
 ///
 /// Returns `None` when no repository above `from` has a main worktree.
 pub fn climb(from: &Path) -> Option<PathBuf> {
+    climb_with(from, |dir| {
+        is_checkout(dir).then(|| list_worktrees(dir).ok()).flatten()
+    })
+}
+
+/// The climb itself, over whatever ladder `list` describes.
+///
+/// `list` answers "the repository checked out at this directory", and `None` is
+/// its answer for every directory the climb cannot go on from. That folds two
+/// cases the climb has always treated alike: a directory that is not a checkout
+/// at all, and a checkout whose worktrees will not list. Neither can name a
+/// destination, and the message the caller prints — that no repository above had
+/// a main worktree — is true of both, so one `Option`-returning reader says
+/// exactly what the climb needs to know. The family scan reports an unreadable
+/// repository as a warning because it is missing from a listing the user can
+/// see; here there is no listing.
+///
+/// Taking the reader as an argument is also the only seam a test has: the guard
+/// below ends a climb that revisits a repository, and git will not build the
+/// on-disk tangle that would exercise it.
+fn climb_with(from: &Path, list: impl Fn(&Path) -> Option<RepoWorktrees>) -> Option<PathBuf> {
     // A repository above can be a linked worktree whose own repository sits
     // somewhere else, so the climb is not guaranteed to walk toward the root.
     // Remembering the repositories already asked is what keeps a tangle of
@@ -68,16 +91,7 @@ pub fn climb(from: &Path) -> Option<PathBuf> {
 
     loop {
         let parent = dir.parent()?;
-        if !is_checkout(parent) {
-            return None;
-        }
-
-        // A repository that will not be read ends the climb. The family scan
-        // reports such a repository as a warning because it is missing from a
-        // listing the user can see; here there is no listing, and the message
-        // the caller prints already says no repository above had a main
-        // worktree.
-        let repo = list_worktrees(parent).ok()?;
+        let repo = list(parent)?;
         let key = canonical(&repo.main);
         if asked.iter().any(|seen| paths_equal(seen, &key)) {
             return None;

--- a/src/cwt/src/ascent.rs
+++ b/src/cwt/src/ascent.rs
@@ -1,9 +1,9 @@
 //! The main worktree, and the ladder of them above the one the user stands in.
 //!
-//! `wtm` means "take me to my main worktree". A user who already stands in it
-//! has asked for the next thing up: the repository that holds theirs. This
-//! module owns both halves of that question — which branch names a main
-//! worktree, and how to climb out of one.
+//! `wtm` means "take me to my main worktree". A user whose directory already
+//! is that worktree has asked for the next thing up: the repository that holds
+//! theirs. This module owns both halves of that question — which branch names a
+//! main worktree, and how to climb out of one.
 
 use std::path::{Path, PathBuf};
 

--- a/src/cwt/src/ascent.rs
+++ b/src/cwt/src/ascent.rs
@@ -1,0 +1,191 @@
+//! The main worktree, and the ladder of them above the one the user stands in.
+//!
+//! `wtm` means "take me to my main worktree". A user who already stands in it
+//! has asked for the next thing up: the repository that holds theirs. This
+//! module owns both halves of that question — which branch names a main
+//! worktree, and how to climb out of one.
+
+use std::path::{Path, PathBuf};
+
+use crate::worktree::{canonical, is_checkout, list_worktrees, paths_equal, Worktree};
+
+/// The branch names that identify the main worktree, in order of priority.
+///
+/// `main` comes first. `master` is the fallback for a repository that never
+/// renamed its first branch.
+pub const MAIN_BRANCH_NAMES: [&str; 2] = ["main", "master"];
+
+/// How strongly `branch` claims to be the main branch.
+///
+/// `Some(0)` for the first name of [`MAIN_BRANCH_NAMES`], `Some(1)` for the one
+/// after it, and `None` for a branch that is none of them. A detached worktree
+/// has no branch, so it never claims anything.
+///
+/// The name must match exactly. A substring match is wrong here: in a
+/// repository that has no `main` branch, a branch such as `wt-main-master`
+/// would capture the shortcut and send the user somewhere that is not the main
+/// worktree.
+pub fn main_branch_rank(branch: Option<&str>) -> Option<usize> {
+    let branch = branch?;
+    MAIN_BRANCH_NAMES.iter().position(|name| *name == branch)
+}
+
+/// The main worktree among `worktrees`, or `None` when none of them is on a
+/// main branch.
+fn main_worktree_of(worktrees: &[Worktree]) -> Option<&Worktree> {
+    worktrees
+        .iter()
+        .filter_map(|worktree| {
+            main_branch_rank(worktree.branch.as_deref()).map(|rank| (rank, worktree))
+        })
+        .min_by_key(|(rank, _)| *rank)
+        .map(|(_, worktree)| worktree)
+}
+
+/// The main worktree of the nearest repository above `from`.
+///
+/// `from` is the main worktree of the user's repository — the checkout that
+/// owns the `.git` directory, which is where that repository sits on disk. The
+/// repository that holds it is the one checked out in the directory directly
+/// above, the same one level down that the family scan looks. So the climb goes
+/// repository by repository rather than directory by directory, and the first
+/// directory that is not a checkout ends it.
+///
+/// A repository on the ladder that has no worktree on a main branch cannot be a
+/// destination, so the climb steps over it and asks the repository above it.
+/// This is the one place the rule parts from the first press of `wtm`: a
+/// repository the user chose to stand in owes them an error when it has no main
+/// branch, and a repository they only pass through owes them nothing.
+///
+/// Returns `None` when no repository above `from` has a main worktree.
+pub fn climb(from: &Path) -> Option<PathBuf> {
+    // A repository above can be a linked worktree whose own repository sits
+    // somewhere else, so the climb is not guaranteed to walk toward the root.
+    // Remembering the repositories already asked is what keeps a tangle of
+    // worktrees from looping forever.
+    let mut asked = vec![canonical(from)];
+    let mut dir = from.to_path_buf();
+
+    loop {
+        let parent = dir.parent()?;
+        if !is_checkout(parent) {
+            return None;
+        }
+
+        // A repository that will not be read ends the climb. The family scan
+        // reports such a repository as a warning because it is missing from a
+        // listing the user can see; here there is no listing, and the message
+        // the caller prints already says no repository above had a main
+        // worktree.
+        let repo = list_worktrees(parent).ok()?;
+        let key = canonical(&repo.main);
+        if asked.iter().any(|seen| paths_equal(seen, &key)) {
+            return None;
+        }
+        asked.push(key);
+
+        if let Some(worktree) = main_worktree_of(&repo.all) {
+            return Some(worktree.path.clone());
+        }
+
+        // This repository has no main worktree to offer. Where it sits on disk
+        // is where the climb goes on from.
+        dir = repo.main;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One worktree at `path`, with `branch` checked out.
+    fn worktree(path: &str, branch: Option<&str>) -> Worktree {
+        Worktree {
+            path: PathBuf::from(path),
+            head: "abc1234567890".to_string(),
+            branch: branch.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn main_ranks_ahead_of_master() {
+        assert_eq!(main_branch_rank(Some("main")), Some(0));
+        assert_eq!(main_branch_rank(Some("master")), Some(1));
+    }
+
+    #[test]
+    fn every_name_of_the_constant_is_ranked() {
+        // The ranking is built from the constant, so a name added to it cannot
+        // leave the search behind.
+        for (position, name) in MAIN_BRANCH_NAMES.iter().enumerate() {
+            assert_eq!(
+                main_branch_rank(Some(name)),
+                Some(position),
+                "{name} is in the constant, so it must have a rank"
+            );
+        }
+    }
+
+    #[test]
+    fn a_branch_that_merely_contains_a_main_name_is_not_ranked() {
+        assert_eq!(main_branch_rank(Some("wt-main-master")), None);
+        assert_eq!(main_branch_rank(Some("mainline")), None);
+        assert_eq!(main_branch_rank(Some("Main")), None);
+    }
+
+    #[test]
+    fn a_detached_worktree_is_not_ranked() {
+        assert_eq!(main_branch_rank(None), None);
+    }
+
+    #[test]
+    fn the_main_worktree_of_a_list_prefers_main_over_master() {
+        let worktrees = [
+            worktree("/repo", Some("master")),
+            worktree("/repo-wt/new", Some("main")),
+        ];
+        assert_eq!(
+            main_worktree_of(&worktrees).map(|found| found.path.clone()),
+            Some(PathBuf::from("/repo-wt/new")),
+            "main wins wherever it sits in the list"
+        );
+    }
+
+    #[test]
+    fn the_main_worktree_of_a_list_falls_back_to_master() {
+        let worktrees = [
+            worktree("/repo", Some("trunk")),
+            worktree("/repo-wt/old", Some("master")),
+        ];
+        assert_eq!(
+            main_worktree_of(&worktrees).map(|found| found.path.clone()),
+            Some(PathBuf::from("/repo-wt/old"))
+        );
+    }
+
+    #[test]
+    fn a_list_without_a_main_branch_has_no_main_worktree() {
+        let worktrees = [
+            worktree("/repo", Some("trunk")),
+            worktree("/repo-wt/x", None),
+        ];
+        assert_eq!(
+            main_worktree_of(&worktrees).map(|found| found.path.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn the_climb_stops_where_the_directories_run_out() {
+        // The root of the filesystem has no parent, so the climb has nothing to
+        // ask and must not loop looking for one.
+        assert_eq!(climb(Path::new("/")), None);
+    }
+
+    #[test]
+    fn the_climb_stops_at_a_directory_that_is_not_a_checkout() {
+        let root = std::env::temp_dir();
+        let repo = root.join("no-parent-checkout-should-exist-here");
+        assert_eq!(climb(&repo), None);
+    }
+}

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -32,9 +32,9 @@ pub enum MainTarget {
     /// The repository the user stands in has no worktree on a main branch, so
     /// it has no main worktree to offer.
     NoMainBranch,
-    /// The user already stands in the main worktree, and no repository above
-    /// the one named here has a main worktree either. The path is where that
-    /// repository sits on disk, which is what the climb started from.
+    /// The user's directory is the main worktree itself, and no repository
+    /// above the one named here has a main worktree either. The path is where
+    /// that repository sits on disk, which is what the climb started from.
     AtTheTop(PathBuf),
 }
 
@@ -217,13 +217,23 @@ impl Family {
         })
     }
 
-    /// Where `--main` sends the user.
+    /// Where `--main` sends the user, standing in `cwd`.
     ///
     /// The first answer is the main worktree of the repository the user stands
-    /// in, which [`own_main_worktree`] finds. When the user already stands in
-    /// that worktree, they have asked to go up instead, so the answer becomes
-    /// the main worktree of the repository that holds theirs — see [`climb`],
-    /// which repeats for as deep as the repositories are nested.
+    /// in, which [`own_main_worktree`] finds. That answer holds from anywhere
+    /// inside the repository, a subdirectory of the main worktree included: a
+    /// user below a worktree root asked to be taken to the top of it.
+    ///
+    /// Only a user whose directory *is* the main worktree has asked to go up,
+    /// so the answer becomes the main worktree of the repository that holds
+    /// theirs — see [`climb`], which repeats for as deep as the repositories
+    /// are nested.
+    ///
+    /// That is why `cwd` is asked for rather than the worktree the user is in:
+    /// the whole subtree of the main worktree is "in" it, and the climb belongs
+    /// to one directory of that subtree. A `cwd` that is no worktree — the
+    /// empty path the caller passes when the current directory cannot be read —
+    /// therefore never climbs, and `--main` keeps the meaning it has always had.
     ///
     /// The climb starts at the main worktree of the user's repository, never at
     /// the worktree they stand in. A repository sits on disk where its main
@@ -231,13 +241,14 @@ impl Family {
     /// measured from.
     ///
     /// [`own_main_worktree`]: Family::own_main_worktree
-    pub fn main_worktree(&self) -> MainTarget {
+    pub fn main_worktree(&self, cwd: &Path) -> MainTarget {
         let Some(index) = self.own_main_worktree() else {
             return MainTarget::NoMainBranch;
         };
 
-        if Some(index) != self.current {
-            return MainTarget::Worktree(self.entries[index].worktree.path.clone());
+        let main = self.entries[index].worktree.path.clone();
+        if Some(index) != self.current || !paths_equal(&canonical(cwd), &canonical(&main)) {
+            return MainTarget::Worktree(main);
         }
 
         let home = self.groups[self.entries[index].group].dir.clone();
@@ -903,6 +914,31 @@ mod tests {
             Some(3),
         );
         assert_eq!(whole.own_main_worktree(), Some(2));
+    }
+
+    #[test]
+    fn main_worktree_answers_with_the_main_worktree_from_below_its_root() {
+        // The user is inside the main worktree, not at it. `--main` means "take
+        // me to the top of this worktree" from there, and never a climb out of
+        // the repository.
+        let one = family(vec![("solo", "/repo", "main")], false, Some(0));
+        match one.main_worktree(Path::new("/repo/src/deep")) {
+            MainTarget::Worktree(path) => assert_eq!(path, PathBuf::from("/repo")),
+            other => panic!("Expected the main worktree, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn main_worktree_does_not_climb_when_the_current_directory_is_unknown() {
+        // The caller passes the empty path when the current directory cannot be
+        // read. It is at no worktree, so the answer stays the one `--main` gave
+        // before the climb existed: a directory that cannot be identified must
+        // never be taken for the root of the main worktree.
+        let one = family(vec![("solo", "/repo", "main")], false, Some(0));
+        match one.main_worktree(Path::new("")) {
+            MainTarget::Worktree(path) => assert_eq!(path, PathBuf::from("/repo")),
+            other => panic!("Expected the main worktree, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/cwt/src/family.rs
+++ b/src/cwt/src/family.rs
@@ -16,16 +16,27 @@ use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
-use crate::worktree::{list_worktrees, paths_equal, RepoWorktrees, Worktree};
+use crate::ascent::{climb, main_branch_rank};
+use crate::worktree::{
+    canonical, is_checkout, list_worktrees, paths_equal, RepoWorktrees, Worktree,
+};
 
 /// The indent that puts a worktree under its repository heading.
 const GROUP_INDENT: &str = "  ";
 
-/// The branch names that identify the main worktree, in order of priority.
-///
-/// `main` comes first. `master` is the fallback for a repository that never
-/// renamed its first branch.
-pub const MAIN_BRANCH_NAMES: [&str; 2] = ["main", "master"];
+/// Where `--main` sends the user.
+#[derive(Debug)]
+pub enum MainTarget {
+    /// The main worktree to change to.
+    Worktree(PathBuf),
+    /// The repository the user stands in has no worktree on a main branch, so
+    /// it has no main worktree to offer.
+    NoMainBranch,
+    /// The user already stands in the main worktree, and no repository above
+    /// the one named here has a main worktree either. The path is where that
+    /// repository sits on disk, which is what the climb started from.
+    AtTheTop(PathBuf),
+}
 
 /// Result of searching for a worktree by name.
 #[derive(Debug)]
@@ -206,6 +217,33 @@ impl Family {
         })
     }
 
+    /// Where `--main` sends the user.
+    ///
+    /// The first answer is the main worktree of the repository the user stands
+    /// in, which [`own_main_worktree`] finds. When the user already stands in
+    /// that worktree, they have asked to go up instead, so the answer becomes
+    /// the main worktree of the repository that holds theirs — see [`climb`],
+    /// which repeats for as deep as the repositories are nested.
+    ///
+    /// The climb starts at the main worktree of the user's repository, never at
+    /// the worktree they stand in. A repository sits on disk where its main
+    /// worktree is, so that is the only place the repository above it can be
+    /// measured from.
+    ///
+    /// [`own_main_worktree`]: Family::own_main_worktree
+    pub fn main_worktree(&self) -> MainTarget {
+        let Some(index) = self.own_main_worktree() else {
+            return MainTarget::NoMainBranch;
+        };
+
+        if Some(index) != self.current {
+            return MainTarget::Worktree(self.entries[index].worktree.path.clone());
+        }
+
+        let home = self.groups[self.entries[index].group].dir.clone();
+        climb(&home).map_or(MainTarget::AtTheTop(home), MainTarget::Worktree)
+    }
+
     /// The main worktree of the repository the user stands in: the one on
     /// branch `main`, or the one on branch `master` when no worktree of that
     /// repository is on `main`.
@@ -215,22 +253,30 @@ impl Family {
     /// the current worktree, which keeps the user inside the repository they
     /// work in instead of sending them to the anchor of the family.
     ///
-    /// The branch name must match exactly. The substring match that [`find`]
-    /// does is wrong here: in a repository that has no `main` branch, a branch
-    /// such as `wt-main-master` would capture the shortcut and send the user
-    /// somewhere that is not the main worktree.
+    /// [`main_branch_rank`] ranks the branches, so the name must match exactly.
+    /// The substring match that [`find`] does is wrong here: in a repository
+    /// that has no `main` branch, a branch such as `wt-main-master` would
+    /// capture the shortcut and send the user somewhere that is not the main
+    /// worktree. A detached worktree has no branch, so it is never the main
+    /// worktree.
     ///
-    /// A detached worktree has no branch, so it is never the main worktree.
+    /// Two worktrees of one repository cannot share a branch, so the lowest
+    /// rank belongs to one entry and the tie-break on the index never decides
+    /// anything a user can see.
     ///
     /// [`find`]: Family::find
-    pub fn main_worktree(&self) -> Option<usize> {
+    fn own_main_worktree(&self) -> Option<usize> {
         let group = self.entries.get(self.current?)?.group;
 
-        MAIN_BRANCH_NAMES.iter().find_map(|name| {
-            self.entries
-                .iter()
-                .position(|e| e.group == group && e.worktree.branch.as_deref() == Some(*name))
-        })
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.group == group)
+            .filter_map(|(index, entry)| {
+                main_branch_rank(entry.worktree.branch.as_deref()).map(|rank| (rank, index))
+            })
+            .min()
+            .map(|(_, index)| index)
     }
 
     /// How to name the worktree at `index` in a message, so that the name can
@@ -467,7 +513,7 @@ impl Family {
 fn anchor_of(main_worktree: &Path) -> PathBuf {
     let parent = main_worktree.parent();
     match parent {
-        Some(parent) if parent.join(".git").exists() => parent.to_path_buf(),
+        Some(parent) if is_checkout(parent) => parent.to_path_buf(),
         _ => main_worktree.to_path_buf(),
     }
 }
@@ -482,7 +528,7 @@ fn child_repo_dirs(dir: &Path) -> Vec<PathBuf> {
     let mut children: Vec<PathBuf> = read
         .flatten()
         .map(|entry| entry.path())
-        .filter(|path| path.is_dir() && path.join(".git").exists())
+        .filter(|path| path.is_dir() && is_checkout(path))
         .collect();
     children.sort();
     children
@@ -674,12 +720,6 @@ fn find_current(entries: &[Entry], repo_root: &Path) -> Option<usize> {
     })
 }
 
-/// The resolved form of a path, falling back to the path itself when it cannot
-/// be resolved (a worktree whose directory was deleted, for example).
-fn canonical(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -776,7 +816,7 @@ mod tests {
             false,
             Some(1),
         );
-        assert_eq!(one.main_worktree(), Some(0));
+        assert_eq!(one.own_main_worktree(), Some(0));
     }
 
     #[test]
@@ -790,7 +830,7 @@ mod tests {
             false,
             Some(0),
         );
-        assert_eq!(one.main_worktree(), Some(1));
+        assert_eq!(one.own_main_worktree(), Some(1));
     }
 
     #[test]
@@ -804,7 +844,7 @@ mod tests {
             false,
             Some(0),
         );
-        assert_eq!(one.main_worktree(), Some(1));
+        assert_eq!(one.own_main_worktree(), Some(1));
     }
 
     #[test]
@@ -819,7 +859,7 @@ mod tests {
             false,
             Some(0),
         );
-        assert_eq!(one.main_worktree(), Some(1));
+        assert_eq!(one.own_main_worktree(), Some(1));
     }
 
     #[test]
@@ -832,7 +872,7 @@ mod tests {
             false,
             Some(0),
         );
-        assert_eq!(one.main_worktree(), Some(1));
+        assert_eq!(one.own_main_worktree(), Some(1));
     }
 
     #[test]
@@ -845,7 +885,7 @@ mod tests {
             false,
             Some(0),
         );
-        assert_eq!(one.main_worktree(), None);
+        assert_eq!(one.own_main_worktree(), None);
     }
 
     #[test]
@@ -862,7 +902,7 @@ mod tests {
             true,
             Some(3),
         );
-        assert_eq!(whole.main_worktree(), Some(2));
+        assert_eq!(whole.own_main_worktree(), Some(2));
     }
 
     #[test]
@@ -873,7 +913,7 @@ mod tests {
             true,
             None,
         );
-        assert_eq!(whole.main_worktree(), None);
+        assert_eq!(whole.own_main_worktree(), None);
     }
 
     #[test]

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -17,10 +17,12 @@ use clap::Parser;
 use repowalker::find_git_repo;
 use shellsetup::ShellIntegration;
 
+mod ascent;
 mod family;
 mod worktree;
 
-use family::{Family, WorktreeMatch, MAIN_BRANCH_NAMES};
+use ascent::MAIN_BRANCH_NAMES;
+use family::{Family, MainTarget, WorktreeMatch};
 
 /// Exit codes for different error conditions.
 mod exit_codes {
@@ -66,7 +68,7 @@ macro_rules! error {
 /// cwt           # Show list of worktrees with current highlighted
 /// cwt -f        # Go to next worktree (wraps around)
 /// cwt -p        # Go to previous worktree (wraps around)
-/// cwt -m        # Go to the main worktree (branch main, or master)
+/// cwt -m        # Go to the main worktree, or up a level when you are in it
 /// cwt NAME      # Go to worktree by directory name or branch name
 /// cwt TEXT      # Go to worktree by case-insensitive substring match on branch
 /// cwt REPO:NAME # Go to a worktree of one repository in the family
@@ -90,7 +92,7 @@ macro_rules! error {
 ///
 /// alias wtf='wt -f'  # Next worktree
 /// alias wtb='wt -p'  # Previous worktree (back)
-/// alias wtm='wt --main'  # Main worktree (branch main, or master)
+/// alias wtm='wt --main'  # Main worktree, or a level up when you are in it
 /// ```
 ///
 /// # Exit Codes
@@ -126,6 +128,11 @@ struct Cli {
     ///
     /// The main worktree is the one on branch `main`, or the one on branch `master` when
     /// no worktree is on `main`. The branch name must match exactly.
+    ///
+    /// When you already stand in the main worktree, this goes up a level instead. It
+    /// goes to the main worktree of the repository that holds yours, and it repeats
+    /// that climb for each level above. A repository on the way with no main worktree
+    /// is stepped over.
     #[arg(short = 'm', long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "target", "shell_setup"])]
     main: bool,
 
@@ -150,7 +157,7 @@ struct Cli {
     ///   wt [target]  - List worktrees or change to one
     ///   wtf          - Next worktree (forward)
     ///   wtb          - Previous worktree (back)
-    ///   wtm          - Main worktree (branch main, or master)
+    ///   wtm          - Main worktree, or a level up when you are in it
     #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "main", "target"])]
     shell_setup: bool,
 
@@ -226,7 +233,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt --main'  # Main worktree (branch main, or master)
+alias wtm='wt --main'  # Main worktree, or a level up when you are in it
 "#;
 
 /// Sets up shell integration by adding the wt function to the user's shell config.
@@ -235,7 +242,7 @@ fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
         .with_command("wt", "List worktrees or change to one")
         .with_command("wtf", "Next worktree")
         .with_command("wtb", "Previous worktree (back)")
-        .with_command("wtm", "Main worktree (branch main, or master)")
+        .with_command("wtm", "Main worktree, or a level up when you are in it")
         // Old installations ended with this alias (before end marker was added)
         .with_old_end_marker("alias wtb='wt -p'");
 
@@ -296,16 +303,30 @@ fn main() {
         println!("{}", family.path(index).display());
     } else if cli.main {
         // Main worktree: branch main, or branch master when there is no main.
-        let Some(index) = family.main_worktree() else {
-            error!(
-                cli.quiet,
-                "Error: No worktree is on branch {}",
-                quoted_branch_alternatives(&MAIN_BRANCH_NAMES)
-            );
-            print_available(&family, cli.quiet);
-            exit(exit_codes::WORKTREE_NOT_FOUND);
-        };
-        println!("{}", family.path(index).display());
+        // Standing in it already is a request to go up a level instead.
+        match family.main_worktree() {
+            MainTarget::Worktree(path) => println!("{}", path.display()),
+            MainTarget::NoMainBranch => {
+                error!(
+                    cli.quiet,
+                    "Error: No worktree is on branch {}",
+                    quoted_branch_alternatives(&MAIN_BRANCH_NAMES)
+                );
+                print_available(&family, cli.quiet);
+                exit(exit_codes::WORKTREE_NOT_FOUND);
+            }
+            MainTarget::AtTheTop(home) => {
+                // No worktree listing follows this one. The worktrees of this
+                // repository are not candidates: the user is standing in the
+                // main one, and asked for what is above it.
+                error!(
+                    cli.quiet,
+                    "Error: No repository above {} has a main worktree",
+                    home.display()
+                );
+                exit(exit_codes::WORKTREE_NOT_FOUND);
+            }
+        }
     } else if let Some(name) = &cli.target {
         match family.find(name) {
             WorktreeMatch::Single(index) => {

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -370,8 +370,10 @@ fn main() {
 mod tests {
     use super::*;
 
-    // The tests of the main-worktree search live beside the search itself, in
-    // the family module.
+    // The tests of the main-worktree search live beside the search itself: the
+    // branch-name ranking, the pick of a main worktree out of a list, and the
+    // climb out of one are tested in the ascent module; the choice of which
+    // worktree of a family answers `--main` is tested in the family module.
 
     #[test]
     fn test_quoted_branch_alternatives_quotes_a_single_name() {

--- a/src/cwt/src/main.rs
+++ b/src/cwt/src/main.rs
@@ -68,7 +68,7 @@ macro_rules! error {
 /// cwt           # Show list of worktrees with current highlighted
 /// cwt -f        # Go to next worktree (wraps around)
 /// cwt -p        # Go to previous worktree (wraps around)
-/// cwt -m        # Go to the main worktree, or up a level when you are in it
+/// cwt -m        # Go to the main worktree, or up a level when you are at its root
 /// cwt NAME      # Go to worktree by directory name or branch name
 /// cwt TEXT      # Go to worktree by case-insensitive substring match on branch
 /// cwt REPO:NAME # Go to a worktree of one repository in the family
@@ -92,7 +92,7 @@ macro_rules! error {
 ///
 /// alias wtf='wt -f'  # Next worktree
 /// alias wtb='wt -p'  # Previous worktree (back)
-/// alias wtm='wt --main'  # Main worktree, or a level up when you are in it
+/// alias wtm='wt --main'  # Main worktree, or a level up when you are at its root
 /// ```
 ///
 /// # Exit Codes
@@ -129,10 +129,13 @@ struct Cli {
     /// The main worktree is the one on branch `main`, or the one on branch `master` when
     /// no worktree is on `main`. The branch name must match exactly.
     ///
-    /// When you already stand in the main worktree, this goes up a level instead. It
-    /// goes to the main worktree of the repository that holds yours, and it repeats
-    /// that climb for each level above. A repository on the way with no main worktree
-    /// is stepped over.
+    /// From anywhere below a worktree — a subdirectory of the main worktree included —
+    /// this takes you to the top of that repository's main worktree.
+    ///
+    /// When the directory you are in is the main worktree itself, this goes up a level
+    /// instead. It goes to the main worktree of the repository that holds yours, and it
+    /// repeats that climb for each level above. A repository on the way with no main
+    /// worktree is stepped over.
     #[arg(short = 'm', long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "target", "shell_setup"])]
     main: bool,
 
@@ -157,7 +160,7 @@ struct Cli {
     ///   wt [target]  - List worktrees or change to one
     ///   wtf          - Next worktree (forward)
     ///   wtb          - Previous worktree (back)
-    ///   wtm          - Main worktree, or a level up when you are in it
+    ///   wtm          - Main worktree, or a level up when you are at its root
     #[arg(long, verbatim_doc_comment, conflicts_with_all = ["forward", "prev", "main", "target"])]
     shell_setup: bool,
 
@@ -233,7 +236,7 @@ function wt() {
 # Quick navigation aliases
 alias wtf='wt -f'  # Next worktree
 alias wtb='wt -p'  # Previous worktree (back)
-alias wtm='wt --main'  # Main worktree, or a level up when you are in it
+alias wtm='wt --main'  # Main worktree, or a level up when you are at its root
 "#;
 
 /// Sets up shell integration by adding the wt function to the user's shell config.
@@ -242,7 +245,10 @@ fn setup_shell_integration() -> Result<(), shellsetup::ShellSetupError> {
         .with_command("wt", "List worktrees or change to one")
         .with_command("wtf", "Next worktree")
         .with_command("wtb", "Previous worktree (back)")
-        .with_command("wtm", "Main worktree, or a level up when you are in it")
+        .with_command(
+            "wtm",
+            "Main worktree, or a level up when you are at its root",
+        )
         // Old installations ended with this alias (before end marker was added)
         .with_old_end_marker("alias wtb='wt -p'");
 
@@ -303,8 +309,14 @@ fn main() {
         println!("{}", family.path(index).display());
     } else if cli.main {
         // Main worktree: branch main, or branch master when there is no main.
-        // Standing in it already is a request to go up a level instead.
-        match family.main_worktree() {
+        // Standing at it — in its top directory, not merely somewhere inside
+        // it — is a request to go up a level instead, so the directory the user
+        // is in decides, not the worktree that holds them. A current directory
+        // that cannot be read falls back to the empty path, which is at no
+        // worktree, so `--main` goes to the main worktree rather than climbing
+        // out of one by accident.
+        let here = std::env::current_dir().unwrap_or_default();
+        match family.main_worktree(&here) {
             MainTarget::Worktree(path) => println!("{}", path.display()),
             MainTarget::NoMainBranch => {
                 error!(

--- a/src/cwt/src/worktree.rs
+++ b/src/cwt/src/worktree.rs
@@ -146,6 +146,24 @@ pub fn list_worktrees(repo_root: &Path) -> Result<RepoWorktrees, String> {
     })
 }
 
+/// The name git gives the marker it puts at the root of a checkout.
+const GIT_MARKER: &str = ".git";
+
+/// True when `dir` is a checkout: a repository, or one of its linked worktrees.
+///
+/// Git marks the main worktree with a `.git` directory and a linked worktree
+/// with a `.git` file, so the presence of the name — not what it is — is what
+/// tells a checkout from a plain directory.
+pub fn is_checkout(dir: &Path) -> bool {
+    dir.join(GIT_MARKER).exists()
+}
+
+/// The resolved form of a path, falling back to the path itself when it cannot
+/// be resolved (a worktree whose directory was deleted, for example).
+pub fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Compares two paths, handling case-insensitivity on macOS.
 pub fn paths_equal(a: &Path, b: &Path) -> bool {
     // On macOS, the default filesystem is case-insensitive

--- a/src/cwt/tests/main-worktree-climb.rs
+++ b/src/cwt/tests/main-worktree-climb.rs
@@ -54,6 +54,43 @@ fn a_feature_worktree_still_reaches_its_own_main_worktree() {
 }
 
 #[test]
+fn a_subdirectory_of_the_main_worktree_still_reaches_the_top_of_it() {
+    // The first press of wtm, from where a developer normally stands: inside
+    // the main worktree, below its root. That is a request to go to the top of
+    // the worktree, not out of the repository. Only the root itself climbs.
+    let nest = Nest::build();
+    let inside = "top/middle/leaf/src/deep";
+    nest.deepen(inside);
+
+    assert_goes_to(&nest, inside, &["--main"], "top/middle/leaf");
+}
+
+#[test]
+fn a_subdirectory_of_the_topmost_repository_still_reaches_the_top_of_it() {
+    // The same press in the repository the climb has nothing above. Standing
+    // below its root must take the user to it, never report that no repository
+    // holds it: the user asked to go to the top of their worktree and there is
+    // one to go to.
+    let nest = Nest::build();
+    let inside = "top/src/deep";
+    nest.deepen(inside);
+
+    assert_goes_to(&nest, inside, &["--main"], "top");
+}
+
+#[test]
+fn a_subdirectory_of_a_feature_worktree_still_reaches_its_own_main_worktree() {
+    // The case the fix must leave alone. A linked worktree already answered
+    // with its repository's main worktree from its root, and standing below
+    // that root changes nothing.
+    let nest = Nest::build();
+    let inside = "top/middle/leaf-worktrees/feature/src/deep";
+    nest.deepen(inside);
+
+    assert_goes_to(&nest, inside, &["--main"], "top/middle/leaf");
+}
+
+#[test]
 fn the_main_worktree_climbs_to_the_repository_that_holds_it() {
     // The second press. leaf is a repository inside middle, so middle answers.
     // middle is on master, which proves the climb ranks branches the way the

--- a/src/cwt/tests/main-worktree-climb.rs
+++ b/src/cwt/tests/main-worktree-climb.rs
@@ -1,0 +1,148 @@
+//! What `--main` does when the user already stands in the main worktree.
+//!
+//! `family-main-worktree.rs` proves which repository answers the first press of
+//! `wtm`: the one the user stands in. These tests prove what the next press
+//! does. A user who is already in their main worktree has asked to go up, so
+//! `--main` climbs to the repository that holds theirs and takes its main
+//! worktree, and repeats that for as deep as the nest goes.
+//!
+//! The climb starts at the main worktree of the user's repository, never at the
+//! worktree they stand in. That is what keeps the first press of `wtm` in a
+//! child's feature worktree from skipping the child and landing on the parent.
+
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
+mod support;
+
+use support::{code, combined, cwt, target_path, Nest};
+
+/// The exit code `cwt` uses when it finds no worktree.
+const WORKTREE_NOT_FOUND: i32 = 3;
+
+/// Asserts that `cwt` with `args`, run in `from`, printed the path of `expected`.
+fn assert_goes_to(nest: &Nest, from: &str, args: &[&str], expected: &str) {
+    let output = cwt(&nest.at(from), args);
+
+    assert_eq!(
+        code(&output),
+        0,
+        "cwt {args:?} failed in {from}: {}",
+        combined(&output)
+    );
+    assert_eq!(
+        target_path(&output),
+        nest.path_of(expected),
+        "cwt {args:?} in {from} must go to {expected}"
+    );
+}
+
+#[test]
+fn a_feature_worktree_still_reaches_its_own_main_worktree() {
+    // The first press of wtm. The climb must not fire here: the user is not in
+    // the main worktree yet, and the repository above holds a main worktree of
+    // its own that would swallow this one.
+    let nest = Nest::build();
+
+    assert_goes_to(
+        &nest,
+        "top/middle/leaf-worktrees/feature",
+        &["--main"],
+        "top/middle/leaf",
+    );
+}
+
+#[test]
+fn the_main_worktree_climbs_to_the_repository_that_holds_it() {
+    // The second press. leaf is a repository inside middle, so middle answers.
+    // middle is on master, which proves the climb ranks branches the way the
+    // first press does.
+    let nest = Nest::build();
+
+    assert_goes_to(&nest, "top/middle/leaf", &["--main"], "top/middle");
+}
+
+#[test]
+fn the_climb_repeats_for_every_level_of_the_nest() {
+    // The third press. The nest is three deep, so the climb has to happen more
+    // than once to reach the top of it.
+    let nest = Nest::build();
+
+    assert_goes_to(&nest, "top/middle", &["--main"], "top");
+}
+
+#[test]
+fn the_top_of_the_nest_reports_that_no_repository_holds_it() {
+    let nest = Nest::build();
+    let output = cwt(&nest.at("top"), &["--main"]);
+
+    assert_eq!(
+        code(&output),
+        WORKTREE_NOT_FOUND,
+        "cwt --main at the top must report not found, got: {}",
+        combined(&output)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "cwt must print no path when nothing holds the repository, got: {}",
+        combined(&output)
+    );
+}
+
+#[test]
+fn the_top_of_the_nest_names_the_repository_it_climbed_from() {
+    // The message has to say which repository has nothing above it, or the user
+    // cannot tell this apart from a repository with no main branch.
+    let nest = Nest::build();
+    let output = cwt(&nest.at("top"), &["--main"]);
+    let message = combined(&output);
+
+    assert!(
+        message.contains("No repository above"),
+        "the message must say that nothing holds this repository, got: {message}"
+    );
+    assert!(
+        message.contains(&nest.path_of("top")),
+        "the message must name the repository it climbed from, got: {message}"
+    );
+}
+
+#[test]
+fn a_repository_on_the_ladder_without_a_main_branch_is_stepped_over() {
+    // hub is on trunk, so it has no main worktree to offer. It cannot be a
+    // destination, and it must not stop the climb either: top is above it and
+    // does have one.
+    let nest = Nest::build();
+
+    assert_goes_to(&nest, "top/hub/twig", &["--main"], "top");
+}
+
+#[test]
+fn the_climb_reaches_the_main_branch_of_the_repository_above_not_its_directory() {
+    // away is on trunk and keeps main in a worktree beside itself. The climb
+    // finds the repository by the directory that holds sprig, and then has to
+    // ask that repository for its main worktree like any other.
+    let nest = Nest::build();
+
+    assert_goes_to(
+        &nest,
+        "top/away/sprig",
+        &["--main"],
+        "top/away-worktrees/main",
+    );
+}
+
+#[test]
+fn opting_out_of_the_family_still_climbs() {
+    // --no-family says which repositories the listing shows. The climb is not a
+    // listing, and wtm has to behave the same either way.
+    let nest = Nest::build();
+
+    assert_goes_to(
+        &nest,
+        "top/middle/leaf",
+        &["--no-family", "--main"],
+        "top/middle",
+    );
+}

--- a/src/cwt/tests/main-worktree-climb.rs
+++ b/src/cwt/tests/main-worktree-climb.rs
@@ -1,10 +1,15 @@
-//! What `--main` does when the user already stands in the main worktree.
+//! What `--main` does when the user's directory is the main worktree itself.
 //!
 //! `family-main-worktree.rs` proves which repository answers the first press of
 //! `wtm`: the one the user stands in. These tests prove what the next press
-//! does. A user who is already in their main worktree has asked to go up, so
-//! `--main` climbs to the repository that holds theirs and takes its main
+//! does. A user standing at the top of their main worktree has asked to go up,
+//! so `--main` climbs to the repository that holds theirs and takes its main
 //! worktree, and repeats that for as deep as the nest goes.
+//!
+//! Standing *inside* the main worktree is not standing at it. From a
+//! subdirectory the answer is still the top of that worktree, which is why the
+//! directory the user is in — not the worktree that holds them — is what fires
+//! the climb.
 //!
 //! The climb starts at the main worktree of the user's repository, never at the
 //! worktree they stand in. That is what keeps the first press of `wtm` in a

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -269,8 +269,8 @@ pub fn add_worktree(repo: &Path, relative: &str, branch: &str) {
 }
 
 /// A nest of repositories: repositories checked out inside repositories, three
-/// levels deep, for the climb `--main` makes when the user already stands in a
-/// main worktree.
+/// levels deep, for the climb `--main` makes when the user's directory is a
+/// main worktree itself.
 ///
 /// ```text
 /// root/

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -267,3 +267,77 @@ pub fn make_repo(path: &Path, branch: &str) {
 pub fn add_worktree(repo: &Path, relative: &str, branch: &str) {
     git(repo, &["worktree", "add", "-b", branch, relative]);
 }
+
+/// A nest of repositories: repositories checked out inside repositories, three
+/// levels deep, for the climb `--main` makes when the user already stands in a
+/// main worktree.
+///
+/// ```text
+/// root/
+///   top/                                repository, branch main
+///   top/middle/                         repository, branch master
+///   top/middle/leaf/                    repository, branch main
+///   top/middle/leaf-worktrees/feature   worktree of leaf, branch feature
+///   top/hub/                            repository, branch trunk
+///   top/hub/twig/                       repository, branch main
+///   top/away/                           repository, branch trunk
+///   top/away-worktrees/main             worktree of away, branch main
+///   top/away/sprig/                     repository, branch main
+/// ```
+///
+/// Each of the three branches of the nest proves one thing about the climb:
+///
+/// - `middle` is the plain ladder. `leaf` climbs to `middle`, which is on
+///   `master`, and `middle` climbs to `top`. Above `top` there is nothing.
+/// - `hub` has neither `main` nor `master`, so it can never be a destination.
+///   `twig` must step over it and reach `top`.
+/// - `away` is on `trunk` and keeps its `main` branch in a worktree beside
+///   itself. `sprig` must reach that worktree, not the directory that holds
+///   the repository.
+pub struct Nest {
+    /// Kept alive so the temp directory outlives the test.
+    _tmp: TempDir,
+    /// The canonical path of the temp directory, for the reason [`Family`]
+    /// canonicalizes its own.
+    root: PathBuf,
+}
+
+impl Nest {
+    /// Build the nest described in the type documentation.
+    pub fn build() -> Self {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let root = tmp
+            .path()
+            .canonicalize()
+            .expect("failed to canonicalize temp dir");
+
+        make_repo(&root.join("top"), "main");
+
+        make_repo(&root.join("top/middle"), "master");
+        make_repo(&root.join("top/middle/leaf"), "main");
+        add_worktree(
+            &root.join("top/middle/leaf"),
+            "../leaf-worktrees/feature",
+            "feature",
+        );
+
+        make_repo(&root.join("top/hub"), "trunk");
+        make_repo(&root.join("top/hub/twig"), "main");
+
+        make_repo(&root.join("top/away"), "trunk");
+        add_worktree(&root.join("top/away"), "../away-worktrees/main", "main");
+        make_repo(&root.join("top/away/sprig"), "main");
+
+        Self { _tmp: tmp, root }
+    }
+
+    /// Resolve a path inside the nest, for example `top/middle/leaf`.
+    pub fn at(&self, relative: &str) -> PathBuf {
+        self.root.join(relative)
+    }
+
+    /// The path of a worktree as a string, for comparison with `cwt` output.
+    pub fn path_of(&self, relative: &str) -> String {
+        self.at(relative).display().to_string()
+    }
+}

--- a/src/cwt/tests/support/mod.rs
+++ b/src/cwt/tests/support/mod.rs
@@ -336,6 +336,17 @@ impl Nest {
         self.root.join(relative)
     }
 
+    /// Create a plain directory inside the nest, and every directory above it.
+    ///
+    /// A user stands anywhere inside a worktree, not only at its root, and
+    /// `--main` has to answer for both places. This is where a test puts a
+    /// directory below one, so that it can run `cwt` from there.
+    pub fn deepen(&self, relative: &str) -> PathBuf {
+        let path = self.at(relative);
+        std::fs::create_dir_all(&path).expect("failed to create a directory inside the nest");
+        path
+    }
+
     /// The path of a worktree as a string, for comparison with `cwt` output.
     pub fn path_of(&self, relative: &str) -> String {
         self.at(relative).display().to_string()


### PR DESCRIPTION
## What changed

`wtm` (`cwt --main`) took you to the main worktree of your repository. When you already stood in that main worktree, a second press did nothing. But a user who presses `wtm` there asked to go up. So `cwt --main` now climbs: it answers with the main worktree of the repository that **holds** yours, and it repeats that climb for each level above.

```bash
cd keyboards/zmk-config-corne-worktrees/guard-the-commit-hashes-in-prose
wtm   # -> keyboards/zmk-config-corne        the repository's own main worktree
wtm   # -> keyboards                         the repository that holds it
wtm   # Error: No repository above /code/keyboards has a main worktree
```

## How it works

- A new `ascent` module owns both halves of the question: which branch names a main worktree, and how to climb out of one.
- `Family::main_worktree` returns a `MainTarget`, so the caller can tell a repository with no main branch from the top of the nest. The two conditions get different messages.
- The climb starts at the repository's own main worktree, never at the worktree the user stands in. Thus a first press in a child's feature worktree cannot skip the child.
- A rung with no main worktree is stepped over. The climb asks the repository above it.
- Only the directory directly above counts, which is the same one level that the family scan looks down.
- `--no-family` does not change the climb. That flag says which repositories the **listing** shows, and the climb is not a listing.
- When nothing above has a main worktree, `cwt -m` says so and exits with code 3.
- The `.git` marker test and the canonical-path helper move to `worktree.rs`. Three call sites now share them.

## Tests

`src/cwt/tests/main-worktree-climb.rs` holds the new integration tests. Each one builds a real nest of repositories in a process-unique temporary directory.

## Documentation

README.md gets a new section, "Pressing it again climbs out". The `wtm` alias comments and the TLDR.md entry for `cwt` also say that `wtm` climbs.

## Verification

The pre-commit gates ran by hand over the merged tree. All four passed:

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo machete` | pass, no unused dependencies |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace --all-features` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
