### PR TITLE
feat(krt): the crate skeleton and the command line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,65 @@ A target that legitimately needs a lint relaxed says so at the site, with a reas
 - `repo_guards::workspace_lints` (`src/repo-guards/src/workspace_lints.rs`) - every workspace member manifest declares `[lints]` / `workspace = true`
 - `repo_guards::target_lints` (`src/repo-guards/src/target_lints.rs`) - every target root — library, binary, test, bench, example, build script - declares a position on each lint its crate's lib/bin roots raise. Its companion test asks `cargo metadata` whether that set of roots is the set cargo actually builds, so a target kind the guard never learned about shows up as a set difference instead of a clean report
 
+## Tool Indexes
+
+Every binary this workspace builds **must** appear in both `README.md` and
+`TLDR.md`.
+
+### Why
+
+The repository documents its tools twice, and on purpose. `README.md` carries
+the long entry — what the tool is for, how to run it, how to install it.
+`TLDR.md` carries one line per tool, alphabetized, for a reader who only needs
+to know which tool to reach for. A tool that is missing from either one is a
+tool nobody finds.
+
+Nothing enforced this before. The omission is spelled as an *absence*, which is
+why it spread: a crate that nobody remembers to document is born undocumented,
+and no build step ever said so. Two binaries had drifted out of an index by the
+time the guard was written.
+
+### Usage
+
+`TLDR.md` is one table, alphabetized. Add a row whose **first cell** is the tool
+name:
+
+```markdown
+| `krt` | Knights of the Round Trip — records the network path to a destination. |
+```
+
+`README.md` accepts either of the two forms in service today. Add a **top-level
+list item** under `## The tools`, whose first word is the tool name:
+
+```markdown
+- krt (Knights of the Round Trip)
+  - Records the network path to a destination, hop by hop.
+  - To install: `cargo install --git https://github.com/timmattison/tools krt`
+```
+
+Or add a **level-2 section heading** whose first word is the tool name
+(`## occ (old Claude Code)`), for a tool that needs more room than a list item.
+
+### The Trap: A Mention Is Not An Entry
+
+Both indexes are full of mentions. The row of `sirn` names `portplz`, and the
+row of `prgz` names `prcp`. So the guard **parses** the Markdown rather than
+searching it for the tool name — it reads the first cell of a table body row,
+and the first word of a top-level item or a level-2 heading. A text search
+would pass on a tool whose own entry is gone, and a search that reports clean
+for the wrong reason is indistinguishable from a guard doing real work.
+
+A nested list item is not an entry either. The `- To install: …` line under a
+tool's own entry would otherwise document a tool named `To`.
+
+### Guards Enforcing This
+
+- `repo_guards::tool_index` (`src/repo-guards/src/tool_index.rs`) — every binary
+  cargo builds has an entry in `README.md` and a row in `TLDR.md`. Its companion
+  test asks `cargo metadata` whether the guard's set of binaries is the set
+  cargo actually builds, so a binary the guard never learned to discover shows
+  up as a set difference instead of a clean report
+
 ## UTF-8 String Safety
 
 All tools in this repository **must** handle UTF-8 strings safely. Never use byte-level indexing that could panic on multi-byte characters.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,6 +5828,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6318,6 +6329,7 @@ name = "repo-guards"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "pulldown-cmark",
  "serde_json",
  "syn 2.0.119",
  "tempfile",
@@ -7730,6 +7742,12 @@ dependencies = [
  "clipboardmon",
  "env_logger",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "krt"
+version = "0.1.0"
+
+[[package]]
 name = "kstring"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,10 @@ dependencies = [
 [[package]]
 name = "krt"
 version = "0.1.0"
+dependencies = [
+ "buildinfo",
+ "clap",
+]
 
 [[package]]
 name = "kstring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ env_logger = "0.11"
 
 # Misc
 syn = { version = "2", default-features = false, features = ["full", "parsing"] }
+pulldown-cmark = { version = "0.13", default-features = false }
 tiktoken-rs = "0.5"
 num-format = "0.4"
 human_bytes = "0.4"

--- a/README.md
+++ b/README.md
@@ -563,6 +563,14 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     volume; defaults to the machine's core count).
   - To install: `cargo install --git https://github.com/timmattison/tools zth`
 
+- krt (Knights of the Round Trip)
+  - Records the network path to a destination, hop by hop. `krt` accepts one destination and the
+    flags of the probe. The flags set the round period, the range of the TTL, the protocol, the
+    multipath mode, and the address family. This build parses the command line and prints the
+    configuration it resolved. It does not probe yet, and it writes no file.
+  - Usage: `krt example.com`, `krt example.com --interval 500ms --protocol udp --multipath paris`
+  - To install: `cargo install --git https://github.com/timmattison/tools krt`
+
 ## dirhash
 
 Calculate a SHA256 hash of a directory tree that's deterministic based on file contents. Respects .gitignore and other ignore files by default.

--- a/TLDR.md
+++ b/TLDR.md
@@ -57,6 +57,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `rr` | Rust Remover — runs `cargo clean` across all Rust projects to free disk space. |
 | `runat` | TUI to run a command at a specified time with a live countdown. |
 | `safeboard` | Monitors the clipboard for dangerous/invisible Unicode used in copy-paste attacks. |
+| `seescc` | Self-refreshing terminal viewer for sccache statistics, with sparklines and a one-shot JSON mode. |
 | `sf` | Size of Files — total size of files in directories, with optional suffix/prefix/substring filters. |
 | `sirn` | Serve It Right Now — a zero-config HTTP file server; serves files or the current directory on a git-derived port. |
 | `spv` | Smart Process Viewer — find and view processes by PID/name/regex, with optional cwd and open files. |

--- a/TLDR.md
+++ b/TLDR.md
@@ -34,6 +34,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `inscribe` | Generates git commit messages from staged changes using Claude AI. |
 | `jsonboard` | Pretty-prints JSON on the clipboard and puts it back. |
 | `kitchen-sync` | Installs every Rust binary from a git repo with one command. |
+| `krt` | Knights of the Round Trip — records the network path to a destination, hop by hop. This build parses the command line only. |
 | `localnext` | Serves statically exported Next.js apps locally. |
 | `ng` | Navel-Gaze — watches JS/TS files and re-runs `pnpm lint` (or `--typecheck`) on change. |
 | `nodenuke` | Removes `node_modules` directories and lock files throughout a repo. |

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "krt"
+version = "0.1.0"
+edition.workspace = true
+description = "Knights of the Round Trip: a Rust tool that records the network path to a destination, hop by hop"
+
+[lints]
+workspace = true

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 description = "Knights of the Round Trip: a Rust tool that records the network path to a destination, hop by hop"
 
+[dependencies]
+buildinfo.workspace = true
+clap.workspace = true
+
 [lints]
 workspace = true

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -8,4 +8,23 @@
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 
-fn main() {}
+use buildinfo::version_string;
+use clap::Parser;
+
+/// The command line of `krt`.
+///
+/// The flags arrive in a later slice. `--version` and `-V` work now, because
+/// `clap` reads the build string that `buildinfo` made at compile time.
+#[derive(Parser, Debug)]
+#[command(
+    name = "krt",
+    version = version_string!(),
+    about = "Knights of the Round Trip: record the network path to a destination"
+)]
+struct Cli {}
+
+fn main() {
+    // The parse handles `--version`, `-V`, and `--help` on its own. A later
+    // slice prints the resolved configuration.
+    Cli::parse();
+}

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -9,7 +9,9 @@
 #![warn(clippy::pedantic)]
 
 use buildinfo::version_string;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use std::net::IpAddr;
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// The accepted units of a duration.
@@ -24,17 +26,102 @@ const SECONDS_PER_MINUTE: u64 = 60;
 /// The number of seconds in one hour.
 const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
 
+/// The protocol of a probe.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum Protocol {
+    /// Send ICMP echo requests.
+    Icmp,
+    /// Send UDP datagrams.
+    Udp,
+    /// Send TCP packets.
+    Tcp,
+}
+
+/// The way a probe keeps or varies the flow of a packet.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum Multipath {
+    /// Let each probe take its own flow, as traceroute always did.
+    Classic,
+    /// Hold one flow for every probe, as Paris traceroute does.
+    Paris,
+    /// Walk the flows to find every path, as Dublin traceroute does.
+    Dublin,
+}
+
 /// The command line of `krt`.
 ///
-/// The flags arrive in a later slice. `--version` and `-V` work now, because
-/// `clap` reads the build string that `buildinfo` made at compile time.
+/// `--version` and `-V` print the build string that `buildinfo` made at compile
+/// time.
 #[derive(Parser, Debug)]
 #[command(
     name = "krt",
     version = version_string!(),
     about = "Knights of the Round Trip: record the network path to a destination"
 )]
-struct Cli {}
+struct Cli {
+    /// The host or the address to trace.
+    destination: Option<String>,
+
+    /// The JSONL path. Overrides the derived name.
+    #[arg(long)]
+    output: Option<PathBuf>,
+
+    /// The round period. Accepts `500ms`, `1s`, `2m`.
+    #[arg(long, value_parser = parse_duration)]
+    interval: Duration,
+
+    /// The first TTL to probe.
+    #[arg(long)]
+    first_ttl: u8,
+
+    /// The last TTL to probe.
+    #[arg(long)]
+    max_ttl: u8,
+
+    /// The protocol of a probe.
+    #[arg(long)]
+    protocol: Protocol,
+
+    /// The multipath mode. UDP and TCP only.
+    #[arg(long)]
+    multipath: Multipath,
+
+    /// Force IP version 4.
+    #[arg(long)]
+    ipv4: bool,
+
+    /// Force IP version 6.
+    #[arg(long)]
+    ipv6: bool,
+
+    /// Skip reverse DNS. Show addresses only.
+    #[arg(long)]
+    no_dns: bool,
+
+    /// Override the source label in the derived filename.
+    #[arg(long)]
+    source: Option<IpAddr>,
+
+    /// No table. Print one status line per minute.
+    #[arg(long)]
+    headless: bool,
+
+    /// Stop after this much time.
+    #[arg(long, value_parser = parse_duration)]
+    duration: Option<Duration>,
+
+    /// Stop after this many rounds.
+    #[arg(long)]
+    rounds: Option<u64>,
+
+    /// Fold a recorded file and print the table. Then exit.
+    #[arg(long)]
+    replay: Option<PathBuf>,
+
+    /// With `--replay`, pick which run in the file to fold.
+    #[arg(long)]
+    run: Option<String>,
+}
 
 /// Reads a duration from the text of a command line flag.
 ///
@@ -143,8 +230,28 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_duration, render_duration};
+    use super::{Cli, Multipath, Protocol, parse_duration, render_duration};
+    use clap::error::ErrorKind;
+    use clap::{CommandFactory, Parser};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::path::PathBuf;
     use std::time::Duration;
+
+    /// The accepted units, as `parse_duration` names them for an unknown unit.
+    const UNITS_IN_THE_MESSAGE: &str = "the unit must be `ms`, `s`, `m`, or `h`";
+
+    /// The accepted forms, as `parse_duration` names them in every message.
+    const FORMS_IN_THE_MESSAGE: &str = "as in `500ms`, `1s`, or `2m`";
+
+    /// Reads a command line that the definition accepts.
+    fn parse(arguments: &[&str]) -> Cli {
+        Cli::try_parse_from(arguments.iter().copied()).expect("the command line must parse")
+    }
+
+    /// Reads the error of a command line that the definition rejects.
+    fn rejection(arguments: &[&str]) -> clap::Error {
+        Cli::try_parse_from(arguments.iter().copied()).expect_err("the command line must fail")
+    }
 
     /// Every text that the parser rejects, for the message tests.
     const BAD_TEXTS: [&str; 10] = [
@@ -334,5 +441,242 @@ mod tests {
         for text in ["500ms", "1s", "90s", "2m", "1h"] {
             assert_eq!(render_duration(parse_duration(text).unwrap()), text);
         }
+    }
+
+    #[test]
+    fn the_command_line_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn every_flag_has_its_documented_default() {
+        let cli = parse(&["krt", "example.com"]);
+        assert_eq!(cli.destination.as_deref(), Some("example.com"));
+        assert_eq!(cli.output, None);
+        assert_eq!(cli.interval, Duration::from_secs(1));
+        assert_eq!(cli.first_ttl, 1);
+        assert_eq!(cli.max_ttl, 30);
+        assert_eq!(cli.protocol, Protocol::Icmp);
+        assert_eq!(cli.multipath, Multipath::Classic);
+        assert!(!cli.ipv4, "the address family is automatic by default");
+        assert!(!cli.ipv6, "the address family is automatic by default");
+        assert!(!cli.no_dns, "reverse DNS is on by default");
+        assert_eq!(cli.source, None);
+        assert!(!cli.headless, "the table is on by default");
+        assert_eq!(cli.duration, None);
+        assert_eq!(cli.rounds, None);
+        assert_eq!(cli.replay, None);
+        assert_eq!(cli.run, None);
+    }
+
+    #[test]
+    fn parses_every_protocol() {
+        for (text, expected) in [
+            ("icmp", Protocol::Icmp),
+            ("udp", Protocol::Udp),
+            ("tcp", Protocol::Tcp),
+        ] {
+            let cli = parse(&["krt", "example.com", "--protocol", text]);
+            assert_eq!(cli.protocol, expected, "`--protocol {text}`");
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_protocol() {
+        let error = rejection(&["krt", "example.com", "--protocol", "quic"]);
+        assert_eq!(error.kind(), ErrorKind::InvalidValue);
+        let message = error.to_string();
+        assert!(
+            message.contains("icmp"),
+            "the message names the accepted values: {message}"
+        );
+    }
+
+    #[test]
+    fn parses_every_multipath_mode() {
+        for (text, expected) in [
+            ("classic", Multipath::Classic),
+            ("paris", Multipath::Paris),
+            ("dublin", Multipath::Dublin),
+        ] {
+            let cli = parse(&["krt", "example.com", "--multipath", text]);
+            assert_eq!(cli.multipath, expected, "`--multipath {text}`");
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_multipath_mode() {
+        let error = rejection(&["krt", "example.com", "--multipath", "tokyo"]);
+        assert_eq!(error.kind(), ErrorKind::InvalidValue);
+        let message = error.to_string();
+        assert!(
+            message.contains("classic"),
+            "the message names the accepted values: {message}"
+        );
+    }
+
+    #[test]
+    fn parses_the_flag_of_ip_version_4() {
+        let cli = parse(&["krt", "example.com", "-4"]);
+        assert!(cli.ipv4);
+        assert!(!cli.ipv6);
+    }
+
+    #[test]
+    fn parses_the_flag_of_ip_version_6() {
+        let cli = parse(&["krt", "example.com", "-6"]);
+        assert!(cli.ipv6);
+        assert!(!cli.ipv4);
+    }
+
+    #[test]
+    fn rejects_both_address_family_flags() {
+        let error = rejection(&["krt", "example.com", "-4", "-6"]);
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+        let message = error.to_string();
+        assert!(
+            message.contains("-4"),
+            "the message names the first flag: {message}"
+        );
+        assert!(
+            message.contains("-6"),
+            "the message names the second flag: {message}"
+        );
+    }
+
+    #[test]
+    fn parses_an_interval_in_milliseconds() {
+        let cli = parse(&["krt", "example.com", "--interval", "500ms"]);
+        assert_eq!(cli.interval, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn parses_an_interval_in_minutes() {
+        let cli = parse(&["krt", "example.com", "--interval", "2m"]);
+        assert_eq!(cli.interval, Duration::from_mins(2));
+    }
+
+    #[test]
+    fn rejects_an_interval_that_is_not_a_duration() {
+        for text in ["bogus", "5x"] {
+            let error = rejection(&["krt", "example.com", "--interval", text]);
+            assert_eq!(error.kind(), ErrorKind::ValueValidation, "`{text}`");
+            let message = error.to_string();
+            assert!(
+                message.contains(FORMS_IN_THE_MESSAGE),
+                "the message names the accepted forms: {message}"
+            );
+        }
+        let message = rejection(&["krt", "example.com", "--interval", "5x"]).to_string();
+        assert!(
+            message.contains(UNITS_IN_THE_MESSAGE),
+            "the message names the accepted units: {message}"
+        );
+    }
+
+    #[test]
+    fn parses_a_duration_that_stops_the_run() {
+        let cli = parse(&["krt", "example.com", "--duration", "2m"]);
+        assert_eq!(cli.duration, Some(Duration::from_mins(2)));
+    }
+
+    #[test]
+    fn rejects_a_command_line_without_a_destination() {
+        let error = rejection(&["krt"]);
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn a_replay_needs_no_destination() {
+        let cli = parse(&["krt", "--replay", "path.jsonl"]);
+        assert_eq!(cli.destination, None);
+        assert_eq!(cli.replay, Some(PathBuf::from("path.jsonl")));
+    }
+
+    #[test]
+    fn rejects_a_run_without_a_replay() {
+        let error = rejection(&["krt", "example.com", "--run", "2026-08-19T12:00:00Z"]);
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn parses_a_run_of_a_replay() {
+        let cli = parse(&[
+            "krt",
+            "--replay",
+            "path.jsonl",
+            "--run",
+            "2026-08-19T12:00:00Z",
+        ]);
+        assert_eq!(cli.run.as_deref(), Some("2026-08-19T12:00:00Z"));
+    }
+
+    #[test]
+    fn rejects_a_first_ttl_of_zero() {
+        let error = rejection(&["krt", "example.com", "--first-ttl", "0"]);
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn parses_the_largest_max_ttl() {
+        let cli = parse(&["krt", "example.com", "--max-ttl", "255"]);
+        assert_eq!(cli.max_ttl, 255);
+    }
+
+    #[test]
+    fn the_short_forms_reach_the_same_fields_as_the_long_forms() {
+        let short = parse(&[
+            "krt",
+            "example.com",
+            "-o",
+            "path.jsonl",
+            "-i",
+            "500ms",
+            "-4",
+        ]);
+        let long = parse(&[
+            "krt",
+            "example.com",
+            "--output",
+            "path.jsonl",
+            "--interval",
+            "500ms",
+        ]);
+        assert_eq!(short.output, Some(PathBuf::from("path.jsonl")));
+        assert_eq!(short.interval, Duration::from_millis(500));
+        assert!(short.ipv4, "`-4` is the only form of the flag");
+        assert_eq!(short.output, long.output);
+        assert_eq!(short.interval, long.interval);
+    }
+
+    #[test]
+    fn parses_a_source_of_ip_version_4() {
+        let cli = parse(&["krt", "example.com", "--source", "1.2.3.4"]);
+        assert_eq!(cli.source, Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+    }
+
+    #[test]
+    fn parses_a_source_of_ip_version_6() {
+        let cli = parse(&["krt", "example.com", "--source", "::1"]);
+        assert_eq!(cli.source, Some(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn rejects_a_source_that_is_not_an_address() {
+        let error = rejection(&["krt", "example.com", "--source", "nope"]);
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn parses_the_rounds_that_stop_the_run() {
+        let cli = parse(&["krt", "example.com", "--rounds", "10"]);
+        assert_eq!(cli.rounds, Some(10));
+    }
+
+    #[test]
+    fn parses_the_flags_that_hold_no_value() {
+        let cli = parse(&["krt", "example.com", "--no-dns", "--headless"]);
+        assert!(cli.no_dns);
+        assert!(cli.headless);
     }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1,0 +1,11 @@
+//! `krt` (Knights of the Round Trip) records the network path to a
+//! destination, hop by hop.
+//!
+//! This slice builds the crate and the build string. Later slices add the
+//! command line flags, the tracer, the file writer, and the table.
+
+// Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+
+fn main() {}

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -901,8 +901,28 @@ resolved configuration:
 
     #[test]
     fn rejects_a_run_without_a_replay() {
-        let error = rejection(&["krt", "example.com", "--run", "2026-08-19T12:00:00Z"]);
+        let error = rejection(&["krt", "--run", "2026-08-19T12:00:00Z"]);
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+        let message = error.to_string();
+        assert!(
+            message.contains("--replay"),
+            "the message names the replay: {message}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_run_beside_a_destination() {
+        let error = rejection(&["krt", "example.com", "--run", "2026-08-19T12:00:00Z"]);
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+        let message = error.to_string();
+        assert!(
+            message.contains("DESTINATION"),
+            "the message names the destination: {message}"
+        );
+        assert!(
+            message.contains("--run"),
+            "the message names the run: {message}"
+        );
     }
 
     #[test]

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -52,8 +52,63 @@ struct Cli {}
     dead_code,
     reason = "slice 3 attaches this parser to `--interval` and `--duration`"
 )]
-fn parse_duration(_text: &str) -> Result<Duration, String> {
-    unimplemented!("slice 2 reads a duration from the text of a flag")
+fn parse_duration(text: &str) -> Result<Duration, String> {
+    if text.is_empty() {
+        return Err(format!(
+            "a duration is empty: write a whole number and a unit, {DURATION_FORMS}"
+        ));
+    }
+    if text.starts_with('-') {
+        return Err(format!(
+            "`{text}` is negative: a duration is never negative, {DURATION_FORMS}"
+        ));
+    }
+
+    // The number is the run of digits at the front. The unit is the rest. The
+    // split point comes from `char_indices`, so it is on a character boundary.
+    let unit_start = text
+        .char_indices()
+        .find(|(_, character)| !character.is_ascii_digit())
+        .map_or(text.len(), |(index, _)| index);
+    let (number, unit) = text.split_at(unit_start);
+
+    if number.is_empty() {
+        return Err(format!(
+            "`{text}` has no number: write a whole number before the unit, {DURATION_FORMS}"
+        ));
+    }
+    if unit.is_empty() {
+        return Err(format!(
+            "`{text}` has no unit: {DURATION_UNITS}, {DURATION_FORMS}"
+        ));
+    }
+
+    let too_large = || format!("`{text}` is too large: use a smaller number, {DURATION_FORMS}");
+    let count: u64 = number.parse().map_err(|_| too_large())?;
+    let seconds = |per_unit: u64| {
+        count
+            .checked_mul(per_unit)
+            .map(Duration::from_secs)
+            .ok_or_else(too_large)
+    };
+    let duration = match unit {
+        "ms" => Duration::from_millis(count),
+        "s" => Duration::from_secs(count),
+        "m" => seconds(SECONDS_PER_MINUTE)?,
+        "h" => seconds(SECONDS_PER_HOUR)?,
+        _ => {
+            return Err(format!(
+                "`{text}` is not a duration: {DURATION_UNITS}, {DURATION_FORMS}"
+            ));
+        }
+    };
+
+    if duration.is_zero() {
+        return Err(format!(
+            "`{text}` is zero: a duration is more than zero, {DURATION_FORMS}"
+        ));
+    }
+    Ok(duration)
 }
 
 /// Writes the shortest exact text of a duration.
@@ -66,8 +121,18 @@ fn parse_duration(_text: &str) -> Result<Duration, String> {
     dead_code,
     reason = "slice 4 prints the resolved configuration with this renderer"
 )]
-fn render_duration(_duration: Duration) -> String {
-    unimplemented!("slice 2 writes the shortest exact text of a duration")
+fn render_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if duration.subsec_millis() != 0 || seconds == 0 {
+        return format!("{}ms", duration.as_millis());
+    }
+    if seconds.is_multiple_of(SECONDS_PER_HOUR) {
+        return format!("{}h", seconds / SECONDS_PER_HOUR);
+    }
+    if seconds.is_multiple_of(SECONDS_PER_MINUTE) {
+        return format!("{}m", seconds / SECONDS_PER_MINUTE);
+    }
+    format!("{seconds}s")
 }
 
 fn main() {
@@ -83,7 +148,16 @@ mod tests {
 
     /// Every text that the parser rejects, for the message tests.
     const BAD_TEXTS: [&str; 10] = [
-        "", "1", "1sec", "5x", "ms", "abc", "-1s", "0s", "0ms", "99999999999999999999m",
+        "",
+        "1",
+        "1sec",
+        "5x",
+        "ms",
+        "abc",
+        "-1s",
+        "0s",
+        "0ms",
+        "99999999999999999999m",
     ];
 
     fn error_of(text: &str) -> String {
@@ -115,12 +189,12 @@ mod tests {
 
     #[test]
     fn parses_minutes() {
-        assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+        assert_eq!(parse_duration("2m").unwrap(), Duration::from_mins(2));
     }
 
     #[test]
     fn parses_hours() {
-        assert_eq!(parse_duration("3h").unwrap(), Duration::from_secs(10800));
+        assert_eq!(parse_duration("3h").unwrap(), Duration::from_hours(3));
     }
 
     #[test]
@@ -131,8 +205,14 @@ mod tests {
     #[test]
     fn rejects_text_without_a_unit() {
         let message = error_of("1");
-        assert!(message.contains("`1`"), "the message names the text: {message}");
-        assert!(message.contains("no unit"), "the message names the fault: {message}");
+        assert!(
+            message.contains("`1`"),
+            "the message names the text: {message}"
+        );
+        assert!(
+            message.contains("no unit"),
+            "the message names the fault: {message}"
+        );
         assert!(
             message.contains("the unit must be `ms`, `s`, `m`, or `h`"),
             "the message names the accepted units: {message}"
@@ -222,17 +302,26 @@ mod tests {
 
     #[test]
     fn renders_minutes() {
-        assert_eq!(render_duration(Duration::from_secs(120)), "2m");
+        assert_eq!(render_duration(Duration::from_mins(2)), "2m");
     }
 
     #[test]
     fn renders_one_hour() {
+        assert_eq!(render_duration(Duration::from_hours(1)), "1h");
+    }
+
+    #[test]
+    #[allow(
+        clippy::duration_suboptimal_units,
+        reason = "the seconds are the behavior: a duration of 3600 seconds renders as hours"
+    )]
+    fn renders_seconds_that_make_a_whole_hour_as_hours() {
         assert_eq!(render_duration(Duration::from_secs(3600)), "1h");
     }
 
     #[test]
     fn renders_whole_hours_as_hours() {
-        assert_eq!(render_duration(Duration::from_secs(7200)), "2h");
+        assert_eq!(render_duration(Duration::from_hours(2)), "2h");
     }
 
     #[test]

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -10,6 +10,19 @@
 
 use buildinfo::version_string;
 use clap::Parser;
+use std::time::Duration;
+
+/// The accepted units of a duration.
+const DURATION_UNITS: &str = "the unit must be `ms`, `s`, `m`, or `h`";
+
+/// Examples of a duration, for the end of an error message.
+const DURATION_FORMS: &str = "as in `500ms`, `1s`, or `2m`";
+
+/// The number of seconds in one minute.
+const SECONDS_PER_MINUTE: u64 = 60;
+
+/// The number of seconds in one hour.
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
 
 /// The command line of `krt`.
 ///
@@ -23,8 +36,214 @@ use clap::Parser;
 )]
 struct Cli {}
 
+/// Reads a duration from the text of a command line flag.
+///
+/// The text holds a whole number and one unit, with no space between them. The
+/// units are `ms` for milliseconds, `s` for seconds, `m` for minutes, and `h`
+/// for hours. `500ms`, `1s`, `2m`, and `3h` are examples.
+///
+/// # Errors
+///
+/// Returns the reason as text when the number is absent, the unit is absent or
+/// unknown, the text carries a sign, the duration is zero, or the number is too
+/// large. Each message names the fault and the accepted forms, so the user
+/// reads one line and corrects the flag.
+#[allow(
+    dead_code,
+    reason = "slice 3 attaches this parser to `--interval` and `--duration`"
+)]
+fn parse_duration(_text: &str) -> Result<Duration, String> {
+    unimplemented!("slice 2 reads a duration from the text of a flag")
+}
+
+/// Writes the shortest exact text of a duration.
+///
+/// A duration that carries milliseconds becomes milliseconds. A whole number of
+/// hours becomes hours. A whole number of minutes becomes minutes. Every other
+/// duration becomes seconds. The text reads like the text a user types, so
+/// `Duration::from_secs(3600)` becomes `1h`.
+#[allow(
+    dead_code,
+    reason = "slice 4 prints the resolved configuration with this renderer"
+)]
+fn render_duration(_duration: Duration) -> String {
+    unimplemented!("slice 2 writes the shortest exact text of a duration")
+}
+
 fn main() {
     // The parse handles `--version`, `-V`, and `--help` on its own. A later
     // slice prints the resolved configuration.
     Cli::parse();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_duration, render_duration};
+    use std::time::Duration;
+
+    /// Every text that the parser rejects, for the message tests.
+    const BAD_TEXTS: [&str; 10] = [
+        "", "1", "1sec", "5x", "ms", "abc", "-1s", "0s", "0ms", "99999999999999999999m",
+    ];
+
+    fn error_of(text: &str) -> String {
+        parse_duration(text).expect_err("the parser must reject this text")
+    }
+
+    #[test]
+    fn parses_milliseconds() {
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn parses_many_milliseconds() {
+        assert_eq!(
+            parse_duration("1500ms").unwrap(),
+            Duration::from_millis(1500)
+        );
+    }
+
+    #[test]
+    fn parses_seconds() {
+        assert_eq!(parse_duration("1s").unwrap(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn parses_many_seconds() {
+        assert_eq!(parse_duration("90s").unwrap(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn parses_minutes() {
+        assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn parses_hours() {
+        assert_eq!(parse_duration("3h").unwrap(), Duration::from_secs(10800));
+    }
+
+    #[test]
+    fn rejects_empty_text() {
+        assert!(error_of("").contains("empty"));
+    }
+
+    #[test]
+    fn rejects_text_without_a_unit() {
+        let message = error_of("1");
+        assert!(message.contains("`1`"), "the message names the text: {message}");
+        assert!(message.contains("no unit"), "the message names the fault: {message}");
+        assert!(
+            message.contains("the unit must be `ms`, `s`, `m`, or `h`"),
+            "the message names the accepted units: {message}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_unknown_unit() {
+        for text in ["1sec", "5x"] {
+            let message = error_of(text);
+            assert!(
+                message.contains(text),
+                "the message names the text: {message}"
+            );
+            assert!(
+                message.contains("the unit must be `ms`, `s`, `m`, or `h`"),
+                "the message names the accepted units: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_text_without_a_number() {
+        for text in ["ms", "abc"] {
+            let message = error_of(text);
+            assert!(
+                message.contains("no number"),
+                "the message names the fault: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_negative_duration() {
+        let message = error_of("-1s");
+        assert!(
+            message.contains("never negative"),
+            "the message names the fault: {message}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_zero_duration() {
+        for text in ["0s", "0ms"] {
+            let message = error_of(text);
+            assert!(
+                message.contains("zero"),
+                "the message names the fault: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_number_that_overflows() {
+        let message = error_of("99999999999999999999m");
+        assert!(
+            message.contains("too large"),
+            "the message names the fault: {message}"
+        );
+    }
+
+    #[test]
+    fn every_error_names_the_accepted_forms() {
+        for text in BAD_TEXTS {
+            let message = error_of(text);
+            assert!(
+                message.contains("as in `500ms`, `1s`, or `2m`"),
+                "the message names the accepted forms: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn renders_milliseconds() {
+        assert_eq!(render_duration(Duration::from_millis(500)), "500ms");
+    }
+
+    #[test]
+    fn renders_one_second() {
+        assert_eq!(render_duration(Duration::from_secs(1)), "1s");
+    }
+
+    #[test]
+    fn renders_many_seconds() {
+        assert_eq!(render_duration(Duration::from_secs(90)), "90s");
+    }
+
+    #[test]
+    fn renders_minutes() {
+        assert_eq!(render_duration(Duration::from_secs(120)), "2m");
+    }
+
+    #[test]
+    fn renders_one_hour() {
+        assert_eq!(render_duration(Duration::from_secs(3600)), "1h");
+    }
+
+    #[test]
+    fn renders_whole_hours_as_hours() {
+        assert_eq!(render_duration(Duration::from_secs(7200)), "2h");
+    }
+
+    #[test]
+    fn renders_a_duration_that_carries_milliseconds_as_milliseconds() {
+        assert_eq!(render_duration(Duration::from_millis(1500)), "1500ms");
+    }
+
+    #[test]
+    fn a_parsed_duration_renders_as_the_text_of_the_parse() {
+        for text in ["500ms", "1s", "90s", "2m", "1h"] {
+            assert_eq!(render_duration(parse_duration(text).unwrap()), text);
+        }
+    }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1,16 +1,15 @@
 //! `krt` (Knights of the Round Trip) records the network path to a
 //! destination, hop by hop.
 //!
-//! This slice adds the flags of the command line and their defaults. Later
-//! slices print the resolved configuration, then add the tracer, the file
-//! writer, and the table.
+//! This slice resolves the command line and prints the configuration of the
+//! run. Later slices add the tracer, the file writer, and the table.
 
 // Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 
 use buildinfo::version_string;
-use clap::{Parser, ValueEnum};
+use clap::{CommandFactory, Parser, ValueEnum};
 use std::fmt;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -43,6 +42,23 @@ const FIRST_TTL_DEFAULT: u8 = 1;
 
 /// The last TTL of a run, when the user names none.
 const MAX_TTL_DEFAULT: u8 = 30;
+
+/// The width of the key field of the resolved configuration block.
+///
+/// The longest key is `address family:`, and one space follows it.
+const CONFIG_KEY_WIDTH: usize = 16;
+
+/// The value of a flag that holds no limit and no file.
+const ABSENT: &str = "none";
+
+/// The value of the output, when the user names no file.
+const OUTPUT_DERIVED: &str = "derived at run time";
+
+/// The value of the source, when the user names no address.
+const SOURCE_DISCOVERED: &str = "discovered at run time";
+
+/// The value of the run, when the user names no run of a replay.
+const RUN_LATEST: &str = "the last run";
 
 /// The protocol of a probe.
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -77,20 +93,40 @@ enum AddressFamily {
     Version6,
 }
 
-/// The command line of `krt`.
+impl fmt::Display for AddressFamily {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Auto => "auto",
+            Self::Version4 => "ipv4",
+            Self::Version6 => "ipv6",
+        })
+    }
+}
+
+/// Reads the text that the parser accepts for one value of a value enum.
 ///
-/// `--version` and `-V` print the build string that `buildinfo` made at compile
-/// time.
+/// The printer and the parser then read the same table, so the text of the
+/// output and the text of the command line can never part company.
+///
+/// # Panics
+///
+/// Panics when the variant carries no name. Every variant of a value enum of
+/// `krt` carries one, because no variant is hidden from the parser.
+fn value_name<T: ValueEnum>(value: &T) -> String {
+    value
+        .to_possible_value()
+        .expect("every variant of a value enum of `krt` carries a name")
+        .get_name()
+        .to_owned()
+}
+
+/// Knights of the Round Trip: record the network path to a destination.
+///
+/// `krt` probes every hop to the destination once per round, and it records
+/// each round in a file. This build parses the command line and prints the
+/// configuration it resolved.
 #[derive(Parser, Debug)]
-#[command(
-    name = "krt",
-    version = version_string!(),
-    about = "Knights of the Round Trip: record the network path to a destination"
-)]
-#[allow(
-    dead_code,
-    reason = "slice 4 reads every field when it prints the resolved configuration, and slice 4 removes this attribute"
-)]
+#[command(name = "krt", version = version_string!())]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "each flag of the design is one switch of the command line"
@@ -227,13 +263,109 @@ impl Cli {
     /// TTL above the max TTL leaves no hop to probe. A multipath mode other
     /// than `classic` needs UDP or TCP, because ICMP carries no flow to vary.
     fn resolve(self) -> Result<ResolvedConfig, String> {
-        unimplemented!("slice 4 resolves the command line")
+        if self.first_ttl > self.max_ttl {
+            return Err(format!(
+                "`--first-ttl {}` is above `--max-ttl {}`: the first TTL starts the probe and the max TTL ends it",
+                self.first_ttl, self.max_ttl
+            ));
+        }
+
+        let carries_a_flow = matches!(self.protocol, Protocol::Udp | Protocol::Tcp);
+        if self.multipath != Multipath::Classic && !carries_a_flow {
+            return Err(format!(
+                "`--multipath {}` needs `--protocol udp` or `--protocol tcp`, but the protocol is `{}`",
+                value_name(&self.multipath),
+                value_name(&self.protocol)
+            ));
+        }
+
+        // The parser rejects the two flags of the address family together, so
+        // one flag at most is true here.
+        let address_family = if self.ipv4 {
+            AddressFamily::Version4
+        } else if self.ipv6 {
+            AddressFamily::Version6
+        } else {
+            AddressFamily::Auto
+        };
+
+        Ok(ResolvedConfig {
+            destination: self.destination,
+            output: self.output,
+            interval: self.interval,
+            first_ttl: self.first_ttl,
+            max_ttl: self.max_ttl,
+            protocol: self.protocol,
+            multipath: self.multipath,
+            address_family,
+            reverse_dns: !self.no_dns,
+            source: self.source,
+            headless: self.headless,
+            duration: self.duration,
+            rounds: self.rounds,
+            replay: self.replay,
+            run: self.run,
+        })
     }
 }
 
 impl fmt::Display for ResolvedConfig {
-    fn fmt(&self, _formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unimplemented!("slice 4 prints the resolved configuration")
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let path_or = |path: Option<&PathBuf>, absent: &str| {
+            path.map_or_else(|| absent.to_owned(), |path| path.display().to_string())
+        };
+        let rows = [
+            (
+                "destination",
+                self.destination
+                    .clone()
+                    .unwrap_or_else(|| ABSENT.to_owned()),
+            ),
+            ("output", path_or(self.output.as_ref(), OUTPUT_DERIVED)),
+            ("interval", render_duration(self.interval)),
+            ("first ttl", self.first_ttl.to_string()),
+            ("max ttl", self.max_ttl.to_string()),
+            ("protocol", value_name(&self.protocol)),
+            ("multipath", value_name(&self.multipath)),
+            ("address family", self.address_family.to_string()),
+            (
+                "reverse dns",
+                if self.reverse_dns { "on" } else { "off" }.to_owned(),
+            ),
+            (
+                "source",
+                self.source.map_or_else(
+                    || SOURCE_DISCOVERED.to_owned(),
+                    |address| address.to_string(),
+                ),
+            ),
+            (
+                "display",
+                if self.headless { "headless" } else { "table" }.to_owned(),
+            ),
+            (
+                "duration limit",
+                self.duration
+                    .map_or_else(|| ABSENT.to_owned(), render_duration),
+            ),
+            (
+                "round limit",
+                self.rounds
+                    .map_or_else(|| ABSENT.to_owned(), |rounds| rounds.to_string()),
+            ),
+            ("replay", path_or(self.replay.as_ref(), ABSENT)),
+            (
+                "run",
+                self.run.clone().unwrap_or_else(|| RUN_LATEST.to_owned()),
+            ),
+        ];
+
+        writeln!(formatter, "resolved configuration:")?;
+        for (key, value) in rows {
+            let key = format!("{key}:");
+            writeln!(formatter, "  {key:<CONFIG_KEY_WIDTH$}{value}")?;
+        }
+        Ok(())
     }
 }
 
@@ -314,10 +446,6 @@ fn parse_duration(text: &str) -> Result<Duration, String> {
 /// hours becomes hours. A whole number of minutes becomes minutes. Every other
 /// duration becomes seconds. The text reads like the text a user types, so
 /// `Duration::from_secs(3600)` becomes `1h`.
-#[allow(
-    dead_code,
-    reason = "slice 4 prints the resolved configuration with this renderer"
-)]
 fn render_duration(duration: Duration) -> String {
     let seconds = duration.as_secs();
     if duration.subsec_millis() != 0 || seconds == 0 {
@@ -333,9 +461,16 @@ fn render_duration(duration: Duration) -> String {
 }
 
 fn main() {
-    // The parse handles `--version`, `-V`, and `--help` on its own. A later
-    // slice prints the resolved configuration.
-    Cli::parse();
+    // The parse handles `--version`, `-V`, and `--help` on its own. A
+    // contradiction between two flags leaves the parser, so `clap` writes it to
+    // standard error in the style of every other error of a command line.
+    let cli = Cli::parse();
+    match cli.resolve() {
+        Ok(config) => print!("{config}"),
+        Err(message) => Cli::command()
+            .error(clap::error::ErrorKind::ValueValidation, message)
+            .exit(),
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1,8 +1,9 @@
 //! `krt` (Knights of the Round Trip) records the network path to a
 //! destination, hop by hop.
 //!
-//! This slice builds the crate and the build string. Later slices add the
-//! command line flags, the tracer, the file writer, and the table.
+//! This slice adds the flags of the command line and their defaults. Later
+//! slices print the resolved configuration, then add the tracer, the file
+//! writer, and the table.
 
 // Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -25,6 +26,22 @@ const SECONDS_PER_MINUTE: u64 = 60;
 
 /// The number of seconds in one hour.
 const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+
+/// The lowest TTL that a probe carries. A TTL of zero leaves no hop to reach.
+///
+/// The type is the type that `clap` takes for the bound of a range.
+const TTL_LOWEST: i64 = 1;
+
+/// The highest TTL that a probe carries. The field of the packet holds one byte.
+///
+/// The type is the type that `clap` takes for the bound of a range.
+const TTL_HIGHEST: i64 = 255;
+
+/// The first TTL of a run, when the user names none.
+const FIRST_TTL_DEFAULT: u8 = 1;
+
+/// The last TTL of a run, when the user names none.
+const MAX_TTL_DEFAULT: u8 = 30;
 
 /// The protocol of a probe.
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -58,40 +75,65 @@ enum Multipath {
     version = version_string!(),
     about = "Knights of the Round Trip: record the network path to a destination"
 )]
+#[allow(
+    dead_code,
+    reason = "slice 4 reads every field when it prints the resolved configuration, and slice 4 removes this attribute"
+)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "each flag of the design is one switch of the command line"
+)]
 struct Cli {
     /// The host or the address to trace.
+    #[arg(value_name = "DESTINATION", required_unless_present = "replay")]
     destination: Option<String>,
 
     /// The JSONL path. Overrides the derived name.
-    #[arg(long)]
+    #[arg(short, long, value_name = "FILE")]
     output: Option<PathBuf>,
 
     /// The round period. Accepts `500ms`, `1s`, `2m`.
-    #[arg(long, value_parser = parse_duration)]
+    #[arg(
+        short,
+        long,
+        value_name = "DUR",
+        default_value = "1s",
+        value_parser = parse_duration,
+    )]
     interval: Duration,
 
     /// The first TTL to probe.
-    #[arg(long)]
+    #[arg(
+        long,
+        value_name = "N",
+        default_value_t = FIRST_TTL_DEFAULT,
+        value_parser = clap::value_parser!(u8).range(TTL_LOWEST..=TTL_HIGHEST),
+    )]
     first_ttl: u8,
 
     /// The last TTL to probe.
-    #[arg(long)]
+    #[arg(
+        long,
+        value_name = "N",
+        default_value_t = MAX_TTL_DEFAULT,
+        value_parser = clap::value_parser!(u8).range(TTL_LOWEST..=TTL_HIGHEST),
+    )]
     max_ttl: u8,
 
     /// The protocol of a probe.
-    #[arg(long)]
+    #[arg(long, value_name = "P", value_enum, default_value_t = Protocol::Icmp)]
     protocol: Protocol,
 
     /// The multipath mode. UDP and TCP only.
-    #[arg(long)]
+    #[arg(long, value_name = "M", value_enum, default_value_t = Multipath::Classic)]
     multipath: Multipath,
 
     /// Force IP version 4.
-    #[arg(long)]
+    #[arg(short = '4', conflicts_with = "ipv6")]
     ipv4: bool,
 
     /// Force IP version 6.
-    #[arg(long)]
+    #[arg(short = '6')]
     ipv6: bool,
 
     /// Skip reverse DNS. Show addresses only.
@@ -99,7 +141,7 @@ struct Cli {
     no_dns: bool,
 
     /// Override the source label in the derived filename.
-    #[arg(long)]
+    #[arg(long, value_name = "IP")]
     source: Option<IpAddr>,
 
     /// No table. Print one status line per minute.
@@ -107,19 +149,19 @@ struct Cli {
     headless: bool,
 
     /// Stop after this much time.
-    #[arg(long, value_parser = parse_duration)]
+    #[arg(long, value_name = "DUR", value_parser = parse_duration)]
     duration: Option<Duration>,
 
     /// Stop after this many rounds.
-    #[arg(long)]
+    #[arg(long, value_name = "N")]
     rounds: Option<u64>,
 
     /// Fold a recorded file and print the table. Then exit.
-    #[arg(long)]
+    #[arg(long, value_name = "FILE")]
     replay: Option<PathBuf>,
 
     /// With `--replay`, pick which run in the file to fold.
-    #[arg(long)]
+    #[arg(long, value_name = "ID", requires = "replay")]
     run: Option<String>,
 }
 
@@ -135,10 +177,6 @@ struct Cli {
 /// unknown, the text carries a sign, the duration is zero, or the number is too
 /// large. Each message names the fault and the accepted forms, so the user
 /// reads one line and corrects the flag.
-#[allow(
-    dead_code,
-    reason = "slice 3 attaches this parser to `--interval` and `--duration`"
-)]
 fn parse_duration(text: &str) -> Result<Duration, String> {
     if text.is_empty() {
         return Err(format!(
@@ -230,7 +268,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Multipath, Protocol, parse_duration, render_duration};
+    use super::{parse_duration, render_duration, Cli, Multipath, Protocol};
     use clap::error::ErrorKind;
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -885,6 +885,21 @@ resolved configuration:
     }
 
     #[test]
+    fn rejects_a_destination_beside_a_replay() {
+        let error = rejection(&["krt", "example.com", "--replay", "path.jsonl"]);
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+        let message = error.to_string();
+        assert!(
+            message.contains("DESTINATION"),
+            "the message names the destination: {message}"
+        );
+        assert!(
+            message.contains("--replay"),
+            "the message names the replay: {message}"
+        );
+    }
+
+    #[test]
     fn rejects_a_run_without_a_replay() {
         let error = rejection(&["krt", "example.com", "--run", "2026-08-19T12:00:00Z"]);
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -11,6 +11,7 @@
 
 use buildinfo::version_string;
 use clap::{Parser, ValueEnum};
+use std::fmt;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -63,6 +64,17 @@ enum Multipath {
     Paris,
     /// Walk the flows to find every path, as Dublin traceroute does.
     Dublin,
+}
+
+/// The IP version of a probe, after the two flags of the command line resolve.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AddressFamily {
+    /// Let the resolver pick the version.
+    Auto,
+    /// Force IP version 4.
+    Version4,
+    /// Force IP version 6.
+    Version6,
 }
 
 /// The command line of `krt`.
@@ -163,6 +175,66 @@ struct Cli {
     /// With `--replay`, pick which run in the file to fold.
     #[arg(long, value_name = "ID", requires = "replay")]
     run: Option<String>,
+}
+
+/// The configuration of one run, after the command line resolves.
+///
+/// Every field holds a resolved value and not a flag, so a later slice reads
+/// the behavior of the run and never reads the switch that made it.
+#[derive(Debug)]
+struct ResolvedConfig {
+    /// The host or the address to trace. A replay traces nothing.
+    destination: Option<String>,
+    /// The JSONL path the user named. An absent path is derived at run time.
+    output: Option<PathBuf>,
+    /// The period of one round.
+    interval: Duration,
+    /// The first TTL to probe.
+    first_ttl: u8,
+    /// The last TTL to probe.
+    max_ttl: u8,
+    /// The protocol of a probe.
+    protocol: Protocol,
+    /// The way a probe keeps or varies the flow of a packet.
+    multipath: Multipath,
+    /// The IP version of a probe.
+    address_family: AddressFamily,
+    /// True when the tool reads the name of each hop.
+    reverse_dns: bool,
+    /// The source address the user named for the derived filename.
+    source: Option<IpAddr>,
+    /// True when the tool prints status lines and no table.
+    headless: bool,
+    /// The time that stops the run. An absent time runs until the user stops it.
+    duration: Option<Duration>,
+    /// The number of rounds that stops the run.
+    rounds: Option<u64>,
+    /// The recorded file to fold and print.
+    replay: Option<PathBuf>,
+    /// The run in the replay file to fold.
+    run: Option<String>,
+}
+
+impl Cli {
+    /// Resolves the command line into the configuration of one run.
+    ///
+    /// The two flags of the address family collapse into one value, and the
+    /// `--no-dns` switch becomes the behavior it controls.
+    ///
+    /// # Errors
+    ///
+    /// Returns the reason as text when two flags contradict each other. A first
+    /// TTL above the max TTL leaves no hop to probe. A multipath mode other
+    /// than `classic` needs UDP or TCP, because ICMP carries no flow to vary.
+    fn resolve(self) -> Result<ResolvedConfig, String> {
+        unimplemented!("slice 4 resolves the command line")
+    }
+}
+
+impl fmt::Display for ResolvedConfig {
+    fn fmt(&self, _formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!("slice 4 prints the resolved configuration")
+    }
 }
 
 /// Reads a duration from the text of a command line flag.
@@ -268,7 +340,9 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_duration, render_duration, Cli, Multipath, Protocol};
+    use super::{
+        parse_duration, render_duration, AddressFamily, Cli, Multipath, Protocol, ResolvedConfig,
+    };
     use clap::error::ErrorKind;
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -290,6 +364,40 @@ mod tests {
     fn rejection(arguments: &[&str]) -> clap::Error {
         Cli::try_parse_from(arguments.iter().copied()).expect_err("the command line must fail")
     }
+
+    /// Resolves a command line that holds no contradiction.
+    fn resolve(arguments: &[&str]) -> ResolvedConfig {
+        parse(arguments)
+            .resolve()
+            .expect("the command line must resolve")
+    }
+
+    /// Reads the message of a command line that contradicts itself.
+    fn contradiction(arguments: &[&str]) -> String {
+        parse(arguments)
+            .resolve()
+            .expect_err("the command line must contradict itself")
+    }
+
+    /// The block that `krt example.com` prints, with every default.
+    const DEFAULT_BLOCK: &str = "\
+resolved configuration:
+  destination:    example.com
+  output:         derived at run time
+  interval:       1s
+  first ttl:      1
+  max ttl:        30
+  protocol:       icmp
+  multipath:      classic
+  address family: auto
+  reverse dns:    on
+  source:         discovered at run time
+  display:        table
+  duration limit: none
+  round limit:    none
+  replay:         none
+  run:            the last run
+";
 
     /// Every text that the parser rejects, for the message tests.
     const BAD_TEXTS: [&str; 10] = [
@@ -716,5 +824,188 @@ mod tests {
         let cli = parse(&["krt", "example.com", "--no-dns", "--headless"]);
         assert!(cli.no_dns);
         assert!(cli.headless);
+    }
+
+    #[test]
+    fn a_resolved_configuration_holds_every_documented_default() {
+        let config = resolve(&["krt", "example.com"]);
+        assert_eq!(config.destination.as_deref(), Some("example.com"));
+        assert_eq!(config.output, None);
+        assert_eq!(config.interval, Duration::from_secs(1));
+        assert_eq!(config.first_ttl, 1);
+        assert_eq!(config.max_ttl, 30);
+        assert_eq!(config.protocol, Protocol::Icmp);
+        assert_eq!(config.multipath, Multipath::Classic);
+        assert_eq!(config.address_family, AddressFamily::Auto);
+        assert!(config.reverse_dns, "reverse DNS is on by default");
+        assert_eq!(config.source, None);
+        assert!(!config.headless, "the table is on by default");
+        assert_eq!(config.duration, None);
+        assert_eq!(config.rounds, None);
+        assert_eq!(config.replay, None);
+        assert_eq!(config.run, None);
+    }
+
+    #[test]
+    fn the_flag_of_ip_version_4_resolves_to_version_4() {
+        let config = resolve(&["krt", "example.com", "-4"]);
+        assert_eq!(config.address_family, AddressFamily::Version4);
+    }
+
+    #[test]
+    fn the_flag_of_ip_version_6_resolves_to_version_6() {
+        let config = resolve(&["krt", "example.com", "-6"]);
+        assert_eq!(config.address_family, AddressFamily::Version6);
+    }
+
+    #[test]
+    fn the_no_dns_flag_turns_reverse_dns_off() {
+        let config = resolve(&["krt", "example.com", "--no-dns"]);
+        assert!(!config.reverse_dns);
+    }
+
+    #[test]
+    fn rejects_a_first_ttl_above_the_max_ttl() {
+        let message = contradiction(&["krt", "example.com", "--first-ttl", "5", "--max-ttl", "3"]);
+        for part in ["--first-ttl", "5", "--max-ttl", "3"] {
+            assert!(
+                message.contains(part),
+                "the message names `{part}`: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_first_ttl_equal_to_the_max_ttl_resolves() {
+        let config = resolve(&["krt", "example.com", "--first-ttl", "4", "--max-ttl", "4"]);
+        assert_eq!(config.first_ttl, 4);
+        assert_eq!(config.max_ttl, 4);
+    }
+
+    #[test]
+    fn rejects_a_multipath_mode_that_the_protocol_cannot_carry() {
+        let message = contradiction(&["krt", "example.com", "--multipath", "paris"]);
+        for part in ["--multipath", "paris", "--protocol", "icmp"] {
+            assert!(
+                message.contains(part),
+                "the message names `{part}`: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_multipath_mode_resolves_with_udp_and_with_tcp() {
+        for (mode, protocol) in [("paris", "udp"), ("dublin", "tcp")] {
+            let config = resolve(&[
+                "krt",
+                "example.com",
+                "--multipath",
+                mode,
+                "--protocol",
+                protocol,
+            ]);
+            assert_eq!(
+                config.multipath,
+                match mode {
+                    "paris" => Multipath::Paris,
+                    _ => Multipath::Dublin,
+                },
+                "`--multipath {mode} --protocol {protocol}`"
+            );
+        }
+    }
+
+    #[test]
+    fn the_classic_multipath_mode_resolves_with_every_protocol() {
+        let config = resolve(&["krt", "example.com", "--multipath", "classic"]);
+        assert_eq!(config.multipath, Multipath::Classic);
+        assert_eq!(config.protocol, Protocol::Icmp);
+    }
+
+    #[test]
+    fn prints_every_default_of_a_resolved_configuration() {
+        assert_eq!(resolve(&["krt", "example.com"]).to_string(), DEFAULT_BLOCK);
+    }
+
+    #[test]
+    fn prints_every_value_that_a_flag_changed() {
+        let config = resolve(&[
+            "krt",
+            "example.com",
+            "--output",
+            "/tmp/x.jsonl",
+            "--interval",
+            "500ms",
+            "--first-ttl",
+            "2",
+            "--max-ttl",
+            "20",
+            "--protocol",
+            "udp",
+            "--multipath",
+            "paris",
+            "-6",
+            "--no-dns",
+            "--source",
+            "1.2.3.4",
+            "--headless",
+            "--duration",
+            "2m",
+            "--rounds",
+            "10",
+        ]);
+        assert_eq!(
+            config.to_string(),
+            "\
+resolved configuration:
+  destination:    example.com
+  output:         /tmp/x.jsonl
+  interval:       500ms
+  first ttl:      2
+  max ttl:        20
+  protocol:       udp
+  multipath:      paris
+  address family: ipv6
+  reverse dns:    off
+  source:         1.2.3.4
+  display:        headless
+  duration limit: 2m
+  round limit:    10
+  replay:         none
+  run:            the last run
+"
+        );
+    }
+
+    #[test]
+    fn prints_the_file_and_the_run_of_a_replay() {
+        let config = resolve(&[
+            "krt",
+            "--replay",
+            "/tmp/r.jsonl",
+            "--run",
+            "2026-08-19T12:00:00Z",
+        ]);
+        assert_eq!(
+            config.to_string(),
+            "\
+resolved configuration:
+  destination:    none
+  output:         derived at run time
+  interval:       1s
+  first ttl:      1
+  max ttl:        30
+  protocol:       icmp
+  multipath:      classic
+  address family: auto
+  reverse dns:    on
+  source:         discovered at run time
+  display:        table
+  duration limit: none
+  round limit:    none
+  replay:         /tmp/r.jsonl
+  run:            2026-08-19T12:00:00Z
+"
+        );
     }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -551,7 +551,7 @@ resolved configuration:
 ";
 
     /// Every text that the parser rejects, for the message tests.
-    const BAD_TEXTS: [&str; 10] = [
+    const BAD_TEXTS: [&str; 16] = [
         "",
         "1",
         "1sec",
@@ -562,7 +562,25 @@ resolved configuration:
         "0s",
         "0ms",
         "99999999999999999999m",
+        "1秒",
+        "1🎉",
+        "1é",
+        "秒",
+        "café",
+        "½s",
     ];
+
+    /// Every text where a digit runs into a multi-byte character that is no unit.
+    ///
+    /// The characters are 3 bytes, 4 bytes, and 2 bytes long, in that order. The
+    /// parser makes the message for an unknown unit.
+    const MULTI_BYTE_UNKNOWN_UNITS: [&str; 3] = ["1秒", "1🎉", "1é"];
+
+    /// Every text that starts with a multi-byte character in the place of a digit.
+    ///
+    /// `½` is a numeric character to Unicode, but it is no ASCII digit, so the
+    /// parser makes the message for a text without a number.
+    const MULTI_BYTE_TEXTS_WITHOUT_A_NUMBER: [&str; 3] = ["秒", "café", "½s"];
 
     fn error_of(text: &str) -> String {
         parse_duration(text).expect_err("the parser must reject this text")
@@ -625,7 +643,7 @@ resolved configuration:
 
     #[test]
     fn rejects_an_unknown_unit() {
-        for text in ["1sec", "5x"] {
+        for text in ["1sec", "5x"].into_iter().chain(MULTI_BYTE_UNKNOWN_UNITS) {
             let message = error_of(text);
             assert!(
                 message.contains(text),
@@ -640,11 +658,37 @@ resolved configuration:
 
     #[test]
     fn rejects_text_without_a_number() {
-        for text in ["ms", "abc"] {
+        for text in ["ms", "abc"]
+            .into_iter()
+            .chain(MULTI_BYTE_TEXTS_WITHOUT_A_NUMBER)
+        {
             let message = error_of(text);
             assert!(
                 message.contains("no number"),
                 "the message names the fault: {message}"
+            );
+        }
+    }
+
+    /// The parser splits a text on a character boundary.
+    ///
+    /// The parser reads the split point from `char_indices`, so the point is
+    /// always on a character boundary. A split point that mixes a count of
+    /// characters with a count of bytes cuts a multi-byte character in half,
+    /// and `split_at` panics. A measurement of the unit from the end of the
+    /// text, such as `text.len() - text.chars().rev().take_while(|c|
+    /// !c.is_ascii_digit()).count()`, is one such point: it panics on `½s`,
+    /// `秒`, `1秒`, `1🎉`, and `1é`. This test holds the boundary in place.
+    #[test]
+    fn a_duration_that_holds_a_multi_byte_character_never_panics() {
+        for text in MULTI_BYTE_UNKNOWN_UNITS
+            .into_iter()
+            .chain(MULTI_BYTE_TEXTS_WITHOUT_A_NUMBER)
+        {
+            let message = error_of(text);
+            assert!(
+                message.contains(text),
+                "the message names the text: {message}"
             );
         }
     }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -456,12 +456,15 @@ fn parse_duration(text: &str) -> Result<Duration, String> {
     Ok(duration)
 }
 
-/// Writes the shortest exact text of a duration.
+/// Writes the shortest text of a duration, to the millisecond.
 ///
 /// A duration that carries milliseconds becomes milliseconds. A whole number of
 /// hours becomes hours. A whole number of minutes becomes minutes. Every other
 /// duration becomes seconds. The text reads like the text a user types, so
-/// `Duration::from_secs(3600)` becomes `1h`.
+/// `Duration::from_secs(3600)` becomes `1h`. A duration that carries less than
+/// one millisecond loses that remainder. No caller gives such a duration today,
+/// because every duration comes from `parse_duration`, which stops at
+/// milliseconds.
 fn render_duration(duration: Duration) -> String {
     let seconds = duration.as_secs();
     if duration.subsec_millis() != 0 || seconds == 0 {

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -955,6 +955,18 @@ resolved configuration:
     }
 
     #[test]
+    fn parses_a_round_limit_of_one() {
+        let cli = parse(&["krt", "example.com", "--rounds", "1"]);
+        assert_eq!(cli.rounds, Some(1));
+    }
+
+    #[test]
+    fn rejects_a_round_limit_of_zero() {
+        let error = rejection(&["krt", "example.com", "--rounds", "0"]);
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
     fn parses_the_flags_that_hold_no_value() {
         let cli = parse(&["krt", "example.com", "--no-dns", "--headless"]);
         assert!(cli.no_dns);

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -43,6 +43,12 @@ const FIRST_TTL_DEFAULT: u8 = 1;
 /// The last TTL of a run, when the user names none.
 const MAX_TTL_DEFAULT: u8 = 30;
 
+/// The lowest number of rounds that stops a run. A run of zero rounds records
+/// nothing.
+///
+/// The type is the type that `clap` takes for the bound of a range.
+const ROUNDS_LOWEST: u64 = 1;
+
 /// The width of the key field of the resolved configuration block.
 ///
 /// The longest key is `address family:`, and one space follows it.
@@ -201,7 +207,11 @@ struct Cli {
     duration: Option<Duration>,
 
     /// Stop after this many rounds.
-    #[arg(long, value_name = "N")]
+    #[arg(
+        long,
+        value_name = "N",
+        value_parser = clap::value_parser!(u64).range(ROUNDS_LOWEST..),
+    )]
     rounds: Option<u64>,
 
     /// Fold a recorded file and print the table. Then exit.

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -138,8 +138,12 @@ fn value_name<T: ValueEnum>(value: &T) -> String {
     reason = "each flag of the design is one switch of the command line"
 )]
 struct Cli {
-    /// The host or the address to trace.
-    #[arg(value_name = "DESTINATION", required_unless_present = "replay")]
+    /// The host or the address to trace. A replay takes no destination.
+    #[arg(
+        value_name = "DESTINATION",
+        required_unless_present = "replay",
+        conflicts_with_all = ["replay", "run"],
+    )]
     destination: Option<String>,
 
     /// The JSONL path. Overrides the derived name.
@@ -214,7 +218,8 @@ struct Cli {
     )]
     rounds: Option<u64>,
 
-    /// Fold a recorded file and print the table. Then exit.
+    /// Fold a recorded file and print the table. Then exit. A replay takes no
+    /// destination.
     #[arg(long, value_name = "FILE")]
     replay: Option<PathBuf>,
 
@@ -229,7 +234,8 @@ struct Cli {
 /// the behavior of the run and never reads the switch that made it.
 #[derive(Debug)]
 struct ResolvedConfig {
-    /// The host or the address to trace. A replay traces nothing.
+    /// The host or the address to trace. A replay traces nothing, so a replay
+    /// takes no destination and this field holds none.
     destination: Option<String>,
     /// The JSONL path the user named. An absent path is derived at run time.
     output: Option<PathBuf>,

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -203,3 +203,14 @@ fn a_command_line_without_a_destination_fails() {
     let stderr = failure(&[]);
     assert!(!stderr.is_empty(), "the failure carries a message");
 }
+
+#[test]
+fn a_destination_beside_a_replay_fails_and_names_both() {
+    let stderr = failure(&["example.com", "--replay", "old.jsonl"]);
+    for part in ["DESTINATION", "--replay"] {
+        assert!(
+            stderr.contains(part),
+            "the message names `{part}`: {stderr}"
+        );
+    }
+}

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -184,6 +184,15 @@ fn a_first_ttl_above_the_max_ttl_fails_and_names_both_flags() {
 }
 
 #[test]
+fn a_round_limit_of_zero_fails_and_names_the_flag() {
+    let stderr = failure(&["--rounds", "0", "example.com"]);
+    assert!(
+        stderr.contains("--rounds"),
+        "the message names `--rounds`: {stderr}"
+    );
+}
+
+#[test]
 fn both_address_family_flags_fail() {
     let stderr = failure(&["-4", "-6", "example.com"]);
     assert!(!stderr.is_empty(), "the failure carries a message");

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -1,0 +1,91 @@
+//! Black-box coverage for the `krt` command line, driving the real binary.
+//!
+//! The build string is what a user reads when a bug report asks which build
+//! made the trace. It must name the tool, the package version, the commit, and
+//! whether the tree was clean. The test reads the line the binary printed, so
+//! it covers the whole path from the flag to standard output.
+//!
+//! The commit hash and the status change with every build, so the test asserts
+//! the shape of the line and not its exact text.
+
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "each unwrap here is an assertion about the harness, not an unhandled error: the spawn of the freshly built binary, and the decode of the output that binary wrote. A failure of either one is a broken harness, and a panic names it at once"
+)]
+
+use std::process::Command;
+
+/// The text before the commit hash of the build string.
+const BUILD_STRING_PREFIX: &str = "krt 0.1.0 (";
+
+/// The separator between the commit hash and the status.
+const FIELD_SEPARATOR: &str = ", ";
+
+/// The number of characters of an abbreviated commit hash.
+const HASH_LENGTH: usize = 7;
+
+/// The text `buildinfo` writes for a field it cannot read from git.
+const UNKNOWN: &str = "unknown";
+
+/// The words `buildinfo` writes for the state of the working tree.
+const STATUS_WORDS: [&str; 3] = ["clean", "dirty", UNKNOWN];
+
+/// Invoke the freshly built `krt` binary.
+fn krt() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_krt"))
+}
+
+/// Assert that `flag` makes `krt` print one build string and exit with success.
+fn assert_flag_prints_the_build_string(flag: &str) {
+    let output = krt().arg(flag).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`krt {flag}` must exit with success, but it exited with {}; stderr: {stderr}",
+        output.status
+    );
+
+    let mut lines = stdout.lines();
+    let line = lines.next().unwrap_or_default();
+    assert!(
+        lines.next().is_none(),
+        "`krt {flag}` must print one line, but it printed {stdout:?}"
+    );
+
+    let fields = line
+        .strip_prefix(BUILD_STRING_PREFIX)
+        .and_then(|rest| rest.strip_suffix(')'));
+    let Some(fields) = fields else {
+        panic!("`krt {flag}` must print `krt 0.1.0 (<hash>, <status>)`, but it printed {line:?}");
+    };
+
+    let parts: Vec<&str> = fields.split(FIELD_SEPARATOR).collect();
+    let [hash, status] = parts.as_slice() else {
+        panic!("`krt {flag}` must print one hash and one status, but the parentheses hold {fields:?}");
+    };
+
+    let hash_is_valid = *hash == UNKNOWN
+        || (hash.chars().count() == HASH_LENGTH
+            && hash.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')));
+    assert!(
+        hash_is_valid,
+        "`krt {flag}` must print {HASH_LENGTH} lowercase hexadecimal characters or `{UNKNOWN}` for the hash, but it printed {hash:?}"
+    );
+
+    assert!(
+        STATUS_WORDS.contains(status),
+        "`krt {flag}` must print one of {STATUS_WORDS:?} for the status, but it printed {status:?}"
+    );
+}
+
+#[test]
+fn version_flags_report_the_build_string() {
+    assert_flag_prints_the_build_string("--version");
+    assert_flag_prints_the_build_string("-V");
+}

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -7,6 +7,10 @@
 //!
 //! The commit hash and the status change with every build, so the test asserts
 //! the shape of the line and not its exact text.
+//!
+//! The rest of the file covers the resolved configuration. A good command line
+//! prints the block and exits with success. A command line that contradicts
+//! itself prints the reason on standard error and exits with a failure.
 
 // Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -90,4 +94,103 @@ fn assert_flag_prints_the_build_string(flag: &str) {
 fn version_flags_report_the_build_string() {
     assert_flag_prints_the_build_string("--version");
     assert_flag_prints_the_build_string("-V");
+}
+
+/// The block that `krt example.com` prints, with every default.
+const DEFAULT_BLOCK: &str = "\
+resolved configuration:
+  destination:    example.com
+  output:         derived at run time
+  interval:       1s
+  first ttl:      1
+  max ttl:        30
+  protocol:       icmp
+  multipath:      classic
+  address family: auto
+  reverse dns:    on
+  source:         discovered at run time
+  display:        table
+  duration limit: none
+  round limit:    none
+  replay:         none
+  run:            the last run
+";
+
+/// What one run of the binary wrote, and whether it succeeded.
+struct Run {
+    /// True when the binary exited with success.
+    success: bool,
+    /// The text the binary wrote to standard output.
+    stdout: String,
+    /// The text the binary wrote to standard error.
+    stderr: String,
+}
+
+/// Runs `krt` with the arguments and reads what it wrote.
+fn run(arguments: &[&str]) -> Run {
+    let output = krt().args(arguments).output().unwrap();
+    Run {
+        success: output.status.success(),
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+/// Asserts that the arguments make `krt` fail, and reads the message.
+fn failure(arguments: &[&str]) -> String {
+    let result = run(arguments);
+    assert!(
+        !result.success,
+        "`krt {}` must fail, but it succeeded; stdout: {}",
+        arguments.join(" "),
+        result.stdout
+    );
+    result.stderr
+}
+
+#[test]
+fn a_destination_prints_the_resolved_configuration() {
+    let result = run(&["example.com"]);
+    assert!(
+        result.success,
+        "`krt example.com` must exit with success; stderr: {}",
+        result.stderr
+    );
+    assert_eq!(result.stdout, DEFAULT_BLOCK);
+    assert_eq!(
+        result.stderr, "",
+        "a good command line writes nothing to standard error"
+    );
+}
+
+#[test]
+fn an_interval_that_is_not_a_duration_fails_and_names_the_accepted_forms() {
+    let stderr = failure(&["--interval", "bogus", "example.com"]);
+    assert!(
+        stderr.contains("as in `500ms`, `1s`, or `2m`"),
+        "the message names the accepted forms: {stderr}"
+    );
+}
+
+#[test]
+fn a_first_ttl_above_the_max_ttl_fails_and_names_both_flags() {
+    let stderr = failure(&["--first-ttl", "5", "--max-ttl", "3", "example.com"]);
+    for flag in ["--first-ttl", "--max-ttl"] {
+        assert!(
+            stderr.contains(flag),
+            "the message names `{flag}`: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn both_address_family_flags_fail() {
+    let stderr = failure(&["-4", "-6", "example.com"]);
+    assert!(!stderr.is_empty(), "the failure carries a message");
+}
+
+#[test]
+fn a_command_line_without_a_destination_fails() {
+    let stderr = failure(&[]);
+    assert!(!stderr.is_empty(), "the failure carries a message");
 }

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -67,7 +67,9 @@ fn assert_flag_prints_the_build_string(flag: &str) {
 
     let parts: Vec<&str> = fields.split(FIELD_SEPARATOR).collect();
     let [hash, status] = parts.as_slice() else {
-        panic!("`krt {flag}` must print one hash and one status, but the parentheses hold {fields:?}");
+        panic!(
+            "`krt {flag}` must print one hash and one status, but the parentheses hold {fields:?}"
+        );
     };
 
     let hash_is_valid = *hash == UNKNOWN

--- a/src/repo-guards/Cargo.toml
+++ b/src/repo-guards/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 glob.workspace = true
+pulldown-cmark.workspace = true
 syn.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/src/repo-guards/src/lib.rs
+++ b/src/repo-guards/src/lib.rs
@@ -17,4 +17,5 @@
 // move module-doc link resolution to the crate root, silently breaking every
 // intra-doc link inside those headers.
 pub mod target_lints;
+pub mod tool_index;
 pub mod workspace_lints;

--- a/src/repo-guards/src/tool_index.rs
+++ b/src/repo-guards/src/tool_index.rs
@@ -3,35 +3,201 @@
 //! The repository documents its tools twice, and on purpose. `README.md`
 //! carries the long entry — what the tool is for, how to run it, how to install
 //! it. `TLDR.md` carries one line per tool, alphabetized, for a reader who only
-//! needs to know which tool to reach for. A tool that is missing from either one
-//! is a tool nobody finds.
+//! needs to know which tool to reach for. A tool missing from either one is a
+//! tool nobody finds.
 //!
 //! Nothing enforced this before. The omission is spelled as an *absence*, which
-//! is why it spread: a new crate that nobody remembers to document is born
-//! undocumented, and no build step ever says so.
+//! is why it spread: a crate that nobody remembers to document is born
+//! undocumented, and no build step ever says so. Two of the workspace's
+//! binaries had drifted out of an index by the time this guard was written.
 //!
-//! [`audit`] closes that hole.
+//! [`audit`] closes that hole. Three design rules make it a real guard rather
+//! than a comfortable one:
+//!
+//! 1. **Enumerate, never allowlist.** The tools come from the binary targets
+//!    cargo builds, resolved from [`workspace_lints::members`] and each member's
+//!    manifest. A hardcoded list of tool names would make the next new tool
+//!    invisible to the guard, which is the exact failure this exists to prevent.
+//! 2. **Parse, never text-match.** "`TLDR.md` has a table row whose first cell
+//!    names this tool" and "`README.md` has an entry for this tool" both name
+//!    syntactic categories of Markdown, so both are answered with a Markdown
+//!    parser. Searching the file for the tool's name instead would pass on a
+//!    *mention*, and the indexes are full of mentions: `sirn`'s row names
+//!    `portplz`, and `prgz`'s row names `prcp`. Delete either of those tools'
+//!    own rows and a text search still reports clean — which is
+//!    indistinguishable from a guard doing real work.
+//! 3. **Refuse rather than shrink.** Everything that could quietly reduce the
+//!    audited set — an unreadable index, a `TLDR.md` with no table, a `README.md`
+//!    with no tools section, a workspace with no binaries, a manifest that moves
+//!    cargo's target discovery — is an error rather than a clean verdict. See
+//!    [`ToolIndexError`].
+//!
+//! # What counts as an entry
+//!
+//! `TLDR.md` is one table, and a tool is listed when the **first cell of a body
+//! row** names it. The head row and every later cell are ignored, so the prose
+//! that describes one tool can name another without documenting it.
+//!
+//! `README.md` uses two forms, both of which are in service today, so the guard
+//! accepts either:
+//!
+//! - a **top-level list item** under the `## The tools` heading, whose first
+//!   word is the tool name (`- zth (zero the hero)`), and
+//! - a **level-2 section heading** whose first word is the tool name
+//!   (`## occ (old Claude Code)`).
+//!
+//! Nested list items are not entries. The `- To install: …` line under a tool's
+//! own entry would otherwise document a tool named `To`.
 
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use thiserror::Error;
+use toml::Value;
+
+use crate::workspace_lints::{self, parse_manifest, WorkspaceLintsError, CARGO_TOML};
+
+/// The long index, at the repository root.
+const README: &str = "README.md";
+
+/// The one-line index, at the repository root.
+const TLDR: &str = "TLDR.md";
+
+/// The `README.md` heading that opens the list of tools. Matched on its prefix,
+/// so the heading may carry trailing words without breaking the guard.
+const TOOLS_SECTION: &str = "The tools";
+
+/// The manifest table that holds package metadata.
+const PACKAGE_KEY: &str = "package";
+
+/// The manifest key naming a package.
+const NAME_KEY: &str = "name";
+
+/// The manifest array-of-tables declaring binaries explicitly.
+const BIN_KEY: &str = "bin";
+
+/// The `[package]` key that turns cargo's binary auto-discovery on or off.
+///
+/// This guard models the default discovery rules only. A manifest that changes
+/// them is refused rather than guessed at.
+const AUTOBINS_KEY: &str = "autobins";
+
+/// The conventional root of a package's one binary.
+const SRC_MAIN_RS: &str = "src/main.rs";
+
+/// The directory whose Rust files are each their own binary.
+const SRC_BIN: &str = "src/bin";
+
+/// The conventional entry point of a directory-shaped binary
+/// (`src/bin/foo/main.rs`).
+const MAIN_RS: &str = "main.rs";
+
+/// Rust source extension, used when auto-discovering binary roots.
+const RS: &str = "rs";
 
 /// Everything that can stop the audit from reaching a verdict.
+///
+/// Every variant is a *refusal*. A guard that cannot enumerate the tools must
+/// say so loudly, because "every tool is documented" and "I found no tools" are
+/// the same sentence to a CI log and only one of them is good news.
 #[derive(Debug, Error)]
 pub enum ToolIndexError {
+    /// The workspace members could not be enumerated, or a member manifest
+    /// could not be read or parsed.
+    #[error("cannot enumerate the workspace: {0}")]
+    Members(#[from] WorkspaceLintsError),
+
     /// An index file could not be read from disk.
     #[error("cannot read the index {}: {source}", path.display())]
     ReadIndex {
         /// The index that could not be read.
         path: PathBuf,
         /// The underlying I/O failure.
-        source: std::io::Error,
+        source: io::Error,
+    },
+
+    /// The workspace builds no binaries at all.
+    #[error(
+        "the workspace builds no binaries; refusing to report every tool documented when there are no tools"
+    )]
+    NoBinaries,
+
+    /// `TLDR.md` holds no table body row, so no tool can be listed in it.
+    #[error(
+        "{} holds no table row; refusing to report a clean index that lists nothing",
+        path.display()
+    )]
+    NoTableRows {
+        /// The index that holds no table.
+        path: PathBuf,
+    },
+
+    /// `README.md` has no `## The tools` heading, so the list index is gone.
+    #[error(
+        "{} has no `## {TOOLS_SECTION}` heading; refusing to audit a README whose tool list cannot be found",
+        path.display()
+    )]
+    NoToolsSection {
+        /// The index that lost its tools section.
+        path: PathBuf,
+    },
+
+    /// A member manifest declares no `package.name`, so its binary cannot be
+    /// named.
+    #[error("{} declares no `package.name`", path.display())]
+    MissingPackageName {
+        /// The member manifest.
+        path: PathBuf,
+    },
+
+    /// A `[[bin]]` entry has no string `name`.
+    #[error("`[[bin]]` entry #{index} in {} has no string `name`", path.display())]
+    NonStringBinName {
+        /// The member manifest.
+        path: PathBuf,
+        /// Zero-based position of the bad entry.
+        index: usize,
+    },
+
+    /// A member manifest moves cargo's binary auto-discovery, which this guard
+    /// does not model.
+    #[error(
+        "{} sets `package.{AUTOBINS_KEY}`; this guard models cargo's default binary discovery only, and refuses to guess",
+        path.display()
+    )]
+    AutoDiscoveryOverride {
+        /// The member manifest.
+        path: PathBuf,
+    },
+
+    /// A `src/bin` directory could not be walked.
+    #[error("cannot read {}: {source}", path.display())]
+    UnreadableBinDir {
+        /// The directory that could not be walked.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: io::Error,
+    },
+
+    /// A discovered binary root has a name that is not valid UTF-8, so it
+    /// cannot be compared against an index entry.
+    #[error("the binary root {} has a name that is not valid UTF-8", path.display())]
+    NonUtf8BinName {
+        /// The offending path.
+        path: PathBuf,
     },
 }
 
 /// The verdict of one audit: how many binaries were examined, and which of them
 /// are absent from each index.
-#[derive(Debug, Clone, Default)]
+///
+/// The remediation text lives here rather than at the call site, so every
+/// caller — test, CI job, or CLI — reports the same thing.
+#[derive(Debug, Clone)]
 pub struct Report {
     /// Number of binary targets the audit enumerated.
     binaries_examined: usize,
@@ -70,13 +236,333 @@ impl Report {
     }
 }
 
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_compliant() {
+            return write!(
+                f,
+                "Checked {} binaries; all appear in {README} and {TLDR}.",
+                self.binaries_examined
+            );
+        }
+
+        writeln!(
+            f,
+            "Of {} binaries the workspace builds, some are absent from a tool index.",
+            self.binaries_examined
+        )?;
+
+        for (index, missing) in [
+            (README, &self.missing_from_readme),
+            (TLDR, &self.missing_from_tldr),
+        ] {
+            if missing.is_empty() {
+                continue;
+            }
+            writeln!(f)?;
+            writeln!(f, "Absent from {index}: {}", missing.join(", "))?;
+        }
+
+        writeln!(f)?;
+        writeln!(
+            f,
+            "Add an entry to {README} — a top-level item under `## {TOOLS_SECTION}`, or a `## <tool>` section —"
+        )?;
+        write!(
+            f,
+            "and a row to the table in {TLDR}, whose first cell is the tool name."
+        )
+    }
+}
+
 /// Audit the tool indexes of the workspace rooted at `repo_root`.
+///
+/// Binaries come from [`binaries`]. Each index is parsed as Markdown, and a
+/// binary is documented when its name is an entry as the module header defines
+/// one.
 ///
 /// # Errors
 ///
 /// Returns [`ToolIndexError`] — never a clean [`Report`] — when the workspace
-/// or its indexes cannot be read with confidence.
+/// or its indexes cannot be read with confidence: the members cannot be
+/// enumerated ([`Members`](ToolIndexError::Members)), an index is unreadable
+/// ([`ReadIndex`](ToolIndexError::ReadIndex)), `TLDR.md` holds no table
+/// ([`NoTableRows`](ToolIndexError::NoTableRows)), `README.md` has no tools
+/// section ([`NoToolsSection`](ToolIndexError::NoToolsSection)), or the
+/// workspace builds no binaries ([`NoBinaries`](ToolIndexError::NoBinaries)).
 pub fn audit(repo_root: &Path) -> Result<Report, ToolIndexError> {
-    let _ = repo_root;
-    Ok(Report::default())
+    let names = binaries(repo_root)?;
+
+    let readme_path = repo_root.join(README);
+    let readme_names =
+        readme_entries(&read_index(&readme_path)?).ok_or(ToolIndexError::NoToolsSection {
+            path: readme_path.clone(),
+        })?;
+
+    let tldr_path = repo_root.join(TLDR);
+    let tldr_names = tldr_entries(&read_index(&tldr_path)?);
+    if tldr_names.is_empty() {
+        return Err(ToolIndexError::NoTableRows { path: tldr_path });
+    }
+
+    Ok(Report {
+        binaries_examined: names.len(),
+        missing_from_readme: absent(&names, &readme_names),
+        missing_from_tldr: absent(&names, &tldr_names),
+    })
+}
+
+/// Every binary name the workspace rooted at `repo_root` builds, sorted and
+/// deduplicated.
+///
+/// Public so a companion test can compare this set against `cargo metadata` —
+/// the guard's model of cargo's discovery rules is worth exactly as much as its
+/// agreement with cargo, and a binary the guard never enumerates is one it can
+/// never report as undocumented.
+///
+/// # Errors
+///
+/// Returns [`ToolIndexError`] when the members cannot be enumerated, a member
+/// manifest cannot be read or parsed, a manifest moves cargo's binary discovery
+/// or omits a name the guard needs, or the workspace builds no binaries at all.
+pub fn binaries(repo_root: &Path) -> Result<BTreeSet<String>, ToolIndexError> {
+    let mut names = BTreeSet::new();
+    for dir in workspace_lints::members(repo_root)? {
+        let manifest_path = dir.join(CARGO_TOML);
+        let manifest = parse_manifest(&manifest_path)?;
+        names.extend(binary_names(&dir, &manifest, &manifest_path)?);
+    }
+
+    if names.is_empty() {
+        return Err(ToolIndexError::NoBinaries);
+    }
+    Ok(names)
+}
+
+/// The names in `wanted` that `documented` does not hold, in sorted order.
+fn absent(wanted: &BTreeSet<String>, documented: &BTreeSet<String>) -> Vec<String> {
+    wanted.difference(documented).cloned().collect()
+}
+
+/// Read one index file, attributing the failure to its path.
+fn read_index(path: &Path) -> Result<String, ToolIndexError> {
+    fs::read_to_string(path).map_err(|source| ToolIndexError::ReadIndex {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// The binary names one member builds, following cargo's default discovery:
+/// every explicit `[[bin]]`, plus `src/main.rs` named for the package, plus
+/// each `src/bin/*.rs` and `src/bin/*/main.rs`.
+///
+/// A path an explicit `[[bin]]` already claims is not discovered a second time,
+/// which is what keeps a package that renames its binary from being counted
+/// under both names.
+fn binary_names(
+    dir: &Path,
+    manifest: &Value,
+    manifest_path: &Path,
+) -> Result<Vec<String>, ToolIndexError> {
+    let package = manifest.get(PACKAGE_KEY);
+    if package.and_then(|table| table.get(AUTOBINS_KEY)).is_some() {
+        return Err(ToolIndexError::AutoDiscoveryOverride {
+            path: manifest_path.to_path_buf(),
+        });
+    }
+
+    let mut names = Vec::new();
+    let mut claimed = BTreeSet::new();
+    if let Some(bins) = manifest.get(BIN_KEY).and_then(Value::as_array) {
+        for (index, bin) in bins.iter().enumerate() {
+            let name = bin.get(NAME_KEY).and_then(Value::as_str).ok_or(
+                ToolIndexError::NonStringBinName {
+                    path: manifest_path.to_path_buf(),
+                    index,
+                },
+            )?;
+            names.push(name.to_owned());
+            if let Some(path) = bin.get("path").and_then(Value::as_str) {
+                claimed.insert(path.replace('\\', "/"));
+            }
+        }
+    }
+
+    if dir.join(SRC_MAIN_RS).is_file() && !claimed.contains(SRC_MAIN_RS) {
+        names.push(
+            package
+                .and_then(|table| table.get(NAME_KEY))
+                .and_then(Value::as_str)
+                .ok_or(ToolIndexError::MissingPackageName {
+                    path: manifest_path.to_path_buf(),
+                })?
+                .to_owned(),
+        );
+    }
+
+    names.extend(discovered_bin_dir(dir, &claimed)?);
+    Ok(names)
+}
+
+/// Every binary `src/bin` contributes: one per `*.rs` file, and one per
+/// subdirectory holding a `main.rs`.
+fn discovered_bin_dir(
+    dir: &Path,
+    claimed: &BTreeSet<String>,
+) -> Result<Vec<String>, ToolIndexError> {
+    let bin_dir = dir.join(SRC_BIN);
+    if !bin_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let entries = fs::read_dir(&bin_dir).map_err(|source| ToolIndexError::UnreadableBinDir {
+        path: bin_dir.clone(),
+        source,
+    })?;
+
+    let mut names = Vec::new();
+    for entry in entries {
+        let path = entry
+            .map_err(|source| ToolIndexError::UnreadableBinDir {
+                path: bin_dir.clone(),
+                source,
+            })?
+            .path();
+
+        let (stem, relative) = if path.is_file() && path.extension().is_some_and(|ext| ext == RS) {
+            (path.file_stem(), format!("{SRC_BIN}/{}", file_name(&path)?))
+        } else if path.is_dir() && path.join(MAIN_RS).is_file() {
+            (
+                path.file_name(),
+                format!("{SRC_BIN}/{}/{MAIN_RS}", file_name(&path)?),
+            )
+        } else {
+            continue;
+        };
+
+        if claimed.contains(&relative) {
+            continue;
+        }
+        names.push(
+            stem.and_then(|s| s.to_str())
+                .ok_or(ToolIndexError::NonUtf8BinName { path: path.clone() })?
+                .to_owned(),
+        );
+    }
+    Ok(names)
+}
+
+/// The final component of `path` as UTF-8, or a refusal.
+fn file_name(path: &Path) -> Result<&str, ToolIndexError> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(ToolIndexError::NonUtf8BinName {
+            path: path.to_path_buf(),
+        })
+}
+
+/// The tool names in the first cell of every body row of `markdown`'s tables.
+///
+/// The head row is skipped, and so is every cell after the first, so a
+/// description that names another tool does not document it.
+fn tldr_entries(markdown: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let mut in_head = false;
+    let mut cell = 0_usize;
+    let mut capturing = false;
+    let mut buffer = String::new();
+
+    for event in Parser::new_ext(markdown, Options::ENABLE_TABLES) {
+        match event {
+            Event::Start(Tag::TableHead) => in_head = true,
+            Event::End(TagEnd::TableHead) => in_head = false,
+            Event::Start(Tag::TableRow) => cell = 0,
+            Event::Start(Tag::TableCell) => {
+                capturing = !in_head && cell == 0;
+                buffer.clear();
+            }
+            Event::End(TagEnd::TableCell) => {
+                if capturing {
+                    insert_trimmed(&mut names, &buffer);
+                    capturing = false;
+                }
+                cell += 1;
+            }
+            Event::Text(text) | Event::Code(text) if capturing => buffer.push_str(&text),
+            _ => {}
+        }
+    }
+    names
+}
+
+/// The tool names `markdown` documents: the first word of every top-level list
+/// item under `## The tools`, and the first word of every other level-2
+/// heading.
+///
+/// Returns `None` when the tools section is absent, which is a refusal rather
+/// than an empty answer — a README that lost its list would otherwise report
+/// every tool undocumented.
+fn readme_entries(markdown: &str) -> Option<BTreeSet<String>> {
+    let mut names = BTreeSet::new();
+    let mut found_section = false;
+    let mut in_tools = false;
+    let mut heading = None;
+    let mut list_depth = 0_usize;
+    let mut capturing_item = false;
+    let mut buffer = String::new();
+
+    for event in Parser::new_ext(markdown, Options::empty()) {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                heading = Some(level);
+                buffer.clear();
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if heading == Some(HeadingLevel::H2) {
+                    in_tools = buffer.trim().starts_with(TOOLS_SECTION);
+                    if in_tools {
+                        found_section = true;
+                    } else {
+                        insert_first_word(&mut names, &buffer);
+                    }
+                }
+                heading = None;
+            }
+            Event::Start(Tag::List(_)) => list_depth += 1,
+            Event::End(TagEnd::List(_)) => list_depth = list_depth.saturating_sub(1),
+            Event::Start(Tag::Item) if list_depth == 1 => {
+                capturing_item = in_tools;
+                buffer.clear();
+            }
+            Event::End(TagEnd::Item) if list_depth == 1 => {
+                if capturing_item {
+                    insert_first_word(&mut names, &buffer);
+                }
+                capturing_item = false;
+            }
+            Event::Text(text) | Event::Code(text)
+                if heading.is_some() || (capturing_item && list_depth == 1) =>
+            {
+                buffer.push_str(&text);
+            }
+            _ => {}
+        }
+    }
+
+    found_section.then_some(names)
+}
+
+/// Insert `text`'s first whitespace-separated word, when it has one.
+fn insert_first_word(names: &mut BTreeSet<String>, text: &str) {
+    if let Some(word) = text.split_whitespace().next() {
+        names.insert(word.to_owned());
+    }
+}
+
+/// Insert `text` without its surrounding whitespace, when anything remains.
+fn insert_trimmed(names: &mut BTreeSet<String>, text: &str) {
+    let trimmed = text.trim();
+    if !trimmed.is_empty() {
+        names.insert(trimmed.to_owned());
+    }
 }

--- a/src/repo-guards/src/tool_index.rs
+++ b/src/repo-guards/src/tool_index.rs
@@ -1,0 +1,82 @@
+//! Guard: every binary the workspace builds must appear in both tool indexes.
+//!
+//! The repository documents its tools twice, and on purpose. `README.md`
+//! carries the long entry — what the tool is for, how to run it, how to install
+//! it. `TLDR.md` carries one line per tool, alphabetized, for a reader who only
+//! needs to know which tool to reach for. A tool that is missing from either one
+//! is a tool nobody finds.
+//!
+//! Nothing enforced this before. The omission is spelled as an *absence*, which
+//! is why it spread: a new crate that nobody remembers to document is born
+//! undocumented, and no build step ever says so.
+//!
+//! [`audit`] closes that hole.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Everything that can stop the audit from reaching a verdict.
+#[derive(Debug, Error)]
+pub enum ToolIndexError {
+    /// An index file could not be read from disk.
+    #[error("cannot read the index {}: {source}", path.display())]
+    ReadIndex {
+        /// The index that could not be read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: std::io::Error,
+    },
+}
+
+/// The verdict of one audit: how many binaries were examined, and which of them
+/// are absent from each index.
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    /// Number of binary targets the audit enumerated.
+    binaries_examined: usize,
+    /// Binary names with no entry in `README.md`. Sorted.
+    missing_from_readme: Vec<String>,
+    /// Binary names with no row in `TLDR.md`. Sorted.
+    missing_from_tldr: Vec<String>,
+}
+
+impl Report {
+    /// True when every examined binary appears in both indexes.
+    #[must_use]
+    pub fn is_compliant(&self) -> bool {
+        self.missing_from_readme.is_empty() && self.missing_from_tldr.is_empty()
+    }
+
+    /// Binary names with no entry in `README.md`, sorted.
+    #[must_use]
+    pub fn missing_from_readme(&self) -> &[String] {
+        &self.missing_from_readme
+    }
+
+    /// Binary names with no row in `TLDR.md`, sorted.
+    #[must_use]
+    pub fn missing_from_tldr(&self) -> &[String] {
+        &self.missing_from_tldr
+    }
+
+    /// How many binary targets the audit enumerated.
+    ///
+    /// A caller should assert this is non-zero: a guard that scans nothing
+    /// reports clean for the wrong reason.
+    #[must_use]
+    pub fn binaries_examined(&self) -> usize {
+        self.binaries_examined
+    }
+}
+
+/// Audit the tool indexes of the workspace rooted at `repo_root`.
+///
+/// # Errors
+///
+/// Returns [`ToolIndexError`] — never a clean [`Report`] — when the workspace
+/// or its indexes cannot be read with confidence.
+pub fn audit(repo_root: &Path) -> Result<Report, ToolIndexError> {
+    let _ = repo_root;
+    Ok(Report::default())
+}

--- a/src/repo-guards/tests/tool_index_coverage.rs
+++ b/src/repo-guards/tests/tool_index_coverage.rs
@@ -1,0 +1,92 @@
+//! Guard tests for `repo_guards::tool_index::audit`.
+//!
+//! Every test builds a real workspace on disk and feeds it to the real
+//! `audit()` — member enumeration, binary discovery, markdown parsing, and
+//! comparison together, rather than a string predicate in isolation.
+//!
+//! Parallel safety: this workspace's tests share `./target` with the pre-commit
+//! hook's own `cargo test`, so two copies of any test here can run at the same
+//! moment. Every fixture lives in its own `tempfile::TempDir`, whose name the
+//! OS makes unique. Nothing is keyed on a fixed path under the temp dir, the
+//! repo, or the home dir.
+
+use std::fs;
+use std::path::Path;
+
+use repo_guards::tool_index;
+use tempfile::TempDir;
+
+/// A `README.md` that documents `aa` as a list entry and `bb` as a section.
+///
+/// Both forms are in use in the real README, so a fixture that carried only one
+/// of them would leave the other untested.
+const README_WITH_BOTH: &str = "\
+# Tools
+
+## The tools
+
+- aa
+  - Prints the caller identity.
+  - To install: `cargo install aa`
+
+## bb (the other one)
+
+Does the other thing.
+";
+
+/// A `TLDR.md` whose table holds a row for `aa` and none for `bb`.
+const TLDR_WITH_AA_ONLY: &str = "\
+# TL;DR
+
+| Tool | What it does |
+| --- | --- |
+| `aa` | Prints the caller identity. |
+";
+
+/// Build a workspace on disk: one member crate per name in `bins`, each with a
+/// `src/main.rs`, plus the two index files at the root.
+fn workspace(bins: &[&str], readme: &str, tldr: &str) -> TempDir {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "README.md", readme);
+    write(root, "TLDR.md", tldr);
+
+    for name in bins {
+        let member = root.join("src").join(name);
+        write(
+            &member,
+            "Cargo.toml",
+            &format!("[package]\nname = \"{name}\"\nedition = \"2021\"\n"),
+        );
+        write(&member, "src/main.rs", "fn main() {}\n");
+    }
+
+    dir
+}
+
+/// Write `contents` to `dir/relative`, creating the parent directories.
+fn write(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    let parent = path.parent().expect("a path with a parent");
+    fs::create_dir_all(parent)
+        .unwrap_or_else(|e| panic!("cannot create {}: {e}", parent.display()));
+    fs::write(&path, contents).unwrap_or_else(|e| panic!("cannot write {}: {e}", path.display()));
+}
+
+#[test]
+fn a_binary_with_no_tldr_row_is_reported() {
+    let ws = workspace(&["aa", "bb"], README_WITH_BOTH, TLDR_WITH_AA_ONLY);
+
+    let report = tool_index::audit(ws.path()).expect("the audit reaches a verdict");
+
+    assert_eq!(report.missing_from_tldr(), ["bb".to_owned()]);
+    assert!(
+        report.missing_from_readme().is_empty(),
+        "both tools are in the README, so nothing is missing from it: {:?}",
+        report.missing_from_readme()
+    );
+    assert!(!report.is_compliant(), "a missing row is not compliant");
+    assert_eq!(report.binaries_examined(), 2);
+}

--- a/src/repo-guards/tests/tool_index_coverage.rs
+++ b/src/repo-guards/tests/tool_index_coverage.rs
@@ -10,8 +10,10 @@
 //! OS makes unique. Nothing is keyed on a fixed path under the temp dir, the
 //! repo, or the home dir.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use repo_guards::tool_index;
 use tempfile::TempDir;
@@ -41,6 +43,17 @@ const TLDR_WITH_AA_ONLY: &str = "\
 | Tool | What it does |
 | --- | --- |
 | `aa` | Prints the caller identity. |
+";
+
+/// A `TLDR.md` whose table holds a row for both tools, used as the fixed half
+/// of a fixture that varies `README.md`.
+const TLDR_WITH_BOTH: &str = "\
+# TL;DR
+
+| Tool | What it does |
+| --- | --- |
+| `aa` | Prints the caller identity. |
+| `bb` | Does the other thing. |
 ";
 
 /// Build a workspace on disk: one member crate per name in `bins`, each with a
@@ -110,4 +123,433 @@ fn every_binary_of_this_repository_appears_in_both_indexes() {
          enumerated the wrong thing and would report clean for the wrong reason: {report:?}"
     );
     assert!(report.is_compliant(), "{report}");
+}
+
+// ---------------------------------------------------------------------------
+// Mutation tests.
+//
+// A guard that cannot fail is worse than no guard, because "clean" and "I never
+// looked" print identically. Each test below feeds `audit()` a form the tool
+// name can arrive in and asserts the verdict the form deserves.
+//
+// The set is organised by *syntactic form*, not by the one spelling that
+// prompted the guard. A fixture set with one shape per construct is what stops
+// the guard from silently accepting the next shape somebody writes.
+// ---------------------------------------------------------------------------
+
+/// A `README.md` that documents `aa` and nothing else, used as the fixed half
+/// of a fixture that varies `TLDR.md`.
+const README_AA_ONLY: &str = "\
+# Tools
+
+## The tools
+
+- aa
+  - Prints the caller identity.
+";
+
+/// A `TLDR.md` that lists `aa` and nothing else, used as the fixed half of a
+/// fixture that varies `README.md`.
+const TLDR_AA_ONLY: &str = "\
+# TL;DR
+
+| Tool | What it does |
+| --- | --- |
+| `aa` | Prints the caller identity. |
+";
+
+/// The verdict for a workspace of `aa` and `bb`, where only `bb` is in doubt.
+fn verdict(readme: &str, tldr: &str) -> tool_index::Report {
+    let ws = workspace(&["aa", "bb"], readme, tldr);
+    tool_index::audit(ws.path()).expect("the audit reaches a verdict")
+}
+
+#[test]
+fn a_name_only_in_a_tldr_description_is_not_an_entry() {
+    // The second row's description is *exactly* a tool name, not a sentence
+    // that merely contains one. A guard that read every cell would take the
+    // whole cell as one name, so a fixture whose description is prose cannot
+    // tell the two apart: "Pairs with `bb`." is not the string "bb" either way.
+    // This shape is the one that fails when the guard stops reading only the
+    // first cell.
+    let report = verdict(
+        README_WITH_BOTH,
+        "\
+# TL;DR
+
+| Tool | What it does |
+| --- | --- |
+| `aa` | Prints the caller identity. Pairs with `bb`. |
+| `zz` | bb |
+",
+    );
+
+    assert_eq!(
+        report.missing_from_tldr(),
+        ["bb".to_owned()],
+        "a name in another row's description is not a row of its own"
+    );
+}
+
+#[test]
+fn a_name_only_in_the_tldr_head_row_is_not_an_entry() {
+    let report = verdict(
+        README_WITH_BOTH,
+        "\
+# TL;DR
+
+| bb | What it does |
+| --- | --- |
+| `aa` | Prints the caller identity. |
+",
+    );
+
+    assert_eq!(report.missing_from_tldr(), ["bb".to_owned()]);
+}
+
+#[test]
+fn a_tldr_row_without_backticks_is_an_entry() {
+    let report = verdict(
+        README_WITH_BOTH,
+        "\
+# TL;DR
+
+| Tool | What it does |
+| --- | --- |
+| aa | Prints the caller identity. |
+| bb | Does the other thing. |
+",
+    );
+
+    assert!(
+        report.missing_from_tldr().is_empty(),
+        "the guard reads the cell, not its decoration: {report}"
+    );
+}
+
+#[test]
+fn a_name_only_in_a_readme_code_block_is_not_an_entry() {
+    let report = verdict(
+        "\
+# Tools
+
+## The tools
+
+- aa
+  - Prints the caller identity.
+
+## Examples
+
+```bash
+bb --help
+```
+",
+        TLDR_WITH_BOTH,
+    );
+
+    assert_eq!(
+        report.missing_from_readme(),
+        ["bb".to_owned()],
+        "a command line in a code block documents nothing"
+    );
+}
+
+#[test]
+fn a_name_only_in_a_nested_readme_item_is_not_an_entry() {
+    let report = verdict(
+        "\
+# Tools
+
+## The tools
+
+- aa
+  - Prints the caller identity.
+  - bb
+",
+        TLDR_WITH_BOTH,
+    );
+
+    assert_eq!(
+        report.missing_from_readme(),
+        ["bb".to_owned()],
+        "a nested item describes its parent; it is not an entry of its own"
+    );
+}
+
+#[test]
+fn a_name_only_in_readme_prose_is_not_an_entry() {
+    let report = verdict(
+        "\
+# Tools
+
+## The tools
+
+- aa
+  - Prints the caller identity.
+
+## Notes
+
+Run bb when you need the other thing.
+",
+        TLDR_WITH_BOTH,
+    );
+
+    assert_eq!(report.missing_from_readme(), ["bb".to_owned()]);
+}
+
+#[test]
+fn a_readme_item_or_heading_with_a_parenthetical_is_an_entry() {
+    let report = verdict(
+        "\
+# Tools
+
+## The tools
+
+- aa (the identity one)
+  - Prints the caller identity.
+
+## bb (the other one)
+
+Does the other thing.
+",
+        TLDR_WITH_BOTH,
+    );
+
+    assert!(
+        report.missing_from_readme().is_empty(),
+        "the entry is the first word of the item or heading: {report}"
+    );
+}
+
+#[test]
+fn a_binary_declared_by_an_explicit_bin_table_is_examined() {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "README.md", README_AA_ONLY);
+    write(root, "TLDR.md", TLDR_AA_ONLY);
+    // The package is named `renamed`, and the binary it builds is named `aa`.
+    // Counting the package name here would report a tool that does not exist.
+    let member = root.join("src").join("renamed");
+    write(
+        &member,
+        "Cargo.toml",
+        "[package]\nname = \"renamed\"\nedition = \"2021\"\n\n[[bin]]\nname = \"aa\"\npath = \"src/main.rs\"\n",
+    );
+    write(&member, "src/main.rs", "fn main() {}\n");
+
+    let report = tool_index::audit(root).expect("the audit reaches a verdict");
+
+    assert_eq!(report.binaries_examined(), 1);
+    assert!(report.is_compliant(), "{report}");
+}
+
+#[test]
+fn a_binary_under_src_bin_is_examined() {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "README.md", README_AA_ONLY);
+    write(root, "TLDR.md", TLDR_AA_ONLY);
+    let member = root.join("src").join("host");
+    write(
+        &member,
+        "Cargo.toml",
+        "[package]\nname = \"host\"\nedition = \"2021\"\n",
+    );
+    write(&member, "src/lib.rs", "");
+    write(&member, "src/bin/bb.rs", "fn main() {}\n");
+
+    let report = tool_index::audit(root).expect("the audit reaches a verdict");
+
+    assert_eq!(
+        report.missing_from_readme(),
+        ["bb".to_owned()],
+        "a binary cargo builds from src/bin is a tool like any other: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed refusals. Each asks the guard to report on something it cannot
+// see, and asserts it refuses rather than returning a clean verdict.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_readme_with_no_tools_section_refuses() {
+    let ws = workspace(&["aa"], "# Tools\n\nNothing here.\n", TLDR_AA_ONLY);
+
+    let error = tool_index::audit(ws.path()).expect_err("a README with no tool list is a refusal");
+
+    assert!(
+        matches!(error, tool_index::ToolIndexError::NoToolsSection { .. }),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn a_tldr_with_no_table_refuses() {
+    let ws = workspace(&["aa"], README_AA_ONLY, "# TL;DR\n\nNothing here.\n");
+
+    let error = tool_index::audit(ws.path()).expect_err("a TLDR with no table is a refusal");
+
+    assert!(
+        matches!(error, tool_index::ToolIndexError::NoTableRows { .. }),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn a_workspace_with_no_binaries_refuses() {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "README.md", README_AA_ONLY);
+    write(root, "TLDR.md", TLDR_AA_ONLY);
+    let member = root.join("src").join("libonly");
+    write(
+        &member,
+        "Cargo.toml",
+        "[package]\nname = \"libonly\"\nedition = \"2021\"\n",
+    );
+    write(&member, "src/lib.rs", "");
+
+    let error = tool_index::audit(root).expect_err("a workspace with no tools is a refusal");
+
+    assert!(
+        matches!(error, tool_index::ToolIndexError::NoBinaries),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn a_missing_index_refuses() {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "TLDR.md", TLDR_AA_ONLY);
+    let member = root.join("src").join("aa");
+    write(
+        &member,
+        "Cargo.toml",
+        "[package]\nname = \"aa\"\nedition = \"2021\"\n",
+    );
+    write(&member, "src/main.rs", "fn main() {}\n");
+
+    let error = tool_index::audit(root).expect_err("an absent index is a refusal");
+
+    assert!(
+        matches!(error, tool_index::ToolIndexError::ReadIndex { .. }),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn a_manifest_that_moves_binary_discovery_refuses() {
+    let dir = TempDir::new().expect("a temp dir");
+    let root = dir.path();
+    write(root, "Cargo.toml", "[workspace]\nmembers = [\"src/*\"]\n");
+    write(root, "README.md", README_AA_ONLY);
+    write(root, "TLDR.md", TLDR_AA_ONLY);
+    let member = root.join("src").join("aa");
+    write(
+        &member,
+        "Cargo.toml",
+        "[package]\nname = \"aa\"\nedition = \"2021\"\nautobins = false\n",
+    );
+    write(&member, "src/main.rs", "fn main() {}\n");
+
+    let error = tool_index::audit(root).expect_err("a moved discovery rule is a refusal");
+
+    assert!(
+        matches!(
+            error,
+            tool_index::ToolIndexError::AutoDiscoveryOverride { .. }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Parity with cargo.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_guard_enumerates_exactly_the_binaries_cargo_builds() {
+    let root = repo_root();
+
+    let guard: BTreeSet<String> = tool_index::binaries(&root).expect("the binaries are enumerable");
+    let cargo = cargo_binary_names(&root);
+
+    assert_eq!(
+        guard, cargo,
+        "the guard's model of cargo's binary discovery has drifted from cargo's own answer; \
+         a binary the guard never enumerates is one it can never report as undocumented"
+    );
+}
+
+/// Every binary target name `cargo metadata` reports for the workspace at
+/// `repo_root`.
+///
+/// This is the *ground truth* the guard is measured against. Asking cargo is
+/// what turns "the guard found nothing wrong" into a claim about the tools that
+/// exist, rather than about the tools the guard happened to look for.
+fn cargo_binary_names(repo_root: &Path) -> BTreeSet<String> {
+    let output = Command::new(env!("CARGO"))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(repo_root)
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "cannot run `cargo metadata` in {}: {e}",
+                repo_root.display()
+            )
+        });
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "`cargo metadata` in {} exited with {}:\n{stderr}",
+        repo_root.display(),
+        output.status
+    );
+
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!("cannot parse the output of `cargo metadata` as JSON: {e}\nstderr:\n{stderr}")
+    });
+
+    let packages = metadata
+        .get("packages")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("`cargo metadata` reported no `packages` array"));
+
+    let mut names = BTreeSet::new();
+    for package in packages {
+        let targets = package
+            .get("targets")
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("a package in `cargo metadata` has no `targets` array"));
+        for target in targets {
+            let kinds = target
+                .get("kind")
+                .and_then(serde_json::Value::as_array)
+                .unwrap_or_else(|| panic!("a target in `cargo metadata` has no `kind` array"));
+            if kinds.iter().any(|kind| kind.as_str() == Some("bin")) {
+                names.insert(
+                    target
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_else(|| {
+                            panic!("a binary target in `cargo metadata` has no name")
+                        })
+                        .to_owned(),
+                );
+            }
+        }
+    }
+
+    assert!(
+        !names.is_empty(),
+        "`cargo metadata` reported no binaries at all, so the comparison would prove nothing"
+    );
+    names
 }

--- a/src/repo-guards/tests/tool_index_coverage.rs
+++ b/src/repo-guards/tests/tool_index_coverage.rs
@@ -11,7 +11,7 @@
 //! repo, or the home dir.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use repo_guards::tool_index;
 use tempfile::TempDir;
@@ -89,4 +89,25 @@ fn a_binary_with_no_tldr_row_is_reported() {
     );
     assert!(!report.is_compliant(), "a missing row is not compliant");
     assert_eq!(report.binaries_examined(), 2);
+}
+
+/// Absolute, canonical path to this repository's root, derived from the crate
+/// being compiled rather than the working directory (which `cargo test` does
+/// not pin).
+fn repo_root() -> PathBuf {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    fs::canonicalize(&root)
+        .unwrap_or_else(|e| panic!("cannot canonicalize {}: {e}", root.display()))
+}
+
+#[test]
+fn every_binary_of_this_repository_appears_in_both_indexes() {
+    let report = tool_index::audit(&repo_root()).expect("the audit reaches a verdict");
+
+    assert!(
+        report.binaries_examined() > 50,
+        "this workspace builds dozens of binaries, so a smaller count means the guard \
+         enumerated the wrong thing and would report clean for the wrong reason: {report:?}"
+    );
+    assert!(report.is_compliant(), "{report}");
 }


### PR DESCRIPTION
Closes #365.

## What this slice builds

`krt` records the network path to a destination, hop by hop. This slice builds
the crate and the command line, and nothing more.

The binary parses every flag of section 9 of the design spec and reports its
build string. A run with a destination prints the configuration it resolved and
exits 0. A later slice replaces that output.

The binary does not probe. It writes no file. It draws no table. The crate holds
no async code, and it starts no runtime of its own. It takes no dependency that
this slice does not use.

## The resolved configuration

```
$ krt example.com --interval 500ms --protocol udp --multipath paris -6
resolved configuration:
  destination:    example.com
  output:         derived at run time
  interval:       500ms
  first ttl:      1
  max ttl:        30
  protocol:       udp
  multipath:      paris
  address family: ipv6
  reverse dns:    on
  source:         discovered at run time
  display:        table
  duration limit: none
  round limit:    none
  replay:         none
  run:            the last run
```

The parser and the printer read one table of names, so the text of the command
line and the text of the output can never part company.

## Acceptance criteria

- [x] The crate is a workspace member, and its manifest carries `[lints]` with `workspace = true`.
- [x] Every target root declares a position on each lint the crate raises. `repo_guards::workspace_lints` and `repo_guards::target_lints` both pass.
- [x] `krt --version` and `krt -V` print `krt 0.1.0 (a298f93, clean)` through `buildinfo`.
- [x] The command line accepts one destination and every flag of section 9, with the documented defaults.
- [x] `--interval` accepts `500ms`, `1s`, and `2m`. A value it cannot parse gives a clear message and exit code 2.
- [x] `--protocol` accepts `icmp`, `udp`, and `tcp`. `--multipath` accepts `classic`, `paris`, and `dublin`.
- [x] `-4` and `-6` conflict, and the parser says so.
- [x] `krt <destination>` prints the resolved configuration and exits 0.
- [x] Tests cover the defaults of every flag and the interval parser.
- [x] `cargo test`, `cargo clippy`, `cargo fmt --check`, and `cargo machete` are clean at the workspace level.

## How I built it

Four red/green pairs, in this order:

1. The build string through `buildinfo`.
2. The parser and the printer of a duration.
3. Every flag with its documented default.
4. The block of the resolved configuration.

Each red commit fails for a missing behavior. Each green commit makes it pass.

## Verification

I ran the four gates by hand over the whole workspace at the head of the branch:

| Gate | Result |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo machete` | no unused dependency |
| `cargo clippy --workspace --all-targets` | no warning |
| `cargo test --workspace` | exit 0, no failure |

`cargo test -p krt` runs 60 unit tests and 6 tests of the command line.

## The two indexes

`krt` now has an entry in `README.md` and a row in `TLDR.md`. Both say that
this build parses the command line and does not probe, so the text matches the
tool a reader installs today. A later slice widens the text when the tool
probes.

## The guard

Nothing enforced the two indexes, which is how `krt` and `seescc` each came to
be missing one. `repo_guards::tool_index` now enforces both, beside
`workspace_lints` and `target_lints`.

It enumerates the binaries cargo builds and parses each index as Markdown. A
tool is listed in `TLDR.md` when the first cell of a table body row names it,
and in `README.md` when a top-level item under `## The tools`, or a level-2
heading, starts with its name.

**It parses rather than searches for the name.** Both indexes are full of
mentions: the row of `sirn` names `portplz`, and the row of `prgz` names
`prcp`. Delete either of those tools' own rows and a text search still reports
clean, which is indistinguishable from a guard doing real work.

Everything that could shrink the audited set is a refusal rather than a clean
verdict: an unreadable index, a `TLDR.md` with no table, a `README.md` with no
tools section, a workspace with no binaries, and a manifest that moves cargo's
binary discovery.

### How I know it works

`seescc` is how. The test that reads this repository was red the day it landed,
and it named `seescc` absent from `TLDR.md`. The commit after it gave `seescc`
a row.

The guard carries 17 tests. One fixture covers each syntactic form a tool name
arrives in — a first cell, a description cell, a head cell, a top-level item, a
nested item, a heading, prose, and a code block — and four assert a refusal
where the guard cannot see. A parity test asks `cargo metadata` for the
binaries it builds, so a binary the guard never learned to discover shows up as
a set difference rather than a clean report. The two sets agree on all 63.

Each fixture was measured against a deliberately broken guard. That measurement
found a weak one: the first description-cell fixture survived a guard that read
*every* cell, because a cell of prose is not a tool name whichever cell it comes
from. The fixture now carries a description that is exactly a name. Six
mutations each kill exactly the test that owns the behavior, and none of them
passes.

### One thing to know about these tests

The mutation and parity tests came **after** the implementation. They lock in
behavior the first green already had, rather than having driven it. The two
red/green pairs that did drive the guard are `10f7a1f`/`34aba7e` and
`86b6dfe`/`b296c67`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

