### PR TITLE
fix(krt): the review fixes that missed the merge of #374

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,10 @@
 # languages in this repo: Rust first, then Go. Each language's gates only run
 # when a staged change touches that language's files (see the trigger regexes
 # below), so a Go-only commit never pays for the Rust toolchain and vice versa.
+# The tool-index block below is the one deliberate exception: a commit that
+# stages README.md or TLDR.md and no Rust file runs one Rust test target,
+# because the guard that protects the two Markdown indexes lives in the Rust
+# suite.
 #
 # The four Rust gates run cheapest-first so a commit fails fast on the
 # quickest check:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -74,6 +74,33 @@ if git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$|(^|/)Cargo
     # `testcolor::with_forced_ansi` still forces the codes on.
     env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
         CLICOLOR_FORCE=1 cargo test --workspace
+    rust_gate_ran=yes
+fi
+
+# Both tool indexes are Markdown, and the Rust gate above triggers on Rust files
+# only, so a commit that edits README.md or TLDR.md and nothing else would run
+# no gate at all. The guard that holds every binary in both indexes
+# (repo_guards::tool_index) lives in the Rust suite, so such a commit has to
+# name it directly.
+#
+# This is what closes the direction the guard cannot otherwise reach. Adding a
+# crate touches a Cargo.toml and so pays the Rust gate above, which runs the
+# guard; REMOVING a tool's entry from an index touches Markdown alone. Issue
+# #311, which clears the ~563-violation markdownlint backlog, is a bulk rewrite
+# of exactly that shape.
+#
+# It runs the one test target rather than the workspace suite, so it costs a
+# fraction of the Rust block. The rust_gate_ran guard keeps a commit that
+# touches both languages from running the same test twice.
+#
+# --diff-filter carries D on top of ACMR: deleting an index outright is the
+# fault this catches, not only editing one. The same git-env scrub as the gates
+# above keeps the three symmetric.
+if [ "${rust_gate_ran:-}" != yes ] &&
+    git diff --cached --name-only --diff-filter=ACMRD | grep -qE '^(README|TLDR)\.md$'; then
+    echo "pre-commit: running cargo test -p repo-guards --test tool_index_coverage"
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX \
+        cargo test -p repo-guards --test tool_index_coverage
 fi
 
 # The Go module gets the same treatment, again cheapest-first:

--- a/.review-decisions.md
+++ b/.review-decisions.md
@@ -87,3 +87,41 @@ change, or that bundles unrelated work, is a real finding. It does not cover the
 squash-merge subject and body themselves, which do reach `main` and are the thing
 the convention actually protects. And it does not license skipping verification —
 the gates are run, or the finding stands.
+
+## Commit order on a pushed branch — the test after the block, not before it
+
+**Settled** 2026-08-20 (branch issue-365-followup, finding R-20260820T153740Z#N2)
+
+The review found that the tool-index block of `.husky/pre-commit` landed in `3ff2e53`
+and its tests landed in `3a7fc6e`, the commit after it. The TDD rule in `CLAUDE.md`
+calls for the failing test first, and a red phase was available here:
+`src/repo-guards/tests/pre_commit_hook.rs` already ran the real hook against
+throwaway fixtures, so a test of the new trigger could have been written and
+committed red. The body of `3ff2e53` says `No test: a hook is configuration, and it
+has no runtime behavior the suite can reach`. The body of `3a7fc6e` says that claim
+was wrong. The finding is accurate.
+
+It is not fixed, because the defect is the order of two commits and nothing else.
+
+**The coverage is real, and it was verified rather than asserted.** Removing the
+block from the hook makes `staged_tool_index_alone_triggers_the_index_guard` fail on
+an empty output, and the other three tests of that file still pass. That mutation was
+run twice: once by the author, and once by the review, independently. What TDD buys —
+a test proven able to fail for the behavioral reason — is present. Only the order in
+which the two commits landed is wrong.
+
+**The one fix is a force-push, and it buys nothing durable.** The branch is published
+as PR #375, so reordering `3ff2e53` and `3a7fc6e` rewrites already-pushed history and
+the next push needs `--force-with-lease`. Against that: this repository squash-merges
+every PR with an explicit `--subject` and `--body`, so no commit on this branch
+reaches `main`. Both commit messages are discarded by the merge either way. Paying a
+force-push, and the window where a collaborator's fetch disagrees with the remote, to
+reorder two commits that are about to be deleted is the wrong trade.
+
+**The boundary.** This decision settles *the order of already-pushed commits on a
+squash-merged branch*, where the test exists and is mutation-verified by the time the
+branch is reviewed. It does not settle a missing test: a change that ships with no
+test, or with a test never shown able to fail, is a real finding. It does not settle
+the order of commits on an unpushed branch, where a rebase is free. And it does not
+license writing implementation first as a habit — the red commit is still the rule,
+and this is a record of one branch that broke it and could not cheaply undo it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,8 +386,9 @@ tool nobody finds.
 
 Nothing enforced this before. The omission is spelled as an *absence*, which is
 why it spread: a crate that nobody remembers to document is born undocumented,
-and no build step ever said so. Two binaries had drifted out of an index by the
-time the guard was written.
+and no build step ever said so. One binary, `seescc`, had drifted out of an
+index by the time the guard was written: it carried a `README.md` entry and no
+`TLDR.md` row.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -566,9 +566,12 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
 - krt (Knights of the Round Trip)
   - Records the network path to a destination, hop by hop. `krt` accepts one destination and the
     flags of the probe. The flags set the round period, the range of the TTL, the protocol, the
-    multipath mode, and the address family. This build parses the command line and prints the
-    configuration it resolved. It does not probe yet, and it writes no file.
-  - Usage: `krt example.com`, `krt example.com --interval 500ms --protocol udp --multipath paris`
+    multipath mode, and the address family. The `replay` command folds a file that an earlier run
+    wrote, so it takes no destination and no flag of a probe, and `--run` picks which run in that
+    file to fold. This build parses the command line and prints the configuration it resolved. It
+    does not probe yet, and it writes no file.
+  - Usage: `krt example.com`, `krt example.com --interval 500ms --protocol udp --multipath paris`,
+    `krt replay trace.jsonl`, `krt replay trace.jsonl --run 2026-08-19T12:00:00Z`
   - To install: `cargo install --git https://github.com/timmattison/tools krt`
 
 ## dirhash

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1011,11 +1011,17 @@ resolved configuration:
     /// A destination, for a row that carries one.
     const A_DESTINATION: &str = "example.com";
 
+    /// The path of a recorded file, for a row that carries one.
+    const A_REPLAY_FILE: &str = "path.jsonl";
+
+    /// The id of one run of a recorded file, for a row that carries one.
+    const A_RUN_ID: &str = "2026-08-19T12:00:00Z";
+
     /// A replay file, for a row that carries one.
-    const A_REPLAY: [&str; 2] = ["--replay", "path.jsonl"];
+    const A_REPLAY: [&str; 2] = ["--replay", A_REPLAY_FILE];
 
     /// A run id, for a row that carries one.
-    const A_RUN: [&str; 2] = ["--run", "2026-08-19T12:00:00Z"];
+    const A_RUN: [&str; 2] = ["--run", A_RUN_ID];
 
     /// Every combination of the destination, the replay, and the run.
     ///
@@ -1086,17 +1092,53 @@ resolved configuration:
         }
     }
 
-    /// The argv that supplies the argument clap names in a rejection.
+    /// The text that starts the first usage line of a message.
+    const USAGE_PREFIX: &str = "Usage: ";
+
+    /// The word of a usage line that stands for every optional flag.
     ///
-    /// The names come from the error, so an argument the test does not know is
-    /// a new argument that belongs in the matrix.
-    fn supply(name: &str) -> Vec<&'static str> {
+    /// It names no one argument, so a filled command line leaves it out.
+    const OPTIONS_PLACEHOLDER: &str = "[OPTIONS]";
+
+    /// Reads the value that one placeholder of a message stands for.
+    ///
+    /// clap writes a placeholder in angle brackets, and it writes an optional
+    /// element of a usage line in square brackets. Both spellings name the same
+    /// argument, so this function reads either one.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a placeholder the test does not know. Such a placeholder is a
+    /// new argument, and it belongs in the matrix.
+    fn value_of(placeholder: &str) -> &'static str {
+        let name = placeholder.trim_matches(|character| matches!(character, '<' | '>' | '[' | ']'));
         match name {
-            "<DESTINATION>" => vec![A_DESTINATION],
-            "--replay <FILE>" => A_REPLAY.to_vec(),
-            "--run <ID>" => A_RUN.to_vec(),
+            "DESTINATION" => A_DESTINATION,
+            "FILE" => A_REPLAY_FILE,
+            "ID" => A_RUN_ID,
             other => panic!("the test cannot supply `{other}`; add it to the matrix"),
         }
+    }
+
+    /// Writes the arguments that one fragment of a message asks for.
+    ///
+    /// The fragment is one name of the list of the missing arguments, such as
+    /// `--replay <FILE>`, or one whole usage line. A word in brackets is a
+    /// placeholder, and it becomes a value. Every other word is literal text of
+    /// a command line, such as a flag, the name of a command, or the name of the
+    /// program, and it stays as it is.
+    fn arguments_of(fragment: &str) -> Vec<String> {
+        fragment
+            .split_whitespace()
+            .filter(|word| *word != OPTIONS_PLACEHOLDER)
+            .map(|word| {
+                if word.starts_with('<') || word.starts_with('[') {
+                    value_of(word).to_owned()
+                } else {
+                    word.to_owned()
+                }
+            })
+            .collect()
     }
 
     /// The arguments a missing-argument rejection names.
@@ -1107,12 +1149,60 @@ resolved configuration:
         }
     }
 
+    /// The usage lines of a rejection, as the user reads them.
+    ///
+    /// The first line starts with `Usage: `, and clap indents every line after
+    /// it to the same column. The block ends at the first empty line.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the message carries no usage line. Every rejection carries
+    /// one, so an empty result means clap now writes the block another way, and
+    /// a test that read it would then hold nothing.
+    fn usage_forms(error: &clap::Error) -> Vec<String> {
+        let rendered = error.render().to_string();
+        let mut forms = Vec::new();
+        let mut lines = rendered
+            .lines()
+            .skip_while(|line| !line.starts_with(USAGE_PREFIX));
+        if let Some(first) = lines.next() {
+            forms.push(first[USAGE_PREFIX.len()..].to_owned());
+        }
+        for line in lines {
+            if line.trim().is_empty() {
+                break;
+            }
+            forms.push(line.trim().to_owned());
+        }
+        assert!(
+            !forms.is_empty(),
+            "the message carries no usage line: {rendered}"
+        );
+        forms
+    }
+
+    /// Asserts that the parser accepts the command line the message asked for.
+    fn assert_the_parser_accepts(line: &[String], what_asked: &str) {
+        assert!(
+            Cli::try_parse_from(line.iter()).is_ok(),
+            "{what_asked} `{}`, which the parser rejects",
+            line.join(" ")
+        );
+    }
+
     /// A message that asks for an argument must ask for one the parser accepts.
     ///
     /// A rejection that names a missing argument tells the user to supply it. The
     /// user obeys, and the parser must then accept the line. It does not, when
     /// the named argument conflicts with an argument the line already carries,
     /// and the user reads two messages that each send them back to the other.
+    ///
+    /// The user obeys two parts of such a message. The list of the missing
+    /// arguments holds what to add to the line they typed. Each usage line under
+    /// that list holds a whole command line of its own, so the test fills the
+    /// line in and parses it as it stands. A test of the list alone reads the
+    /// machine-readable half and passes on a usage line that offers an argument
+    /// the parser then rejects, because the list never names that argument.
     #[test]
     fn obeying_a_missing_argument_message_gives_a_command_line_that_parses() {
         for row in &ARGUMENT_MATRIX {
@@ -1123,17 +1213,28 @@ resolved configuration:
                 continue;
             }
             let error = rejection(row.arguments);
-            let mut obeyed: Vec<&str> = row.arguments.to_vec();
-            for name in missing_arguments(&error) {
-                obeyed.extend(supply(&name));
+            let typed = row.arguments.join(" ");
+            let named = missing_arguments(&error);
+
+            let mut obeyed: Vec<String> = row
+                .arguments
+                .iter()
+                .map(|word| (*word).to_owned())
+                .collect();
+            for name in &named {
+                obeyed.extend(arguments_of(name));
             }
-            let line = obeyed.join(" ");
-            assert!(
-                Cli::try_parse_from(obeyed.iter().copied()).is_ok(),
-                "`{}` names {:?}, and obeying it gives `{line}`, which the parser rejects",
-                row.arguments.join(" "),
-                missing_arguments(&error)
+            assert_the_parser_accepts(
+                &obeyed,
+                &format!("`{typed}` names {named:?}, and obeying that list gives"),
             );
+
+            for form in usage_forms(&error) {
+                assert_the_parser_accepts(
+                    &arguments_of(&form),
+                    &format!("`{typed}` offers the usage line `{form}`, and obeying it gives"),
+                );
+            }
         }
     }
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -9,7 +9,7 @@
 #![warn(clippy::pedantic)]
 
 use buildinfo::version_string;
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use std::fmt;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -129,22 +129,29 @@ fn value_name<T: ValueEnum>(value: &T) -> String {
 /// Knights of the Round Trip: record the network path to a destination.
 ///
 /// `krt` probes every hop to the destination once per round, and it records
-/// each round in a file. This build parses the command line and prints the
-/// configuration it resolved.
+/// each round in a file. The `replay` command reads a file that an earlier run
+/// wrote, so it takes no destination and no flag of a probe. This build parses
+/// the command line and prints the configuration it resolved.
 #[derive(Parser, Debug)]
-#[command(name = "krt", version = version_string!())]
+// `args_conflicts_with_subcommands` rejects a flag of a probe beside a command,
+// because a replay probes nothing. `subcommand_negates_reqs` lifts the demand
+// for a destination when the line names a command, so the destination stays
+// plainly required and a replay still needs none. The two rules then live in
+// the shape of the command line, and no message can ask for an argument that
+// another rule forbids.
+#[command(
+    name = "krt",
+    version = version_string!(),
+    args_conflicts_with_subcommands = true,
+    subcommand_negates_reqs = true,
+)]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "each flag of the design is one switch of the command line"
 )]
 struct Cli {
-    /// The host or the address to trace. A replay takes no destination, and
-    /// neither does a run of a replay.
-    #[arg(
-        value_name = "DESTINATION",
-        required_unless_present_any = ["replay", "run"],
-        conflicts_with_all = ["replay", "run"],
-    )]
+    /// The host or the address to trace.
+    #[arg(value_name = "DESTINATION", required = true)]
     destination: Option<String>,
 
     /// The JSONL path. Overrides the derived name.
@@ -219,14 +226,24 @@ struct Cli {
     )]
     rounds: Option<u64>,
 
-    /// Fold a recorded file and print the table. Then exit. A replay takes no
-    /// destination.
-    #[arg(long, value_name = "FILE")]
-    replay: Option<PathBuf>,
+    /// The command that reads recorded work in the place of a trace.
+    #[command(subcommand)]
+    command: Option<Command>,
+}
 
-    /// With `--replay`, pick which run in the file to fold.
-    #[arg(long, value_name = "ID", requires = "replay")]
-    run: Option<String>,
+/// A command that reads recorded work in the place of a new trace.
+#[derive(Subcommand, Debug, PartialEq, Eq)]
+enum Command {
+    /// Fold a recorded file and print the table. Then exit.
+    Replay {
+        /// The recorded file to fold.
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+
+        /// Pick which run in the file to fold. The last run is the default.
+        #[arg(long, value_name = "ID")]
+        run: Option<String>,
+    },
 }
 
 /// The configuration of one run, after the command line resolves.
@@ -235,8 +252,8 @@ struct Cli {
 /// the behavior of the run and never reads the switch that made it.
 #[derive(Debug)]
 struct ResolvedConfig {
-    /// The host or the address to trace. A replay traces nothing, so a replay
-    /// takes no destination and this field holds none.
+    /// The host or the address to trace. A replay traces nothing, so the
+    /// `replay` command takes no destination and this field holds none.
     destination: Option<String>,
     /// The JSONL path the user named. An absent path is derived at run time.
     output: Option<PathBuf>,
@@ -262,9 +279,9 @@ struct ResolvedConfig {
     duration: Option<Duration>,
     /// The number of rounds that stops the run.
     rounds: Option<u64>,
-    /// The recorded file to fold and print.
+    /// The recorded file to fold and print. The `replay` command names it.
     replay: Option<PathBuf>,
-    /// The run in the replay file to fold.
+    /// The run in the recorded file to fold.
     run: Option<String>,
 }
 
@@ -272,7 +289,10 @@ impl Cli {
     /// Resolves the command line into the configuration of one run.
     ///
     /// The two flags of the address family collapse into one value, and the
-    /// `--no-dns` switch becomes the behavior it controls.
+    /// `--no-dns` switch becomes the behavior it controls. The `replay` command
+    /// becomes the recorded file and the run to fold, so every later slice
+    /// reads one flat configuration and never reads the shape of the command
+    /// line.
     ///
     /// # Errors
     ///
@@ -306,6 +326,11 @@ impl Cli {
             AddressFamily::Auto
         };
 
+        let (replay, run) = match self.command {
+            Some(Command::Replay { file, run }) => (Some(file), run),
+            None => (None, None),
+        };
+
         Ok(ResolvedConfig {
             destination: self.destination,
             output: self.output,
@@ -320,8 +345,8 @@ impl Cli {
             headless: self.headless,
             duration: self.duration,
             rounds: self.rounds,
-            replay: self.replay,
-            run: self.run,
+            replay,
+            run,
         })
     }
 }
@@ -496,7 +521,8 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_duration, render_duration, AddressFamily, Cli, Multipath, Protocol, ResolvedConfig,
+        parse_duration, render_duration, AddressFamily, Cli, Command, Multipath, Protocol,
+        ResolvedConfig,
     };
     use clap::error::{ContextKind, ContextValue, ErrorKind};
     use clap::{CommandFactory, Parser};
@@ -810,8 +836,7 @@ resolved configuration:
         assert!(!cli.headless, "the table is on by default");
         assert_eq!(cli.duration, None);
         assert_eq!(cli.rounds, None);
-        assert_eq!(cli.replay, None);
-        assert_eq!(cli.run, None);
+        assert_eq!(cli.command, None, "a trace runs no command");
     }
 
     #[test]
@@ -933,14 +958,20 @@ resolved configuration:
 
     #[test]
     fn a_replay_needs_no_destination() {
-        let cli = parse(&["krt", "--replay", "path.jsonl"]);
+        let cli = parse(&["krt", "replay", "path.jsonl"]);
         assert_eq!(cli.destination, None);
-        assert_eq!(cli.replay, Some(PathBuf::from("path.jsonl")));
+        assert_eq!(
+            cli.command,
+            Some(Command::Replay {
+                file: PathBuf::from("path.jsonl"),
+                run: None,
+            })
+        );
     }
 
     #[test]
     fn rejects_a_destination_beside_a_replay() {
-        let error = rejection(&["krt", "example.com", "--replay", "path.jsonl"]);
+        let error = rejection(&["krt", "example.com", "replay", "path.jsonl"]);
         assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
         let message = error.to_string();
         assert!(
@@ -948,31 +979,27 @@ resolved configuration:
             "the message names the destination: {message}"
         );
         assert!(
-            message.contains("--replay"),
+            message.contains("replay"),
             "the message names the replay: {message}"
         );
     }
 
     #[test]
-    fn rejects_a_run_without_a_replay() {
+    fn rejects_a_run_outside_the_replay_command() {
         let error = rejection(&["krt", "--run", "2026-08-19T12:00:00Z"]);
-        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
         let message = error.to_string();
         assert!(
-            message.contains("--replay"),
-            "the message names the replay: {message}"
+            message.contains("--run"),
+            "the message names the run: {message}"
         );
     }
 
     #[test]
     fn rejects_a_run_beside_a_destination() {
         let error = rejection(&["krt", "example.com", "--run", "2026-08-19T12:00:00Z"]);
-        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
         let message = error.to_string();
-        assert!(
-            message.contains("DESTINATION"),
-            "the message names the destination: {message}"
-        );
         assert!(
             message.contains("--run"),
             "the message names the run: {message}"
@@ -983,12 +1010,18 @@ resolved configuration:
     fn parses_a_run_of_a_replay() {
         let cli = parse(&[
             "krt",
-            "--replay",
+            "replay",
             "path.jsonl",
             "--run",
             "2026-08-19T12:00:00Z",
         ]);
-        assert_eq!(cli.run.as_deref(), Some("2026-08-19T12:00:00Z"));
+        assert_eq!(
+            cli.command,
+            Some(Command::Replay {
+                file: PathBuf::from("path.jsonl"),
+                run: Some("2026-08-19T12:00:00Z".to_owned()),
+            })
+        );
     }
 
     /// The verdict the parser must reach for one row of the argument matrix.
@@ -1000,7 +1033,7 @@ resolved configuration:
         Rejects(ErrorKind),
     }
 
-    /// One row of the matrix of the three arguments that constrain each other.
+    /// One row of the matrix of the arguments that constrain each other.
     struct ArgumentRow {
         /// The command line, program name included.
         arguments: &'static [&'static str],
@@ -1011,16 +1044,19 @@ resolved configuration:
     /// A destination, for a row that carries one.
     const A_DESTINATION: &str = "example.com";
 
+    /// The name of the command that folds a recorded file.
+    const REPLAY: &str = "replay";
+
     /// The path of a recorded file, for a row that carries one.
     const A_REPLAY_FILE: &str = "path.jsonl";
 
     /// The id of one run of a recorded file, for a row that carries one.
     const A_RUN_ID: &str = "2026-08-19T12:00:00Z";
 
-    /// A replay file, for a row that carries one.
-    const A_REPLAY: [&str; 2] = ["--replay", A_REPLAY_FILE];
+    /// A whole replay, for a row that carries one.
+    const A_REPLAY: [&str; 2] = [REPLAY, A_REPLAY_FILE];
 
-    /// A run id, for a row that carries one.
+    /// A run of a replay, for a row that carries one.
     const A_RUN: [&str; 2] = ["--run", A_RUN_ID];
 
     /// Every combination of the destination, the replay, and the run.
@@ -1029,37 +1065,61 @@ resolved configuration:
     /// relationships together rather than one at a time. A change to one of them
     /// moves the verdict of rows that name the other two, so the whole matrix is
     /// stated here and not one row per test. Two defects of this branch were of
-    /// that kind: `conflicts_with_all` on the destination stopped the `requires`
-    /// of `--run` from firing, and it later made the message of a missing
-    /// argument name a destination that no longer fits beside `--run`.
-    const ARGUMENT_MATRIX: [ArgumentRow; 8] = [
+    /// that kind, while `--replay` and `--run` were flags of a trace:
+    /// `conflicts_with_all` on the destination stopped the `requires` of
+    /// `--run` from firing, and it later made the usage line of a missing
+    /// argument offer a destination that no longer fit beside `--run`. The
+    /// `replay` command now holds both rules in the grammar, so the matrix
+    /// records what the grammar gives.
+    ///
+    /// The replay holds three states, because the command carries the file it
+    /// folds: no command, the command alone, and the command with a file. The
+    /// run holds two, and the destination holds two, so the matrix has twelve
+    /// rows.
+    const ARGUMENT_MATRIX: [ArgumentRow; 12] = [
         ArgumentRow {
             arguments: &["krt"],
             verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
         },
         ArgumentRow {
-            arguments: &["krt", A_DESTINATION],
-            verdict: Verdict::Parses,
+            arguments: &["krt", A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::UnknownArgument),
+        },
+        ArgumentRow {
+            arguments: &["krt", REPLAY],
+            verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
+        },
+        ArgumentRow {
+            arguments: &["krt", REPLAY, A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
         },
         ArgumentRow {
             arguments: &["krt", A_REPLAY[0], A_REPLAY[1]],
             verdict: Verdict::Parses,
         },
         ArgumentRow {
-            arguments: &["krt", A_DESTINATION, A_REPLAY[0], A_REPLAY[1]],
-            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
+            arguments: &["krt", A_REPLAY[0], A_REPLAY[1], A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Parses,
         },
         ArgumentRow {
-            arguments: &["krt", A_RUN[0], A_RUN[1]],
-            verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
+            arguments: &["krt", A_DESTINATION],
+            verdict: Verdict::Parses,
         },
         ArgumentRow {
             arguments: &["krt", A_DESTINATION, A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::UnknownArgument),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_DESTINATION, REPLAY],
             verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
         },
         ArgumentRow {
-            arguments: &["krt", A_REPLAY[0], A_REPLAY[1], A_RUN[0], A_RUN[1]],
-            verdict: Verdict::Parses,
+            arguments: &["krt", A_DESTINATION, REPLAY, A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_DESTINATION, A_REPLAY[0], A_REPLAY[1]],
+            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
         },
         ArgumentRow {
             arguments: &[
@@ -1123,10 +1183,10 @@ resolved configuration:
     /// Writes the arguments that one fragment of a message asks for.
     ///
     /// The fragment is one name of the list of the missing arguments, such as
-    /// `--replay <FILE>`, or one whole usage line. A word in brackets is a
-    /// placeholder, and it becomes a value. Every other word is literal text of
-    /// a command line, such as a flag, the name of a command, or the name of the
-    /// program, and it stays as it is.
+    /// `<FILE>` or `--run <ID>`, or one whole usage line. A word in brackets is
+    /// a placeholder, and it becomes a value. Every other word is literal text
+    /// of a command line, such as a flag, the name of a command, or the name of
+    /// the program, and it stays as it is.
     fn arguments_of(fragment: &str) -> Vec<String> {
         fragment
             .split_whitespace()
@@ -1162,17 +1222,15 @@ resolved configuration:
     fn usage_forms(error: &clap::Error) -> Vec<String> {
         let rendered = error.render().to_string();
         let mut forms = Vec::new();
-        let mut lines = rendered
-            .lines()
-            .skip_while(|line| !line.starts_with(USAGE_PREFIX));
-        if let Some(first) = lines.next() {
-            forms.push(first[USAGE_PREFIX.len()..].to_owned());
-        }
-        for line in lines {
-            if line.trim().is_empty() {
-                break;
+        let mut lines = rendered.lines();
+        if let Some(first) = lines.find_map(|line| line.strip_prefix(USAGE_PREFIX)) {
+            forms.push(first.trim().to_owned());
+            for line in lines {
+                if line.trim().is_empty() {
+                    break;
+                }
+                forms.push(line.trim().to_owned());
             }
-            forms.push(line.trim().to_owned());
         }
         assert!(
             !forms.is_empty(),
@@ -1474,7 +1532,7 @@ resolved configuration:
     fn prints_the_file_and_the_run_of_a_replay() {
         let config = resolve(&[
             "krt",
-            "--replay",
+            "replay",
             "/tmp/r.jsonl",
             "--run",
             "2026-08-19T12:00:00Z",

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -990,6 +990,101 @@ resolved configuration:
         assert_eq!(cli.run.as_deref(), Some("2026-08-19T12:00:00Z"));
     }
 
+    /// The verdict the parser must reach for one row of the argument matrix.
+    #[derive(Debug)]
+    enum Verdict {
+        /// The command line is accepted.
+        Parses,
+        /// The command line is rejected, with this reason.
+        Rejects(ErrorKind),
+    }
+
+    /// One row of the matrix of the three arguments that constrain each other.
+    struct ArgumentRow {
+        /// The command line, program name included.
+        arguments: &'static [&'static str],
+        /// The verdict the parser must reach.
+        verdict: Verdict,
+    }
+
+    /// A destination, for a row that carries one.
+    const A_DESTINATION: &str = "example.com";
+
+    /// A replay file, for a row that carries one.
+    const A_REPLAY: [&str; 2] = ["--replay", "path.jsonl"];
+
+    /// A run id, for a row that carries one.
+    const A_RUN: [&str; 2] = ["--run", "2026-08-19T12:00:00Z"];
+
+    /// Every combination of the destination, the replay, and the run.
+    ///
+    /// The three arguments constrain each other, and clap resolves such
+    /// relationships together rather than one at a time. A change to one of them
+    /// moves the verdict of rows that name the other two, so the whole matrix is
+    /// stated here and not one row per test. Two defects of this branch were of
+    /// that kind: `conflicts_with_all` on the destination stopped the `requires`
+    /// of `--run` from firing, and it later made the message of a missing
+    /// argument name a destination that no longer fits beside `--run`.
+    const ARGUMENT_MATRIX: [ArgumentRow; 8] = [
+        ArgumentRow {
+            arguments: &["krt"],
+            verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_DESTINATION],
+            verdict: Verdict::Parses,
+        },
+        ArgumentRow {
+            arguments: &["krt", A_REPLAY[0], A_REPLAY[1]],
+            verdict: Verdict::Parses,
+        },
+        ArgumentRow {
+            arguments: &["krt", A_DESTINATION, A_REPLAY[0], A_REPLAY[1]],
+            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::MissingRequiredArgument),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_DESTINATION, A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
+        },
+        ArgumentRow {
+            arguments: &["krt", A_REPLAY[0], A_REPLAY[1], A_RUN[0], A_RUN[1]],
+            verdict: Verdict::Parses,
+        },
+        ArgumentRow {
+            arguments: &[
+                "krt",
+                A_DESTINATION,
+                A_REPLAY[0],
+                A_REPLAY[1],
+                A_RUN[0],
+                A_RUN[1],
+            ],
+            verdict: Verdict::Rejects(ErrorKind::ArgumentConflict),
+        },
+    ];
+
+    #[test]
+    fn the_argument_matrix_holds() {
+        for row in &ARGUMENT_MATRIX {
+            let line = row.arguments.join(" ");
+            match row.verdict {
+                Verdict::Parses => {
+                    assert!(
+                        Cli::try_parse_from(row.arguments.iter().copied()).is_ok(),
+                        "`{line}` must parse"
+                    );
+                }
+                Verdict::Rejects(kind) => {
+                    assert_eq!(rejection(row.arguments).kind(), kind, "`{line}`");
+                }
+            }
+        }
+    }
+
     #[test]
     fn rejects_a_first_ttl_of_zero() {
         let error = rejection(&["krt", "example.com", "--first-ttl", "0"]);

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -497,7 +497,7 @@ mod tests {
     use super::{
         parse_duration, render_duration, AddressFamily, Cli, Multipath, Protocol, ResolvedConfig,
     };
-    use clap::error::ErrorKind;
+    use clap::error::{ContextKind, ContextValue, ErrorKind};
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::path::PathBuf;
@@ -1082,6 +1082,57 @@ resolved configuration:
                     assert_eq!(rejection(row.arguments).kind(), kind, "`{line}`");
                 }
             }
+        }
+    }
+
+    /// The argv that supplies the argument clap names in a rejection.
+    ///
+    /// The names come from the error, so an argument the test does not know is
+    /// a new argument that belongs in the matrix.
+    fn supply(name: &str) -> Vec<&'static str> {
+        match name {
+            "<DESTINATION>" => vec![A_DESTINATION],
+            "--replay <FILE>" => A_REPLAY.to_vec(),
+            "--run <ID>" => A_RUN.to_vec(),
+            other => panic!("the test cannot supply `{other}`; add it to the matrix"),
+        }
+    }
+
+    /// The arguments a missing-argument rejection names.
+    fn missing_arguments(error: &clap::Error) -> Vec<String> {
+        match error.get(ContextKind::InvalidArg) {
+            Some(ContextValue::Strings(names)) => names.clone(),
+            other => panic!("the rejection names no missing argument: {other:?}"),
+        }
+    }
+
+    /// A message that asks for an argument must ask for one the parser accepts.
+    ///
+    /// A rejection that names a missing argument tells the user to supply it. The
+    /// user obeys, and the parser must then accept the line. It does not, when
+    /// the named argument conflicts with an argument the line already carries,
+    /// and the user reads two messages that each send them back to the other.
+    #[test]
+    fn obeying_a_missing_argument_message_gives_a_command_line_that_parses() {
+        for row in &ARGUMENT_MATRIX {
+            if !matches!(
+                row.verdict,
+                Verdict::Rejects(ErrorKind::MissingRequiredArgument)
+            ) {
+                continue;
+            }
+            let error = rejection(row.arguments);
+            let mut obeyed: Vec<&str> = row.arguments.to_vec();
+            for name in missing_arguments(&error) {
+                obeyed.extend(supply(&name));
+            }
+            let line = obeyed.join(" ");
+            assert!(
+                Cli::try_parse_from(obeyed.iter().copied()).is_ok(),
+                "`{}` names {:?}, and obeying it gives `{line}`, which the parser rejects",
+                row.arguments.join(" "),
+                missing_arguments(&error)
+            );
         }
     }
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -138,10 +138,11 @@ fn value_name<T: ValueEnum>(value: &T) -> String {
     reason = "each flag of the design is one switch of the command line"
 )]
 struct Cli {
-    /// The host or the address to trace. A replay takes no destination.
+    /// The host or the address to trace. A replay takes no destination, and
+    /// neither does a run of a replay.
     #[arg(
         value_name = "DESTINATION",
-        required_unless_present = "replay",
+        required_unless_present_any = ["replay", "run"],
         conflicts_with_all = ["replay", "run"],
     )]
     destination: Option<String>,

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1140,10 +1140,9 @@ resolved configuration:
             let line = row.arguments.join(" ");
             match row.verdict {
                 Verdict::Parses => {
-                    assert!(
-                        Cli::try_parse_from(row.arguments.iter().copied()).is_ok(),
-                        "`{line}` must parse"
-                    );
+                    if let Err(error) = Cli::try_parse_from(row.arguments.iter().copied()) {
+                        panic!("`{line}` must parse, but the parser rejected it: {error}");
+                    }
                 }
                 Verdict::Rejects(kind) => {
                     assert_eq!(rejection(row.arguments).kind(), kind, "`{line}`");

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -38,6 +38,15 @@ const UNKNOWN: &str = "unknown";
 /// The words `buildinfo` writes for the state of the working tree.
 const STATUS_WORDS: [&str; 3] = ["clean", "dirty", UNKNOWN];
 
+/// The name of the command that folds a recorded file.
+const REPLAY: &str = "replay";
+
+/// The recorded file that the tests of the replay name.
+///
+/// The command line resolves before anything reads the file, so this build
+/// never opens it.
+const A_RECORDED_FILE: &str = "old.jsonl";
+
 /// Invoke the freshly built `krt` binary.
 fn krt() -> Command {
     Command::new(env!("CARGO_BIN_EXE_krt"))
@@ -206,11 +215,32 @@ fn a_command_line_without_a_destination_fails() {
 
 #[test]
 fn a_destination_beside_a_replay_fails_and_names_both() {
-    let stderr = failure(&["example.com", "--replay", "old.jsonl"]);
-    for part in ["DESTINATION", "--replay"] {
+    let stderr = failure(&["example.com", REPLAY, A_RECORDED_FILE]);
+    for part in ["DESTINATION", REPLAY] {
         assert!(
             stderr.contains(part),
             "the message names `{part}`: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn a_replay_needs_no_destination_and_prints_the_resolved_configuration() {
+    let result = run(&[REPLAY, A_RECORDED_FILE]);
+    assert!(
+        result.success,
+        "`krt {REPLAY} {A_RECORDED_FILE}` must exit with success; stderr: {}",
+        result.stderr
+    );
+    for row in [
+        "  destination:    none",
+        "  replay:         old.jsonl",
+        "  run:            the last run",
+    ] {
+        assert!(
+            result.stdout.contains(row),
+            "the block holds `{row}`: {}",
+            result.stdout
         );
     }
 }

--- a/src/repo-guards/src/tool_index.rs
+++ b/src/repo-guards/src/tool_index.rs
@@ -8,8 +8,9 @@
 //!
 //! Nothing enforced this before. The omission is spelled as an *absence*, which
 //! is why it spread: a crate that nobody remembers to document is born
-//! undocumented, and no build step ever says so. Two of the workspace's
-//! binaries had drifted out of an index by the time this guard was written.
+//! undocumented, and no build step ever says so. One binary, `seescc`, had
+//! drifted out of an index by the time this guard was written: it carried a
+//! `README.md` entry and no `TLDR.md` row.
 //!
 //! [`audit`] closes that hole. Three design rules make it a real guard rather
 //! than a comfortable one:

--- a/src/repo-guards/tests/pre_commit_hook.rs
+++ b/src/repo-guards/tests/pre_commit_hook.rs
@@ -125,6 +125,33 @@ fn run_hook(dir: &Path) -> bool {
         .success()
 }
 
+/// Run the real hook as [`run_hook`] does, and give back what it printed.
+///
+/// The status alone cannot tell which block ran. A fixture repo is not this
+/// workspace, so a block naming a package of this workspace fails there for a
+/// reason that has nothing to do with the trigger under test. Each block
+/// announces itself before it runs, so the announcement is what proves the
+/// trigger fired.
+fn run_hook_output(dir: &Path) -> String {
+    let output = Command::new("bash")
+        .arg(hook_path())
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .expect("failed to spawn pre-commit hook");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// The line the hook prints before it runs the tool-index guard.
+const INDEX_GUARD_ANNOUNCEMENT: &str =
+    "pre-commit: running cargo test -p repo-guards --test tool_index_coverage";
+
 /// Best-effort cleanup; the per-process+nanos path is the real isolation, so a
 /// failed removal cannot collide with another run.
 fn cleanup(dir: &Path) {
@@ -182,25 +209,68 @@ fn staged_toolchain_config_alone_triggers_the_gate() {
     }
 }
 
-/// When only a non-Rust file is staged, the trigger condition is false and the
-/// gate is skipped — so the hook exits zero even though a misformatted
-/// `src/main.rs` sits on disk (unstaged). This proves the trigger, not the
-/// formatter, is what runs: if the gate fired anyway it would catch the file
-/// and fail.
+/// When only a file that no trigger names is staged, every gate is skipped — so
+/// the hook exits zero even though a misformatted `src/main.rs` sits on disk
+/// (unstaged). This proves the trigger, not the formatter, is what runs: if the
+/// gate fired anyway it would catch the file and fail.
+///
+/// The staged file is `NOTES.md` and not `README.md`. `README.md` is one of the
+/// two tool indexes, and a third block names those directly, so a fixture
+/// staging one of them no longer skips everything. See
+/// [`staged_tool_index_alone_triggers_the_index_guard`].
 #[test]
-fn staged_non_rust_file_skips_the_gate() {
+fn staged_unnamed_file_skips_every_gate() {
     let dir = unique_fixture_dir();
     write_fixture_package(&dir);
-    fs::write(dir.join("README.md"), "# fixture\n").expect("write README.md");
+    fs::write(dir.join("NOTES.md"), "# fixture\n").expect("write NOTES.md");
 
-    // Only the README is staged; the misformatted main.rs stays unstaged.
-    git_init_and_stage(&dir, &["README.md"]);
+    // Only the notes are staged; the misformatted main.rs stays unstaged.
+    git_init_and_stage(&dir, &["NOTES.md"]);
 
+    let output = run_hook_output(&dir);
     let passed = run_hook(&dir);
     cleanup(&dir);
 
     assert!(
         passed,
-        "hook should skip the gate when no Rust/Cargo files are staged, but it exited non-zero"
+        "hook should skip every gate when no named file is staged, but it exited non-zero: {output}"
     );
+    assert!(
+        !output.contains(INDEX_GUARD_ANNOUNCEMENT),
+        "an unrelated Markdown file must not run the tool-index guard: {output}"
+    );
+}
+
+/// Staging either tool index alone must run the tool-index guard.
+///
+/// This is the one direction the guard cannot otherwise reach. Adding a crate
+/// touches a `Cargo.toml`, which fires the Rust gate and runs the whole suite;
+/// REMOVING a tool's entry from an index touches Markdown alone, and before the
+/// third block existed such a commit ran no gate at all.
+///
+/// The assertion reads the announcement rather than the exit status. A fixture
+/// repo holds no `repo-guards` package, so `cargo test -p repo-guards` fails
+/// there whatever the trigger did, and a status assertion would pass for that
+/// reason instead of for the trigger. Proven able to fail by mutation: against
+/// the hook as it stood before the third block, both index files produce no
+/// announcement and this test fails.
+#[test]
+fn staged_tool_index_alone_triggers_the_index_guard() {
+    for index in ["README.md", "TLDR.md"] {
+        let dir = unique_fixture_dir();
+        write_fixture_package(&dir);
+        fs::write(dir.join(index), "# fixture\n").expect("write the index");
+
+        // Only the index is staged; the misformatted main.rs stays unstaged, so
+        // the Rust gate cannot be what fires.
+        git_init_and_stage(&dir, &[index]);
+
+        let output = run_hook_output(&dir);
+        cleanup(&dir);
+
+        assert!(
+            output.contains(INDEX_GUARD_ANNOUNCEMENT),
+            "staging {index} must run the tool-index guard: {output}"
+        );
+    }
 }

--- a/src/repo-guards/tests/pre_commit_hook.rs
+++ b/src/repo-guards/tests/pre_commit_hook.rs
@@ -110,30 +110,26 @@ fn run_git(dir: &Path, args: &[&str]) {
     );
 }
 
-/// Run the real hook with `dir` as CWD, scrubbing inherited git env vars so the
-/// hook operates on the fixture repo rather than this test's repo. Returns true
-/// if the hook exited zero.
-fn run_hook(dir: &Path) -> bool {
-    Command::new("bash")
-        .arg(hook_path())
-        .current_dir(dir)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .status()
-        .expect("failed to spawn pre-commit hook")
-        .success()
+/// Both halves of one run of the hook. A test reads the half it needs, or both
+/// halves, from the single run that produced them.
+struct HookRun {
+    /// True when the hook exited zero.
+    passed: bool,
+    /// What the hook printed: its standard output, and then its standard error.
+    ///
+    /// The status alone cannot tell which block ran. A fixture repo is not this
+    /// workspace, so a block naming a package of this workspace fails there for
+    /// a reason that has nothing to do with the trigger under test. Each block
+    /// announces itself before it runs, so the announcement is what proves the
+    /// trigger fired.
+    output: String,
 }
 
-/// Run the real hook as [`run_hook`] does, and give back what it printed.
-///
-/// The status alone cannot tell which block ran. A fixture repo is not this
-/// workspace, so a block naming a package of this workspace fails there for a
-/// reason that has nothing to do with the trigger under test. Each block
-/// announces itself before it runs, so the announcement is what proves the
-/// trigger fired.
-fn run_hook_output(dir: &Path) -> String {
-    let output = Command::new("bash")
+/// Run the real hook once with `dir` as CWD, scrubbing inherited git env vars so
+/// the hook operates on the fixture repo rather than this test's repo. Gives
+/// back the exit status and the printed output of that one run.
+fn run_hook(dir: &Path) -> HookRun {
+    let completed = Command::new("bash")
         .arg(hook_path())
         .current_dir(dir)
         .env_remove("GIT_DIR")
@@ -141,11 +137,14 @@ fn run_hook_output(dir: &Path) -> String {
         .env_remove("GIT_INDEX_FILE")
         .output()
         .expect("failed to spawn pre-commit hook");
-    format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
+    HookRun {
+        passed: completed.status.success(),
+        output: format!(
+            "{}{}",
+            String::from_utf8_lossy(&completed.stdout),
+            String::from_utf8_lossy(&completed.stderr)
+        ),
+    }
 }
 
 /// The line the hook prints before it runs the tool-index guard.
@@ -167,7 +166,7 @@ fn staged_misformatted_rust_file_fails_the_gate() {
     write_fixture_package(&dir);
     git_init_and_stage(&dir, &["src/main.rs", "Cargo.toml", "rust-toolchain.toml"]);
 
-    let passed = run_hook(&dir);
+    let HookRun { passed, .. } = run_hook(&dir);
     cleanup(&dir);
 
     assert!(
@@ -199,7 +198,7 @@ fn staged_toolchain_config_alone_triggers_the_gate() {
         // so the gate must fire on the config file alone to catch it.
         git_init_and_stage(&dir, &[config_file]);
 
-        let passed = run_hook(&dir);
+        let HookRun { passed, .. } = run_hook(&dir);
         cleanup(&dir);
 
         assert!(
@@ -227,8 +226,7 @@ fn staged_unnamed_file_skips_every_gate() {
     // Only the notes are staged; the misformatted main.rs stays unstaged.
     git_init_and_stage(&dir, &["NOTES.md"]);
 
-    let output = run_hook_output(&dir);
-    let passed = run_hook(&dir);
+    let HookRun { passed, output } = run_hook(&dir);
     cleanup(&dir);
 
     assert!(
@@ -265,7 +263,7 @@ fn staged_tool_index_alone_triggers_the_index_guard() {
         // the Rust gate cannot be what fires.
         git_init_and_stage(&dir, &[index]);
 
-        let output = run_hook_output(&dir);
+        let HookRun { output, .. } = run_hook(&dir);
         cleanup(&dir);
 
         assert!(


### PR DESCRIPTION
Follows #374. These seven commits address the second review round of `issue-365`
and were never pushed, so the squash merge of #374 landed without them.

## What this branch fixes

- **`krt --run ID` printed a message that instructed a command line the parser
  rejects.** `required_unless_present` named the replay alone, so the parser
  asked for a destination that conflicts with `--run`. It now reads
  `required_unless_present_any = ["replay", "run"]`.
- **A Markdown-only commit ran no gate, so `repo_guards::tool_index` never
  fired on the one direction it cannot otherwise reach.** `.husky/pre-commit`
  gained a third block that runs the guard when `README.md` or `TLDR.md` is
  staged.
- **The module header of `tool_index.rs` and `CLAUDE.md` both said two binaries
  had drifted out of an index.** The count is one. Both now name `seescc`.

## Verification

The tree is unchanged from the pre-rebase head, and every gate is green at this
head: `cargo fmt --check` clean, `cargo machete` clean, `cargo clippy
--all-targets --workspace -- -D warnings` clean, and `cargo test --workspace`
reports 2290 passed and 0 failed.
