### PR TITLE
feat(thermal-watch): report CPU throttling by clock, not by pressure level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "jni",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.4.3",
  "ndk",
  "ndk-context",
  "oboe",
@@ -4167,6 +4167,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.5.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4630,15 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -7324,6 +7343,23 @@ name = "testcolor"
 version = "0.1.0"
 dependencies = [
  "colored",
+]
+
+[[package]]
+name = "thermal-watch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buildinfo",
+ "clap",
+ "colored",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libc",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,9 @@ mockito = "1.7"
 
 # Platform-specific
 procfs = "0.17"
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+io-kit-sys = "0.5"
 windows-sys = { version = "0.60", features = [
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Foundation",

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       measured P-cluster frequency against the DVFS table of the chip is the ground truth. This tool samples both
       once a second, optionally makes its own full P-core load, and reports how far the clock decayed from its
       early peak. `--load` makes the load, `--duration` sets how long, up to 86400 seconds, and `--json` prints
-      one object per sample.
+      one object per sample and then one final object that carries the verdict.
       Needs `sudo`, because `powermetrics` does.
     - To install: `cargo install --git https://github.com/timmattison/tools thermal-watch`
 - htmlboard

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       `Critical`) tells applications to do less work and stays `Nominal` through most real throttling, while the
       measured P-cluster frequency against the DVFS table of the chip is the ground truth. This tool samples both
       once a second, optionally makes its own full P-core load, and reports how far the clock decayed from its
-      early peak. `--load` makes the load, `--duration` sets how long, and `--json` prints one object per sample.
+      early peak. `--load` makes the load, `--duration` sets how long, up to 86400 seconds, and `--json` prints
+      one object per sample.
       Needs `sudo`, because `powermetrics` does.
     - To install: `cargo install --git https://github.com/timmattison/tools thermal-watch`
 - htmlboard

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
       (GPT-3.5-turbo, GPT-4, GPT-4o) and can read from stdin or multiple files. Shows counts with
       thousands separators for easy reading.
     - To install: `cargo install --git https://github.com/timmattison/tools tc`
+- thermal-watch
+    - Shows whether this Apple Silicon Mac decreases its clock under sustained load. macOS reports two different
+      signals and only one of them answers the question: the thermal pressure level (`Nominal`, `Fair`, `Serious`,
+      `Critical`) tells applications to do less work and stays `Nominal` through most real throttling, while the
+      measured P-cluster frequency against the DVFS table of the chip is the ground truth. This tool samples both
+      once a second, optionally makes its own full P-core load, and reports how far the clock decayed from its
+      early peak. `--load` makes the load, `--duration` sets how long, and `--json` prints one object per sample.
+      Needs `sudo`, because `powermetrics` does.
+    - To install: `cargo install --git https://github.com/timmattison/tools thermal-watch`
 - htmlboard
     - Waits for HTML to be put on the clipboard and then pretty prints it and puts it back in the clipboard.
     - To install: `cargo install --git https://github.com/timmattison/tools htmlboard`

--- a/TLDR.md
+++ b/TLDR.md
@@ -65,6 +65,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `swt` | Subagent Worktree — isolated-worktree helper for parallel TDD (create/merge with green checks). |
 | `symfix` | Recursively finds and optionally fixes broken symlinks. |
 | `tc` | Token Count — counts estimated LLM tokens in files (multiple OpenAI tokenizers, stdin support). |
+| `thermal-watch` | Shows whether an Apple Silicon Mac decreases its clock under sustained load, measuring the P-cluster frequency against the DVFS table of the chip rather than trusting the thermal pressure level. |
 | `tsm` | Terminal Session Manager — records every shell command to JSONL logs you can search and replay. |
 | `tubeboard` | Extracts the video ID from a YouTube URL on the clipboard. |
 | `unescapeboard` | Unescapes one level of `\"`-style escaping in clipboard text. |

--- a/src/thermal-watch/Cargo.toml
+++ b/src/thermal-watch/Cargo.toml
@@ -17,5 +17,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [lints]
 workspace = true

--- a/src/thermal-watch/Cargo.toml
+++ b/src/thermal-watch/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "thermal-watch"
+version = "0.1.0"
+edition.workspace = true
+description = "Show whether an Apple Silicon Mac decreases its clock under sustained load"
+
+[dependencies]
+anyhow.workspace = true
+buildinfo.workspace = true
+clap.workspace = true
+colored.workspace = true
+core-foundation.workspace = true
+core-foundation-sys.workspace = true
+io-kit-sys.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+libc.workspace = true
+
+[lints]
+workspace = true

--- a/src/thermal-watch/Cargo.toml
+++ b/src/thermal-watch/Cargo.toml
@@ -17,8 +17,5 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
-[dev-dependencies]
-libc.workspace = true
-
 [lints]
 workspace = true

--- a/src/thermal-watch/Cargo.toml
+++ b/src/thermal-watch/Cargo.toml
@@ -12,6 +12,7 @@ colored.workspace = true
 core-foundation.workspace = true
 core-foundation-sys.workspace = true
 io-kit-sys.workspace = true
+libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/src/thermal-watch/Cargo.toml
+++ b/src/thermal-watch/Cargo.toml
@@ -17,8 +17,5 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
-[dev-dependencies]
-serde_json.workspace = true
-
 [lints]
 workspace = true

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -27,11 +27,11 @@ verdict is built on.
 4. Compares the mean clock at the start of the load against the mean clock at
    the end of it. That decay is the throttling. Each window is one third of the
    busy span or less, so the two windows never share a sample. The busy span is
-   the time from the first busy sample to the last busy sample, which is the
-   full run with `--load` but less for a load that you start part way through.
-   The early window is the full 20 seconds on a busy span of 60 seconds or
-   more. The late window is the full 60 seconds on a busy span of 180 seconds
-   or more.
+   the time from the first busy sample to the last busy sample. With `--load`
+   that span is the full run, but a load that you start part way through gives
+   a shorter span. The early window is the full 20 seconds on a busy span of 60
+   seconds or more. The late window is the full 60 seconds on a busy span of
+   180 seconds or more.
 
 ## Usage
 

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -44,7 +44,7 @@ sudo thermal-watch --json                 # one JSON object for each sample
 | Option | What it does |
 | --- | --- |
 | `--load` | Make a full P-core load instead of watching one you started. |
-| `--duration <SECONDS>` | How long to watch. The default is 300. |
+| `--duration <SECONDS>` | How long to watch. The default is 300. The maximum is 86400, which is one day. |
 | `--json` | Print one JSON object for each sample instead of the live display. |
 
 ## Reading the output

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -38,16 +38,19 @@ verdict is built on.
 sudo thermal-watch --load                 # make a 5-minute load and watch it
 sudo thermal-watch --load --duration 900  # 15 minutes, the interesting case
 sudo thermal-watch                        # watch a build you started
-sudo thermal-watch --json                 # one JSON object for each sample
+sudo thermal-watch --json                 # one object for each sample, then the verdict
 ```
 
 | Option | What it does |
 | --- | --- |
 | `--load` | Make a full P-core load instead of watching one you started. |
 | `--duration <SECONDS>` | How long to watch. The default is 300. The maximum is 86400, which is one day. |
-| `--json` | Print one JSON object for each sample instead of the live display. |
+| `--json` | Print one JSON object for each sample, and then one final object that carries the verdict, instead of the live display. |
 
 ## Reading the output
+
+Both modes end with the verdict. The live display writes it as a report, and
+the `--json` mode writes it as one final object.
 
 Each line of the live display carries the time from the start, a bar of the
 clock against the peak of the chip, the clock itself, how busy the P-cluster
@@ -62,17 +65,38 @@ Making a full P-core load for 900s. Press Ctrl-C to stop early.
 04:31  ██████████████████▎      3.44 GHz ( 76% of max)  busy  99.9%  cpu  27.1W  Nominal
 ```
 
-The run ends with one of four verdicts:
+The run ends with one of four verdicts. Each mode names them in its own way:
+the report prints the name in the first column, and the JSON `outcome` key
+holds the name in the second.
 
-| Verdict | What it means |
-| --- | --- |
-| `HeldClock` | The clock held near the peak for the whole run. No throttling. |
-| `Throttled` | The clock started near the peak and then decreased. This is thermal throttling, or a power limit. |
-| `NeverReachedPeak` | The clock was low from the first sample on. It never decayed, so this is not heat — look for another load on the machine. |
-| `NotEnoughData` | The P-cluster was never busy for long enough to judge. |
+| Verdict | In JSON | What it means |
+| --- | --- | --- |
+| `HeldClock` | `held_clock` | The clock held near the peak for the whole run. No throttling. |
+| `Throttled` | `throttled` | The clock started near the peak and then decreased. This is thermal throttling, or a power limit. |
+| `NeverReachedPeak` | `never_reached_peak` | The clock was low from the first sample on. It never decayed, so this is not heat — look for another load on the machine. |
+| `NotEnoughData` | `not_enough_data` | The P-cluster was never busy for long enough to judge. |
 
 A `Throttled` verdict beside a `Nominal` pressure level is the normal case, not
 a contradiction. The report says so.
+
+### The JSON mode
+
+`--json` prints the same run as line-delimited JSON. Each sample is one object.
+The last line is one more object, and it carries the verdict of the run.
+
+```text
+{"at_seconds":7.0,"p_freq":4500,"p_active_pct":99.9,"e_freq":1020,"cpu_power_mw":38200,"gpu_power_mw":0,"pressure":"nominal"}
+{"verdict":{"outcome":"throttled","decay":0.244,"peak":4500,"early_mean":4500,"late_mean":3400,"late_ratio_of_max":0.754,"peak_power_mw":48500,"worst_pressure":"nominal"}}
+```
+
+A reader tells the two kinds of line apart by one key: a sample carries
+`at_seconds` and no `verdict`, and the verdict carries `verdict` and no
+`at_seconds`.
+
+The data of the outcome sits beside `outcome`, not under it. `throttled` adds
+`decay`, which is the share of the early mean that was lost. `not_enough_data`
+adds `busy_samples`, which is the count of busy samples the run collected. The
+other two outcomes add nothing.
 
 ## Why the IO Registry, and not `ioreg`
 

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -1,0 +1,98 @@
+# thermal-watch
+
+Show whether an Apple Silicon Mac decreases its clock under sustained load.
+
+## The question this answers
+
+Every process-level monitor on macOS reports a **thermal pressure level** —
+`Nominal`, `Fair`, `Serious`, or `Critical`. It is easy to read that as "the
+chip is at full speed", and it is not what the level means. macOS raises the
+level to tell *applications* to do less work, and Apple Silicon decreases its
+clock long before the level ever leaves `Nominal`.
+
+So a machine can report `Nominal` while its P-cores run 20% below their peak
+clock, and no pressure-based tool says a word about it.
+
+`thermal-watch` measures the other signal: the **achieved P-cluster frequency**,
+against the DVFS table of the chip. That is the ground truth, and it is what the
+verdict is built on.
+
+## What it does
+
+1. Reads the DVFS table of the running chip from the IO Registry, which needs no
+   special privilege. The largest P-cluster step is the peak clock of the chip.
+2. Runs `powermetrics` once a second and reads the achieved clock, the active
+   residency, the CPU power, and the thermal pressure level from each sample.
+3. Optionally makes its own full P-core load, so no separate build is necessary.
+4. Compares the mean clock over the first 20 seconds against the mean clock over
+   the last 60 seconds. That decay is the throttling.
+
+## Usage
+
+`powermetrics` needs root, so this tool does too. It never runs `sudo` itself.
+
+```bash
+sudo thermal-watch --load                 # make a 5-minute load and watch it
+sudo thermal-watch --load --duration 900  # 15 minutes, the interesting case
+sudo thermal-watch                        # watch a build you started
+sudo thermal-watch --json                 # one JSON object for each sample
+```
+
+| Option | What it does |
+| --- | --- |
+| `--load` | Make a full P-core load instead of watching one you started. |
+| `--duration <SECONDS>` | How long to watch. The default is 300. |
+| `--json` | Print one JSON object for each sample instead of the live display. |
+
+## Reading the output
+
+Each line of the live display carries the time from the start, a bar of the
+clock against the peak of the chip, the clock itself, how busy the P-cluster
+was, the CPU power, and the thermal pressure level.
+
+```text
+P-cores: max 4.51 GHz over 19 steps   E-cores: max 2.59 GHz
+Sampling powermetrics (cpu_power,thermal) once a second.
+Making a full P-core load for 900s. Press Ctrl-C to stop early.
+
+00:07  ████████████████████████ 4.51 GHz (100% of max)  busy  99.9%  cpu  38.2W  Nominal
+04:31  ██████████████████▎      3.44 GHz ( 76% of max)  busy  99.9%  cpu  27.1W  Nominal
+```
+
+The run ends with one of four verdicts:
+
+| Verdict | What it means |
+| --- | --- |
+| `HeldClock` | The clock held near the peak for the whole run. No throttling. |
+| `Throttled` | The clock started near the peak and then decreased. This is thermal throttling, or a power limit. |
+| `NeverReachedPeak` | The clock was low from the first sample on. It never decayed, so this is not heat — look for another load on the machine. |
+| `NotEnoughData` | The P-cluster was never busy for long enough to judge. |
+
+A `Throttled` verdict beside a `Nominal` pressure level is the normal case, not
+a contradiction. The report says so.
+
+## Why the IO Registry, and not `ioreg`
+
+The command line tool `ioreg` renders the DVFS tables as hexadecimal inside a
+wall of text, so reading them that way means a regular expression over the
+output of another program. "What does this property of this registry node hold"
+names a structure rather than a piece of text, so this crate asks IOKit itself.
+
+The `powermetrics` output is a different case. It is line-oriented, prints no
+machine-readable form that carries the same fields, and every field wanted here
+is a labelled line — so that half is a line scan, which is the correct
+instrument for a genuinely lexical format.
+
+## Why the load generator cannot outlive the process
+
+A load generator whose only stop is a call after the loop never stops when its
+caller dies. Each worker here carries its own deadline and checks it, so the
+load ends on time even when nothing calls `stop`. The workers are threads rather
+than processes, so they also end when the process ends. Neither guarantee
+depends on the other, and `load_bounds.rs` holds both.
+
+## Installation
+
+```bash
+cargo install --git https://github.com/timmattison/tools thermal-watch
+```

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -25,9 +25,10 @@ verdict is built on.
    residency, the CPU power, and the thermal pressure level from each sample.
 3. Optionally makes its own full P-core load, so no separate build is necessary.
 4. Compares the mean clock at the start of the load against the mean clock at
-   the end of it. That decay is the throttling. The two windows are 20 seconds
-   and 60 seconds on a run of 80 seconds or more. On a shorter run each window
-   becomes one third of the run, so the two windows never share a sample.
+   the end of it. That decay is the throttling. Each window is one third of the
+   run or less, so the two windows never share a sample. The early window is
+   the full 20 seconds on a run of 60 seconds or more. The late window is the
+   full 60 seconds on a run of 180 seconds or more.
 
 ## Usage
 

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -26,9 +26,12 @@ verdict is built on.
 3. Optionally makes its own full P-core load, so no separate build is necessary.
 4. Compares the mean clock at the start of the load against the mean clock at
    the end of it. That decay is the throttling. Each window is one third of the
-   run or less, so the two windows never share a sample. The early window is
-   the full 20 seconds on a run of 60 seconds or more. The late window is the
-   full 60 seconds on a run of 180 seconds or more.
+   busy span or less, so the two windows never share a sample. The busy span is
+   the time from the first busy sample to the last busy sample, which is the
+   full run with `--load` but less for a load that you start part way through.
+   The early window is the full 20 seconds on a busy span of 60 seconds or
+   more. The late window is the full 60 seconds on a busy span of 180 seconds
+   or more.
 
 ## Usage
 

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -98,6 +98,31 @@ The data of the outcome sits beside `outcome`, not under it. `throttled` adds
 adds `busy_samples`, which is the count of busy samples the run collected. The
 other two outcomes add nothing.
 
+The outcome also decides which measurements the line carries. A
+`not_enough_data` run measured no clock at all, so its line leaves out `peak`,
+`early_mean`, `late_mean` and `late_ratio_of_max`. A zero in those keys would
+read as a measurement, and an absent key cannot. The line keeps
+`peak_power_mw` and `worst_pressure`, because the run measured both of them
+even though it could not support a verdict.
+
+```text
+{"verdict":{"outcome":"not_enough_data","busy_samples":3,"peak_power_mw":48500,"worst_pressure":"nominal"}}
+```
+
+The other three outcomes carry every key in the table below.
+
+| Key | On which outcomes | What it holds |
+| --- | --- | --- |
+| `outcome` | all four | The name of the verdict, in lower snake case. |
+| `decay` | `throttled` | The share of the early mean that was lost. |
+| `busy_samples` | `not_enough_data` | The count of busy samples the run collected. |
+| `peak` | the three judged ones | The peak clock under load, in megahertz. |
+| `early_mean` | the three judged ones | The mean clock over the early window, in megahertz. |
+| `late_mean` | the three judged ones | The mean clock over the late window, in megahertz. |
+| `late_ratio_of_max` | the three judged ones | The late mean as a share of the peak of the chip. |
+| `peak_power_mw` | all four | The highest CPU package power, in milliwatts. |
+| `worst_pressure` | all four | The worst thermal pressure level of the run. |
+
 ## Why the IO Registry, and not `ioreg`
 
 The command line tool `ioreg` renders the DVFS tables as hexadecimal inside a

--- a/src/thermal-watch/README.md
+++ b/src/thermal-watch/README.md
@@ -24,8 +24,10 @@ verdict is built on.
 2. Runs `powermetrics` once a second and reads the achieved clock, the active
    residency, the CPU power, and the thermal pressure level from each sample.
 3. Optionally makes its own full P-core load, so no separate build is necessary.
-4. Compares the mean clock over the first 20 seconds against the mean clock over
-   the last 60 seconds. That decay is the throttling.
+4. Compares the mean clock at the start of the load against the mean clock at
+   the end of it. That decay is the throttling. The two windows are 20 seconds
+   and 60 seconds on a run of 80 seconds or more. On a shorter run each window
+   becomes one third of the run, so the two windows never share a sample.
 
 ## Usage
 

--- a/src/thermal-watch/src/dvfs.rs
+++ b/src/thermal-watch/src/dvfs.rs
@@ -14,6 +14,15 @@
 //! registry node hold" — names a structure, not a piece of text, so this module
 //! asks the IO Registry itself through IOKit. Nothing is text-matched.
 
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::data::CFData;
+use core_foundation::string::CFString;
+use core_foundation_sys::base::kCFAllocatorDefault;
+use io_kit_sys::keys::kIOServicePlane;
+use io_kit_sys::{
+    kIOMasterPortDefault, kIORegistryIterateRecursively, IOObjectRelease,
+    IORegistryEntrySearchCFProperty, IORegistryGetRootEntry,
+};
 use thiserror::Error;
 
 use crate::mhz::Mhz;
@@ -75,7 +84,16 @@ impl DvfsTable {
     /// Returns [`DvfsError`] when the IO Registry carries no DVFS property,
     /// when the property is not raw data, or when it decodes to no usable step.
     pub fn read() -> Result<Self, DvfsError> {
-        Err(DvfsError::PropertyMissing { key: P_CLUSTER_KEY })
+        let p_steps = decode_voltage_states(&read_property(P_CLUSTER_KEY)?);
+        if p_steps.is_empty() {
+            return Err(DvfsError::TableEmpty { key: P_CLUSTER_KEY });
+        }
+        // A chip whose E-cluster property is absent still answers the question
+        // this tool asks, so the E-cluster is read but never required.
+        let e_steps = read_property(E_CLUSTER_KEY)
+            .map(|raw| decode_voltage_states(&raw))
+            .unwrap_or_default();
+        Ok(Self { p_steps, e_steps })
     }
 
     /// Build a table from already-decoded steps. Used by tests, and by
@@ -116,12 +134,55 @@ impl DvfsTable {
 /// kilohertz, then a voltage. A trailing partial entry is ignored, and a step
 /// whose frequency is zero is padding rather than a real step.
 #[must_use]
-pub fn decode_voltage_states(_raw: &[u8]) -> Vec<Mhz> {
-    Vec::new()
+pub fn decode_voltage_states(raw: &[u8]) -> Vec<Mhz> {
+    raw.chunks_exact(ENTRY_BYTES)
+        .filter_map(|entry| {
+            let (frequency, _voltage) = entry.split_at(ENTRY_BYTES / 2);
+            let kilohertz = u32::from_le_bytes(frequency.try_into().ok()?);
+            (kilohertz > 0).then(|| Mhz::from_khz(kilohertz))
+        })
+        .collect()
 }
 
 /// Read one IO Registry property as raw bytes, searching the whole service
 /// plane from the root.
-fn read_property(_key: &'static str) -> Result<Vec<u8>, DvfsError> {
-    Err(DvfsError::PropertyMissing { key: P_CLUSTER_KEY })
+fn read_property(key: &'static str) -> Result<Vec<u8>, DvfsError> {
+    let name = CFString::new(key);
+
+    // SAFETY: `IORegistryGetRootEntry` takes a mach port and returns an entry
+    // this thread owns. `kIOMasterPortDefault` is the port IOKit publishes for
+    // this purpose. A returned zero means no entry, which is checked below
+    // before the handle is used.
+    let root = unsafe { IORegistryGetRootEntry(kIOMasterPortDefault) };
+    if root == 0 {
+        return Err(DvfsError::PropertyMissing { key });
+    }
+
+    // SAFETY: `root` is a live registry entry from the call above.
+    // `kIOServicePlane` is a static C string from IOKit, and `name` outlives
+    // the call. The create rule applies to the result, so the wrapper below
+    // takes ownership of it. The entry is released whatever the result is.
+    let raw = unsafe {
+        let property = IORegistryEntrySearchCFProperty(
+            root,
+            kIOServicePlane,
+            name.as_concrete_TypeRef(),
+            kCFAllocatorDefault,
+            kIORegistryIterateRecursively,
+        );
+        IOObjectRelease(root);
+        property
+    };
+
+    if raw.is_null() {
+        return Err(DvfsError::PropertyMissing { key });
+    }
+
+    // SAFETY: `raw` is a non-null Core Foundation value returned under the
+    // create rule, so this wrapper owns it and releases it on drop.
+    let value = unsafe { CFType::wrap_under_create_rule(raw) };
+    let data = value
+        .downcast::<CFData>()
+        .ok_or(DvfsError::PropertyNotData { key })?;
+    Ok(data.bytes().to_vec())
 }

--- a/src/thermal-watch/src/dvfs.rs
+++ b/src/thermal-watch/src/dvfs.rs
@@ -1,0 +1,127 @@
+//! Read the DVFS table of an Apple Silicon SoC from the IO Registry.
+//!
+//! DVFS means dynamic voltage and frequency scaling. The SoC carries one table
+//! for each cluster, and each table lists the frequency and voltage of every
+//! step the cluster can run at. The last entry of the P-cluster table is the
+//! peak clock of the chip, and it is the number every measurement in this crate
+//! is judged against.
+//!
+//! # Why the IO Registry, and not `ioreg`
+//!
+//! The command line tool `ioreg` renders these tables as hexadecimal inside a
+//! wall of text, so reading them that way means a regular expression over the
+//! output of another program. The question — "what does this property of this
+//! registry node hold" — names a structure, not a piece of text, so this module
+//! asks the IO Registry itself through IOKit. Nothing is text-matched.
+
+use thiserror::Error;
+
+use crate::mhz::Mhz;
+
+/// The IO Registry property that holds the DVFS table of the P-cluster.
+const P_CLUSTER_KEY: &str = "voltage-states5-sram";
+
+/// The IO Registry property that holds the DVFS table of the E-cluster.
+const E_CLUSTER_KEY: &str = "voltage-states1-sram";
+
+/// Each entry of a DVFS table is two little-endian `u32` words: a frequency in
+/// kilohertz, then a voltage.
+const ENTRY_BYTES: usize = 8;
+
+/// A DVFS table could not be read.
+#[derive(Debug, Error)]
+pub enum DvfsError {
+    /// The IO Registry has no such property anywhere under the service plane.
+    ///
+    /// An Intel Mac reaches this, because it carries no such property. So does
+    /// a future SoC that renames the key.
+    #[error("no `{key}` property in the IO Registry; this tool needs an Apple Silicon Mac")]
+    PropertyMissing {
+        /// The property that was searched for.
+        key: &'static str,
+    },
+
+    /// The property exists but does not hold the raw bytes of a table.
+    #[error("the `{key}` property is not raw data")]
+    PropertyNotData {
+        /// The property whose type was wrong.
+        key: &'static str,
+    },
+
+    /// The property holds bytes, but no complete entry with a frequency above
+    /// zero. Reporting an empty table as a maximum of zero would make every
+    /// later ratio read as full throttling.
+    #[error("the `{key}` property holds no usable frequency step")]
+    TableEmpty {
+        /// The property whose table could not be decoded.
+        key: &'static str,
+    },
+}
+
+/// The frequency steps of the two CPU clusters of an Apple Silicon SoC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DvfsTable {
+    /// P-cluster steps, in the order the SoC lists them.
+    p_steps: Vec<Mhz>,
+    /// E-cluster steps, in the order the SoC lists them.
+    e_steps: Vec<Mhz>,
+}
+
+impl DvfsTable {
+    /// Read the table of the running machine from the IO Registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DvfsError`] when the IO Registry carries no DVFS property,
+    /// when the property is not raw data, or when it decodes to no usable step.
+    pub fn read() -> Result<Self, DvfsError> {
+        Err(DvfsError::PropertyMissing { key: P_CLUSTER_KEY })
+    }
+
+    /// Build a table from already-decoded steps. Used by tests, and by
+    /// [`Self::read`] once the bytes are decoded.
+    #[must_use]
+    pub fn from_steps(p_steps: Vec<Mhz>, e_steps: Vec<Mhz>) -> Self {
+        Self { p_steps, e_steps }
+    }
+
+    /// The peak clock of the P-cluster.
+    #[must_use]
+    pub fn p_max(&self) -> Mhz {
+        self.p_steps.iter().copied().max().unwrap_or(Mhz::new(0))
+    }
+
+    /// The peak clock of the E-cluster.
+    #[must_use]
+    pub fn e_max(&self) -> Mhz {
+        self.e_steps.iter().copied().max().unwrap_or(Mhz::new(0))
+    }
+
+    /// Every P-cluster step, in the order the SoC lists them.
+    #[must_use]
+    pub fn p_steps(&self) -> &[Mhz] {
+        &self.p_steps
+    }
+
+    /// Every E-cluster step, in the order the SoC lists them.
+    #[must_use]
+    pub fn e_steps(&self) -> &[Mhz] {
+        &self.e_steps
+    }
+}
+
+/// Decode the raw bytes of a DVFS property into frequency steps.
+///
+/// The layout is a repeated pair of little-endian `u32` words: a frequency in
+/// kilohertz, then a voltage. A trailing partial entry is ignored, and a step
+/// whose frequency is zero is padding rather than a real step.
+#[must_use]
+pub fn decode_voltage_states(_raw: &[u8]) -> Vec<Mhz> {
+    Vec::new()
+}
+
+/// Read one IO Registry property as raw bytes, searching the whole service
+/// plane from the root.
+fn read_property(_key: &'static str) -> Result<Vec<u8>, DvfsError> {
+    Err(DvfsError::PropertyMissing { key: P_CLUSTER_KEY })
+}

--- a/src/thermal-watch/src/lib.rs
+++ b/src/thermal-watch/src/lib.rs
@@ -1,0 +1,30 @@
+//! `thermal-watch` shows whether an Apple Silicon Mac decreases its clock under
+//! sustained load.
+//!
+//! macOS reports two different signals, and only one of them answers the
+//! question:
+//!
+//! 1. **Thermal pressure** (`Nominal`, `Fair`, `Serious`, `Critical`). The OS
+//!    raises this level to tell applications to do less work. Apple Silicon
+//!    decreases its clock long before the level changes, so `Nominal` under
+//!    full load does not mean full speed. Every process-level tool that reports
+//!    "thermals nominal" reads this signal.
+//! 2. **The measured P-cluster frequency**, against the maximum frequency in
+//!    the DVFS table of the chip. This is the ground truth, and it is what this
+//!    tool judges on.
+//!
+//! The two signals disagree often, and the disagreement is the point: a machine
+//! can sit at `Nominal` while its P-cores run 20% below their peak clock.
+
+pub mod dvfs;
+pub mod load;
+pub mod mhz;
+pub mod powermetrics;
+pub mod render;
+pub mod report;
+
+pub use dvfs::{DvfsError, DvfsTable};
+pub use load::Load;
+pub use mhz::Mhz;
+pub use powermetrics::{PressureLevel, Sample, SampleStream};
+pub use report::{Outcome, Verdict};

--- a/src/thermal-watch/src/load.rs
+++ b/src/thermal-watch/src/load.rs
@@ -8,10 +8,20 @@
 //! calls [`Load::stop`]. The workers are threads rather than processes, so they
 //! also end when the process ends. Neither guarantee depends on the other.
 
-use std::sync::atomic::AtomicBool;
+use std::ffi::CString;
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::thread::JoinHandle;
+use std::thread::{self, available_parallelism, JoinHandle};
 use std::time::Instant;
+
+/// The sysctl that reports how many performance cores an Apple Silicon Mac has.
+const PERFORMANCE_CORES: &str = "hw.perflevel0.physicalcpu";
+
+/// The sysctl that reports the total count of physical cores, used when the
+/// machine reports no performance level.
+const PHYSICAL_CORES: &str = "hw.physicalcpu";
 
 /// How many arithmetic operations run between two checks of the deadline.
 ///
@@ -32,11 +42,25 @@ impl Load {
     /// Start one worker for each performance core, every one of them ending at
     /// `deadline`.
     #[must_use]
-    pub fn start(_threads: usize, _deadline: Instant) -> Self {
-        Self {
-            workers: Vec::new(),
-            stop: Arc::new(AtomicBool::new(false)),
-        }
+    pub fn start(threads: usize, deadline: Instant) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let workers = (0..threads)
+            .map(|_| {
+                let stop = Arc::clone(&stop);
+                thread::spawn(move || {
+                    let mut accumulator = 1.0_f64;
+                    while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+                        for step in 0..BATCH {
+                            accumulator = (accumulator * 1.000_000_1_f64 + f64::from(step)).sqrt();
+                        }
+                    }
+                    // Keep the optimizer from removing the loop that is the
+                    // whole point of this thread.
+                    black_box(accumulator);
+                })
+            })
+            .collect();
+        Self { workers, stop }
     }
 
     /// How many workers are running.
@@ -46,8 +70,29 @@ impl Load {
     }
 
     /// Stop every worker and wait for it to end.
-    pub fn stop(self) {
-        let _ = &self.stop;
+    pub fn stop(mut self) {
+        self.shutdown();
+    }
+
+    /// Set the flag and join every worker that is still running.
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        for worker in self.workers.drain(..) {
+            // A worker that panicked has already stopped burning cycles, which
+            // is the only thing this call is here to guarantee.
+            drop(worker.join());
+        }
+    }
+}
+
+impl Drop for Load {
+    /// Stop the workers even when the caller never reaches [`Self::stop`].
+    ///
+    /// This runs on the panic path too. It is a convenience rather than the
+    /// guarantee: the deadline inside each worker is what bounds the load when
+    /// nothing runs at all.
+    fn drop(&mut self) {
+        self.shutdown();
     }
 }
 
@@ -57,5 +102,37 @@ impl Load {
 /// gives its total count of cores instead.
 #[must_use]
 pub fn performance_core_count() -> usize {
-    0
+    sysctl_usize(PERFORMANCE_CORES)
+        .or_else(|| sysctl_usize(PHYSICAL_CORES))
+        .unwrap_or_else(|| available_parallelism().map_or(1, NonZeroUsize::get))
+}
+
+/// Read one integer sysctl by name.
+///
+/// A name the kernel does not publish gives `None`, which is how a machine with
+/// no performance core level reports itself.
+fn sysctl_usize(name: &str) -> Option<usize> {
+    let key = CString::new(name).ok()?;
+    let mut value: u32 = 0;
+    let mut size = size_of::<u32>();
+
+    // SAFETY: `key` is a NUL-terminated C string that outlives the call.
+    // `value` and `size` are live locals, and `size` holds the size of `value`,
+    // so the kernel writes at most that many bytes. Both output pointers are
+    // non-null and the two input pointers are null, which this interface
+    // accepts for a read by name.
+    let result = unsafe {
+        libc::sysctlbyname(
+            key.as_ptr(),
+            std::ptr::from_mut(&mut value).cast(),
+            &raw mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+
+    if result != 0 || size != size_of::<u32>() || value == 0 {
+        return None;
+    }
+    Some(value as usize)
 }

--- a/src/thermal-watch/src/load.rs
+++ b/src/thermal-watch/src/load.rs
@@ -25,8 +25,12 @@ const PHYSICAL_CORES: &str = "hw.physicalcpu";
 
 /// How many arithmetic operations run between two checks of the deadline.
 ///
-/// A check on every operation would cost more than the work it guards. A batch
-/// this size keeps the check under a millisecond of delay.
+/// A check on every operation costs more than the work it guards. A batch of
+/// this size delays each check by about 7 milliseconds. One batch took 6.677 ms
+/// in a release build on an Apple Silicon machine. A worker goes past its
+/// deadline, and obeys [`Load::stop`], that much later. This constant is a
+/// count of floating point operations, not a time, so a different machine gives
+/// a different delay.
 pub const BATCH: u32 = 1_000_000;
 
 /// A running full-speed load on the performance cores.
@@ -39,8 +43,10 @@ pub struct Load {
 }
 
 impl Load {
-    /// Start one worker for each performance core, every one of them ending at
-    /// `deadline`.
+    /// Start `threads` workers, every one of them ending at `deadline`.
+    ///
+    /// The caller sets the count. To load all of the performance cores, the
+    /// caller gives [`performance_core_count`].
     #[must_use]
     pub fn start(threads: usize, deadline: Instant) -> Self {
         let stop = Arc::new(AtomicBool::new(false));

--- a/src/thermal-watch/src/load.rs
+++ b/src/thermal-watch/src/load.rs
@@ -1,0 +1,61 @@
+//! Make a full P-core load that cannot outlive the process.
+//!
+//! # Why the deadline is inside each worker
+//!
+//! A load generator whose only stop is a call after the loop is a load
+//! generator that never stops when the caller dies. Each worker here carries
+//! its own deadline and checks it, so the load ends on time even when nothing
+//! calls [`Load::stop`]. The workers are threads rather than processes, so they
+//! also end when the process ends. Neither guarantee depends on the other.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+/// How many arithmetic operations run between two checks of the deadline.
+///
+/// A check on every operation would cost more than the work it guards. A batch
+/// this size keeps the check under a millisecond of delay.
+pub const BATCH: u32 = 1_000_000;
+
+/// A running full-speed load on the performance cores.
+#[derive(Debug)]
+pub struct Load {
+    /// One handle for each worker thread.
+    workers: Vec<JoinHandle<()>>,
+    /// Set to stop every worker before its deadline.
+    stop: Arc<AtomicBool>,
+}
+
+impl Load {
+    /// Start one worker for each performance core, every one of them ending at
+    /// `deadline`.
+    #[must_use]
+    pub fn start(_threads: usize, _deadline: Instant) -> Self {
+        Self {
+            workers: Vec::new(),
+            stop: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// How many workers are running.
+    #[must_use]
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Stop every worker and wait for it to end.
+    pub fn stop(self) {
+        let _ = &self.stop;
+    }
+}
+
+/// How many performance cores this machine has.
+///
+/// A machine that reports no performance core level, such as an Intel Mac,
+/// gives its total count of cores instead.
+#[must_use]
+pub fn performance_core_count() -> usize {
+    0
+}

--- a/src/thermal-watch/src/main.rs
+++ b/src/thermal-watch/src/main.rs
@@ -1,10 +1,34 @@
 //! Command line entrance for `thermal-watch`.
 
-use anyhow::Result;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
 use buildinfo::version_string;
 use clap::Parser;
+use colored::Colorize;
+use thermal_watch::dvfs::DvfsTable;
+use thermal_watch::load::{performance_core_count, Load};
+use thermal_watch::powermetrics::{SampleStream, SAMPLERS};
+use thermal_watch::render::sample_line;
+use thermal_watch::report::{judge, Outcome, Verdict, BUSY_THRESHOLD_PCT, HOLD_RATIO};
+
+/// How often `powermetrics` reports a sample.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How long the load runs past the end of the watch, so the last sample is
+/// taken under load rather than during the wind-down.
+const LOAD_MARGIN: Duration = Duration::from_secs(5);
+
+/// The width of the rule that separates the display from the report.
+const RULE_WIDTH: usize = 72;
 
 /// Show whether this Mac decreases its clock under sustained load.
+///
+/// macOS reports two different signals. The thermal pressure level tells
+/// applications to do less work, and stays `Nominal` through most real
+/// throttling. The measured P-cluster frequency, against the DVFS table of the
+/// chip, is the ground truth. This tool samples both and judges on the second.
 #[derive(Parser, Debug)]
 #[clap(author, version = version_string!(), about)]
 struct Args {
@@ -22,6 +46,165 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    let _args = Args::parse();
-    anyhow::bail!("not implemented")
+    let args = Args::parse();
+
+    if args.duration == 0 {
+        anyhow::bail!("--duration needs a positive number of seconds");
+    }
+
+    let table = DvfsTable::read().context("cannot read the DVFS table of this machine")?;
+    let watch_for = Duration::from_secs(args.duration);
+    let sample_count = u32::try_from(args.duration).unwrap_or(u32::MAX);
+
+    if !args.json {
+        announce(&table, args.load, args.duration);
+    }
+
+    // The load starts first, so the first sample is already taken under load.
+    let load = args.load.then(|| {
+        Load::start(
+            performance_core_count(),
+            Instant::now() + watch_for + LOAD_MARGIN,
+        )
+    });
+
+    let stream = SampleStream::spawn(SAMPLE_INTERVAL, sample_count)
+        .context("cannot start powermetrics; it needs root, so run this tool with sudo")?;
+
+    let mut samples = Vec::with_capacity(usize::try_from(args.duration).unwrap_or_default());
+    let mut out = io::stdout().lock();
+    for sample in stream {
+        if args.json {
+            writeln!(out, "{}", serde_json::to_string(&sample)?)?;
+        } else {
+            writeln!(out, "{}", sample_line(&sample, table.p_max()))?;
+        }
+        out.flush()?;
+        samples.push(sample);
+    }
+
+    if let Some(load) = load {
+        load.stop();
+    }
+
+    if !args.json {
+        report(&judge(&samples, &table), args.load, &mut out)?;
+    }
+    Ok(())
+}
+
+/// Print what the run is about to do.
+fn announce(table: &DvfsTable, generates_load: bool, duration: u64) {
+    println!(
+        "P-cores: max {} over {} steps   E-cores: max {}",
+        table.p_max(),
+        table.p_steps().len(),
+        table.e_max(),
+    );
+    println!("Sampling powermetrics ({SAMPLERS}) once a second.");
+    if generates_load {
+        println!("Making a full P-core load for {duration}s. Press Ctrl-C to stop early.\n");
+    } else {
+        println!("Watching for {duration}s. Start your load now. Press Ctrl-C to stop early.\n");
+    }
+}
+
+/// Print the verdict of the run.
+fn report(verdict: &Verdict, generated_load: bool, out: &mut impl Write) -> Result<()> {
+    let rule = "─".repeat(RULE_WIDTH);
+    writeln!(out, "\n{rule}")?;
+
+    if let Outcome::NotEnoughData { busy_samples } = verdict.outcome {
+        writeln!(
+            out,
+            "The P-cluster was busy for {busy_samples} samples, which cannot support a verdict.",
+        )?;
+        writeln!(
+            out,
+            "A cluster counts as busy above {BUSY_THRESHOLD_PCT:.0}% active residency."
+        )?;
+        if generated_load {
+            writeln!(out, "\nTwo causes are possible:")?;
+            writeln!(
+                out,
+                "  1. Apple changed the output of powermetrics, and the parser no longer reads it."
+            )?;
+            writeln!(
+                out,
+                "     Compare `sudo powermetrics --samplers {SAMPLERS} -n 1` against the parser."
+            )?;
+            writeln!(out, "  2. The load did not reach the performance cores.")?;
+        } else {
+            writeln!(
+                out,
+                "\nStart a real load (a build, a render, a benchmark), then run this tool again."
+            )?;
+        }
+        return Ok(());
+    }
+
+    writeln!(out, "Peak clock under load : {}", verdict.peak)?;
+    writeln!(out, "Early mean            : {}", verdict.early_mean)?;
+    writeln!(
+        out,
+        "Late mean             : {}  ({:.0}% of the maximum of the chip)",
+        verdict.late_mean,
+        verdict.late_ratio_of_max * 100.0,
+    )?;
+    writeln!(
+        out,
+        "Peak CPU power        : {:.1} W",
+        f64::from(verdict.peak_power_mw) / 1_000.0,
+    )?;
+    writeln!(out, "Worst pressure level  : {:?}", verdict.worst_pressure)?;
+    writeln!(out, "{rule}")?;
+
+    match verdict.outcome {
+        Outcome::HeldClock => {
+            writeln!(
+                out,
+                "{} no thermal throttling. The clock held near the maximum.",
+                "VERDICT:".green().bold(),
+            )?;
+        }
+        Outcome::Throttled { decay } => {
+            writeln!(
+                out,
+                "{} the clock decreased {:.0}% from its early mean, and ends at {:.0}% of the maximum.",
+                "VERDICT:".red().bold(),
+                decay * 100.0,
+                verdict.late_ratio_of_max * 100.0,
+            )?;
+            writeln!(
+                out,
+                "This is thermal throttling, or a power limit. Both decrease the clock."
+            )?;
+            if verdict.worst_pressure == thermal_watch::PressureLevel::Nominal {
+                writeln!(
+                    out,
+                    "{}",
+                    "\nThe pressure level stayed Nominal through all of it. That is normal.\n\
+                     macOS raises that level to tell applications to do less work, not to\n\
+                     report each decrease of the clock."
+                        .dimmed(),
+                )?;
+            }
+        }
+        Outcome::NeverReachedPeak => {
+            writeln!(
+                out,
+                "{} the clock sat at {:.0}% of the maximum from the first sample on.",
+                "VERDICT:".yellow().bold(),
+                verdict.late_ratio_of_max * 100.0,
+            )?;
+            writeln!(
+                out,
+                "It never decayed, so this is not heat. A clock below {:.0}% of the maximum\n\
+                 for a whole run points at another load on the machine.",
+                HOLD_RATIO * 100.0,
+            )?;
+        }
+        Outcome::NotEnoughData { .. } => unreachable!("handled above"),
+    }
+    Ok(())
 }

--- a/src/thermal-watch/src/main.rs
+++ b/src/thermal-watch/src/main.rs
@@ -1,0 +1,27 @@
+//! Command line entrance for `thermal-watch`.
+
+use anyhow::Result;
+use buildinfo::version_string;
+use clap::Parser;
+
+/// Show whether this Mac decreases its clock under sustained load.
+#[derive(Parser, Debug)]
+#[clap(author, version = version_string!(), about)]
+struct Args {
+    /// Make a full P-core load instead of watching a load you started
+    #[clap(long)]
+    load: bool,
+
+    /// How long to watch, in seconds
+    #[clap(long, default_value_t = 300)]
+    duration: u64,
+
+    /// Print one JSON object for each sample instead of a live display
+    #[clap(long)]
+    json: bool,
+}
+
+fn main() -> Result<()> {
+    let _args = Args::parse();
+    anyhow::bail!("not implemented")
+}

--- a/src/thermal-watch/src/main.rs
+++ b/src/thermal-watch/src/main.rs
@@ -11,7 +11,9 @@ use thermal_watch::dvfs::DvfsTable;
 use thermal_watch::load::{performance_core_count, Load};
 use thermal_watch::powermetrics::{SampleStream, SAMPLERS};
 use thermal_watch::render::sample_line;
-use thermal_watch::report::{judge, Outcome, Verdict, BUSY_THRESHOLD_PCT, HOLD_RATIO};
+use thermal_watch::report::{
+    judge, verdict_line, Outcome, Verdict, BUSY_THRESHOLD_PCT, HOLD_RATIO,
+};
 
 /// How often `powermetrics` reports a sample.
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
@@ -48,7 +50,8 @@ struct Args {
     #[clap(long, default_value_t = 300)]
     duration: u64,
 
-    /// Print one JSON object for each sample instead of a live display
+    /// Print one JSON object for each sample and then one final object that
+    /// carries the verdict, instead of a live display
     #[clap(long)]
     json: bool,
 }
@@ -111,8 +114,15 @@ fn main() -> Result<()> {
         load.stop();
     }
 
-    if !args.json {
-        report(&judge(&samples, &table), args.load, &mut out)?;
+    // Both modes end with the verdict. A machine-readable run that stopped at
+    // the last sample gave the measurements and never the answer, and left its
+    // reader to rebuild the judgement from the numbers.
+    let verdict = judge(&samples, &table);
+    if args.json {
+        writeln!(out, "{}", serde_json::to_string(&verdict_line(&verdict))?)?;
+        out.flush()?;
+    } else {
+        report(&verdict, args.load, &mut out)?;
     }
     Ok(())
 }

--- a/src/thermal-watch/src/main.rs
+++ b/src/thermal-watch/src/main.rs
@@ -23,6 +23,14 @@ const LOAD_MARGIN: Duration = Duration::from_secs(5);
 /// The width of the rule that separates the display from the report.
 const RULE_WIDTH: usize = 72;
 
+/// The longest watch the tool accepts, in seconds.
+///
+/// A day is far past every real test of the thermal behavior of a machine. The
+/// bound also keeps the sample count and the size of the sample list inside the
+/// limits of their types, so a very large value gives a clean error instead of
+/// a panic.
+const MAXIMUM_DURATION_SECONDS: u64 = 86_400;
+
 /// Show whether this Mac decreases its clock under sustained load.
 ///
 /// macOS reports two different signals. The thermal pressure level tells
@@ -36,7 +44,7 @@ struct Args {
     #[clap(long)]
     load: bool,
 
-    /// How long to watch, in seconds
+    /// How long to watch, in seconds. The maximum is 86400, which is one day
     #[clap(long, default_value_t = 300)]
     duration: u64,
 
@@ -50,6 +58,11 @@ fn main() -> Result<()> {
 
     if args.duration == 0 {
         anyhow::bail!("--duration needs a positive number of seconds");
+    }
+    if args.duration > MAXIMUM_DURATION_SECONDS {
+        anyhow::bail!(
+            "--duration accepts no more than {MAXIMUM_DURATION_SECONDS} seconds, which is one day"
+        );
     }
 
     let table = DvfsTable::read().context("cannot read the DVFS table of this machine")?;

--- a/src/thermal-watch/src/main.rs
+++ b/src/thermal-watch/src/main.rs
@@ -68,12 +68,12 @@ fn main() -> Result<()> {
         )
     });
 
-    let stream = SampleStream::spawn(SAMPLE_INTERVAL, sample_count)
+    let mut stream = SampleStream::spawn(SAMPLE_INTERVAL, sample_count)
         .context("cannot start powermetrics; it needs root, so run this tool with sudo")?;
 
     let mut samples = Vec::with_capacity(usize::try_from(args.duration).unwrap_or_default());
     let mut out = io::stdout().lock();
-    for sample in stream {
+    for sample in stream.by_ref() {
         if args.json {
             writeln!(out, "{}", serde_json::to_string(&sample)?)?;
         } else {
@@ -81,6 +81,17 @@ fn main() -> Result<()> {
         }
         out.flush()?;
         samples.push(sample);
+    }
+
+    // A run that refused to start and a run that measured a quiet machine both
+    // give no sample. Reporting the first as the second sends the reader after
+    // a load problem that is really a privilege problem.
+    if let Some(status) = stream.exit_status() {
+        if !status.success() && samples.is_empty() {
+            anyhow::bail!(
+                "powermetrics ended with {status} and measured nothing; it needs root, so run this tool with sudo"
+            );
+        }
     }
 
     if let Some(load) = load {

--- a/src/thermal-watch/src/mhz.rs
+++ b/src/thermal-watch/src/mhz.rs
@@ -24,8 +24,8 @@ impl Mhz {
     /// Build a frequency from a count of kilohertz, as the DVFS table reports
     /// it. The result is rounded to the nearest megahertz.
     #[must_use]
-    pub const fn from_khz(_kilohertz: u32) -> Self {
-        Self(0)
+    pub const fn from_khz(kilohertz: u32) -> Self {
+        Self(kilohertz.saturating_add(500) / 1_000)
     }
 
     /// The frequency as a count of megahertz.
@@ -45,8 +45,11 @@ impl Mhz {
     /// A `maximum` of zero gives `0.0` rather than an infinity, so a caller
     /// that reads an empty DVFS table still renders.
     #[must_use]
-    pub fn ratio_of(self, _maximum: Self) -> f64 {
-        0.0
+    pub fn ratio_of(self, maximum: Self) -> f64 {
+        if maximum.0 == 0 {
+            return 0.0;
+        }
+        f64::from(self.0) / f64::from(maximum.0)
     }
 }
 

--- a/src/thermal-watch/src/mhz.rs
+++ b/src/thermal-watch/src/mhz.rs
@@ -1,0 +1,57 @@
+//! A clock frequency in megahertz.
+
+use std::fmt;
+
+use serde::Serialize;
+
+/// A clock frequency in megahertz.
+///
+/// Every frequency in this crate arrives from one of two places: the DVFS table
+/// of the chip, which reports kilohertz, or `powermetrics`, which reports
+/// megahertz. A newtype keeps the two units from mixing, and keeps a raw `u32`
+/// from standing in for a percentage or a count of cores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct Mhz(u32);
+
+impl Mhz {
+    /// Build a frequency from a count of megahertz.
+    #[must_use]
+    pub const fn new(megahertz: u32) -> Self {
+        Self(megahertz)
+    }
+
+    /// Build a frequency from a count of kilohertz, as the DVFS table reports
+    /// it. The result is rounded to the nearest megahertz.
+    #[must_use]
+    pub const fn from_khz(_kilohertz: u32) -> Self {
+        Self(0)
+    }
+
+    /// The frequency as a count of megahertz.
+    #[must_use]
+    pub const fn megahertz(self) -> u32 {
+        self.0
+    }
+
+    /// The frequency in gigahertz, for display.
+    #[must_use]
+    pub fn gigahertz(self) -> f64 {
+        f64::from(self.0) / 1_000.0
+    }
+
+    /// This frequency as a share of `maximum`, in the range `0.0` to `1.0`.
+    ///
+    /// A `maximum` of zero gives `0.0` rather than an infinity, so a caller
+    /// that reads an empty DVFS table still renders.
+    #[must_use]
+    pub fn ratio_of(self, _maximum: Self) -> f64 {
+        0.0
+    }
+}
+
+impl fmt::Display for Mhz {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.2} GHz", self.gigahertz())
+    }
+}

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -10,7 +10,7 @@
 //! this module runs `sudo`. The caller decides.
 
 use std::io::{BufRead, BufReader};
-use std::process::{Child, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
 use serde::{Serialize, Serializer};
@@ -290,6 +290,8 @@ pub struct SampleStream {
     block: Vec<String>,
     /// True once the process closed its output.
     ended: bool,
+    /// How the run ended, once it has been waited for.
+    status: Option<ExitStatus>,
 }
 
 impl SampleStream {
@@ -300,13 +302,28 @@ impl SampleStream {
     /// Returns the error of the spawn when `powermetrics` cannot be started,
     /// which is what a caller without root sees.
     pub fn spawn(interval: Duration, count: u32) -> std::io::Result<Self> {
-        let mut child = Command::new("powermetrics")
+        let mut command = Command::new("powermetrics");
+        command
             .arg("--samplers")
             .arg(SAMPLERS)
             .arg("-i")
             .arg(interval.as_millis().to_string())
             .arg("-n")
-            .arg(count.to_string())
+            .arg(count.to_string());
+        Self::from_command(command)
+    }
+
+    /// Start an already-built command and read its output as samples.
+    ///
+    /// [`Self::spawn`] builds the `powermetrics` invocation and hands it here.
+    /// A test hands a stand-in instead, which is how the lifecycle of a run is
+    /// covered without root.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error of the spawn when the command cannot be started.
+    pub fn from_command(mut command: Command) -> std::io::Result<Self> {
+        let mut child = command
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -315,7 +332,7 @@ impl SampleStream {
         let stdout = child
             .stdout
             .take()
-            .ok_or_else(|| std::io::Error::other("powermetrics started with no standard output"))?;
+            .ok_or_else(|| std::io::Error::other("the command started with no standard output"))?;
 
         Ok(Self {
             child,
@@ -323,7 +340,21 @@ impl SampleStream {
             started: Instant::now(),
             block: Vec::new(),
             ended: false,
+            status: None,
         })
+    }
+
+    /// How the run ended.
+    ///
+    /// A run that measured nothing and a run that refused to start are the same
+    /// shape at the iterator — both give no sample — and they need different
+    /// answers. `powermetrics` without root is the second: it writes a refusal
+    /// and exits non-zero. This tells the two apart.
+    ///
+    /// The status is kept, so asking more than once gives the same answer.
+    pub fn exit_status(&mut self) -> Option<ExitStatus> {
+        let _ = &mut self.status;
+        None
     }
 
     /// Take the lines collected so far as one sample.

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -44,7 +44,8 @@ const CLUSTER_SUFFIX: &str = "-Cluster";
 /// Which cluster a `powermetrics` line describes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Cluster {
-    /// The efficiency cores.
+    /// The efficiency cores. A chip with more than one E-cluster names them
+    /// `E0`, `E1`, and so on, and every one of them is this kind.
     Efficiency,
     /// The performance cores. A chip with more than one P-cluster names them
     /// `P0`, `P1`, and so on, and every one of them is this kind.
@@ -54,9 +55,9 @@ enum Cluster {
 /// Read which cluster a line names from the text before its label.
 ///
 /// The names in service are `E-Cluster`, `P-Cluster`, and the numbered
-/// `P0-Cluster` form of a chip with more than one performance cluster. A name
-/// this function does not recognize gives `None`, so an unfamiliar line is
-/// dropped rather than counted as a P-cluster.
+/// `E0-Cluster` and `P0-Cluster` forms of a chip with more than one cluster of
+/// a kind. A name this function does not recognize gives `None`, so an
+/// unfamiliar line is dropped rather than counted as a P-cluster.
 fn cluster_of(head: &str) -> Option<Cluster> {
     let name = head.trim().strip_suffix(CLUSTER_SUFFIX)?;
     let mut characters = name.chars();
@@ -183,7 +184,7 @@ pub struct Sample {
     /// Mean active residency across every P-cluster that reported, as a
     /// percentage.
     pub p_active_pct: Option<f64>,
-    /// Active frequency of the E-cluster.
+    /// Mean active frequency across every E-cluster that reported.
     pub e_freq: Option<Mhz>,
     /// CPU package power, in milliwatts.
     pub cpu_power_mw: Option<u32>,
@@ -197,13 +198,15 @@ impl Sample {
     /// Read one sample from the block of text between two sample headers.
     ///
     /// A chip with more than one P-cluster, such as an M4 Pro, prints
-    /// `P0-Cluster` and `P1-Cluster`. Both are read, and the frequencies are
-    /// averaged, so the caller sees one number for the P-cores.
+    /// `P0-Cluster` and `P1-Cluster`. An Ultra joins two dies, and prints an
+    /// E-cluster and a P-cluster for each die. Every cluster line is read, and
+    /// the frequencies of each kind are averaged, so the caller sees one number
+    /// for the P-cores and one number for the E-cores.
     #[must_use]
     pub fn parse_block(block: &str, at: Duration) -> Self {
         let mut p_freqs: Vec<f64> = Vec::new();
         let mut p_residencies: Vec<f64> = Vec::new();
-        let mut e_freq = None;
+        let mut e_freqs: Vec<f64> = Vec::new();
         let mut cpu_power_mw = None;
         let mut gpu_power_mw = None;
         let mut pressure = PressureLevel::Unknown;
@@ -219,7 +222,9 @@ impl Sample {
                         }
                     }
                     Some(Cluster::Efficiency) => {
-                        e_freq = leading_number(tail).map(round_to_mhz);
+                        if let Some(mhz) = leading_number(tail) {
+                            e_freqs.push(mhz);
+                        }
                     }
                     None => {}
                 }
@@ -254,7 +259,7 @@ impl Sample {
             at,
             p_freq: mean(&p_freqs).map(round_to_mhz),
             p_active_pct: mean(&p_residencies),
-            e_freq,
+            e_freq: mean(&e_freqs).map(round_to_mhz),
             cpu_power_mw,
             gpu_power_mw,
             pressure,

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -9,9 +9,11 @@
 //! The command needs root. Nothing in this module asks for it, and nothing in
 //! this module runs `sudo`. The caller decides.
 
-use std::time::Duration;
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::mhz::Mhz;
 
@@ -20,6 +22,112 @@ pub const SAMPLE_HEADER: &str = "*** Sampled system activity";
 
 /// The samplers this tool asks `powermetrics` for.
 pub const SAMPLERS: &str = "cpu_power,thermal";
+
+/// The part of a cluster line that carries the achieved clock.
+const FREQUENCY_LABEL: &str = "HW active frequency:";
+
+/// The part of a cluster line that carries how busy the cluster was.
+const RESIDENCY_LABEL: &str = "HW active residency:";
+
+/// The line that carries CPU package power.
+const CPU_POWER_LABEL: &str = "CPU Power:";
+
+/// The line that carries GPU power.
+const GPU_POWER_LABEL: &str = "GPU Power:";
+
+/// The part of the thermal line that comes before the level.
+const PRESSURE_LABEL: &str = "pressure level:";
+
+/// The suffix every cluster name carries.
+const CLUSTER_SUFFIX: &str = "-Cluster";
+
+/// Which cluster a `powermetrics` line describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Cluster {
+    /// The efficiency cores.
+    Efficiency,
+    /// The performance cores. A chip with more than one P-cluster names them
+    /// `P0`, `P1`, and so on, and every one of them is this kind.
+    Performance,
+}
+
+/// Read which cluster a line names from the text before its label.
+///
+/// The names in service are `E-Cluster`, `P-Cluster`, and the numbered
+/// `P0-Cluster` form of a chip with more than one performance cluster. A name
+/// this function does not recognize gives `None`, so an unfamiliar line is
+/// dropped rather than counted as a P-cluster.
+fn cluster_of(head: &str) -> Option<Cluster> {
+    let name = head.trim().strip_suffix(CLUSTER_SUFFIX)?;
+    let mut characters = name.chars();
+    let letter = characters.next()?;
+    if !characters.all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+    match letter {
+        'E' | 'e' => Some(Cluster::Efficiency),
+        'P' | 'p' => Some(Cluster::Performance),
+        _ => None,
+    }
+}
+
+/// Read the number at the start of `text`, ignoring the unit after it.
+fn leading_number(text: &str) -> Option<f64> {
+    let trimmed = text.trim_start();
+    let digits: String = trimmed
+        .chars()
+        .take_while(|character| character.is_ascii_digit() || *character == '.')
+        .collect();
+    digits.parse().ok()
+}
+
+/// Split on `needle` without regard to case, giving the text after it.
+fn split_once_ignoring_case<'a>(line: &'a str, needle: &str) -> Option<(&'a str, &'a str)> {
+    let position = line
+        .to_ascii_lowercase()
+        .find(&needle.to_ascii_lowercase())?;
+    let (head, rest) = line.split_at(position);
+    let tail = rest.get(needle.len()..)?;
+    Some((head, tail))
+}
+
+/// The mean of a list of numbers, or `None` when the list is empty.
+fn mean(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let total: f64 = values.iter().sum();
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "a sample carries a handful of clusters, far below the precision of f64"
+    )]
+    Some(total / values.len() as f64)
+}
+
+/// Round a measured frequency onto the nearest whole megahertz.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "powermetrics reports a non-negative clock below 100 GHz, which fits in u32"
+)]
+fn round_to_mhz(value: f64) -> Mhz {
+    Mhz::new(value.round().clamp(0.0, f64::from(u32::MAX)) as u32)
+}
+
+/// Round a measured power onto the nearest whole milliwatt.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "powermetrics reports a non-negative power far below u32::MAX milliwatts"
+)]
+fn round_to_milliwatts(value: f64) -> u32 {
+    value.round().clamp(0.0, f64::from(u32::MAX)) as u32
+}
+
+/// Write a duration as a count of seconds, so a JSON sample stays readable.
+fn as_seconds<S: Serializer>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_f64(value.as_secs_f64())
+}
 
 /// How much work the OS believes the thermal budget can still absorb.
 ///
@@ -43,9 +151,19 @@ pub enum PressureLevel {
 
 impl PressureLevel {
     /// Read a level from the word `powermetrics` prints after `pressure level:`.
+    ///
+    /// A word this tool does not know reads as [`Self::Unknown`] rather than as
+    /// [`Self::Nominal`]. Reading an unfamiliar level as the calmest one would
+    /// report a hot machine as a cool one.
     #[must_use]
-    pub fn parse(_word: &str) -> Self {
-        Self::Unknown
+    pub fn parse(word: &str) -> Self {
+        match word.trim().to_ascii_lowercase().as_str() {
+            "nominal" => Self::Nominal,
+            "fair" => Self::Fair,
+            "serious" => Self::Serious,
+            "critical" => Self::Critical,
+            _ => Self::Unknown,
+        }
     }
 }
 
@@ -58,6 +176,7 @@ impl PressureLevel {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Sample {
     /// Time from the start of the run to this sample.
+    #[serde(rename = "at_seconds", serialize_with = "as_seconds")]
     pub at: Duration,
     /// Mean active frequency across every P-cluster that reported.
     pub p_freq: Option<Mhz>,
@@ -81,15 +200,64 @@ impl Sample {
     /// `P0-Cluster` and `P1-Cluster`. Both are read, and the frequencies are
     /// averaged, so the caller sees one number for the P-cores.
     #[must_use]
-    pub fn parse_block(_block: &str, at: Duration) -> Self {
+    pub fn parse_block(block: &str, at: Duration) -> Self {
+        let mut p_freqs: Vec<f64> = Vec::new();
+        let mut p_residencies: Vec<f64> = Vec::new();
+        let mut e_freq = None;
+        let mut cpu_power_mw = None;
+        let mut gpu_power_mw = None;
+        let mut pressure = PressureLevel::Unknown;
+
+        for line in block.lines() {
+            let line = line.trim();
+
+            if let Some((head, tail)) = line.split_once(FREQUENCY_LABEL) {
+                match cluster_of(head) {
+                    Some(Cluster::Performance) => {
+                        if let Some(mhz) = leading_number(tail) {
+                            p_freqs.push(mhz);
+                        }
+                    }
+                    Some(Cluster::Efficiency) => {
+                        e_freq = leading_number(tail).map(round_to_mhz);
+                    }
+                    None => {}
+                }
+                continue;
+            }
+
+            if let Some((head, tail)) = line.split_once(RESIDENCY_LABEL) {
+                if matches!(cluster_of(head), Some(Cluster::Performance)) {
+                    if let Some(percent) = leading_number(tail) {
+                        p_residencies.push(percent);
+                    }
+                }
+                continue;
+            }
+
+            if let Some(tail) = line.strip_prefix(CPU_POWER_LABEL) {
+                cpu_power_mw = leading_number(tail).map(round_to_milliwatts);
+                continue;
+            }
+
+            if let Some(tail) = line.strip_prefix(GPU_POWER_LABEL) {
+                gpu_power_mw = leading_number(tail).map(round_to_milliwatts);
+                continue;
+            }
+
+            if let Some((_, tail)) = split_once_ignoring_case(line, PRESSURE_LABEL) {
+                pressure = PressureLevel::parse(tail);
+            }
+        }
+
         Self {
             at,
-            p_freq: None,
-            p_active_pct: None,
-            e_freq: None,
-            cpu_power_mw: None,
-            gpu_power_mw: None,
-            pressure: PressureLevel::Unknown,
+            p_freq: mean(&p_freqs).map(round_to_mhz),
+            p_active_pct: mean(&p_residencies),
+            e_freq,
+            cpu_power_mw,
+            gpu_power_mw,
+            pressure,
         }
     }
 
@@ -98,8 +266,7 @@ impl Sample {
     /// throttling.
     #[must_use]
     pub fn p_cluster_is_busy(&self, threshold_pct: f64) -> bool {
-        let _ = threshold_pct;
-        false
+        self.p_freq.is_some() && self.p_active_pct.is_some_and(|pct| pct >= threshold_pct)
     }
 }
 
@@ -107,8 +274,106 @@ impl Sample {
 ///
 /// The process is stopped when this value is dropped, so an early return or a
 /// panic cannot leave it behind.
+///
+/// `powermetrics` needs root. This type does not ask for it and never runs
+/// `sudo`: a caller without the privilege gets the refusal of the command
+/// itself, which says so plainly.
 #[derive(Debug)]
 pub struct SampleStream {
-    /// Placeholder until the process is wired up.
-    _private: (),
+    /// The running process, killed on drop.
+    child: Child,
+    /// Buffered standard output of the process.
+    output: BufReader<ChildStdout>,
+    /// When the run started, which every sample time is measured from.
+    started: Instant,
+    /// Lines of the sample being read, not yet complete.
+    block: Vec<String>,
+    /// True once the process closed its output.
+    ended: bool,
+}
+
+impl SampleStream {
+    /// Start `powermetrics`, asking for `count` samples `interval` apart.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error of the spawn when `powermetrics` cannot be started,
+    /// which is what a caller without root sees.
+    pub fn spawn(interval: Duration, count: u32) -> std::io::Result<Self> {
+        let mut child = Command::new("powermetrics")
+            .arg("--samplers")
+            .arg(SAMPLERS)
+            .arg("-i")
+            .arg(interval.as_millis().to_string())
+            .arg("-n")
+            .arg(count.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| std::io::Error::other("powermetrics started with no standard output"))?;
+
+        Ok(Self {
+            child,
+            output: BufReader::new(stdout),
+            started: Instant::now(),
+            block: Vec::new(),
+            ended: false,
+        })
+    }
+
+    /// Take the lines collected so far as one sample.
+    fn take_block(&mut self) -> Option<Sample> {
+        if self.block.is_empty() {
+            return None;
+        }
+        let text = self.block.join("\n");
+        self.block.clear();
+        Some(Sample::parse_block(&text, self.started.elapsed()))
+    }
+}
+
+impl Iterator for SampleStream {
+    type Item = Sample;
+
+    /// Read lines until the header of the next sample, then give the sample
+    /// that just ended. The last sample is given when the output closes, so no
+    /// sample is dropped at the end of a run.
+    fn next(&mut self) -> Option<Sample> {
+        if self.ended {
+            return None;
+        }
+
+        loop {
+            let mut line = String::new();
+            match self.output.read_line(&mut line) {
+                Ok(0) | Err(_) => {
+                    self.ended = true;
+                    return self.take_block();
+                }
+                Ok(_) => {}
+            }
+
+            let line = line.trim_end().to_owned();
+            if line.starts_with(SAMPLE_HEADER) {
+                if let Some(sample) = self.take_block() {
+                    self.block.push(line);
+                    return Some(sample);
+                }
+            }
+            self.block.push(line);
+        }
+    }
+}
+
+impl Drop for SampleStream {
+    /// Stop `powermetrics` rather than leave it sampling after this tool ends.
+    fn drop(&mut self) {
+        drop(self.child.kill());
+        drop(self.child.wait());
+    }
 }

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -353,8 +353,10 @@ impl SampleStream {
     ///
     /// The status is kept, so asking more than once gives the same answer.
     pub fn exit_status(&mut self) -> Option<ExitStatus> {
-        let _ = &mut self.status;
-        None
+        if self.status.is_none() {
+            self.status = self.child.wait().ok();
+        }
+        self.status
     }
 
     /// Take the lines collected so far as one sample.
@@ -391,12 +393,20 @@ impl Iterator for SampleStream {
 
             let line = line.trim_end().to_owned();
             if line.starts_with(SAMPLE_HEADER) {
-                if let Some(sample) = self.take_block() {
-                    self.block.push(line);
-                    return Some(sample);
+                let finished = self.take_block();
+                self.block.push(line);
+                if finished.is_some() {
+                    return finished;
                 }
+                continue;
             }
-            self.block.push(line);
+
+            // Anything before the first header is the banner `powermetrics`
+            // prints at the start of a run. It carries no measurement, so it is
+            // dropped rather than turned into a sample.
+            if !self.block.is_empty() {
+                self.block.push(line);
+            }
         }
     }
 }
@@ -404,6 +414,11 @@ impl Iterator for SampleStream {
 impl Drop for SampleStream {
     /// Stop `powermetrics` rather than leave it sampling after this tool ends.
     fn drop(&mut self) {
+        if self.status.is_some() {
+            // Already waited for, so there is no process left to stop and no
+            // zombie left to reap.
+            return;
+        }
         drop(self.child.kill());
         drop(self.child.wait());
     }

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -356,9 +356,17 @@ impl SampleStream {
     /// answers. `powermetrics` without root is the second: it writes a refusal
     /// and exits non-zero. This tells the two apart.
     ///
+    /// The status is available only after the run ends. A caller that asks
+    /// earlier gets `None`. Read every sample first. A wait before the output
+    /// closes stops forever, because nothing reads the pipe during the wait,
+    /// and the process stops when the pipe is full.
+    ///
     /// The status is kept, so asking more than once gives the same answer.
     pub fn exit_status(&mut self) -> Option<ExitStatus> {
         if self.status.is_none() {
+            if !self.ended {
+                return None;
+            }
             self.status = self.child.wait().ok();
         }
         self.status

--- a/src/thermal-watch/src/powermetrics.rs
+++ b/src/thermal-watch/src/powermetrics.rs
@@ -1,0 +1,114 @@
+//! Run `powermetrics` and turn its output into samples.
+//!
+//! `powermetrics` is the only interface that reports the achieved clock of each
+//! CPU cluster, and it prints plain text with no machine-readable mode that
+//! carries the same fields. Its output is line-oriented, and each field this
+//! module wants is a labelled line, so a line scan is the correct instrument
+//! here rather than a parser.
+//!
+//! The command needs root. Nothing in this module asks for it, and nothing in
+//! this module runs `sudo`. The caller decides.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::mhz::Mhz;
+
+/// The line that opens each sample of `powermetrics` output.
+pub const SAMPLE_HEADER: &str = "*** Sampled system activity";
+
+/// The samplers this tool asks `powermetrics` for.
+pub const SAMPLERS: &str = "cpu_power,thermal";
+
+/// How much work the OS believes the thermal budget can still absorb.
+///
+/// macOS raises this level to tell applications to do less work. It is not a
+/// report of the clock: Apple Silicon decreases its clock long before the level
+/// leaves [`PressureLevel::Nominal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PressureLevel {
+    /// No pressure reported.
+    Nominal,
+    /// Light pressure.
+    Fair,
+    /// Heavy pressure.
+    Serious,
+    /// The OS is about to stop work to protect the hardware.
+    Critical,
+    /// The sample carried no pressure line, or one this tool does not know.
+    Unknown,
+}
+
+impl PressureLevel {
+    /// Read a level from the word `powermetrics` prints after `pressure level:`.
+    #[must_use]
+    pub fn parse(_word: &str) -> Self {
+        Self::Unknown
+    }
+}
+
+/// One sample of `powermetrics` output.
+///
+/// Every measured field is optional because `powermetrics` omits the lines of a
+/// cluster that is offline. An absent P-cluster frequency means "not measured",
+/// which is a different fact from "measured, and it was low" — reporting the
+/// first as a zero would make an idle machine look fully throttled.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Sample {
+    /// Time from the start of the run to this sample.
+    pub at: Duration,
+    /// Mean active frequency across every P-cluster that reported.
+    pub p_freq: Option<Mhz>,
+    /// Mean active residency across every P-cluster that reported, as a
+    /// percentage.
+    pub p_active_pct: Option<f64>,
+    /// Active frequency of the E-cluster.
+    pub e_freq: Option<Mhz>,
+    /// CPU package power, in milliwatts.
+    pub cpu_power_mw: Option<u32>,
+    /// GPU power, in milliwatts.
+    pub gpu_power_mw: Option<u32>,
+    /// The thermal pressure level of this sample.
+    pub pressure: PressureLevel,
+}
+
+impl Sample {
+    /// Read one sample from the block of text between two sample headers.
+    ///
+    /// A chip with more than one P-cluster, such as an M4 Pro, prints
+    /// `P0-Cluster` and `P1-Cluster`. Both are read, and the frequencies are
+    /// averaged, so the caller sees one number for the P-cores.
+    #[must_use]
+    pub fn parse_block(_block: &str, at: Duration) -> Self {
+        Self {
+            at,
+            p_freq: None,
+            p_active_pct: None,
+            e_freq: None,
+            cpu_power_mw: None,
+            gpu_power_mw: None,
+            pressure: PressureLevel::Unknown,
+        }
+    }
+
+    /// True when the P-cluster was busy enough for its frequency to mean
+    /// something. An idle cluster reports a low clock, and that is not
+    /// throttling.
+    #[must_use]
+    pub fn p_cluster_is_busy(&self, threshold_pct: f64) -> bool {
+        let _ = threshold_pct;
+        false
+    }
+}
+
+/// A running `powermetrics` process, read one sample at a time.
+///
+/// The process is stopped when this value is dropped, so an early return or a
+/// panic cannot leave it behind.
+#[derive(Debug)]
+pub struct SampleStream {
+    /// Placeholder until the process is wired up.
+    _private: (),
+}

--- a/src/thermal-watch/src/render.rs
+++ b/src/thermal-watch/src/render.rs
@@ -18,12 +18,81 @@ const GOOD_RATIO: f64 = 0.95;
 /// A ratio outside `0.0` to `1.0` is clamped rather than refused, because the
 /// caller draws a live display and a single strange sample must not stop it.
 #[must_use]
-pub fn bar(_ratio: f64, _width: usize) -> String {
-    String::new()
+pub fn bar(ratio: f64, width: usize) -> String {
+    // A sample that reports nothing gives a ratio that is not a number, and a
+    // live display must keep drawing rather than stop on it.
+    let clamped = if ratio.is_finite() {
+        ratio.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+
+    let cells = eighths(clamped, width);
+    let full = cells / 8;
+    let remainder = cells % 8;
+
+    let mut drawn = String::with_capacity(width * 4);
+    for _ in 0..full {
+        drawn.push(BLOCKS[7]);
+    }
+    if remainder > 0 {
+        drawn.push(BLOCKS[remainder - 1]);
+    }
+    for _ in (full + usize::from(remainder > 0))..width {
+        drawn.push(' ');
+    }
+    drawn
 }
 
+/// How many eighths of a cell a ratio fills across `width` cells.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "the value is clamped between zero and the cell count before the cast"
+)]
+fn eighths(ratio: f64, width: usize) -> usize {
+    let total = width.saturating_mul(BLOCKS.len());
+    (ratio * total as f64).round().clamp(0.0, total as f64) as usize
+}
+
+/// How many cells wide the bar of the live display is.
+pub const BAR_WIDTH: usize = 24;
+
 /// Draw the live line for one sample.
+///
+/// The line leads with the time from the start of the run, so a reader can see
+/// where in the run a change happened. The bar and the clock follow, then how
+/// busy the P-cluster was, the CPU power, and the thermal pressure level.
 #[must_use]
-pub fn sample_line(_sample: &Sample, _p_max: Mhz) -> String {
-    String::new()
+pub fn sample_line(sample: &Sample, p_max: Mhz) -> String {
+    let ratio = sample.p_freq.map_or(0.0, |clock| clock.ratio_of(p_max));
+    let drawn = bar(ratio, BAR_WIDTH);
+    let colored_bar = if ratio >= GOOD_RATIO {
+        drawn.green()
+    } else if ratio >= HOLD_RATIO {
+        drawn.yellow()
+    } else {
+        drawn.red()
+    };
+
+    let clock = sample
+        .p_freq
+        .map_or_else(|| "    idle".to_owned(), |value| format!("{value}"));
+    let busy = sample
+        .p_active_pct
+        .map_or_else(|| "  -- ".to_owned(), |pct| format!("{pct:5.1}%"));
+    let watts = sample.cpu_power_mw.map_or_else(
+        || "   -- ".to_owned(),
+        |mw| format!("{:5.1}W", f64::from(mw) / 1_000.0),
+    );
+
+    let seconds = sample.at.as_secs();
+    format!(
+        "{:02}:{:02}  {colored_bar} {clock} {}  busy {busy}  cpu {watts}  {:?}",
+        seconds / 60,
+        seconds % 60,
+        format!("({:3.0}% of max)", ratio * 100.0).dimmed(),
+        sample.pressure,
+    )
 }

--- a/src/thermal-watch/src/render.rs
+++ b/src/thermal-watch/src/render.rs
@@ -1,0 +1,29 @@
+//! Draw the live line for one sample.
+
+use colored::Colorize;
+
+use crate::mhz::Mhz;
+use crate::powermetrics::Sample;
+use crate::report::HOLD_RATIO;
+
+/// The eighths of a block, from one eighth to a full block.
+const BLOCKS: [char; 8] = ['▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
+
+/// A clock above this share of the peak of the chip draws green.
+const GOOD_RATIO: f64 = 0.95;
+
+/// Draw a horizontal bar `width` cells wide, filled to `ratio`.
+///
+/// The bar always occupies `width` cells, so a column of bars stays aligned.
+/// A ratio outside `0.0` to `1.0` is clamped rather than refused, because the
+/// caller draws a live display and a single strange sample must not stop it.
+#[must_use]
+pub fn bar(_ratio: f64, _width: usize) -> String {
+    String::new()
+}
+
+/// Draw the live line for one sample.
+#[must_use]
+pub fn sample_line(_sample: &Sample, _p_max: Mhz) -> String {
+    String::new()
+}

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -24,6 +24,15 @@ pub const EARLY_WINDOW: Duration = Duration::from_secs(20);
 /// Samples inside this window from the end form the late mean.
 pub const LATE_WINDOW: Duration = Duration::from_secs(60);
 
+/// The end of the early window and the start of the late window.
+///
+/// The early window holds every busy sample before the first value. The late
+/// window holds every busy sample from the second value on.
+#[must_use]
+pub fn windows(_first_at: Duration, last_at: Duration) -> (Duration, Duration) {
+    (EARLY_WINDOW, last_at.saturating_sub(LATE_WINDOW))
+}
+
 /// A P-cluster below this active residency is idle, not throttled.
 pub const BUSY_THRESHOLD_PCT: f64 = 50.0;
 

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -18,6 +18,8 @@
 
 use std::time::Duration;
 
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
 use crate::dvfs::DvfsTable;
 use crate::mhz::Mhz;
 use crate::powermetrics::{PressureLevel, Sample};
@@ -104,6 +106,36 @@ pub struct Verdict {
     pub peak_power_mw: u32,
     /// The worst thermal pressure level the run reported.
     pub worst_pressure: PressureLevel,
+}
+
+/// One [`Verdict`] in the shape the JSON mode prints it.
+///
+/// The whole verdict sits under a single `verdict` key. A reader of the
+/// line-delimited stream tells a verdict line from a sample line by that key
+/// alone, because a sample line carries `at_seconds` and no `verdict`.
+///
+/// Build one with [`verdict_line`]. The field is private, so the shape has one
+/// entrance and the printed stream cannot drift from what the tests hold.
+#[derive(Debug)]
+pub struct VerdictLine<'a> {
+    /// The verdict this line carries.
+    #[allow(
+        dead_code,
+        reason = "the stub does not read it yet; the real shape comes next"
+    )]
+    verdict: &'a Verdict,
+}
+
+impl Serialize for VerdictLine<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_map(Some(0))?.end()
+    }
+}
+
+/// Wrap a verdict in the shape the JSON mode prints it. See [`VerdictLine`].
+#[must_use]
+pub const fn verdict_line(verdict: &Verdict) -> VerdictLine<'_> {
+    VerdictLine { verdict }
 }
 
 /// Judge a run of samples against the DVFS table of the chip.

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -2,10 +2,14 @@
 //!
 //! The verdict compares three numbers. The **peak** is the highest clock the
 //! P-cluster reached while busy. The **early mean** is the clock over the first
-//! seconds of the run, before the heat sink saturates. The **late mean** is the
-//! clock over the last stretch of the run. A machine that holds its clock has
-//! an early mean and a late mean that agree. A machine that throttles shows a
-//! late mean below both.
+//! seconds of the load, before the heat sink saturates. The **late mean** is
+//! the clock over the last stretch of the load. A machine that holds its clock
+//! has an early mean and a late mean that agree. A machine that throttles
+//! shows a late mean below both.
+//!
+//! Both windows are measured from the busy samples, and [`windows`] keeps each
+//! one to one third of the busy span or less. Thus the two windows never share
+//! a sample, and a short run shows its decay at full size.
 //!
 //! Two failure modes are separated on purpose. A run whose clock **decays** was
 //! fast and then slowed, which is thermal throttling or a power limit. A run
@@ -18,19 +22,32 @@ use crate::dvfs::DvfsTable;
 use crate::mhz::Mhz;
 use crate::powermetrics::{PressureLevel, Sample};
 
-/// Samples inside this window from the start form the early mean.
+/// The longest early window. It starts at the first busy sample.
+///
+/// A run shorter than 80 seconds gets a smaller window. See [`windows`].
 pub const EARLY_WINDOW: Duration = Duration::from_secs(20);
 
-/// Samples inside this window from the end form the late mean.
+/// The longest late window. It ends at the last busy sample.
+///
+/// A run shorter than 180 seconds gets a smaller window. See [`windows`].
 pub const LATE_WINDOW: Duration = Duration::from_secs(60);
 
 /// The end of the early window and the start of the late window.
 ///
 /// The early window holds every busy sample before the first value. The late
-/// window holds every busy sample from the second value on.
+/// window holds every busy sample from the second value on. Give the time of
+/// the first busy sample and the time of the last busy sample.
+///
+/// Each window is not longer than one third of the span between the two
+/// samples. Thus the two windows never share a sample. On a span of 80 seconds
+/// or more, one third is 20 seconds or more, and the windows are the full
+/// [`EARLY_WINDOW`] and [`LATE_WINDOW`].
 #[must_use]
-pub fn windows(_first_at: Duration, last_at: Duration) -> (Duration, Duration) {
-    (EARLY_WINDOW, last_at.saturating_sub(LATE_WINDOW))
+pub fn windows(first_at: Duration, last_at: Duration) -> (Duration, Duration) {
+    let third = last_at.saturating_sub(first_at) / 3;
+    let early_until = first_at.saturating_add(EARLY_WINDOW.min(third));
+    let late_from = last_at.saturating_sub(LATE_WINDOW.min(third));
+    (early_until, late_from)
 }
 
 /// A P-cluster below this active residency is idle, not throttled.
@@ -71,9 +88,11 @@ pub struct Verdict {
     pub outcome: Outcome,
     /// The peak clock the P-cluster reached while busy.
     pub peak: Mhz,
-    /// The mean clock over [`EARLY_WINDOW`] from the start.
+    /// The mean clock over the early window, which starts at the first busy
+    /// sample. See [`windows`].
     pub early_mean: Mhz,
-    /// The mean clock over [`LATE_WINDOW`] to the end.
+    /// The mean clock over the late window, which ends at the last busy
+    /// sample. See [`windows`].
     pub late_mean: Mhz,
     /// The late mean as a share of the peak of the chip.
     pub late_ratio_of_max: f64,
@@ -127,14 +146,20 @@ pub fn judge(samples: &[Sample], table: &DvfsTable) -> Verdict {
     let Some(peak) = busy.iter().filter_map(clock).max().map(Mhz::new) else {
         return empty;
     };
-    let Some(last_at) = busy.last().map(|sample| sample.at) else {
+    // The windows are anchored on the busy samples, not on time zero. A user
+    // who starts a build one minute into the run gets an early mean from the
+    // start of the load.
+    let (Some(first_at), Some(last_at)) = (
+        busy.first().map(|sample| sample.at),
+        busy.last().map(|sample| sample.at),
+    ) else {
         return empty;
     };
-    let late_from = last_at.saturating_sub(LATE_WINDOW);
+    let (early_until, late_from) = windows(first_at, last_at);
 
     let early_mean = mean_clock(
         busy.iter()
-            .filter(|sample| sample.at < EARLY_WINDOW)
+            .filter(|sample| sample.at < early_until)
             .copied(),
     )
     .unwrap_or(peak);

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -1,0 +1,89 @@
+//! Judge a run of samples: did the clock decrease, and by how much.
+//!
+//! The verdict compares three numbers. The **peak** is the highest clock the
+//! P-cluster reached while busy. The **early mean** is the clock over the first
+//! seconds of the run, before the heat sink saturates. The **late mean** is the
+//! clock over the last stretch of the run. A machine that holds its clock has
+//! an early mean and a late mean that agree. A machine that throttles shows a
+//! late mean below both.
+//!
+//! Two failure modes are separated on purpose. A run whose clock **decays** was
+//! fast and then slowed, which is thermal throttling or a power limit. A run
+//! whose clock was **low from the start** never reached its peak at all, which
+//! points at a competing load rather than at heat.
+
+use std::time::Duration;
+
+use crate::dvfs::DvfsTable;
+use crate::mhz::Mhz;
+use crate::powermetrics::{PressureLevel, Sample};
+
+/// Samples inside this window from the start form the early mean.
+pub const EARLY_WINDOW: Duration = Duration::from_secs(20);
+
+/// Samples inside this window from the end form the late mean.
+pub const LATE_WINDOW: Duration = Duration::from_secs(60);
+
+/// A P-cluster below this active residency is idle, not throttled.
+pub const BUSY_THRESHOLD_PCT: f64 = 50.0;
+
+/// A late mean below this share of the peak of the chip counts as a decrease.
+pub const HOLD_RATIO: f64 = 0.9;
+
+/// A decay above this share of the early mean counts as throttling.
+pub const DECAY_TOLERANCE: f64 = 0.05;
+
+/// Fewer busy samples than this cannot support a verdict.
+pub const MINIMUM_BUSY_SAMPLES: usize = 5;
+
+/// What the run showed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Outcome {
+    /// The P-cluster was never busy for long enough to judge.
+    NotEnoughData {
+        /// How many busy samples the run collected.
+        busy_samples: usize,
+    },
+    /// The clock held near the peak of the chip for the whole run.
+    HeldClock,
+    /// The clock started near the peak and then decreased.
+    Throttled {
+        /// The share of the early mean that was lost, from `0.0` to `1.0`.
+        decay: f64,
+    },
+    /// The clock never reached the peak of the chip, from the first sample on.
+    NeverReachedPeak,
+}
+
+/// The measured summary of one run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Verdict {
+    /// What the run showed.
+    pub outcome: Outcome,
+    /// The peak clock the P-cluster reached while busy.
+    pub peak: Mhz,
+    /// The mean clock over [`EARLY_WINDOW`] from the start.
+    pub early_mean: Mhz,
+    /// The mean clock over [`LATE_WINDOW`] to the end.
+    pub late_mean: Mhz,
+    /// The late mean as a share of the peak of the chip.
+    pub late_ratio_of_max: f64,
+    /// The highest CPU package power the run reached, in milliwatts.
+    pub peak_power_mw: u32,
+    /// The worst thermal pressure level the run reported.
+    pub worst_pressure: PressureLevel,
+}
+
+/// Judge a run of samples against the DVFS table of the chip.
+#[must_use]
+pub fn judge(_samples: &[Sample], _table: &DvfsTable) -> Verdict {
+    Verdict {
+        outcome: Outcome::NotEnoughData { busy_samples: 0 },
+        peak: Mhz::new(0),
+        early_mean: Mhz::new(0),
+        late_mean: Mhz::new(0),
+        late_ratio_of_max: 0.0,
+        peak_power_mw: 0,
+        worst_pressure: PressureLevel::Unknown,
+    }
+}

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -18,7 +18,7 @@
 
 use std::time::Duration;
 
-use serde::ser::{Serialize, SerializeMap, Serializer};
+use serde::Serialize;
 
 use crate::dvfs::DvfsTable;
 use crate::mhz::Mhz;
@@ -69,7 +69,13 @@ pub const DECAY_TOLERANCE: f64 = 0.05;
 pub const MINIMUM_BUSY_SAMPLES: usize = 5;
 
 /// What the run showed.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// In JSON, each variant becomes an `outcome` key that names it in lower snake
+/// case, and the data of the variant sits beside that key rather than under it.
+/// [`Outcome::Throttled`] adds `decay`, [`Outcome::NotEnoughData`] adds
+/// `busy_samples`, and the other two add nothing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum Outcome {
     /// The P-cluster was never busy for long enough to judge.
     NotEnoughData {
@@ -88,9 +94,12 @@ pub enum Outcome {
 }
 
 /// The measured summary of one run.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Verdict {
-    /// What the run showed.
+    /// What the run showed. In JSON it becomes an `outcome` key beside the
+    /// measurements, together with the data the outcome carries. See
+    /// [`Outcome`].
+    #[serde(flatten)]
     pub outcome: Outcome,
     /// The peak clock the P-cluster reached while busy.
     pub peak: Mhz,
@@ -116,20 +125,18 @@ pub struct Verdict {
 ///
 /// Build one with [`verdict_line`]. The field is private, so the shape has one
 /// entrance and the printed stream cannot drift from what the tests hold.
-#[derive(Debug)]
+///
+/// ```text
+/// {"verdict":{"outcome":"throttled","decay":0.244,"peak":4500,"early_mean":4500,
+///  "late_mean":3400,"late_ratio_of_max":0.754,"peak_power_mw":48500,
+///  "worst_pressure":"nominal"}}
+/// ```
+///
+/// The tool prints it on one line. It is broken here to fit the page.
+#[derive(Debug, Serialize)]
 pub struct VerdictLine<'a> {
     /// The verdict this line carries.
-    #[allow(
-        dead_code,
-        reason = "the stub does not read it yet; the real shape comes next"
-    )]
     verdict: &'a Verdict,
-}
-
-impl Serialize for VerdictLine<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_map(Some(0))?.end()
-    }
 }
 
 /// Wrap a verdict in the shape the JSON mode prints it. See [`VerdictLine`].

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -24,7 +24,7 @@ use crate::powermetrics::{PressureLevel, Sample};
 
 /// The longest early window. It starts at the first busy sample.
 ///
-/// A run shorter than 80 seconds gets a smaller window. See [`windows`].
+/// A run shorter than 60 seconds gets a smaller window. See [`windows`].
 pub const EARLY_WINDOW: Duration = Duration::from_secs(20);
 
 /// The longest late window. It ends at the last busy sample.
@@ -39,9 +39,13 @@ pub const LATE_WINDOW: Duration = Duration::from_secs(60);
 /// the first busy sample and the time of the last busy sample.
 ///
 /// Each window is not longer than one third of the span between the two
-/// samples. Thus the two windows never share a sample. On a span of 80 seconds
-/// or more, one third is 20 seconds or more, and the windows are the full
-/// [`EARLY_WINDOW`] and [`LATE_WINDOW`].
+/// samples. Thus the two windows never share a sample. The two windows reach
+/// their full length at different spans. One third of the span becomes 20
+/// seconds at a span of 60 seconds, thus the early window is the full
+/// [`EARLY_WINDOW`] on a span of 60 seconds or more. One third of the span
+/// becomes 60 seconds at a span of 180 seconds, thus the late window is the
+/// full [`LATE_WINDOW`] on a span of 180 seconds or more. Only a span of 180
+/// seconds or more gives both windows their full length.
 #[must_use]
 pub fn windows(first_at: Duration, last_at: Duration) -> (Duration, Duration) {
     let third = last_at.saturating_sub(first_at) / 3;

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -18,7 +18,8 @@
 
 use std::time::Duration;
 
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 
 use crate::dvfs::DvfsTable;
 use crate::mhz::Mhz;
@@ -74,6 +75,11 @@ pub const MINIMUM_BUSY_SAMPLES: usize = 5;
 /// case, and the data of the variant sits beside that key rather than under it.
 /// [`Outcome::Throttled`] adds `decay`, [`Outcome::NotEnoughData`] adds
 /// `busy_samples`, and the other two add nothing.
+///
+/// The outcome also decides which measurements the line carries.
+/// [`Outcome::NotEnoughData`] means the run gave no clock numbers at all, so
+/// its line leaves out `peak`, `early_mean`, `late_mean` and
+/// `late_ratio_of_max`. See [`VerdictLine`].
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum Outcome {
@@ -94,6 +100,10 @@ pub enum Outcome {
 }
 
 /// The measured summary of one run.
+///
+/// The four clock fields are always present, so an [`Outcome::NotEnoughData`]
+/// run holds zero in each of them. Read them only beside the outcome. The JSON
+/// mode does not print them on such a run. See [`VerdictLine`].
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Verdict {
     /// What the run showed. In JSON it becomes an `outcome` key beside the
@@ -133,10 +143,85 @@ pub struct Verdict {
 /// ```
 ///
 /// The tool prints it on one line. It is broken here to fit the page.
-#[derive(Debug, Serialize)]
+///
+/// A run that gave no clock numbers carries none. [`Verdict`] fills `peak`,
+/// `early_mean`, `late_mean` and `late_ratio_of_max` with zero on an
+/// [`Outcome::NotEnoughData`] run, because the Rust fields are always present.
+/// A zero on the wire reads as a measurement, so the line leaves the four keys
+/// out instead. `peak_power_mw` and `worst_pressure` stay, because the run
+/// measured both of them.
+///
+/// ```text
+/// {"verdict":{"outcome":"not_enough_data","busy_samples":3,
+///  "peak_power_mw":48500,"worst_pressure":"nominal"}}
+/// ```
+#[derive(Debug)]
 pub struct VerdictLine<'a> {
     /// The verdict this line carries.
     verdict: &'a Verdict,
+}
+
+/// The wire shape of a run the judge could judge. See [`VerdictLine`].
+///
+/// The field order and the flattened outcome match [`Verdict`], so a judged
+/// line reads exactly as it did before the unjudged line lost its four keys.
+#[derive(Serialize)]
+struct JudgedWire<'a> {
+    #[serde(flatten)]
+    outcome: &'a Outcome,
+    peak: Mhz,
+    early_mean: Mhz,
+    late_mean: Mhz,
+    late_ratio_of_max: f64,
+    peak_power_mw: u32,
+    worst_pressure: PressureLevel,
+}
+
+/// The wire shape of a run the judge could not judge. See [`VerdictLine`].
+///
+/// It holds the two measurements such a run still made, and no clock number.
+#[derive(Serialize)]
+struct UnjudgedWire<'a> {
+    #[serde(flatten)]
+    outcome: &'a Outcome,
+    peak_power_mw: u32,
+    worst_pressure: PressureLevel,
+}
+
+impl Serialize for VerdictLine<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let verdict = self.verdict;
+        let mut line = serializer.serialize_struct("VerdictLine", 1)?;
+        // The match is exhaustive on purpose. A new outcome must state whether
+        // its line carries the clock numbers.
+        match verdict.outcome {
+            Outcome::NotEnoughData { .. } => line.serialize_field(
+                "verdict",
+                &UnjudgedWire {
+                    outcome: &verdict.outcome,
+                    peak_power_mw: verdict.peak_power_mw,
+                    worst_pressure: verdict.worst_pressure,
+                },
+            )?,
+            Outcome::HeldClock | Outcome::Throttled { .. } | Outcome::NeverReachedPeak => line
+                .serialize_field(
+                    "verdict",
+                    &JudgedWire {
+                        outcome: &verdict.outcome,
+                        peak: verdict.peak,
+                        early_mean: verdict.early_mean,
+                        late_mean: verdict.late_mean,
+                        late_ratio_of_max: verdict.late_ratio_of_max,
+                        peak_power_mw: verdict.peak_power_mw,
+                        worst_pressure: verdict.worst_pressure,
+                    },
+                )?,
+        }
+        line.end()
+    }
 }
 
 /// Wrap a verdict in the shape the JSON mode prints it. See [`VerdictLine`].
@@ -169,6 +254,10 @@ pub fn judge(samples: &[Sample], table: &DvfsTable) -> Verdict {
         .filter(|sample| sample.p_cluster_is_busy(BUSY_THRESHOLD_PCT))
         .collect();
 
+    // The four clock numbers below are placeholders, not readings. The struct
+    // fields are always present, thus they need a value. The outcome is the
+    // guard against a reader that takes them for measurements, and the JSON
+    // mode leaves all four out of such a line. See `VerdictLine`.
     let empty = Verdict {
         outcome: Outcome::NotEnoughData {
             busy_samples: busy.len(),

--- a/src/thermal-watch/src/report.rs
+++ b/src/thermal-watch/src/report.rs
@@ -76,14 +76,102 @@ pub struct Verdict {
 
 /// Judge a run of samples against the DVFS table of the chip.
 #[must_use]
-pub fn judge(_samples: &[Sample], _table: &DvfsTable) -> Verdict {
-    Verdict {
-        outcome: Outcome::NotEnoughData { busy_samples: 0 },
+pub fn judge(samples: &[Sample], table: &DvfsTable) -> Verdict {
+    // An unknown level is the absence of a reading, not a level above
+    // `Critical`, so it never wins the comparison for the worst one.
+    let worst_pressure = samples
+        .iter()
+        .map(|sample| sample.pressure)
+        .filter(|level| *level != PressureLevel::Unknown)
+        .max()
+        .unwrap_or(PressureLevel::Unknown);
+    let peak_power_mw = samples
+        .iter()
+        .filter_map(|sample| sample.cpu_power_mw)
+        .max()
+        .unwrap_or(0);
+
+    // An idle P-cluster reports a low clock. Counting it would report every
+    // machine that spent a moment idle as a machine that throttled.
+    let busy: Vec<&Sample> = samples
+        .iter()
+        .filter(|sample| sample.p_cluster_is_busy(BUSY_THRESHOLD_PCT))
+        .collect();
+
+    let empty = Verdict {
+        outcome: Outcome::NotEnoughData {
+            busy_samples: busy.len(),
+        },
         peak: Mhz::new(0),
         early_mean: Mhz::new(0),
         late_mean: Mhz::new(0),
         late_ratio_of_max: 0.0,
-        peak_power_mw: 0,
-        worst_pressure: PressureLevel::Unknown,
+        peak_power_mw,
+        worst_pressure,
+    };
+
+    if busy.len() < MINIMUM_BUSY_SAMPLES {
+        return empty;
     }
+
+    let clock = |sample: &&Sample| sample.p_freq.map(Mhz::megahertz);
+    let Some(peak) = busy.iter().filter_map(clock).max().map(Mhz::new) else {
+        return empty;
+    };
+    let Some(last_at) = busy.last().map(|sample| sample.at) else {
+        return empty;
+    };
+    let late_from = last_at.saturating_sub(LATE_WINDOW);
+
+    let early_mean = mean_clock(
+        busy.iter()
+            .filter(|sample| sample.at < EARLY_WINDOW)
+            .copied(),
+    )
+    .unwrap_or(peak);
+    let Some(late_mean) = mean_clock(busy.iter().filter(|sample| sample.at >= late_from).copied())
+    else {
+        return empty;
+    };
+
+    let late_ratio_of_max = late_mean.ratio_of(table.p_max());
+    let decay = 1.0 - late_mean.ratio_of(early_mean);
+
+    let outcome = if decay >= DECAY_TOLERANCE {
+        Outcome::Throttled { decay }
+    } else if late_ratio_of_max >= HOLD_RATIO {
+        Outcome::HeldClock
+    } else {
+        Outcome::NeverReachedPeak
+    };
+
+    Verdict {
+        outcome,
+        peak,
+        early_mean,
+        late_mean,
+        late_ratio_of_max,
+        peak_power_mw,
+        worst_pressure,
+    }
+}
+
+/// The mean clock of the samples that carry one.
+fn mean_clock<'a>(samples: impl Iterator<Item = &'a Sample>) -> Option<Mhz> {
+    let clocks: Vec<u32> = samples
+        .filter_map(|sample| sample.p_freq.map(Mhz::megahertz))
+        .collect();
+    if clocks.is_empty() {
+        return None;
+    }
+    let total: u64 = clocks.iter().map(|&mhz| u64::from(mhz)).sum();
+    let count = clocks.len() as u64;
+    // Round to the nearest megahertz rather than toward zero, so a run at a
+    // steady clock reports exactly that clock.
+    let rounded = (total + count / 2) / count;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "the mean of a list of u32 clocks cannot exceed u32::MAX"
+    )]
+    Some(Mhz::new(rounded as u32))
 }

--- a/src/thermal-watch/tests/duration_bounds.rs
+++ b/src/thermal-watch/tests/duration_bounds.rs
@@ -1,0 +1,158 @@
+//! Tests that `--duration` refuses a value the tool cannot hold.
+//!
+//! Both bounds run before the tool reads the DVFS table and before it starts
+//! `powermetrics`, so these tests need no root and no Apple Silicon. They run
+//! the built binary and read what it prints.
+//!
+//! Parallel safety: each test starts its own short-lived process and reads its
+//! own pipes. Nothing is keyed on a fixed path, port, or name.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The largest duration the tool accepts, as the messages give it.
+const LIMIT: &str = "86400";
+
+/// One second more than the limit.
+const PAST_LIMIT: &str = "86401";
+
+/// A value far past every limit, which is the one that panicked.
+const ABSURD: &str = "18446744073709551615";
+
+/// The part of the refusal that belongs to a value past the limit.
+const TOO_LARGE: &str = "--duration accepts no more than 86400 seconds";
+
+/// The refusal of a duration of zero, which the tool gave before this bound.
+const NOT_POSITIVE: &str = "--duration needs a positive number of seconds";
+
+/// What one run of the tool did.
+struct Run {
+    /// True when the run ended with a failure status.
+    failed: bool,
+    /// Standard output and standard error together, in that order.
+    text: String,
+}
+
+/// A directory that does not exist, named for this process.
+///
+/// The child gets this as its whole `PATH`, so its search for `powermetrics`
+/// ends at once. Nothing makes the directory. The name carries the process id,
+/// so a parallel run cannot make one of these by accident.
+fn unreachable_path() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "thermal-watch-no-powermetrics-{}",
+        std::process::id()
+    ))
+}
+
+/// Run the tool with the duration given, and collect what it printed.
+///
+/// `powermetrics` is put out of reach, so a duration the bounds accept ends the
+/// run in a moment instead of starting a watch of that length. The bounds run
+/// long before that spawn, so a refusal is still visible.
+fn run(duration: &str) -> Run {
+    collect(
+        Command::new(env!("CARGO_BIN_EXE_thermal-watch"))
+            .arg("--duration")
+            .arg(duration)
+            .env("PATH", unreachable_path()),
+    )
+}
+
+/// Run the tool with the duration given, with `powermetrics` reachable.
+///
+/// The panic this suite guards against happens after the spawn of
+/// `powermetrics`, so the run that must show it keeps the path of the test. The
+/// run still ends in a moment: the tool asks for one sample at a time and stops
+/// its child when it ends.
+fn run_with_powermetrics(duration: &str) -> Run {
+    collect(
+        Command::new(env!("CARGO_BIN_EXE_thermal-watch"))
+            .arg("--duration")
+            .arg(duration),
+    )
+}
+
+/// Run a command to its end and read both of its outputs.
+fn collect(command: &mut Command) -> Run {
+    let output = command.output().expect("the tool must start");
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    Run {
+        failed: !output.status.success(),
+        text,
+    }
+}
+
+#[test]
+fn an_absurd_duration_is_refused_instead_of_panicking() {
+    let run = run_with_powermetrics(ABSURD);
+
+    assert!(
+        run.failed,
+        "a duration of {ABSURD} must end the run with a failure, and it printed:\n{}",
+        run.text
+    );
+    assert!(
+        !run.text.contains("panic"),
+        "a duration of {ABSURD} must give an error, not a panic, and it printed:\n{}",
+        run.text
+    );
+    assert!(
+        run.text.contains(LIMIT),
+        "the refusal must name the limit of {LIMIT} seconds, and it printed:\n{}",
+        run.text
+    );
+}
+
+#[test]
+fn a_duration_of_zero_is_still_refused() {
+    let run = run("0");
+
+    assert!(
+        run.failed,
+        "a duration of zero must end the run with a failure, and it printed:\n{}",
+        run.text
+    );
+    assert!(
+        run.text.contains(NOT_POSITIVE),
+        "a duration of zero must give the message about a positive number, and it printed:\n{}",
+        run.text
+    );
+}
+
+#[test]
+fn one_second_past_the_limit_is_refused() {
+    let run = run(PAST_LIMIT);
+
+    assert!(
+        run.failed,
+        "a duration of {PAST_LIMIT} must end the run with a failure, and it printed:\n{}",
+        run.text
+    );
+    assert!(
+        run.text.contains(TOO_LARGE),
+        "a duration of {PAST_LIMIT} must give the message about the limit, and it printed:\n{}",
+        run.text
+    );
+}
+
+#[test]
+fn the_limit_itself_passes_the_bounds_check() {
+    let run = run(LIMIT);
+
+    // The run ends with an error on most machines, because `powermetrics` is
+    // out of reach here and the DVFS table is absent on a machine that is not
+    // an Apple Silicon Mac. Both are later steps. Only the two bounds are
+    // under test, so only their messages are read.
+    assert!(
+        !run.text.contains(TOO_LARGE),
+        "a duration of {LIMIT} must pass the upper bound, and it printed:\n{}",
+        run.text
+    );
+    assert!(
+        !run.text.contains(NOT_POSITIVE),
+        "a duration of {LIMIT} must pass the lower bound, and it printed:\n{}",
+        run.text
+    );
+}

--- a/src/thermal-watch/tests/dvfs_decode.rs
+++ b/src/thermal-watch/tests/dvfs_decode.rs
@@ -1,0 +1,87 @@
+//! Tests for decoding a DVFS property into frequency steps.
+//!
+//! Parallel safety: every test here is pure. Nothing touches a file, a port, or
+//! any other shared resource, so two copies of this binary can run at once.
+
+use thermal_watch::dvfs::{decode_voltage_states, DvfsTable};
+use thermal_watch::mhz::Mhz;
+
+/// Build the raw bytes of a DVFS property from frequency and voltage pairs.
+fn encode(pairs: &[(u32, u32)]) -> Vec<u8> {
+    let mut raw = Vec::with_capacity(pairs.len() * 8);
+    for &(khz, volts) in pairs {
+        raw.extend_from_slice(&khz.to_le_bytes());
+        raw.extend_from_slice(&volts.to_le_bytes());
+    }
+    raw
+}
+
+#[test]
+fn decodes_little_endian_kilohertz_pairs() {
+    let raw = encode(&[(1_260_000, 790), (4_510_000, 938)]);
+    assert_eq!(
+        decode_voltage_states(&raw),
+        vec![Mhz::new(1_260), Mhz::new(4_510)]
+    );
+}
+
+#[test]
+fn keeps_the_order_the_soc_lists() {
+    let raw = encode(&[(2_000_000, 700), (1_000_000, 600), (3_000_000, 800)]);
+    assert_eq!(
+        decode_voltage_states(&raw),
+        vec![Mhz::new(2_000), Mhz::new(1_000), Mhz::new(3_000)],
+        "the decoder must not sort; the caller asks for the maximum itself"
+    );
+}
+
+#[test]
+fn drops_padding_entries_whose_frequency_is_zero() {
+    let raw = encode(&[(1_260_000, 790), (0, 0), (0, 0)]);
+    assert_eq!(decode_voltage_states(&raw), vec![Mhz::new(1_260)]);
+}
+
+#[test]
+fn ignores_a_trailing_partial_entry() {
+    let mut raw = encode(&[(1_260_000, 790)]);
+    raw.extend_from_slice(&[0x11, 0x22, 0x33]);
+    assert_eq!(
+        decode_voltage_states(&raw),
+        vec![Mhz::new(1_260)],
+        "three stray bytes are not a step"
+    );
+}
+
+#[test]
+fn decodes_an_empty_property_to_no_steps() {
+    assert_eq!(decode_voltage_states(&[]), Vec::new());
+}
+
+#[test]
+fn rounds_kilohertz_to_the_nearest_megahertz() {
+    // A real M4 Pro lists 4509104 kHz for its top step, which is 4509 MHz.
+    let raw = encode(&[(4_509_104, 938), (2_499_500, 800)]);
+    assert_eq!(
+        decode_voltage_states(&raw),
+        vec![Mhz::new(4_509), Mhz::new(2_500)]
+    );
+}
+
+#[test]
+fn reports_the_maximum_step_of_each_cluster() {
+    let table = DvfsTable::from_steps(
+        vec![Mhz::new(1_260), Mhz::new(4_510), Mhz::new(3_300)],
+        vec![Mhz::new(1_020), Mhz::new(2_592)],
+    );
+    assert_eq!(table.p_max(), Mhz::new(4_510));
+    assert_eq!(table.e_max(), Mhz::new(2_592));
+    assert_eq!(table.p_steps().len(), 3);
+    assert_eq!(table.e_steps().len(), 2);
+}
+
+#[test]
+fn an_empty_table_reports_a_maximum_of_zero_rather_than_panicking() {
+    let table = DvfsTable::from_steps(Vec::new(), Vec::new());
+    assert_eq!(table.p_max(), Mhz::new(0));
+    assert_eq!(table.e_max(), Mhz::new(0));
+}

--- a/src/thermal-watch/tests/json_output.rs
+++ b/src/thermal-watch/tests/json_output.rs
@@ -131,6 +131,60 @@ fn a_run_with_too_few_busy_samples_carries_the_count_beside_the_outcome() {
     assert!(verdict["decay"].is_null());
 }
 
+/// The four clock numbers of an unjudged run are placeholders, not readings.
+/// A consumer cannot tell a placeholder zero from a measured zero, so the line
+/// must leave the four keys out.
+#[test]
+fn a_verdict_that_judged_nothing_carries_no_clock_measurement() {
+    let line = verdict_json(&steady(3, 4_500));
+    let verdict = &line["verdict"];
+    for key in ["peak", "early_mean", "late_mean", "late_ratio_of_max"] {
+        assert!(
+            verdict[key].is_null(),
+            "an unjudged verdict leaves {key} out, got {line}"
+        );
+    }
+}
+
+/// The power and the pressure are real readings of an unjudged run, and the
+/// outcome and its count describe the run. All four stay on the line.
+#[test]
+fn a_verdict_that_judged_nothing_keeps_the_measurements_it_made() {
+    let line = verdict_json(&steady(3, 4_500));
+    let verdict = &line["verdict"];
+    assert_eq!(verdict["outcome"], "not_enough_data");
+    assert_eq!(verdict["busy_samples"], 3);
+    assert_eq!(
+        verdict["peak_power_mw"], 48_500,
+        "the power is a reading of the run, got {line}"
+    );
+    assert_eq!(
+        verdict["worst_pressure"], "nominal",
+        "the pressure is a reading of the run, got {line}"
+    );
+}
+
+/// A judged outcome keeps every clock number. This holds the line against a
+/// fix that leaves the four keys out of each outcome.
+#[test]
+fn a_verdict_that_judged_the_run_carries_every_clock_measurement() {
+    let throttled = verdict_json(&decaying_run());
+    let verdict = &throttled["verdict"];
+    assert_eq!(verdict["outcome"], "throttled");
+    assert_eq!(verdict["peak"], 4_500, "got {throttled}");
+    assert_eq!(verdict["early_mean"], 4_500, "got {throttled}");
+    assert_eq!(verdict["late_mean"], 3_400, "got {throttled}");
+    assert!(verdict["late_ratio_of_max"].is_f64(), "got {throttled}");
+
+    let held = verdict_json(&steady(180, 4_500));
+    let verdict = &held["verdict"];
+    assert_eq!(verdict["outcome"], "held_clock");
+    assert_eq!(verdict["peak"], 4_500, "got {held}");
+    assert_eq!(verdict["early_mean"], 4_500, "got {held}");
+    assert_eq!(verdict["late_mean"], 4_500, "got {held}");
+    assert!(verdict["late_ratio_of_max"].is_f64(), "got {held}");
+}
+
 #[test]
 fn a_sample_line_and_a_verdict_line_stay_apart_in_the_stream() {
     let sample_line = serde_json::to_string(&busy(7, 4_500)).expect("the sample serializes");

--- a/src/thermal-watch/tests/json_output.rs
+++ b/src/thermal-watch/tests/json_output.rs
@@ -1,0 +1,156 @@
+//! Tests for the JSON mode of the tool.
+//!
+//! The JSON mode prints one object for each sample and one final object that
+//! carries the verdict. A consumer reads the stream line by line, so the two
+//! kinds of line must stay apart: a sample line carries `at_seconds`, and the
+//! verdict line carries `verdict`.
+//!
+//! Parallel safety: every test here is pure. The samples are built in memory,
+//! and nothing is keyed on a fixed path, port, or name.
+
+use std::time::Duration;
+
+use serde_json::Value;
+use thermal_watch::dvfs::DvfsTable;
+use thermal_watch::mhz::Mhz;
+use thermal_watch::powermetrics::{PressureLevel, Sample};
+use thermal_watch::report::{judge, verdict_line, Verdict};
+
+/// The DVFS table of an M4 Pro, trimmed to its two ends.
+fn m4_pro() -> DvfsTable {
+    DvfsTable::from_steps(
+        vec![Mhz::new(1_260), Mhz::new(4_510)],
+        vec![Mhz::new(1_020), Mhz::new(2_592)],
+    )
+}
+
+/// One busy sample at a given second and clock.
+fn busy(second: u64, mhz: u32) -> Sample {
+    Sample {
+        at: Duration::from_secs(second),
+        p_freq: Some(Mhz::new(mhz)),
+        p_active_pct: Some(99.9),
+        e_freq: Some(Mhz::new(1_020)),
+        cpu_power_mw: Some(48_500),
+        gpu_power_mw: Some(0),
+        pressure: PressureLevel::Nominal,
+    }
+}
+
+/// A run of `count` busy samples, one each second, all at the same clock.
+fn steady(count: u64, mhz: u32) -> Vec<Sample> {
+    (0..count).map(|second| busy(second, mhz)).collect()
+}
+
+/// A run that holds its clock and then loses it. This is throttling.
+fn decaying_run() -> Vec<Sample> {
+    let mut samples = steady(20, 4_500);
+    samples.extend((20..180).map(|second| busy(second, 3_400)));
+    samples
+}
+
+/// The verdict of a run, as the JSON mode prints it, parsed back.
+fn verdict_json(samples: &[Sample]) -> Value {
+    parse(&judge(samples, &m4_pro()))
+}
+
+/// Serialize one verdict the way the tool does, then parse it back.
+fn parse(verdict: &Verdict) -> Value {
+    let line = serde_json::to_string(&verdict_line(verdict)).expect("the verdict serializes");
+    serde_json::from_str(&line).expect("the verdict line is JSON")
+}
+
+#[test]
+fn the_verdict_line_carries_the_outcome_and_the_numbers_of_the_run() {
+    let line = verdict_json(&decaying_run());
+    let verdict = &line["verdict"];
+
+    assert_eq!(
+        verdict["outcome"], "throttled",
+        "the outcome names itself in lower snake case, got {line}"
+    );
+    let decay = verdict["decay"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("a throttled verdict carries a decay, got {line}"));
+    assert!(
+        (decay - 0.244_444).abs() < 1e-3_f64,
+        "3400 MHz is about 24% below 4500 MHz, got {decay}"
+    );
+    assert_eq!(
+        verdict["peak"], 4_500,
+        "the peak is a bare megahertz number"
+    );
+    assert_eq!(verdict["early_mean"], 4_500);
+    assert_eq!(verdict["late_mean"], 3_400);
+    assert_eq!(verdict["peak_power_mw"], 48_500);
+    assert_eq!(verdict["worst_pressure"], "nominal");
+    assert!(
+        verdict["late_ratio_of_max"].is_f64(),
+        "the ratio is a number, got {line}"
+    );
+}
+
+#[test]
+fn a_run_that_holds_its_clock_says_so_and_carries_no_variant_data() {
+    let verdict = verdict_json(&steady(180, 4_500))["verdict"].clone();
+    assert_eq!(verdict["outcome"], "held_clock");
+    assert!(verdict["decay"].is_null(), "a held clock lost nothing");
+    assert!(
+        verdict["busy_samples"].is_null(),
+        "a held clock counts no missing samples"
+    );
+}
+
+#[test]
+fn a_run_that_decayed_carries_its_decay_beside_the_outcome() {
+    let verdict = verdict_json(&decaying_run())["verdict"].clone();
+    assert_eq!(verdict["outcome"], "throttled");
+    assert!(
+        verdict["decay"].is_f64(),
+        "the decay sits beside the outcome, not under it"
+    );
+    assert!(verdict["busy_samples"].is_null());
+}
+
+#[test]
+fn a_run_that_never_sped_up_says_so_and_carries_no_variant_data() {
+    let verdict = verdict_json(&steady(180, 2_600))["verdict"].clone();
+    assert_eq!(verdict["outcome"], "never_reached_peak");
+    assert!(verdict["decay"].is_null());
+    assert!(verdict["busy_samples"].is_null());
+}
+
+#[test]
+fn a_run_with_too_few_busy_samples_carries_the_count_beside_the_outcome() {
+    let verdict = verdict_json(&steady(3, 4_500))["verdict"].clone();
+    assert_eq!(verdict["outcome"], "not_enough_data");
+    assert_eq!(
+        verdict["busy_samples"], 3,
+        "the count sits beside the outcome, not under it"
+    );
+    assert!(verdict["decay"].is_null());
+}
+
+#[test]
+fn a_sample_line_and_a_verdict_line_stay_apart_in_the_stream() {
+    let sample_line = serde_json::to_string(&busy(7, 4_500)).expect("the sample serializes");
+    let sample: Value = serde_json::from_str(&sample_line).expect("the sample line is JSON");
+    assert!(
+        !sample["at_seconds"].is_null(),
+        "a sample line carries its time, got {sample_line}"
+    );
+    assert!(
+        sample["verdict"].is_null(),
+        "a sample line carries no verdict, got {sample_line}"
+    );
+
+    let verdict = verdict_json(&decaying_run());
+    assert!(
+        !verdict["verdict"].is_null(),
+        "a verdict line carries the verdict key, got {verdict}"
+    );
+    assert!(
+        verdict["at_seconds"].is_null(),
+        "a verdict line carries no time, got {verdict}"
+    );
+}

--- a/src/thermal-watch/tests/live_machine.rs
+++ b/src/thermal-watch/tests/live_machine.rs
@@ -1,0 +1,53 @@
+//! Tests that read the machine this suite runs on.
+//!
+//! These read the IO Registry, which needs no special privilege. Nothing here
+//! runs `powermetrics`, so nothing here needs root.
+//!
+//! Parallel safety: the IO Registry is read-only here. Nothing is written.
+
+use thermal_watch::dvfs::DvfsTable;
+
+#[test]
+fn reads_a_credible_dvfs_table_from_this_machine() {
+    let read = DvfsTable::read();
+
+    // An Intel Mac and every non-Apple platform carry no such property, so
+    // reporting the absence is the correct result there. On Apple Silicon it is
+    // a defect, and the test says so rather than passing quietly.
+    if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        if let Err(error) = read {
+            println!("no DVFS table on this platform, as expected: {error}");
+            return;
+        }
+    }
+
+    let table = read.expect("an Apple Silicon Mac must report a DVFS table");
+
+    let p_max = table.p_max();
+    assert!(
+        p_max.megahertz() > 1_000,
+        "a P-core maximum of {p_max} is too low to be real"
+    );
+    assert!(
+        p_max.megahertz() < 10_000,
+        "a P-core maximum of {p_max} is too high to be real"
+    );
+    assert!(
+        table.p_steps().len() > 1,
+        "a DVFS table with one step would mean no frequency scaling at all"
+    );
+    assert_eq!(
+        p_max,
+        table.p_steps().iter().copied().max().expect("a step"),
+        "the reported maximum must be the largest step"
+    );
+
+    let e_max = table.e_max();
+    assert!(e_max.megahertz() > 0, "the E-cluster table must not be empty");
+    assert!(
+        e_max < p_max,
+        "the efficiency cores ({e_max}) must be slower than the performance cores ({p_max})"
+    );
+
+    println!("this machine: P max {p_max}, E max {e_max}");
+}

--- a/src/thermal-watch/tests/live_machine.rs
+++ b/src/thermal-watch/tests/live_machine.rs
@@ -43,7 +43,10 @@ fn reads_a_credible_dvfs_table_from_this_machine() {
     );
 
     let e_max = table.e_max();
-    assert!(e_max.megahertz() > 0, "the E-cluster table must not be empty");
+    assert!(
+        e_max.megahertz() > 0,
+        "the E-cluster table must not be empty"
+    );
     assert!(
         e_max < p_max,
         "the efficiency cores ({e_max}) must be slower than the performance cores ({p_max})"

--- a/src/thermal-watch/tests/load_bounds.rs
+++ b/src/thermal-watch/tests/load_bounds.rs
@@ -1,0 +1,102 @@
+//! Tests that the load generator obeys its deadline.
+//!
+//! A load generator whose only stop is a call after the loop is a load
+//! generator that never stops when the caller dies. These tests hold that
+//! guarantee: the workers end on their own deadline, with nothing calling
+//! `stop`.
+//!
+//! Parallel safety: every test here uses only threads of its own process and a
+//! deadline it computes itself. Nothing is keyed on a shared name.
+
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use thermal_watch::load::{performance_core_count, Load};
+
+#[test]
+fn starts_one_worker_for_each_thread_asked_for() {
+    let load = Load::start(3, Instant::now() + Duration::from_millis(200));
+    assert_eq!(load.worker_count(), 3);
+    load.stop();
+}
+
+#[test]
+fn every_worker_ends_at_its_deadline_with_nothing_calling_stop() {
+    let deadline = Instant::now() + Duration::from_millis(300);
+    let load = Load::start(2, deadline);
+
+    // Deliberately never call `stop`. The deadline alone must end the work.
+    sleep(Duration::from_millis(1_500));
+
+    let before = Instant::now();
+    load.stop();
+    assert!(
+        before.elapsed() < Duration::from_millis(500),
+        "the workers had already ended, so joining them must be immediate"
+    );
+    assert!(Instant::now() > deadline);
+}
+
+#[test]
+fn stop_ends_the_workers_well_before_a_distant_deadline() {
+    let load = Load::start(2, Instant::now() + Duration::from_secs(600));
+
+    let before = Instant::now();
+    load.stop();
+    assert!(
+        before.elapsed() < Duration::from_secs(5),
+        "stop must not wait for a deadline ten minutes away"
+    );
+}
+
+#[test]
+fn a_deadline_already_past_starts_no_lasting_work() {
+    let load = Load::start(2, Instant::now() - Duration::from_secs(1));
+    let before = Instant::now();
+    load.stop();
+    assert!(before.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn asking_for_no_workers_starts_none() {
+    let load = Load::start(0, Instant::now() + Duration::from_secs(600));
+    assert_eq!(load.worker_count(), 0);
+    load.stop();
+}
+
+#[test]
+fn the_machine_reports_at_least_one_performance_core() {
+    let count = performance_core_count();
+    assert!(count >= 1, "every machine has at least one core, got {count}");
+    assert!(count < 1_024, "a count of {count} cores is not credible");
+}
+
+#[test]
+fn the_workers_actually_consume_processor_time() {
+    let load = Load::start(2, Instant::now() + Duration::from_secs(3));
+    let before = processor_time();
+    sleep(Duration::from_millis(700));
+    let used = processor_time() - before;
+    load.stop();
+
+    assert!(
+        used > Duration::from_millis(400),
+        "two workers over 700ms must burn more than 400ms of processor time, got {used:?}"
+    );
+}
+
+/// Processor time this process has used, both in user code and in the kernel.
+fn processor_time() -> Duration {
+    // SAFETY: `getrusage` writes one `rusage` into the pointer it is given, and
+    // the pointer is to a live local. The zeroed value is a valid `rusage`.
+    let usage = unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        assert_eq!(libc::getrusage(libc::RUSAGE_SELF, &mut usage), 0);
+        usage
+    };
+    let seconds = |t: libc::timeval| {
+        Duration::from_secs(t.tv_sec.unsigned_abs())
+            + Duration::from_micros(t.tv_usec.unsigned_abs().into())
+    };
+    seconds(usage.ru_utime) + seconds(usage.ru_stime)
+}

--- a/src/thermal-watch/tests/load_bounds.rs
+++ b/src/thermal-watch/tests/load_bounds.rs
@@ -67,7 +67,10 @@ fn asking_for_no_workers_starts_none() {
 #[test]
 fn the_machine_reports_at_least_one_performance_core() {
     let count = performance_core_count();
-    assert!(count >= 1, "every machine has at least one core, got {count}");
+    assert!(
+        count >= 1,
+        "every machine has at least one core, got {count}"
+    );
     assert!(count < 1_024, "a count of {count} cores is not credible");
 }
 

--- a/src/thermal-watch/tests/mhz_units.rs
+++ b/src/thermal-watch/tests/mhz_units.rs
@@ -1,0 +1,37 @@
+//! Tests for the frequency newtype.
+//!
+//! Parallel safety: every test here is pure.
+
+use thermal_watch::mhz::Mhz;
+
+#[test]
+fn converts_kilohertz_to_megahertz() {
+    assert_eq!(Mhz::from_khz(4_510_000), Mhz::new(4_510));
+    assert_eq!(Mhz::from_khz(1_020_000), Mhz::new(1_020));
+}
+
+#[test]
+fn rounds_to_the_nearest_megahertz() {
+    assert_eq!(Mhz::from_khz(4_509_104), Mhz::new(4_509));
+    assert_eq!(Mhz::from_khz(2_499_500), Mhz::new(2_500));
+    assert_eq!(Mhz::from_khz(2_499_499), Mhz::new(2_499));
+}
+
+#[test]
+fn reports_gigahertz_for_display() {
+    assert!((Mhz::new(4_510).gigahertz() - 4.51).abs() < 1e-9_f64);
+    assert_eq!(Mhz::new(4_510).to_string(), "4.51 GHz");
+}
+
+#[test]
+fn reports_a_share_of_a_maximum() {
+    assert!((Mhz::new(2_255).ratio_of(Mhz::new(4_510)) - 0.5).abs() < 1e-9_f64);
+    assert!((Mhz::new(4_510).ratio_of(Mhz::new(4_510)) - 1.0).abs() < 1e-9_f64);
+}
+
+#[test]
+fn a_maximum_of_zero_gives_a_share_of_zero_rather_than_an_infinity() {
+    let ratio = Mhz::new(4_510).ratio_of(Mhz::new(0));
+    assert!(ratio.is_finite(), "a zero maximum must not produce infinity");
+    assert!((ratio - 0.0).abs() < f64::EPSILON);
+}

--- a/src/thermal-watch/tests/mhz_units.rs
+++ b/src/thermal-watch/tests/mhz_units.rs
@@ -32,6 +32,9 @@ fn reports_a_share_of_a_maximum() {
 #[test]
 fn a_maximum_of_zero_gives_a_share_of_zero_rather_than_an_infinity() {
     let ratio = Mhz::new(4_510).ratio_of(Mhz::new(0));
-    assert!(ratio.is_finite(), "a zero maximum must not produce infinity");
+    assert!(
+        ratio.is_finite(),
+        "a zero maximum must not produce infinity"
+    );
     assert!((ratio - 0.0).abs() < f64::EPSILON);
 }

--- a/src/thermal-watch/tests/render_bar.rs
+++ b/src/thermal-watch/tests/render_bar.rs
@@ -1,0 +1,49 @@
+//! Tests for the bar of the live display.
+//!
+//! Parallel safety: every test here is pure.
+
+use thermal_watch::render::bar;
+
+#[test]
+fn a_full_ratio_fills_every_cell() {
+    assert_eq!(bar(1.0, 8), "████████");
+}
+
+#[test]
+fn an_empty_ratio_fills_no_cell() {
+    assert_eq!(bar(0.0, 8), "        ");
+}
+
+#[test]
+fn a_half_ratio_fills_half_the_cells() {
+    assert_eq!(bar(0.5, 8), "████    ");
+}
+
+#[test]
+fn a_partial_cell_uses_an_eighth_block() {
+    // Five and a half cells of eight.
+    assert_eq!(bar(0.687_5, 8), "█████▌  ");
+}
+
+#[test]
+fn a_ratio_outside_the_range_is_clamped_rather_than_refused() {
+    assert_eq!(bar(2.0, 4), "████");
+    assert_eq!(bar(-1.0, 4), "    ");
+    assert_eq!(bar(f64::NAN, 4), "    ", "a strange sample must still draw");
+}
+
+#[test]
+fn every_bar_occupies_the_same_number_of_cells() {
+    for ratio in [0.0_f64, 0.01, 0.13, 0.5, 0.77, 0.99, 1.0] {
+        assert_eq!(
+            bar(ratio, 10).chars().count(),
+            10,
+            "a column of bars must stay aligned, ratio {ratio}"
+        );
+    }
+}
+
+#[test]
+fn a_width_of_zero_draws_nothing() {
+    assert_eq!(bar(0.5, 0), "");
+}

--- a/src/thermal-watch/tests/sample_parse.rs
+++ b/src/thermal-watch/tests/sample_parse.rs
@@ -1,8 +1,9 @@
 //! Tests for reading one `powermetrics` sample.
 //!
 //! Every fixture is a real shape of `powermetrics` output: the two-P-cluster
-//! form of an M-series Pro or Max chip, the single-P-cluster form of a base
-//! chip, and a block whose P-cluster is offline.
+//! form of an M-series Pro or Max chip, the two-die form of an Ultra, the
+//! single-P-cluster form of a base chip, and a block whose P-cluster is
+//! offline.
 //!
 //! Parallel safety: every test here is pure. Nothing runs `powermetrics`.
 
@@ -41,6 +42,56 @@ Combined Power (CPU + GPU + ANE): 32125 mW
 Current pressure level: Nominal
 ";
 
+/// An M-series Ultra joins two dies, and prints the E-cluster and the
+/// P-cluster of each die. The numbers here make the two means easy to read:
+/// the E-clusters give 1500 MHz, and the P-clusters give 3500 MHz.
+const TWO_E_CLUSTERS: &str = "\
+*** Sampled system activity (Fri Aug 22 09:00:00 2026 -0400) (1001.55ms elapsed) ***
+
+**** Processor usage ****
+
+E0-Cluster Online: 0-3
+E0-Cluster HW active frequency: 1000 MHz
+E0-Cluster HW active residency:  70.00% (1020 MHz:  40%)
+E0-Cluster idle residency:  30.00%
+
+P0-Cluster Online: 4-11
+P0-Cluster HW active frequency: 4000 MHz
+P0-Cluster HW active residency:  99.00% (4510 MHz: 55%)
+P0-Cluster idle residency:   1.00%
+
+E1-Cluster Online: 12-15
+E1-Cluster HW active frequency: 2000 MHz
+E1-Cluster HW active residency:  60.00% (2020 MHz:  30%)
+E1-Cluster idle residency:  40.00%
+
+P1-Cluster Online: 16-23
+P1-Cluster HW active frequency: 3000 MHz
+P1-Cluster HW active residency:  99.00% (4510 MHz: 45%)
+P1-Cluster idle residency:   1.00%
+
+CPU Power: 60000 mW
+GPU Power: 40 mW
+Combined Power (CPU + GPU + ANE): 60040 mW
+
+**** Thermal pressure ****
+
+Current pressure level: Nominal
+";
+
+/// A block whose second E-cluster line carries no number. `powermetrics`
+/// prints a dash in place of a measurement it did not get.
+const UNREADABLE_SECOND_E_CLUSTER: &str = "\
+*** Sampled system activity ***
+
+E0-Cluster HW active frequency: 1000 MHz
+E0-Cluster HW active residency:  70.00%
+E1-Cluster HW active frequency: -- MHz
+P0-Cluster HW active frequency: 3000 MHz
+P0-Cluster HW active residency:  99.00%
+CPU Power: 30000 mW
+";
+
 /// A base M-series chip prints one P-cluster.
 const ONE_P_CLUSTER: &str = "\
 *** Sampled system activity ***
@@ -76,6 +127,33 @@ fn averages_every_p_cluster_that_reports() {
     let residency = sample.p_active_pct.expect("a residency");
     assert!((residency - 99.81).abs() < 1e-9_f64);
     assert_eq!(sample.at, Duration::from_secs(7));
+}
+
+#[test]
+fn averages_every_e_cluster_that_reports() {
+    let sample = Sample::parse_block(TWO_E_CLUSTERS, Duration::from_secs(5));
+    assert_eq!(
+        sample.e_freq,
+        Some(Mhz::new(1_500)),
+        "the mean of 1000 MHz and 2000 MHz, not the last cluster of the block"
+    );
+    assert_eq!(
+        sample.p_freq,
+        Some(Mhz::new(3_500)),
+        "the mean of 4000 MHz and 3000 MHz, which the two branches agree on"
+    );
+    assert_eq!(sample.at, Duration::from_secs(5));
+}
+
+#[test]
+fn an_unreadable_e_cluster_line_keeps_the_frequency_already_read() {
+    let sample = Sample::parse_block(UNREADABLE_SECOND_E_CLUSTER, Duration::ZERO);
+    assert_eq!(
+        sample.e_freq,
+        Some(Mhz::new(1_000)),
+        "a line with no number adds nothing, and erases nothing"
+    );
+    assert_eq!(sample.p_freq, Some(Mhz::new(3_000)));
 }
 
 #[test]

--- a/src/thermal-watch/tests/sample_parse.rs
+++ b/src/thermal-watch/tests/sample_parse.rs
@@ -1,0 +1,171 @@
+//! Tests for reading one `powermetrics` sample.
+//!
+//! Every fixture is a real shape of `powermetrics` output: the two-P-cluster
+//! form of an M-series Pro or Max chip, the single-P-cluster form of a base
+//! chip, and a block whose P-cluster is offline.
+//!
+//! Parallel safety: every test here is pure. Nothing runs `powermetrics`.
+
+use std::time::Duration;
+
+use thermal_watch::mhz::Mhz;
+use thermal_watch::powermetrics::{PressureLevel, Sample};
+
+/// An M4 Pro divides its ten P-cores into two clusters, and prints both.
+const TWO_P_CLUSTERS: &str = "\
+*** Sampled system activity (Fri Aug 22 09:00:00 2026 -0400) (1002.31ms elapsed) ***
+
+**** Processor usage ****
+
+E-Cluster Online: 0-3
+E-Cluster HW active frequency: 1332 MHz
+E-Cluster HW active residency:  85.06% (1020 MHz:  12% 1400 MHz: 30%)
+E-Cluster idle residency:  14.94%
+
+P0-Cluster Online: 4-8
+P0-Cluster HW active frequency: 4010 MHz
+P0-Cluster HW active residency:  99.91% (4510 MHz: 60%)
+P0-Cluster idle residency:   0.09%
+
+P1-Cluster Online: 9-13
+P1-Cluster HW active frequency: 3990 MHz
+P1-Cluster HW active residency:  99.71% (4510 MHz: 58%)
+P1-Cluster idle residency:   0.29%
+
+CPU Power: 32104 mW
+GPU Power: 21 mW
+Combined Power (CPU + GPU + ANE): 32125 mW
+
+**** Thermal pressure ****
+
+Current pressure level: Nominal
+";
+
+/// A base M-series chip prints one P-cluster.
+const ONE_P_CLUSTER: &str = "\
+*** Sampled system activity ***
+
+E-Cluster HW active frequency: 972 MHz
+E-Cluster HW active residency:  40.00%
+P-Cluster HW active frequency: 2880 MHz
+P-Cluster HW active residency:  61.25%
+CPU Power: 9000 mW
+GPU Power: 0 mW
+
+**** Thermal pressure ****
+Current pressure level: Serious
+";
+
+/// An idle machine prints no P-cluster lines at all.
+const NO_P_CLUSTER: &str = "\
+*** Sampled system activity ***
+
+E-Cluster HW active frequency: 1020 MHz
+E-Cluster HW active residency:  5.00%
+CPU Power: 120 mW
+";
+
+#[test]
+fn averages_every_p_cluster_that_reports() {
+    let sample = Sample::parse_block(TWO_P_CLUSTERS, Duration::from_secs(7));
+    assert_eq!(
+        sample.p_freq,
+        Some(Mhz::new(4_000)),
+        "the mean of 4010 MHz and 3990 MHz"
+    );
+    let residency = sample.p_active_pct.expect("a residency");
+    assert!((residency - 99.81).abs() < 1e-9_f64);
+    assert_eq!(sample.at, Duration::from_secs(7));
+}
+
+#[test]
+fn reads_the_remaining_fields_of_a_full_sample() {
+    let sample = Sample::parse_block(TWO_P_CLUSTERS, Duration::ZERO);
+    assert_eq!(sample.e_freq, Some(Mhz::new(1_332)));
+    assert_eq!(sample.cpu_power_mw, Some(32_104));
+    assert_eq!(sample.gpu_power_mw, Some(21));
+    assert_eq!(sample.pressure, PressureLevel::Nominal);
+}
+
+#[test]
+fn reads_a_single_p_cluster_chip() {
+    let sample = Sample::parse_block(ONE_P_CLUSTER, Duration::ZERO);
+    assert_eq!(sample.p_freq, Some(Mhz::new(2_880)));
+    let residency = sample.p_active_pct.expect("a residency");
+    assert!((residency - 61.25).abs() < 1e-9_f64);
+    assert_eq!(sample.pressure, PressureLevel::Serious);
+}
+
+#[test]
+fn never_reads_an_e_cluster_line_as_a_p_cluster_line() {
+    let sample = Sample::parse_block(ONE_P_CLUSTER, Duration::ZERO);
+    assert_eq!(sample.e_freq, Some(Mhz::new(972)));
+    assert_ne!(
+        sample.p_freq,
+        Some(Mhz::new(972)),
+        "the E-cluster frequency must never reach the P-cluster field"
+    );
+}
+
+#[test]
+fn an_offline_p_cluster_reads_as_absent_rather_than_as_zero() {
+    let sample = Sample::parse_block(NO_P_CLUSTER, Duration::from_secs(3));
+    assert_eq!(
+        sample.p_freq, None,
+        "an absent measurement is not a measurement of zero"
+    );
+    assert_eq!(sample.p_active_pct, None);
+    assert_eq!(sample.cpu_power_mw, Some(120));
+}
+
+#[test]
+fn a_block_with_no_pressure_line_reads_as_unknown() {
+    let sample = Sample::parse_block(NO_P_CLUSTER, Duration::ZERO);
+    assert_eq!(sample.pressure, PressureLevel::Unknown);
+}
+
+#[test]
+fn reads_every_pressure_level_powermetrics_prints() {
+    assert_eq!(PressureLevel::parse("Nominal"), PressureLevel::Nominal);
+    assert_eq!(PressureLevel::parse("Fair"), PressureLevel::Fair);
+    assert_eq!(PressureLevel::parse("Serious"), PressureLevel::Serious);
+    assert_eq!(PressureLevel::parse("Critical"), PressureLevel::Critical);
+}
+
+#[test]
+fn reads_a_pressure_level_whatever_its_case() {
+    assert_eq!(PressureLevel::parse("nominal"), PressureLevel::Nominal);
+    assert_eq!(PressureLevel::parse("SERIOUS"), PressureLevel::Serious);
+}
+
+#[test]
+fn an_unfamiliar_pressure_level_reads_as_unknown_rather_than_as_nominal() {
+    assert_eq!(
+        PressureLevel::parse("Sleeping"),
+        PressureLevel::Unknown,
+        "a level this tool does not know must never read as the safest one"
+    );
+}
+
+#[test]
+fn a_busy_p_cluster_is_told_apart_from_an_idle_one() {
+    let busy = Sample::parse_block(TWO_P_CLUSTERS, Duration::ZERO);
+    assert!(busy.p_cluster_is_busy(50.0));
+
+    let idle = Sample::parse_block(NO_P_CLUSTER, Duration::ZERO);
+    assert!(
+        !idle.p_cluster_is_busy(50.0),
+        "a sample with no P-cluster measurement is never busy"
+    );
+
+    let light = Sample::parse_block(ONE_P_CLUSTER, Duration::ZERO);
+    assert!(light.p_cluster_is_busy(50.0), "61.25% is above 50%");
+    assert!(!light.p_cluster_is_busy(80.0), "61.25% is below 80%");
+}
+
+#[test]
+fn ranks_the_pressure_levels_from_calm_to_severe() {
+    assert!(PressureLevel::Nominal < PressureLevel::Fair);
+    assert!(PressureLevel::Fair < PressureLevel::Serious);
+    assert!(PressureLevel::Serious < PressureLevel::Critical);
+}

--- a/src/thermal-watch/tests/stream_lifecycle.rs
+++ b/src/thermal-watch/tests/stream_lifecycle.rs
@@ -1,0 +1,108 @@
+//! Tests for the lifecycle of a `powermetrics` run.
+//!
+//! These drive the stream with a stand-in command rather than with
+//! `powermetrics` itself, so they need no root and stay fast. The stand-in
+//! prints the same shapes of output that `powermetrics` prints, including the
+//! banner it writes before its first sample and the refusal it writes when it
+//! is not run as the superuser.
+//!
+//! Parallel safety: each test spawns its own short-lived process and reads its
+//! pipe. Nothing is keyed on a fixed path, port, or name.
+
+use std::process::Command;
+
+use thermal_watch::mhz::Mhz;
+use thermal_watch::powermetrics::SampleStream;
+
+/// One sample block, with the clock given.
+fn block(mhz: u32) -> String {
+    format!(
+        "*** Sampled system activity (1000.00ms elapsed) ***\n\
+         P-Cluster HW active frequency: {mhz} MHz\n\
+         P-Cluster HW active residency:  99.00%\n\
+         CPU Power: 30000 mW\n\
+         Current pressure level: Nominal\n"
+    )
+}
+
+/// A stand-in for `powermetrics` that prints `script` and exits with `code`.
+fn stand_in(script: &str, code: i32) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(format!("printf '%s' \"$0\"; exit {code}"));
+    command.arg(script);
+    command
+}
+
+#[test]
+fn reads_every_sample_a_run_prints() {
+    let script = format!("{}{}{}", block(4_500), block(4_000), block(3_500));
+    let stream = SampleStream::from_command(stand_in(&script, 0)).expect("a stream");
+    let clocks: Vec<Option<Mhz>> = stream.map(|sample| sample.p_freq).collect();
+    assert_eq!(
+        clocks,
+        vec![
+            Some(Mhz::new(4_500)),
+            Some(Mhz::new(4_000)),
+            Some(Mhz::new(3_500)),
+        ],
+        "the last block must be given too, not dropped at the end of the run"
+    );
+}
+
+#[test]
+fn text_before_the_first_sample_header_is_not_a_sample() {
+    // `powermetrics` prints a banner before its first sample.
+    let script = format!(
+        "Machine model: Mac16,11\nSMC version: Unknown\nOS version: 25F1234\n\n{}",
+        block(4_500)
+    );
+    let stream = SampleStream::from_command(stand_in(&script, 0)).expect("a stream");
+    let samples: Vec<_> = stream.collect();
+    assert_eq!(
+        samples.len(),
+        1,
+        "the banner is not a measurement, so it must never become a sample"
+    );
+    assert_eq!(samples[0].p_freq, Some(Mhz::new(4_500)));
+}
+
+#[test]
+fn a_run_that_prints_no_sample_gives_no_sample() {
+    let stream = SampleStream::from_command(stand_in("", 0)).expect("a stream");
+    assert_eq!(stream.count(), 0);
+}
+
+#[test]
+fn reports_the_status_of_a_run_that_failed() {
+    // This is what `powermetrics` does without root: it writes a refusal and
+    // exits non-zero without printing one sample.
+    let mut stream = SampleStream::from_command(stand_in("", 1)).expect("a stream");
+    assert_eq!(stream.by_ref().count(), 0);
+
+    let status = stream.exit_status().expect("the run must report its status");
+    assert!(
+        !status.success(),
+        "a run that failed must be told apart from a run that measured nothing"
+    );
+}
+
+#[test]
+fn reports_the_status_of_a_run_that_finished() {
+    let script = block(4_500);
+    let mut stream = SampleStream::from_command(stand_in(&script, 0)).expect("a stream");
+    assert_eq!(stream.by_ref().count(), 1);
+
+    let status = stream.exit_status().expect("the run must report its status");
+    assert!(status.success());
+}
+
+#[test]
+fn the_status_is_the_same_however_often_it_is_asked_for() {
+    let mut stream = SampleStream::from_command(stand_in("", 3)).expect("a stream");
+    assert_eq!(stream.by_ref().count(), 0);
+
+    let first = stream.exit_status().expect("a status").code();
+    let second = stream.exit_status().expect("a status").code();
+    assert_eq!(first, Some(3));
+    assert_eq!(second, Some(3), "the status must be kept, not waited for twice");
+}

--- a/src/thermal-watch/tests/stream_lifecycle.rs
+++ b/src/thermal-watch/tests/stream_lifecycle.rs
@@ -103,6 +103,28 @@ fn reports_the_status_of_a_run_that_finished() {
 }
 
 #[test]
+fn the_status_is_absent_until_the_run_ends() {
+    // Nothing reads the pipe while the stream waits, so a wait before the
+    // output closes stops forever once the pipe is full. The status stays
+    // absent until the run ends.
+    let script = block(4_500);
+    let mut stream = SampleStream::from_command(stand_in(&script, 7)).expect("a stream");
+
+    assert_eq!(
+        stream.exit_status(),
+        None,
+        "a stream with output still to read must report no status"
+    );
+
+    assert_eq!(stream.by_ref().count(), 1);
+    assert_eq!(
+        stream.exit_status().expect("a status").code(),
+        Some(7),
+        "the status must be available once the output closed"
+    );
+}
+
+#[test]
 fn the_status_is_the_same_however_often_it_is_asked_for() {
     let mut stream = SampleStream::from_command(stand_in("", 3)).expect("a stream");
     assert_eq!(stream.by_ref().count(), 0);

--- a/src/thermal-watch/tests/stream_lifecycle.rs
+++ b/src/thermal-watch/tests/stream_lifecycle.rs
@@ -28,7 +28,9 @@ fn block(mhz: u32) -> String {
 /// A stand-in for `powermetrics` that prints `script` and exits with `code`.
 fn stand_in(script: &str, code: i32) -> Command {
     let mut command = Command::new("/bin/sh");
-    command.arg("-c").arg(format!("printf '%s' \"$0\"; exit {code}"));
+    command
+        .arg("-c")
+        .arg(format!("printf '%s' \"$0\"; exit {code}"));
     command.arg(script);
     command
 }
@@ -79,7 +81,9 @@ fn reports_the_status_of_a_run_that_failed() {
     let mut stream = SampleStream::from_command(stand_in("", 1)).expect("a stream");
     assert_eq!(stream.by_ref().count(), 0);
 
-    let status = stream.exit_status().expect("the run must report its status");
+    let status = stream
+        .exit_status()
+        .expect("the run must report its status");
     assert!(
         !status.success(),
         "a run that failed must be told apart from a run that measured nothing"
@@ -92,7 +96,9 @@ fn reports_the_status_of_a_run_that_finished() {
     let mut stream = SampleStream::from_command(stand_in(&script, 0)).expect("a stream");
     assert_eq!(stream.by_ref().count(), 1);
 
-    let status = stream.exit_status().expect("the run must report its status");
+    let status = stream
+        .exit_status()
+        .expect("the run must report its status");
     assert!(status.success());
 }
 
@@ -104,5 +110,9 @@ fn the_status_is_the_same_however_often_it_is_asked_for() {
     let first = stream.exit_status().expect("a status").code();
     let second = stream.exit_status().expect("a status").code();
     assert_eq!(first, Some(3));
-    assert_eq!(second, Some(3), "the status must be kept, not waited for twice");
+    assert_eq!(
+        second,
+        Some(3),
+        "the status must be kept, not waited for twice"
+    );
 }

--- a/src/thermal-watch/tests/verdict.rs
+++ b/src/thermal-watch/tests/verdict.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use thermal_watch::dvfs::DvfsTable;
 use thermal_watch::mhz::Mhz;
 use thermal_watch::powermetrics::{PressureLevel, Sample};
-use thermal_watch::report::{judge, Outcome};
+use thermal_watch::report::{judge, windows, Outcome};
 
 /// The DVFS table of an M4 Pro, trimmed to its two ends.
 fn m4_pro() -> DvfsTable {
@@ -161,4 +161,79 @@ fn a_short_run_still_reports_a_verdict() {
     assert_eq!(verdict.outcome, Outcome::HeldClock);
     assert_eq!(verdict.early_mean, Mhz::new(4_500));
     assert_eq!(verdict.late_mean, Mhz::new(4_500));
+}
+
+#[test]
+fn a_twenty_second_collapse_is_throttling() {
+    // The clock holds for fifteen seconds and then falls to 2000 MHz. A run
+    // this short must still show the decay.
+    let mut samples = steady(15, 4_500);
+    samples.extend((15..20).map(|second| busy(second, 2_000)));
+
+    let verdict = judge(&samples, &m4_pro());
+    match verdict.outcome {
+        Outcome::Throttled { decay } => {
+            assert!(
+                decay > 0.30_f64,
+                "the clock fell from 4500 MHz to 2000 MHz, got a decay of {decay}"
+            );
+        }
+        other => panic!("expected throttling, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_forty_five_second_run_reports_the_decay_it_measured() {
+    // The true decay is 44.4%. Windows that share samples dilute it to 24.7%.
+    let mut samples = steady(20, 4_500);
+    samples.extend((20..45).map(|second| busy(second, 2_500)));
+
+    let verdict = judge(&samples, &m4_pro());
+    match verdict.outcome {
+        Outcome::Throttled { decay } => {
+            assert!(
+                decay > 0.40_f64,
+                "2500 MHz is 44.4% below 4500 MHz, got a decay of {decay}"
+            );
+        }
+        other => panic!("expected throttling, got {other:?}"),
+    }
+    assert_eq!(verdict.early_mean, Mhz::new(4_500));
+    assert_eq!(verdict.late_mean, Mhz::new(2_500));
+}
+
+#[test]
+fn the_early_window_and_the_late_window_never_share_a_sample() {
+    // Each run starts at second zero and holds one sample each second.
+    for count in [5_u64, 10, 20, 30, 45, 60, 90, 180, 300] {
+        let (early_until, late_from) = windows(Duration::ZERO, Duration::from_secs(count - 1));
+        assert!(
+            early_until <= late_from,
+            "a run of {count} samples ends the early window at {early_until:?} \
+             and starts the late window at {late_from:?}"
+        );
+    }
+}
+
+#[test]
+fn a_load_that_starts_late_takes_its_early_mean_from_the_load() {
+    // The machine is idle for a minute, then the user starts a build. The
+    // early mean must come from the start of the load.
+    let mut samples: Vec<Sample> = (0..60).map(idle).collect();
+    samples.extend((60..=300).map(|second| busy(second, 4_000)));
+    // One spike lifts the peak above the clock of the load.
+    samples[180] = busy(180, 4_500);
+
+    let verdict = judge(&samples, &m4_pro());
+    assert_eq!(verdict.peak, Mhz::new(4_500));
+    assert_eq!(
+        verdict.early_mean,
+        Mhz::new(4_000),
+        "the early mean comes from the start of the load, not from the peak"
+    );
+    assert_eq!(
+        verdict.outcome,
+        Outcome::NeverReachedPeak,
+        "the clock never decayed, so this is not throttling"
+    );
 }

--- a/src/thermal-watch/tests/verdict.rs
+++ b/src/thermal-watch/tests/verdict.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use thermal_watch::dvfs::DvfsTable;
 use thermal_watch::mhz::Mhz;
 use thermal_watch::powermetrics::{PressureLevel, Sample};
-use thermal_watch::report::{judge, windows, Outcome};
+use thermal_watch::report::{judge, windows, Outcome, EARLY_WINDOW, LATE_WINDOW};
 
 /// The DVFS table of an M4 Pro, trimmed to its two ends.
 fn m4_pro() -> DvfsTable {
@@ -214,6 +214,74 @@ fn the_early_window_and_the_late_window_never_share_a_sample() {
              and starts the late window at {late_from:?}"
         );
     }
+}
+
+#[test]
+fn the_early_window_is_full_at_a_span_of_sixty_seconds() {
+    // One third of 60 seconds is 20 seconds. That is the full early window.
+    let (early_until, _) = windows(Duration::ZERO, Duration::from_secs(60));
+    assert_eq!(
+        early_until, EARLY_WINDOW,
+        "a span of 60 seconds gives the early window its full length"
+    );
+}
+
+#[test]
+fn the_early_window_is_shorter_below_a_span_of_sixty_seconds() {
+    // One third of 59 seconds is less than 20 seconds. The window shrinks.
+    let (early_until, _) = windows(Duration::ZERO, Duration::from_secs(59));
+    assert!(
+        early_until < EARLY_WINDOW,
+        "a span of 59 seconds gives a shorter early window, got {early_until:?}"
+    );
+}
+
+#[test]
+fn the_late_window_is_full_at_a_span_of_one_hundred_eighty_seconds() {
+    // One third of 180 seconds is 60 seconds. That is the full late window.
+    let last_at = Duration::from_secs(180);
+    let (_, late_from) = windows(Duration::ZERO, last_at);
+    assert_eq!(
+        late_from,
+        Duration::from_secs(120),
+        "a span of 180 seconds starts the late window at 120 seconds"
+    );
+    assert_eq!(
+        last_at - late_from,
+        LATE_WINDOW,
+        "a span of 180 seconds gives the late window its full length"
+    );
+}
+
+#[test]
+fn the_late_window_is_shorter_below_a_span_of_one_hundred_eighty_seconds() {
+    // One third of 179 seconds is less than 60 seconds. The window shrinks.
+    let last_at = Duration::from_secs(179);
+    let (_, late_from) = windows(Duration::ZERO, last_at);
+    assert!(
+        last_at - late_from < LATE_WINDOW,
+        "a span of 179 seconds gives a shorter late window, got {:?}",
+        last_at - late_from
+    );
+}
+
+#[test]
+fn the_late_window_is_not_full_at_a_span_of_sixty_seconds() {
+    // The two windows reach their full length at different spans. A span of
+    // 60 seconds fills the early window. It leaves the late window at one
+    // third of the span, which is 20 seconds.
+    let last_at = Duration::from_secs(60);
+    let (early_until, late_from) = windows(Duration::ZERO, last_at);
+    assert_eq!(early_until, EARLY_WINDOW);
+    assert_eq!(
+        last_at - late_from,
+        Duration::from_secs(20),
+        "a span of 60 seconds holds the late window to one third of the span"
+    );
+    assert!(
+        last_at - late_from < LATE_WINDOW,
+        "a span of 60 seconds does not fill the late window"
+    );
 }
 
 #[test]

--- a/src/thermal-watch/tests/verdict.rs
+++ b/src/thermal-watch/tests/verdict.rs
@@ -155,8 +155,9 @@ fn throttling_is_found_even_when_the_pressure_level_never_leaves_nominal() {
 
 #[test]
 fn a_short_run_still_reports_a_verdict() {
-    // Thirty seconds is shorter than the early window plus the late window, so
-    // the two windows overlap. The verdict must still be produced.
+    // Thirty seconds is shorter than the early window plus the late window.
+    // Each window becomes one third of the run, so the two windows stay
+    // apart. The verdict must still be produced.
     let verdict = judge(&steady(30, 4_500), &m4_pro());
     assert_eq!(verdict.outcome, Outcome::HeldClock);
     assert_eq!(verdict.early_mean, Mhz::new(4_500));

--- a/src/thermal-watch/tests/verdict.rs
+++ b/src/thermal-watch/tests/verdict.rs
@@ -1,0 +1,164 @@
+//! Tests for the verdict of a run.
+//!
+//! Parallel safety: every test here is pure. The samples are built in memory.
+
+use std::time::Duration;
+
+use thermal_watch::dvfs::DvfsTable;
+use thermal_watch::mhz::Mhz;
+use thermal_watch::powermetrics::{PressureLevel, Sample};
+use thermal_watch::report::{judge, Outcome};
+
+/// The DVFS table of an M4 Pro, trimmed to its two ends.
+fn m4_pro() -> DvfsTable {
+    DvfsTable::from_steps(
+        vec![Mhz::new(1_260), Mhz::new(4_510)],
+        vec![Mhz::new(1_020), Mhz::new(2_592)],
+    )
+}
+
+/// One busy sample at a given second and clock.
+fn busy(second: u64, mhz: u32) -> Sample {
+    Sample {
+        at: Duration::from_secs(second),
+        p_freq: Some(Mhz::new(mhz)),
+        p_active_pct: Some(99.9),
+        e_freq: Some(Mhz::new(1_020)),
+        cpu_power_mw: Some(30_000),
+        gpu_power_mw: Some(0),
+        pressure: PressureLevel::Nominal,
+    }
+}
+
+/// One idle sample at a given second.
+fn idle(second: u64) -> Sample {
+    Sample {
+        at: Duration::from_secs(second),
+        p_freq: None,
+        p_active_pct: None,
+        e_freq: Some(Mhz::new(1_020)),
+        cpu_power_mw: Some(120),
+        gpu_power_mw: Some(0),
+        pressure: PressureLevel::Nominal,
+    }
+}
+
+/// A run of `count` busy samples, one each second, all at the same clock.
+fn steady(count: u64, mhz: u32) -> Vec<Sample> {
+    (0..count).map(|second| busy(second, mhz)).collect()
+}
+
+#[test]
+fn a_clock_that_holds_at_the_peak_is_not_throttling() {
+    let verdict = judge(&steady(180, 4_500), &m4_pro());
+    assert_eq!(verdict.outcome, Outcome::HeldClock);
+    assert_eq!(verdict.peak, Mhz::new(4_500));
+    assert!(verdict.late_ratio_of_max > 0.99);
+}
+
+#[test]
+fn a_clock_that_decays_from_its_early_peak_is_throttling() {
+    let mut samples = steady(20, 4_500);
+    samples.extend((20..180).map(|second| busy(second, 3_400)));
+
+    let verdict = judge(&samples, &m4_pro());
+    match verdict.outcome {
+        Outcome::Throttled { decay } => {
+            assert!(
+                (decay - 0.244_444).abs() < 1e-3_f64,
+                "3400 MHz is about 24% below 4500 MHz, got {decay}"
+            );
+        }
+        other => panic!("expected throttling, got {other:?}"),
+    }
+    assert_eq!(verdict.peak, Mhz::new(4_500));
+    assert_eq!(verdict.early_mean, Mhz::new(4_500));
+    assert_eq!(verdict.late_mean, Mhz::new(3_400));
+}
+
+#[test]
+fn a_clock_that_was_low_from_the_start_is_not_reported_as_decay() {
+    let verdict = judge(&steady(180, 2_600), &m4_pro());
+    assert_eq!(
+        verdict.outcome,
+        Outcome::NeverReachedPeak,
+        "a machine that never sped up did not slow down"
+    );
+}
+
+#[test]
+fn too_few_busy_samples_give_no_verdict() {
+    let verdict = judge(&steady(3, 4_500), &m4_pro());
+    assert_eq!(verdict.outcome, Outcome::NotEnoughData { busy_samples: 3 });
+}
+
+#[test]
+fn idle_samples_never_count_toward_the_verdict() {
+    let idle_run: Vec<Sample> = (0..180).map(idle).collect();
+    let verdict = judge(&idle_run, &m4_pro());
+    assert_eq!(
+        verdict.outcome,
+        Outcome::NotEnoughData { busy_samples: 0 },
+        "an idle machine reports a low clock, and that is not throttling"
+    );
+}
+
+#[test]
+fn an_idle_sample_among_busy_ones_does_not_drag_the_mean_down() {
+    let mut samples = steady(180, 4_500);
+    samples[90] = idle(90);
+
+    let verdict = judge(&samples, &m4_pro());
+    assert_eq!(verdict.outcome, Outcome::HeldClock);
+    assert_eq!(
+        verdict.late_mean,
+        Mhz::new(4_500),
+        "the idle sample must be dropped, not read as 0 MHz"
+    );
+}
+
+#[test]
+fn reports_the_worst_pressure_level_the_run_reached() {
+    let mut samples = steady(180, 4_500);
+    samples[40].pressure = PressureLevel::Fair;
+    samples[41].pressure = PressureLevel::Serious;
+    samples[42].pressure = PressureLevel::Fair;
+
+    let verdict = judge(&samples, &m4_pro());
+    assert_eq!(verdict.worst_pressure, PressureLevel::Serious);
+}
+
+#[test]
+fn reports_the_highest_power_the_run_reached() {
+    let mut samples = steady(180, 4_500);
+    samples[10].cpu_power_mw = Some(48_500);
+
+    let verdict = judge(&samples, &m4_pro());
+    assert_eq!(verdict.peak_power_mw, 48_500);
+}
+
+#[test]
+fn throttling_is_found_even_when_the_pressure_level_never_leaves_nominal() {
+    let mut samples = steady(20, 4_500);
+    samples.extend((20..180).map(|second| busy(second, 3_000)));
+    for sample in &mut samples {
+        sample.pressure = PressureLevel::Nominal;
+    }
+
+    let verdict = judge(&samples, &m4_pro());
+    assert!(
+        matches!(verdict.outcome, Outcome::Throttled { .. }),
+        "the clock is the evidence; the pressure level is not"
+    );
+    assert_eq!(verdict.worst_pressure, PressureLevel::Nominal);
+}
+
+#[test]
+fn a_short_run_still_reports_a_verdict() {
+    // Thirty seconds is shorter than the early window plus the late window, so
+    // the two windows overlap. The verdict must still be produced.
+    let verdict = judge(&steady(30, 4_500), &m4_pro());
+    assert_eq!(verdict.outcome, Outcome::HeldClock);
+    assert_eq!(verdict.early_mean, Mhz::new(4_500));
+    assert_eq!(verdict.late_mean, Mhz::new(4_500));
+}


### PR DESCRIPTION
## What this adds

`thermal-watch` is a new tool. It reports whether the CPU of a Mac runs at
its full clock, and it names the reason when the clock is low.

## How it works

The tool reads `powermetrics` and compares the measured clock against the
DVFS table of the machine. The DVFS table gives the top clock the hardware
offers. A clock below that top step means the machine throttles.

The tool separates two causes that look the same in a pressure level:

- The machine is idle, so the clock is low because there is no work.
- The machine is hot or power-limited, so the clock is low under load.

## Failure reporting

`powermetrics` needs elevated rights. When the run of `powermetrics` fails,
the tool says that the run failed. It does not report a quiet machine.

## Tests

The branch adds 8 test files:

- `dvfs_decode.rs` — the decode of the DVFS table
- `live_machine.rs` — a run against the machine that runs the test
- `load_bounds.rs` — the bounds of the load figures
- `mhz_units.rs` — the unit conversion
- `render_bar.rs` — the render of the bar
- `sample_parse.rs` — the parse of a `powermetrics` sample
- `stream_lifecycle.rs` — the start and the stop of the stream
- `verdict.rs` — the verdict the tool prints

Each feature came from a red commit and then a green commit.

## Documentation

`README.md` and `TLDR.md` both carry an entry, as `repo_guards::tool_index`
requires. `src/thermal-watch/README.md` gives the long description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
