### PR TITLE
fix(swt): compare the help text as glyphs, not as painted bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7112,6 +7112,7 @@ dependencies = [
  "serde_json",
  "signal-hook 0.3.18",
  "tempfile",
+ "testcolor",
 ]
 
 [[package]]

--- a/src/swt/Cargo.toml
+++ b/src/swt/Cargo.toml
@@ -23,6 +23,7 @@ signal-hook.workspace = true
 libc.workspace = true
 regex.workspace = true
 tempfile.workspace = true
+testcolor.workspace = true
 
 [lints]
 workspace = true

--- a/src/swt/tests/cli.rs
+++ b/src/swt/tests/cli.rs
@@ -28,7 +28,7 @@ fn assert_usage_error(output: &Output, invocation: &str) {
         output.status.code(),
         Some(USAGE_EXIT_STATUS),
         "`{invocation}` should exit {USAGE_EXIT_STATUS}, stderr was: {}",
-        String::from_utf8_lossy(&output.stderr)
+        support::stderr(output)
     );
     assert!(
         !output.stderr.is_empty(),
@@ -41,12 +41,12 @@ fn assert_usage_error(output: &Output, invocation: &str) {
 #[test]
 fn version_reports_the_build_it_came_from() {
     let output = run_swt_outside_a_repository(&["--version"]);
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = support::stdout(&output);
 
     assert!(
         output.status.success(),
         "swt --version failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        support::stderr(&output)
     );
     let pattern = Regex::new(r"^swt \d+\.\d+\.\d+ \(.+, (clean|dirty)\)$")
         .expect("version pattern should compile");
@@ -62,7 +62,7 @@ fn bare_invocation_is_a_usage_error_naming_both_commands() {
     let output = run_swt_outside_a_repository(&[]);
 
     assert_usage_error(&output, "swt");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = support::stderr(&output);
     assert!(
         stderr.contains("create") && stderr.contains("merge"),
         "usage should name both commands, got: {stderr}"

--- a/src/swt/tests/create-name-validation.rs
+++ b/src/swt/tests/create-name-validation.rs
@@ -31,7 +31,7 @@ const WORKTREE_NAME_RULE: &str =
 #[test]
 fn create_rejects_a_traversing_name_before_touching_git() {
     let output = run_swt_outside_a_repository(&["create", TRAVERSING_NAME]);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = support::stderr(&output);
 
     assert_eq!(
         output.status.code(),
@@ -52,7 +52,7 @@ fn create_rejects_a_traversing_name_before_touching_git() {
 fn create_rejects_option_looking_names_with_its_own_message() {
     for name in OPTION_LOOKING_NAMES {
         let output = run_swt_outside_a_repository(&["create", name]);
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = support::stderr(&output);
 
         assert_eq!(
             output.status.code(),
@@ -73,7 +73,7 @@ fn create_rejects_option_looking_names_with_its_own_message() {
 fn subcommand_help_still_prints_usage() {
     for command in ["create", "merge"] {
         let output = run_swt_outside_a_repository(&[command, "--help"]);
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stdout = support::stdout(&output);
 
         assert_eq!(
             output.status.code(),

--- a/src/swt/tests/support/mod.rs
+++ b/src/swt/tests/support/mod.rs
@@ -390,6 +390,33 @@ pub fn run_swt(cwd: &Path, args: &[&str]) -> Output {
         .expect("failed to run swt")
 }
 
+/// Standard output of a run, as the visible glyphs a user reads.
+///
+/// clap paints its help and its usage errors when it believes the run writes to
+/// a terminal, and `CLICOLOR_FORCE=1` makes it paint whatever the run writes
+/// to. The escape codes wrap whole words, so a match on one word survives them
+/// and a match on a phrase does not: `Usage: swt create` carries codes between
+/// `Usage:` and `swt create`, because clap gives the two spans different
+/// styles.
+///
+/// A test that compares such a phrase against plain text thus passes in a
+/// redirected run and fails under a hand-typed `git commit`, where the
+/// pre-commit hook passes its terminal straight through. The codes come out
+/// here rather than at each call site, so every assertion reads what a user
+/// reads and none of them depends on the color decision of the run. See
+/// "Colored Output in Tests" in CLAUDE.md.
+pub fn stdout(output: &Output) -> String {
+    testcolor::strip_ansi(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Standard error of a run, as the visible glyphs a user reads.
+///
+/// clap writes its usage errors here, so this side needs the same treatment as
+/// [`stdout`].
+pub fn stderr(output: &Output) -> String {
+    testcolor::strip_ansi(&String::from_utf8_lossy(&output.stderr))
+}
+
 /// Runs the real `swt` binary in an empty directory of its own, outside any
 /// repository, and captures its status, stdout and stderr.
 ///


### PR DESCRIPTION
## The defect

`subcommand_help_still_prints_usage` matched clap's help output against the plain text `Usage: swt create`. clap paints that output when it believes the run writes to a terminal, and the pre-commit hook sets `CLICOLOR_FORCE=1`. Thus the hook made clap paint the output every time.

The escape codes wrap whole words. A match on one word thus survives them, which is why `stderr.contains("create")` in `cli.rs` kept passing. The failing assertion reads a phrase instead. clap gives `Usage:` and `swt create` different styles, so the codes land between the two words, and the phrase is no longer present as bytes.

The result was not a flake. The test failed on every commit that staged a Rust file, in this crate and in every other crate, because the hook runs `cargo test --workspace`. An unrelated change to any tool in the repository wore the blame.

## The fix

`swt` now takes `testcolor` as a dev-dependency and strips the codes in its test-support module. The strip sits beside the spawn entrance that the suite already shares, the way `cwt` does it. Every assertion in these two targets now reads the glyphs that a user reads, so no assertion depends on the color decision of the run.

See "Colored Output in Tests" in `CLAUDE.md`.

No production code changed. The defect was in the test.

## Mutation verification

The repaired assertion was mutation-verified, not assumed. With `override_usage = "swt XYZZY <NAME>"` on the `Create` subcommand, the test fails and names the wrong usage line.

An earlier mutation of the top-level `name` did not move the assertion, because clap builds a subcommand usage line from the real binary name. That spelling proved nothing, and it was discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)