### PR TITLE
fix(swt): ignore .swt-check again, and guard the rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ target
 .op-cache.json
 node_modules
 .wrangler/
+# swt's green-check escape hatch: per-developer, never committed.
+.swt-check

--- a/src/repo-guards/tests/swt_check_ignored.rs
+++ b/src/repo-guards/tests/swt_check_ignored.rs
@@ -1,0 +1,104 @@
+//! Guard: this repository's committed `.gitignore` ignores `.swt-check`.
+//!
+//! `.swt-check` is `swt`'s green-check escape hatch. `swt` resolves it from the
+//! parent repo root and runs it in place of the checks it would otherwise
+//! detect (`src/swt/src/green_check.rs`), so it is a per-developer file by
+//! design. A committed one hands every developer — and every subagent merge
+//! `swt` gates — somebody else's idea of green.
+//!
+//! The rule was already lost once. It arrived on the `swt-fixes` branch against
+//! the TypeScript `swt`, and the Rust port deleted that whole tree without
+//! carrying the `.gitignore` line across. Nothing failed, because the omission
+//! is spelled as an *absence*.
+//!
+//! # Why the test reads the source of the rule
+//!
+//! `git check-ignore` is equally happy with a rule from the developer's own
+//! `core.excludesFile` or from `.git/info/exclude`. Neither one is committed. A
+//! test that accepted them would pass on the machine that already had the file
+//! and fail for everybody else, which is the false green this guard exists to
+//! prevent. So the assertion reads the *source* git names, not just the exit
+//! status, and the host's global and system config is scrubbed out of the run.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// The per-developer override file `swt` looks for at the parent repo root.
+const OVERRIDE_FILE: &str = ".swt-check";
+
+/// The committed ignore file that must carry the rule. `git check-ignore -v`
+/// names its source in this exact spelling when the rule comes from the file at
+/// the repository root.
+const COMMITTED_IGNORE_FILE: &str = ".gitignore";
+
+/// The git location variables git exports into a hook's environment. This
+/// repository's own pre-commit hook runs `cargo test`, so a test that shells out
+/// to git inherits them and answers for whatever repository they name rather
+/// than for this checkout.
+const INHERITED_GIT_ENV: [&str; 4] = ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"];
+
+/// Absolute, canonical path to the repository root, two levels above this
+/// crate's manifest.
+fn repo_root() -> PathBuf {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    std::fs::canonicalize(&root)
+        .unwrap_or_else(|e| panic!("cannot canonicalize repo root {}: {e}", root.display()))
+}
+
+/// Run `git` at the repository root with the host scrubbed out: no inherited
+/// git location variables, and no global or system config.
+///
+/// The config matters as much as the location. `core.excludesFile` is a
+/// per-developer setting, and a rule read from it would make this guard pass on
+/// one machine only.
+fn git_at_repo_root(args: &[&str]) -> Output {
+    let mut command = Command::new("git");
+    command.current_dir(repo_root()).args(args);
+    for name in INHERITED_GIT_ENV {
+        command.env_remove(name);
+    }
+    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    command.env("GIT_CONFIG_SYSTEM", "/dev/null");
+    command
+        .output()
+        .unwrap_or_else(|e| panic!("cannot run git at the repository root: {e}"))
+}
+
+#[test]
+fn committed_gitignore_ignores_the_swt_check_override() {
+    let output = git_at_repo_root(&["check-ignore", "--verbose", OVERRIDE_FILE]);
+
+    // `git check-ignore` exits 0 when a rule matches, 1 when none does, and 128
+    // when it could not reach a verdict at all. The last one is a refusal, not
+    // a clean report, so it gets its own message.
+    match output.status.code() {
+        Some(0) => {}
+        Some(1) => panic!(
+            "`{OVERRIDE_FILE}` is not ignored by this repository.\n\n\
+             It is `swt`'s per-developer green-check override, so a developer who \
+             writes one sees it in `git status` and can commit it. Add this line to \
+             `{COMMITTED_IGNORE_FILE}` at the repository root:\n\n    \
+             {OVERRIDE_FILE}\n\n\
+             (git also reports a path as not ignored when the path is already \
+             tracked. If `{OVERRIDE_FILE}` was committed, remove it from the index \
+             as well.)"
+        ),
+        _ => panic!(
+            "`git check-ignore` failed rather than reaching a verdict: {}\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    }
+
+    // `-v` prints `<source>:<line>:<pattern>` then a tab and the pathname.
+    let verdict = String::from_utf8_lossy(&output.stdout);
+    let source = verdict.split(':').next().unwrap_or_default();
+    assert_eq!(
+        source,
+        COMMITTED_IGNORE_FILE,
+        "`{OVERRIDE_FILE}` is ignored, but the rule comes from `{source}` rather \
+         than from the committed `{COMMITTED_IGNORE_FILE}`. An uncommitted source \
+         covers this developer and nobody else. Full verdict: {}",
+        verdict.trim_end()
+    );
+}


### PR DESCRIPTION
## The gap

`.swt-check` is `swt`'s green-check escape hatch. `swt` resolves it from the parent repo root and runs it in place of the checks it would otherwise detect (`src/swt/src/green_check.rs`), so it is a per-developer file by design. This repository did not ignore it. A developer who wrote one saw it in `git status` and could commit it, and a committed one hands every developer — and every subagent merge `swt` gates — somebody else's idea of green.

## How the rule was lost

The rule existed once. It arrived on the `swt-fixes` branch (PR #322) against the TypeScript `swt`. The Rust port (PR #376) deleted `swt/swt.ts` and every file beside it, and the `.gitignore` line did not come across. Nothing failed, because the omission is spelled as an *absence*.

PR #322 is now closed, because every source file it edits is gone from `main`. Its comment records where each of its fixes lives in the Rust port. This line was the only one that did not survive.

## The guard

`src/repo-guards/tests/swt_check_ignored.rs` asks git whether the **committed** `.gitignore` ignores `.swt-check`.

It reads the *source* of the ignore rule, not only the exit status. `git check-ignore` is equally happy with a rule from the developer's own `core.excludesFile` or from `.git/info/exclude`, and neither one is committed. A test that accepted those would pass on the machine that already had the file and fail for everybody else.

The run also scrubs out `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX`, plus the global and system config. This repository's pre-commit hook runs `cargo test`, and git exports those variables into a hook.

## Verification

Red, then green:

- Red at `e1313ce`: the guard reported `.swt-check` as not ignored.
- Green at `5b97cf5`: the `.gitignore` line is back, and the guard passes.

Mutation-verified rather than assumed. With the rule moved out of `.gitignore` and into `.git/info/exclude`, the guard fails and names the uncommitted source:

```
`.swt-check` is ignored, but the rule comes from `.../.git/info/exclude`
rather than from the committed `.gitignore`.
```

The mutation was reverted, and the shared exclude file is unchanged.

The pre-commit hook gates on staged Rust files, and the green commit stages only `.gitignore`, so the hook skips the Rust gate for it. All four gates were run by hand over the rebased tree:

```
cargo fmt --all -- --check                  clean
cargo machete                               clean
cargo clippy --all-targets --workspace      clean, -D warnings
CLICOLOR_FORCE=1 cargo test --workspace     177 binaries ok, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)