### PR TITLE
feat(krt): prefer the public source address over the local one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -3757,6 +3768,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -4424,6 +4436,8 @@ dependencies = [
  "buildinfo",
  "chrono",
  "clap",
+ "mockito",
+ "reqwest",
  "serde",
  "serde_json",
  "signal-hook 0.3.18",
@@ -4785,6 +4799,31 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -6408,6 +6447,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6997,6 +7037,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/README.md
+++ b/README.md
@@ -593,8 +593,9 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - The default name of the file is `SOURCE-DESTINATION.jsonl` in the working directory, and
     `--output` overrides it. `krt` finds SOURCE in three steps, and the first step that gives an
     address wins. `--source` names the address, and it asks nothing and opens nothing. A run that
-    names no source asks a public address service once at startup, with a timeout of 3 seconds. The
-    host follows the IP version of the trace: `https://api.ipify.org` for IP version 4 and
+    names no source asks a public address service once at startup, with a limit of 3 seconds on the
+    request and 3 seconds on the answer, so the run waits 6 seconds at the most. The host follows
+    the IP version of the trace: `https://api.ipify.org` for IP version 4 and
     `https://api6.ipify.org` for IP version 6, and an answer of the other family counts as no
     answer. A run that reads no address there takes the address of the local interface that reaches
     the destination, and it prints one warning line that says why. The last step opens a socket and

--- a/README.md
+++ b/README.md
@@ -591,8 +591,14 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     and the `run` field separates the runs inside it. The run flushes after every record, so a
     `kill -9` loses at most one round.
   - The default name of the file is `SOURCE-DESTINATION.jsonl` in the working directory, and
-    `--output` overrides it. The default name carries the address of the machine, so a file you
-    share carries it too.
+    `--output` overrides it. `krt` finds SOURCE in three steps, and the first step that gives an
+    address wins. `--source` names the address, and it asks nothing and opens nothing. A run that
+    names no source asks `https://api.ipify.org` once at startup, with a timeout of 3 seconds. A
+    run that reads no address there takes the address of the local interface that reaches the
+    destination, and it prints one warning line that says why. The last step opens a socket and
+    sends no packet, so a captive network and an air-gapped network both still record.
+  - The default name therefore carries the public address of the machine, and a file you share
+    carries it too. `--source` avoids the lookup, and `--output` avoids the name.
   - `--rounds` stops the run after that many rounds, and `--duration` stops it after that much
     time. Each of the two writes the record that closes the run. On macOS and Linux, Ctrl-C also
     stops the run at once and writes that record. Windows gets that key with the table that a

--- a/README.md
+++ b/README.md
@@ -593,9 +593,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - The default name of the file is `SOURCE-DESTINATION.jsonl` in the working directory, and
     `--output` overrides it. `krt` finds SOURCE in three steps, and the first step that gives an
     address wins. `--source` names the address, and it asks nothing and opens nothing. A run that
-    names no source asks `https://api.ipify.org` once at startup, with a timeout of 3 seconds. A
-    run that reads no address there takes the address of the local interface that reaches the
-    destination, and it prints one warning line that says why. The last step opens a socket and
+    names no source asks a public address service once at startup, with a timeout of 3 seconds. The
+    host follows the IP version of the trace: `https://api.ipify.org` for IP version 4 and
+    `https://api6.ipify.org` for IP version 6, and an answer of the other family counts as no
+    answer. A run that reads no address there takes the address of the local interface that reaches
+    the destination, and it prints one warning line that says why. The last step opens a socket and
     sends no packet, so a captive network and an air-gapped network both still record.
   - The default name therefore carries the public address of the machine, and a file you share
     carries it too. `--source` avoids the lookup, and `--output` avoids the name.

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -8,6 +8,7 @@ description = "Knights of the Round Trip: a Rust tool that records the network p
 buildinfo.workspace = true
 chrono.workspace = true
 clap.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true
 signal-hook.workspace = true
@@ -15,6 +16,9 @@ sysinfo.workspace = true
 thiserror.workspace = true
 trippy-core.workspace = true
 trippy-privilege.workspace = true
+
+[dev-dependencies]
+mockito.workspace = true
 
 [lints]
 workspace = true

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -921,6 +921,22 @@ fn source_of(named: Option<IpAddr>, target: IpAddr) -> SourceLabel {
     }
 }
 
+/// The label that the record carries, and the one line that standard error
+/// takes.
+fn source_from(
+    found: std::io::Result<source::Discovery>,
+    target: IpAddr,
+) -> (SourceLabel, Option<String>) {
+    let _ = found;
+    (
+        SourceLabel {
+            addr: target,
+            kind: SourceKind::Local,
+        },
+        None,
+    )
+}
+
 /// The period of one round in milliseconds, for the record that opens a run.
 ///
 /// A period too large for the field takes the largest number the field holds.
@@ -1095,10 +1111,12 @@ fn main() {
 mod tests {
     use super::{
         closing_line, host_name_or, parse_duration, pick_address, render_duration, resolve_target,
-        stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family, Multipath,
-        Protocol, ResolveError, ResolvedConfig, RESOLVE_PORT, UNKNOWN,
+        source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family,
+        Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT,
+        SOURCE_FALLBACK, UNKNOWN,
     };
     use crate::run::Outcome;
+    use crate::source::Discovery;
     use clap::error::{ContextKind, ContextValue, ErrorKind};
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -2373,5 +2391,129 @@ resolved configuration:
         assert!(!user_stopped(&flag), "a clear flag leaves the run going");
         flag.store(true, Ordering::SeqCst);
         assert!(user_stopped(&flag), "a set flag stops the run");
+    }
+
+    /// The reason of a fault that leaves a search without any address.
+    const A_SOURCE_FAULT: &str = "the network is unreachable";
+
+    /// The note of a search that fell back to the local egress address.
+    ///
+    /// `source.rs` builds this line. The text of it is of no interest here:
+    /// what matters is that the caller reads the same characters back.
+    const A_FALLBACK_NOTE: &str = "the public address service answered with text that is not an address: away. The run records the local egress address in its place.";
+
+    /// The unspecified address of ip version 4, as its text reads.
+    const UNSPECIFIED_VERSION_4: &str = "0.0.0.0";
+
+    /// The unspecified address of ip version 6, as its text reads.
+    const UNSPECIFIED_VERSION_6: &str = "::";
+
+    /// Builds the outcome of a search that read no address at all.
+    ///
+    /// The fault is a made one, so the test opens no socket and asks no
+    /// service.
+    fn source_fault() -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::NetworkUnreachable, A_SOURCE_FAULT)
+    }
+
+    /// Reads what a search that read no address hands back for one target.
+    fn failed_search_of(target: &str) -> (SourceLabel, Option<String>) {
+        source_from(Err(source_fault()), address(target))
+    }
+
+    /// A search that read an address hands back that label and no warning.
+    ///
+    /// Without this a run that read its public address writes a warning line
+    /// that names no fault, and every user reads that line on every run.
+    ///
+    /// The target of this test is of the other family than the label, and the
+    /// result holds no part of it. A step that reads the target on this path
+    /// throws the address of the search away.
+    #[test]
+    fn a_search_that_needed_no_fallback_hands_back_no_warning() {
+        let label = SourceLabel {
+            addr: address(AN_IPV4_ADDRESS),
+            kind: SourceKind::Public,
+        };
+        let (source, warning) = source_from(
+            Ok(Discovery {
+                label: label.clone(),
+                note: None,
+            }),
+            address(AN_IPV6_ADDRESS),
+        );
+        assert_eq!(source, label, "the label passes through whole");
+        assert_eq!(
+            warning, None,
+            "a search that needed no fallback carries no warning"
+        );
+    }
+
+    /// A search that fell back hands its note to the caller unchanged.
+    ///
+    /// The note names why the public service gave no address, and the search
+    /// builds it. A step that rewrites the note, or that swallows it, leaves
+    /// the user of a captive network with a file of local addresses and no
+    /// word about why.
+    #[test]
+    fn a_search_that_fell_back_hands_its_note_to_the_caller_unchanged() {
+        let label = SourceLabel {
+            addr: address(AN_IPV4_ADDRESS),
+            kind: SourceKind::Local,
+        };
+        let (source, warning) = source_from(
+            Ok(Discovery {
+                label: label.clone(),
+                note: Some(A_FALLBACK_NOTE.to_owned()),
+            }),
+            address(AN_IPV4_ADDRESS),
+        );
+        assert_eq!(source, label, "the label passes through whole");
+        assert_eq!(
+            warning.as_deref(),
+            Some(A_FALLBACK_NOTE),
+            "the note reaches the caller as the search wrote it"
+        );
+    }
+
+    /// A search that read no address at all records the unspecified address of
+    /// the family of the target, and it names the fault.
+    ///
+    /// Without this the run stops, and a machine on a network with no route out
+    /// records nothing at all. The address is of the family of the target,
+    /// because a record of one family that carries a source of the other reads
+    /// as a fault of the tool.
+    #[test]
+    fn a_search_that_failed_records_the_unspecified_address_of_ip_version_4_and_says_why() {
+        let (source, warning) = failed_search_of(AN_IPV4_ADDRESS);
+        assert_eq!(source.addr, address(UNSPECIFIED_VERSION_4));
+        assert_eq!(source.kind, SourceKind::Local);
+        let warning = warning.expect("a search that read no address carries a warning");
+        assert!(
+            warning.contains(A_SOURCE_FAULT),
+            "the warning names the fault: {warning}"
+        );
+        assert!(
+            warning.contains(SOURCE_FALLBACK),
+            "the warning names what the run recorded in its place: {warning}"
+        );
+    }
+
+    /// The family of the unspecified address follows the family of the target,
+    /// and it never falls back to ip version 4.
+    #[test]
+    fn a_search_that_failed_records_the_unspecified_address_of_ip_version_6_and_says_why() {
+        let (source, warning) = failed_search_of(AN_IPV6_ADDRESS);
+        assert_eq!(source.addr, address(UNSPECIFIED_VERSION_6));
+        assert_eq!(source.kind, SourceKind::Local);
+        let warning = warning.expect("a search that read no address carries a warning");
+        assert!(
+            warning.contains(A_SOURCE_FAULT),
+            "the warning names the fault: {warning}"
+        );
+        assert!(
+            warning.contains(SOURCE_FALLBACK),
+            "the warning names what the run recorded in its place: {warning}"
+        );
     }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -302,7 +302,8 @@ struct Cli {
     #[arg(long)]
     no_dns: bool,
 
-    /// Override the source label in the derived filename.
+    /// Override the source label in the derived filename. Skip the lookup of
+    /// the public address.
     #[arg(long, value_name = "IP")]
     source: Option<IpAddr>,
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -910,7 +910,7 @@ fn unspecified_of(target: IpAddr) -> IpAddr {
 /// captive network and a network with no route out both still record.
 fn source_of(named: Option<IpAddr>, target: IpAddr) -> SourceLabel {
     match source::discover(named, target) {
-        Ok(label) => label,
+        Ok(discovery) => discovery.label,
         Err(error) => {
             eprintln!("{PROGRAM}: the source address did not read: {error}. {SOURCE_FALLBACK}");
             SourceLabel {

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -902,39 +902,40 @@ fn unspecified_of(target: IpAddr) -> IpAddr {
     }
 }
 
-/// The address that the probes leave from.
-///
-/// A machine that names no route to the target still records. The discovery of
-/// the source therefore stops no run: a fault leaves the unspecified address of
-/// the family of the target in the record, and one warning names the fault. A
-/// captive network and a network with no route out both still record.
-fn source_of(named: Option<IpAddr>, target: IpAddr) -> SourceLabel {
-    match source::discover(named, target) {
-        Ok(discovery) => discovery.label,
-        Err(error) => {
-            eprintln!("{PROGRAM}: the source address did not read: {error}. {SOURCE_FALLBACK}");
-            SourceLabel {
-                addr: unspecified_of(target),
-                kind: SourceKind::Local,
-            }
-        }
-    }
-}
-
 /// The label that the record carries, and the one line that standard error
-/// takes.
+/// takes before the display starts.
+///
+/// A machine that names no route to the target still records. The search for
+/// the source therefore stops no run: a search that read no address at all
+/// leaves the unspecified address of the family of the target in the record,
+/// and the warning names the fault. A machine on a captive network, and a
+/// machine on a network with no route out, both still record. The first one
+/// carries the warning that the search wrote, and the second one carries the
+/// warning that this function writes.
+///
+/// The search runs once a run, so the warning prints once a run and never once
+/// a round.
+///
+/// This function reads the outcome of the search and never makes it, and it
+/// hands the warning back and never prints it. A test therefore drives each of
+/// the three outcomes, and it reaches no network. [`trace`] makes the search
+/// and writes the line.
 fn source_from(
     found: std::io::Result<source::Discovery>,
     target: IpAddr,
 ) -> (SourceLabel, Option<String>) {
-    let _ = found;
-    (
-        SourceLabel {
-            addr: target,
-            kind: SourceKind::Local,
-        },
-        None,
-    )
+    match found {
+        Ok(discovery) => (discovery.label, discovery.note),
+        Err(error) => (
+            SourceLabel {
+                addr: unspecified_of(target),
+                kind: SourceKind::Local,
+            },
+            Some(format!(
+                "the source address did not read: {error}. {SOURCE_FALLBACK}"
+            )),
+        ),
+    }
 }
 
 /// The period of one round in milliseconds, for the record that opens a run.
@@ -1005,7 +1006,14 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
     let privilege = trace::acquire_privilege()
         .map_err(|error| TraceFailure::new(&error, EXIT_NO_PRIVILEGES))?;
 
-    let source = source_of(config.source, target.addr);
+    // The search runs here, and it runs once. The warning of a fallback
+    // therefore reaches standard error once a run and never once a round, and
+    // it lands before the recorded file opens and before the display starts, so
+    // no line of the display covers it.
+    let (source, warning) = source_from(source::discover(config.source, target.addr), target.addr);
+    if let Some(warning) = warning {
+        eprintln!("{PROGRAM}: {warning}");
+    }
     let path = source::output_path(config.output.as_deref(), source.addr, destination);
     let mut writer = record::Writer::append(&path).map_err(|error| {
         TraceFailure::new(&format!("{}: {error}", path.display()), EXIT_WRITE_FAILED)

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -700,6 +700,49 @@ mod tests {
     /// the answer and not all of it.
     const LONG_ANSWER_LENGTH: usize = ANSWER_LIMIT * 4;
 
+    /// An answer shaped like the start of a page of HTML.
+    ///
+    /// A service that has broken answers such a page. The page holds three
+    /// line breaks inside its first sixty characters, so a message that counts
+    /// characters and keeps the line breaks writes a warning of four lines,
+    /// and `PUBLIC_FALLBACK` then stands on a line of its own, away from the
+    /// reason that it belongs to.
+    const HTML_ANSWER: &str = "<!DOCTYPE html>\n<html>\n<head>\n<title>Gateway</title>";
+
+    /// The line break that the answer of HTML holds.
+    const LINE_BREAK: char = '\n';
+
+    /// The first two lines of the answer of HTML, joined by one space.
+    ///
+    /// The collapse of the whitespace joins the lines of the answer and drops
+    /// none of them, so the message holds the words of more than one line.
+    const HTML_JOINED: &str = "<!DOCTYPE html> <html>";
+
+    /// The escape character, which starts every sequence that paints a
+    /// terminal.
+    const ESCAPE: char = '\u{1b}';
+
+    /// An answer that holds a sequence which clears the screen of a reader.
+    ///
+    /// The warning line goes to standard error, so a sequence that arrives in
+    /// the answer paints the terminal of the user. `ESC [ 2 J` clears the
+    /// screen.
+    const ANSWER_WITH_A_SEQUENCE: &str = "\u{1b}[2Jgone";
+
+    /// What the answer with a sequence leaves in the message.
+    ///
+    /// The clean drops the escape character alone. The parameter letters of
+    /// the sequence stay as ordinary text, so the terminal keeps its screen
+    /// and the reader still sees what arrived.
+    const SEQUENCE_AS_TEXT: &str = "[2Jgone";
+
+    /// An answer that holds a run of several whitespace characters.
+    ///
+    /// The run holds a line break, a tab, and three spaces, and it stands
+    /// between the two halves of `NOT_AN_ADDRESS`, so the cleaned answer is
+    /// that text.
+    const ANSWER_WITH_A_RUN: &str = "the service\n\t   moved";
+
     /// Reads a mock service that answers one GET of its root with a status and
     /// a body, for a target that the caller names.
     ///
@@ -823,6 +866,71 @@ mod tests {
         assert!(
             message.chars().count() < body.chars().count(),
             "the message is shorter than the answer: {message}"
+        );
+    }
+
+    /// A service that answers with a page of HTML gives a message of one line.
+    ///
+    /// The message becomes the warning line that the run writes to standard
+    /// error. A message that keeps the line breaks of the page breaks that
+    /// warning across lines, and `PUBLIC_FALLBACK` then stands on a line of
+    /// its own, away from the reason that it belongs to. A limit that counts
+    /// characters bounds no line, because the first sixty characters of such a
+    /// page hold three line breaks.
+    ///
+    /// The collapse of the whitespace joins the lines and drops none of them,
+    /// so the message still holds the words of more than one line of the page.
+    #[test]
+    fn an_answer_that_holds_line_breaks_gives_a_message_of_one_line() {
+        let error =
+            answer_of(OK, HTML_ANSWER, TARGET).expect_err("a page of HTML is not an address");
+        let message = error.to_string();
+        assert!(
+            !message.contains(LINE_BREAK),
+            "the message holds no line break: {message:?}"
+        );
+        assert!(
+            message.contains(HTML_JOINED),
+            "the message holds the words of more than one line: {message:?}"
+        );
+    }
+
+    /// A service that answers with a sequence which paints a terminal gives a
+    /// message that holds no escape character.
+    ///
+    /// The warning line goes straight to standard error, and the answer is the
+    /// text of a remote service. A message that keeps the escape character
+    /// lets that service clear the screen of the user, move the cursor, and
+    /// hide what the run wrote.
+    #[test]
+    fn an_answer_that_holds_the_escape_character_gives_a_message_without_it() {
+        let error = answer_of(OK, ANSWER_WITH_A_SEQUENCE, TARGET)
+            .expect_err("a sequence that paints a terminal is not an address");
+        let message = error.to_string();
+        assert!(
+            !message.contains(ESCAPE),
+            "the message holds no escape character: {message:?}"
+        );
+        assert!(
+            message.ends_with(SEQUENCE_AS_TEXT),
+            "the message keeps the letters of the sequence as text: {message:?}"
+        );
+    }
+
+    /// A service that answers with a run of whitespace gives a message that
+    /// holds one space in its place.
+    ///
+    /// `ANSWER_LIMIT` is the whole budget of the warning line. A message that
+    /// keeps a run of whitespace spends that budget on padding, and not on the
+    /// words that name the trouble.
+    #[test]
+    fn an_answer_that_holds_a_run_of_whitespace_gives_a_message_with_one_space() {
+        let error = answer_of(OK, ANSWER_WITH_A_RUN, TARGET)
+            .expect_err("the text of the answer is not an address");
+        let message = error.to_string();
+        assert!(
+            message.ends_with(NOT_AN_ADDRESS),
+            "the run of whitespace became one space: {message:?}"
         );
     }
 

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -1,10 +1,11 @@
 //! Where the probes leave from, and what the recorded file is called.
 //!
 //! The search for the source holds three steps, and the first one that gives an
-//! address wins: the address that the user named, the address that one public
+//! address wins: the address that the user named, the address that a public
 //! service answers with, and the address of the local interface that reaches
-//! the target. The last step reaches no network, so a machine on a captive
-//! network still records.
+//! the target. The public service is the one of the family of the target, and
+//! an answer of the other family counts as no answer. The last step reaches no
+//! network, so a machine on a captive network still records.
 //!
 //! The name of a recorded file holds the source address and the destination, so
 //! one source and one destination keep one file across many runs. Both halves
@@ -159,10 +160,6 @@ const PUBLIC_SERVICE_V4: &str = "https://api.ipify.org";
 /// The host holds records of type AAAA only, so the name resolves to an address
 /// of IP version 6 and the request leaves on that family. It answers the same
 /// plain GET with the address as text, as the service of IP version 4 does.
-#[allow(
-    dead_code,
-    reason = "public_service() picks this in the green half of this fix"
-)]
 const PUBLIC_SERVICE_V6: &str = "https://api6.ipify.org";
 
 /// The service that answers with the address of the family of the target.
@@ -175,8 +172,10 @@ const PUBLIC_SERVICE_V6: &str = "https://api6.ipify.org";
 /// records of one family. The check that [`public_address`] makes on the answer
 /// is the guarantee.
 fn public_service(target: IpAddr) -> &'static str {
-    let _ = target;
-    PUBLIC_SERVICE_V4
+    match target {
+        IpAddr::V4(_) => PUBLIC_SERVICE_V4,
+        IpAddr::V6(_) => PUBLIC_SERVICE_V6,
+    }
 }
 
 /// How long the lookup of the public address waits before it gives up.
@@ -242,10 +241,6 @@ enum PublicError {
     #[error(
         "the public address service answered with {answer}, which is not of the family of {target}"
     )]
-    #[allow(
-        dead_code,
-        reason = "public_address() raises this in the green half of this fix"
-    )]
     Family {
         /// The address that the service answered with.
         answer: IpAddr,
@@ -270,14 +265,22 @@ enum PublicError {
 /// The answer loses the whitespace of both ends before it parses, because a
 /// service that ends its answer with a newline is a common one.
 ///
+/// An address of the family that the target is not of is a failure. The caller
+/// picks a host of the family of the target, and that pick holds only while the
+/// host keeps the records of one family, so this check is the guarantee. A
+/// record of one family that carries a source of the other reads as a fault of
+/// the tool, and it derives the file name that the run of the other family
+/// derives, so two traces of two families then append to one file.
+///
 /// # Errors
 ///
 /// Returns [`PublicError::Request`] when the client does not build, when the
 /// request does not complete inside the timeout, when the service answers with
 /// the status of an error, and when the answer does not read as text. Returns
-/// [`PublicError::Answer`] when the answer is not an address.
+/// [`PublicError::Answer`] when the answer is not an address. Returns
+/// [`PublicError::Family`] when the answer is an address of the family that the
+/// target is not of.
 fn public_address(service: &str, target: IpAddr, timeout: Duration) -> Result<IpAddr, PublicError> {
-    let _ = target;
     let answer = reqwest::blocking::Client::builder()
         .timeout(timeout)
         .build()
@@ -288,9 +291,17 @@ fn public_address(service: &str, target: IpAddr, timeout: Duration) -> Result<Ip
             reason: error.to_string(),
         })?;
     let trimmed = answer.trim();
-    trimmed.parse().map_err(|_| PublicError::Answer {
+    let found: IpAddr = trimmed.parse().map_err(|_| PublicError::Answer {
         answer: shorten(trimmed),
-    })
+    })?;
+    if found.is_ipv4() == target.is_ipv4() {
+        Ok(found)
+    } else {
+        Err(PublicError::Family {
+            answer: found,
+            target,
+        })
+    }
 }
 
 /// What the warning of an unread public address says after the reason.
@@ -313,9 +324,10 @@ pub(crate) struct Discovery {
 /// The search holds three steps, and the first one that gives an address wins.
 /// The address that the user named wins over both of the others, and it asks no
 /// service and opens no socket. A run that names no source asks the public
-/// address service once. A run that reads no address there records the address
-/// of the interface that reaches the target, and it carries the note that says
-/// why.
+/// address service of the family of the target once, and an answer of the other
+/// family counts as no answer. A run that reads no address there records the
+/// address of the interface that reaches the target, and it carries the note
+/// that says why.
 ///
 /// The last step is what keeps a run recording: a machine on a captive network,
 /// and a machine on a network with no route out, both reach the local egress
@@ -613,7 +625,7 @@ mod tests {
 
     /// The address of IP version 6 that a mock service answers with.
     ///
-    /// 2001:db8::/32 is the range that the registries hold for documentation,
+    /// `2001:db8::/32` is the range that the registries hold for documentation,
     /// so no machine of the internet carries this address. Every test that
     /// reads it names a target of IP version 4, so the two families disagree.
     const PUBLIC_ADDRESS_VERSION_6: &str = "2001:db8::7";

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -1,14 +1,21 @@
 //! Where the probes leave from, and what the recorded file is called.
 //!
+//! The search for the source holds three steps, and the first one that gives an
+//! address wins: the address that the user named, the address that one public
+//! service answers with, and the address of the local interface that reaches
+//! the target. The last step reaches no network, so a machine on a captive
+//! network still records.
+//!
 //! The name of a recorded file holds the source address and the destination, so
 //! one source and one destination keep one file across many runs. Both halves
 //! of the name lose every character that a file name must not hold on macOS, on
 //! Linux, or on Windows. The `--output` flag names a file of its own, and it
 //! wins over the derived name.
 //!
-//! The derived name carries the address that the probes leave from. A file that
-//! the user gives to another person carries that address too. `--output`
-//! avoids this.
+//! The derived name carries the address that the probes leave from, and that is
+//! the public address of the machine on most runs. A file that the user gives
+//! to another person therefore names the network of the user, and not only an
+//! address of a private range that every home shares. `--output` avoids this.
 
 use crate::record::{SourceKind, SourceLabel};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, UdpSocket};
@@ -140,10 +147,6 @@ fn egress_address(target: IpAddr) -> std::io::Result<IpAddr> {
 /// so the answer needs no parser of a format and the request needs no key of an
 /// account. A service that goes away, or that starts to limit the rate of a
 /// caller, costs this one line to change.
-#[allow(
-    dead_code,
-    reason = "discover() reads this in the next slice of issue #368"
-)]
 const PUBLIC_SERVICE: &str = "https://api.ipify.org";
 
 /// How long the lookup of the public address waits before it gives up.
@@ -156,10 +159,6 @@ const PUBLIC_SERVICE: &str = "https://api.ipify.org";
 /// The client gives this much time to the request and this much again to the
 /// read of the answer, so a service that answers the headers and then stops
 /// costs twice this at the most.
-#[allow(
-    dead_code,
-    reason = "discover() reads this in the next slice of issue #368"
-)]
 const PUBLIC_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// How many characters of an answer that is not an address the message holds.
@@ -233,10 +232,6 @@ enum PublicError {
 /// request does not complete inside the timeout, when the service answers with
 /// the status of an error, and when the answer does not read as text. Returns
 /// [`PublicError::Answer`] when the answer is not an address.
-#[allow(
-    dead_code,
-    reason = "discover() calls this in the next slice of issue #368; the tests of this module cover it now"
-)]
 fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicError> {
     let answer = reqwest::blocking::Client::builder()
         .timeout(timeout)
@@ -274,47 +269,67 @@ pub(crate) struct Discovery {
 
 /// Finds the address that the probes leave from, and how krt found it.
 ///
-/// The address that the user named wins, and it opens no socket. Every other
-/// run reads the address of the interface that reaches the target.
+/// The search holds three steps, and the first one that gives an address wins.
+/// The address that the user named wins over both of the others, and it asks no
+/// service and opens no socket. A run that names no source asks the public
+/// address service once. A run that reads no address there records the address
+/// of the interface that reaches the target, and it carries the note that says
+/// why.
 ///
-/// The design puts one HTTPS request to a public address service between those
-/// two steps. A later slice adds it.
+/// The last step is what keeps a run recording: a machine on a captive network,
+/// and a machine on a network with no route out, both reach the local egress
+/// address.
 ///
 /// # Errors
 ///
-/// Returns the reason when the socket of the egress address does not open, when
-/// the operating system finds no route to the target, and when the local
-/// address does not read. A run that names a source raises none of these,
-/// because it opens no socket.
+/// Returns the reason when the public lookup gives no address **and** the
+/// socket of the egress address then also fails: the socket does not open, the
+/// operating system finds no route to the target, or the local address does not
+/// read. A run that names a source raises none of these, and neither does a run
+/// that reads a public address, because neither one opens a socket.
 pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result<Discovery> {
     discover_at(named, target, PUBLIC_SERVICE, PUBLIC_TIMEOUT)
 }
 
 /// Finds the source address against the service and the timeout of the caller.
 ///
+/// [`discover`] names the service and the timeout of a run. A test names a
+/// service of its own, which runs on this machine, so no test of this module
+/// reaches the service that `PUBLIC_SERVICE` names.
+///
 /// # Errors
 ///
-/// Returns the reason when the socket of the egress address does not open.
+/// Returns the reason when the public lookup gives no address and the socket of
+/// the egress address then also fails.
 fn discover_at(
     named: Option<IpAddr>,
     target: IpAddr,
     service: &str,
     timeout: Duration,
 ) -> std::io::Result<Discovery> {
-    match named {
-        Some(addr) => Ok(Discovery {
+    if let Some(addr) = named {
+        return Ok(Discovery {
             label: SourceLabel {
                 addr,
                 kind: SourceKind::Override,
             },
             note: None,
+        });
+    }
+    match public_address(service, timeout) {
+        Ok(addr) => Ok(Discovery {
+            label: SourceLabel {
+                addr,
+                kind: SourceKind::Public,
+            },
+            note: None,
         }),
-        None => Ok(Discovery {
+        Err(error) => Ok(Discovery {
             label: SourceLabel {
                 addr: egress_address(target)?,
                 kind: SourceKind::Local,
             },
-            note: None,
+            note: Some(format!("{error}. {PUBLIC_FALLBACK}")),
         }),
     }
 }

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -253,6 +253,25 @@ fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicErro
     })
 }
 
+/// What the warning of an unread public address says after the reason.
+const PUBLIC_FALLBACK: &str = "The run records the local egress address in its place.";
+
+/// What the search for the source address found.
+#[derive(Debug)]
+pub(crate) struct Discovery {
+    /// The address that the probes leave from, and how `krt` found it.
+    pub(crate) label: SourceLabel,
+    /// The one line that names why the public service gave no address.
+    ///
+    /// `main` writes it to standard error before the display starts. A search
+    /// that needed no fallback carries none.
+    #[allow(
+        dead_code,
+        reason = "main() writes this line in the next slice of issue #368"
+    )]
+    pub(crate) note: Option<String>,
+}
+
 /// Finds the address that the probes leave from, and how krt found it.
 ///
 /// The address that the user named wins, and it opens no socket. Every other
@@ -267,15 +286,35 @@ fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicErro
 /// the operating system finds no route to the target, and when the local
 /// address does not read. A run that names a source raises none of these,
 /// because it opens no socket.
-pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result<SourceLabel> {
+pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result<Discovery> {
+    discover_at(named, target, PUBLIC_SERVICE, PUBLIC_TIMEOUT)
+}
+
+/// Finds the source address against the service and the timeout of the caller.
+///
+/// # Errors
+///
+/// Returns the reason when the socket of the egress address does not open.
+fn discover_at(
+    named: Option<IpAddr>,
+    target: IpAddr,
+    service: &str,
+    timeout: Duration,
+) -> std::io::Result<Discovery> {
     match named {
-        Some(addr) => Ok(SourceLabel {
-            addr,
-            kind: SourceKind::Override,
+        Some(addr) => Ok(Discovery {
+            label: SourceLabel {
+                addr,
+                kind: SourceKind::Override,
+            },
+            note: None,
         }),
-        None => Ok(SourceLabel {
-            addr: egress_address(target)?,
-            kind: SourceKind::Local,
+        None => Ok(Discovery {
+            label: SourceLabel {
+                addr: egress_address(target)?,
+                kind: SourceKind::Local,
+            },
+            note: None,
         }),
     }
 }
@@ -283,8 +322,8 @@ pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result
 #[cfg(test)]
 mod tests {
     use super::{
-        bind_address, derive_name, discover, egress_address, output_path, public_address,
-        PublicError, ANSWER_LIMIT, ELLIPSIS,
+        bind_address, derive_name, discover_at, egress_address, output_path, public_address,
+        Discovery, PublicError, ANSWER_LIMIT, ELLIPSIS, PUBLIC_FALLBACK,
     };
     use crate::record::SourceKind;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -477,31 +516,14 @@ mod tests {
         );
     }
 
-    /// A source that the user named opens no socket, and the record marks it an
-    /// override.
-    #[test]
-    fn a_source_that_the_user_named_is_an_override() {
-        let named = address(SOURCE);
-        let label = discover(Some(named), LOOPBACK).expect("a named source opens no socket");
-        assert_eq!(label.addr, named);
-        assert_eq!(label.kind, SourceKind::Override);
-    }
-
-    /// A run that names no source reads the egress address, and the record
-    /// marks it local. The target is the loopback, so the test touches no
-    /// network.
-    #[test]
-    fn no_named_source_gives_the_local_egress_address() {
-        let label = discover(None, LOOPBACK).expect("every machine holds a loopback route");
-        assert_eq!(label.addr, LOOPBACK);
-        assert_eq!(label.kind, SourceKind::Local);
-    }
-
     /// The address that a mock service answers with.
     ///
     /// 203.0.113.0/24 is TEST-NET-3, which the registries hold for
     /// documentation, so no machine of the internet carries this address.
     const PUBLIC_ADDRESS: &str = "203.0.113.7";
+
+    /// The name that the public address and the plain destination derive.
+    const PUBLIC_NAME: &str = "203.0.113.7-example.com.jsonl";
 
     /// The method of the one request that the lookup makes.
     const GET: &str = "GET";
@@ -520,6 +542,11 @@ mod tests {
 
     /// How many requests one lookup makes. One lookup asks once.
     const ONE_REQUEST: usize = 1;
+
+    /// How many requests a search that names its source makes.
+    ///
+    /// Such a search reads no service, so it makes none.
+    const NO_REQUEST: usize = 0;
 
     /// The timeout of a test that reads a service that answers at once.
     ///
@@ -674,6 +701,148 @@ mod tests {
         assert!(
             message.chars().count() < body.chars().count(),
             "the message is shorter than the answer: {message}"
+        );
+    }
+
+    /// Runs the search for the source against a mock service that answers one
+    /// GET of its root with a status and a body.
+    ///
+    /// `requests` is how many requests the search must make. `Mock::assert`
+    /// reads that count when the search returns, so a search that asks the
+    /// service twice, or that asks it at all when the count is zero, fails the
+    /// test. The count is what proves the order of the three steps, because a
+    /// search that asks the service and then throws the answer away gives the
+    /// same label as one that never asks.
+    ///
+    /// The target is the loopback, so the step that reads the local egress
+    /// address opens a socket of the loopback and touches no network. The mock
+    /// service binds the loopback too, and it asks the operating system for a
+    /// port, so two copies of one test that run at the same time take two ports
+    /// and never collide. No test of the search reaches the service that
+    /// `PUBLIC_SERVICE` names.
+    fn search_of(
+        named: Option<IpAddr>,
+        status: usize,
+        body: &str,
+        requests: usize,
+    ) -> std::io::Result<Discovery> {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock(GET, ROOT)
+            .with_status(status)
+            .with_body(body)
+            .expect(requests)
+            .create();
+        let found = discover_at(named, LOOPBACK, &server.url(), TEST_TIMEOUT);
+        mock.assert();
+        found
+    }
+
+    /// A source that the user named wins over both lookups. The record marks it
+    /// an override, the search asks no service, and it opens no socket.
+    ///
+    /// The mock service of this test answers an address, and the result holds
+    /// no part of that answer. A search that asks the service first pays a
+    /// request, and a timeout, for an address that it then throws away.
+    #[test]
+    fn a_source_that_the_user_named_is_an_override() {
+        let named = address(SOURCE);
+        let found = search_of(Some(named), OK, PUBLIC_ADDRESS, NO_REQUEST)
+            .expect("a named source opens no socket");
+        assert_eq!(found.label.addr, named);
+        assert_eq!(found.label.kind, SourceKind::Override);
+        assert_eq!(
+            found.note, None,
+            "a search that needed no fallback carries no warning"
+        );
+    }
+
+    /// A service that answers an address makes that address the source, and the
+    /// record marks it public.
+    ///
+    /// Without this step the record names an address of a local interface,
+    /// which every machine behind one router shares with the others, so two
+    /// machines of one house record to one file.
+    #[test]
+    fn a_service_that_answers_an_address_gives_the_public_source() {
+        let found = search_of(None, OK, PUBLIC_ADDRESS, ONE_REQUEST)
+            .expect("the mock service answers an address");
+        assert_eq!(found.label.addr, address(PUBLIC_ADDRESS));
+        assert_eq!(found.label.kind, SourceKind::Public);
+        assert_eq!(
+            found.note, None,
+            "a search that needed no fallback carries no warning"
+        );
+    }
+
+    /// A run that names no source, and that reads no public address, records
+    /// the local egress address, and the record marks it local.
+    ///
+    /// The service of this test answers the status of an error, and the target
+    /// is the loopback, so the test touches no network. Without this step a
+    /// machine on a captive network, or on a network with no route out, records
+    /// nothing at all.
+    #[test]
+    fn no_named_source_gives_the_local_egress_address() {
+        let found = search_of(None, SERVER_ERROR, PUBLIC_ADDRESS, ONE_REQUEST)
+            .expect("every machine holds a loopback route");
+        assert_eq!(found.label.addr, LOOPBACK);
+        assert_eq!(found.label.kind, SourceKind::Local);
+    }
+
+    /// A search that fell back to the local egress address names the reason and
+    /// names what it did.
+    ///
+    /// The service of this test answers text that is not an address, so the
+    /// note carries that text. A note that names only the reason leaves a
+    /// reader to guess which address the file then holds.
+    #[test]
+    fn a_service_that_answers_no_address_falls_back_and_says_why() {
+        let found = search_of(None, OK, NOT_AN_ADDRESS, ONE_REQUEST)
+            .expect("every machine holds a loopback route");
+        assert_eq!(found.label.addr, LOOPBACK);
+        assert_eq!(found.label.kind, SourceKind::Local);
+        let note = found.note.expect("a search that fell back carries a note");
+        assert!(
+            note.contains(NOT_AN_ADDRESS),
+            "the note names the reason: {note}"
+        );
+        assert!(
+            note.contains(PUBLIC_FALLBACK),
+            "the note names what the run recorded in its place: {note}"
+        );
+    }
+
+    /// One run asks the public service once, and one run therefore writes one
+    /// warning.
+    ///
+    /// The service of this test fails, because the warning belongs to the run
+    /// that falls back. A search that asks once a round pays a request, and a
+    /// timeout, for every round of a run that lasts for hours, and it writes
+    /// that warning once a round. The count of requests that `search_of` reads
+    /// is the proof.
+    #[test]
+    fn one_search_asks_the_public_service_once() {
+        let found = search_of(None, SERVER_ERROR, PUBLIC_ADDRESS, ONE_REQUEST)
+            .expect("every machine holds a loopback route");
+        assert!(
+            found.note.is_some(),
+            "the search fell back, so it carries the one warning of the run"
+        );
+    }
+
+    /// The derived name carries the label that won.
+    ///
+    /// A run that reads a public address keeps one file for that address across
+    /// many runs, and the name loses the characters that a file name must not
+    /// hold, as every derived name does.
+    #[test]
+    fn the_derived_name_carries_the_public_source_that_won() {
+        let found = search_of(None, OK, PUBLIC_ADDRESS, ONE_REQUEST)
+            .expect("the mock service answers an address");
+        assert_eq!(
+            output_path(None, found.label.addr, DESTINATION),
+            PathBuf::from(PUBLIC_NAME)
         );
     }
 }

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -13,6 +13,7 @@
 use crate::record::{SourceKind, SourceLabel};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, UdpSocket};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// The extension of a recorded file.
 const EXTENSION: &str = "jsonl";
@@ -133,6 +134,116 @@ fn egress_address(target: IpAddr) -> std::io::Result<IpAddr> {
     Ok(socket.local_addr()?.ip())
 }
 
+/// The service that answers with the address that the internet sees.
+///
+/// The service answers a plain GET with the address as text and nothing else,
+/// so the answer needs no parser of a format and the request needs no key of an
+/// account. A service that goes away, or that starts to limit the rate of a
+/// caller, costs this one line to change.
+#[allow(
+    dead_code,
+    reason = "discover() reads this in the next slice of issue #368"
+)]
+const PUBLIC_SERVICE: &str = "https://api.ipify.org";
+
+/// How long the lookup of the public address waits before it gives up.
+///
+/// The lookup stands between the source that the user named and the local
+/// egress address, so every run that names no source pays it. Three seconds is
+/// long enough for a service on the other side of an ocean, and short enough
+/// that a service that has broken does not hold the run for long.
+///
+/// The client gives this much time to the request and this much again to the
+/// read of the answer, so a service that answers the headers and then stops
+/// costs twice this at the most.
+#[allow(
+    dead_code,
+    reason = "discover() reads this in the next slice of issue #368"
+)]
+const PUBLIC_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How many characters of an answer that is not an address the message holds.
+///
+/// A service that answers with a page of HTML, and not with an address, writes
+/// that whole page to the warning line of the run without this limit. Sixty
+/// characters name the service and the trouble, and they fit one line.
+const ANSWER_LIMIT: usize = 60;
+
+/// The character that marks an answer that the message cut.
+const ELLIPSIS: &str = "…";
+
+/// The start of an answer, short enough for one line of a warning.
+///
+/// The walk reads characters and never bytes, so a character of more than one
+/// byte survives whole. An answer that the walk cut ends with an ellipsis, so a
+/// reader sees that more of it exists.
+fn shorten(answer: &str) -> String {
+    let mut characters = answer.chars();
+    let start: String = characters.by_ref().take(ANSWER_LIMIT).collect();
+    if characters.next().is_some() {
+        format!("{start}{ELLIPSIS}")
+    } else {
+        start
+    }
+}
+
+/// Why the lookup of the public address gives no address.
+///
+/// The text of each one becomes part of the warning line that the run prints
+/// before it falls back to the local egress address.
+#[derive(Debug, thiserror::Error)]
+enum PublicError {
+    /// The request did not complete.
+    ///
+    /// The client did not build, the name did not resolve, the connection did
+    /// not open, the service answered with the status of an error, or the
+    /// answer did not arrive inside the timeout.
+    #[error("the request to the public address service did not complete: {reason}")]
+    Request {
+        /// The reason that the client gave.
+        reason: String,
+    },
+    /// The answer is not an address.
+    #[error("the public address service answered with text that is not an address: {answer}")]
+    Answer {
+        /// The start of the text that the service answered.
+        answer: String,
+    },
+}
+
+/// The address that the internet sees, from one GET of a public service.
+///
+/// The client of `reqwest` that blocks holds its `tokio` runtime inside itself
+/// and drops that runtime when the call returns. `krt` therefore starts no
+/// runtime of its own and holds no async code.
+///
+/// The caller names the timeout, so a test names a short one and runs fast. The
+/// client gives that time to the request and that time again to the read of the
+/// answer.
+///
+/// A status of an error is a failure. A service that answers `503` answers with
+/// a page of its own, and that page is not an address.
+///
+/// The answer loses the whitespace of both ends before it parses, because a
+/// service that ends its answer with a newline is a common one.
+///
+/// # Errors
+///
+/// Returns [`PublicError::Request`] when the client does not build, when the
+/// request does not complete inside the timeout, when the service answers with
+/// the status of an error, and when the answer does not read as text. Returns
+/// [`PublicError::Answer`] when the answer is not an address.
+#[allow(
+    dead_code,
+    reason = "discover() calls this in the next slice of issue #368; the tests of this module cover it now"
+)]
+fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicError> {
+    let _ = (service, timeout);
+    Err(PublicError::Answer {
+        answer: String::new(),
+    })
+}
+
 /// Finds the address that the probes leave from, and how krt found it.
 ///
 /// The address that the user named wins, and it opens no socket. Every other
@@ -162,10 +273,15 @@ pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result
 
 #[cfg(test)]
 mod tests {
-    use super::{bind_address, derive_name, discover, egress_address, output_path};
+    use super::{
+        ANSWER_LIMIT, ELLIPSIS, PublicError, bind_address, derive_name, discover, egress_address,
+        output_path, public_address,
+    };
     use crate::record::SourceKind;
+    use std::io::Write;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     /// The loopback address of IP version 4.
     ///
@@ -371,5 +487,187 @@ mod tests {
         let label = discover(None, LOOPBACK).expect("every machine holds a loopback route");
         assert_eq!(label.addr, LOOPBACK);
         assert_eq!(label.kind, SourceKind::Local);
+    }
+
+    /// The address that a mock service answers with.
+    ///
+    /// 203.0.113.0/24 is TEST-NET-3, which the registries hold for
+    /// documentation, so no machine of the internet carries this address.
+    const PUBLIC_ADDRESS: &str = "203.0.113.7";
+
+    /// The method of the one request that the lookup makes.
+    const GET: &str = "GET";
+
+    /// The path that the mock service answers on.
+    ///
+    /// `Server::url` gives a URL that carries no path, and a URL that carries
+    /// no path asks for the root.
+    const ROOT: &str = "/";
+
+    /// The status of an answer that carries an address.
+    const OK: usize = 200;
+
+    /// The status of a service that has broken.
+    const SERVER_ERROR: usize = 500;
+
+    /// How many requests one lookup makes. One lookup asks once.
+    const ONE_REQUEST: usize = 1;
+
+    /// The timeout of a test that reads a service that answers at once.
+    ///
+    /// The service runs on the loopback of this machine, so it answers in a
+    /// millisecond or two. Five seconds is large enough that a machine under
+    /// load does not fail the test for a reason that this code does not own.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// The timeout of the test that reads a service that answers too late.
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
+
+    /// How long the slow service waits before it writes the first byte of a
+    /// body.
+    ///
+    /// The value is ten times `SHORT_TIMEOUT`, and the two numbers stand far
+    /// apart on purpose. The service starts to wait when the request arrives,
+    /// and the client starts its clock before it sends that request, so the
+    /// answer cannot reach the client earlier than this. The order of the two
+    /// is therefore fixed and not a race, and the gap makes that plain to a
+    /// reader and leaves room on a machine under load.
+    const SLOW_ANSWER: Duration = Duration::from_millis(500);
+
+    /// An answer that is not an address.
+    const NOT_AN_ADDRESS: &str = "the service moved";
+
+    /// The character that the long answer repeats.
+    ///
+    /// It holds three bytes and one character, so a cut that reads bytes lands
+    /// inside it and panics.
+    const LONG_ANSWER_CHARACTER: char = '日';
+
+    /// How many characters the long answer holds.
+    ///
+    /// The count is more than `ANSWER_LIMIT`, so the message holds a part of
+    /// the answer and not all of it.
+    const LONG_ANSWER_LENGTH: usize = ANSWER_LIMIT * 4;
+
+    /// Reads a mock service that answers one GET of its root with a status and
+    /// a body.
+    ///
+    /// `mockito::Server` binds the loopback and asks the operating system for a
+    /// port, so two copies of one test that run at the same time take two ports
+    /// and never collide. The service is a local one, so no test of the lookup
+    /// reaches the service that `PUBLIC_SERVICE` names.
+    ///
+    /// The guard of the server stays alive until the lookup has its answer, and
+    /// the server stops when the guard drops. `Mock::assert` then reads the
+    /// count of requests, which proves that the lookup asked the mock service
+    /// and asked it once.
+    fn answer_of(status: usize, body: &str) -> Result<IpAddr, PublicError> {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock(GET, ROOT)
+            .with_status(status)
+            .with_body(body)
+            .expect(ONE_REQUEST)
+            .create();
+        let found = public_address(&server.url(), TEST_TIMEOUT);
+        mock.assert();
+        found
+    }
+
+    /// The address that a service which answers at once gives.
+    #[test]
+    fn a_service_that_answers_with_an_address_gives_that_address() {
+        let found = answer_of(OK, PUBLIC_ADDRESS).expect("the mock service answers an address");
+        assert_eq!(found, address(PUBLIC_ADDRESS));
+    }
+
+    /// A service that ends its answer with a newline is a common one, and a
+    /// lookup that keeps that newline parses no address at all.
+    #[test]
+    fn a_service_that_answers_with_an_address_and_whitespace_gives_that_address() {
+        let body = format!("  {PUBLIC_ADDRESS}\r\n");
+        let found = answer_of(OK, &body).expect("the answer loses the whitespace of both ends");
+        assert_eq!(found, address(PUBLIC_ADDRESS));
+    }
+
+    /// A service that answers `500` answers with a page of its own, and that
+    /// page is not an address. A lookup that reads the body of every status
+    /// takes that page for an answer.
+    #[test]
+    fn a_service_that_answers_with_the_status_of_an_error_gives_no_address() {
+        let error = answer_of(SERVER_ERROR, PUBLIC_ADDRESS)
+            .expect_err("the status of an error gives no address");
+        assert!(
+            matches!(error, PublicError::Request { .. }),
+            "the status stops the request before the body parses: {error}"
+        );
+    }
+
+    /// The timeout holds the run to a known cost.
+    ///
+    /// The service writes the first byte of the body after `SLOW_ANSWER`, which
+    /// is ten times the timeout that the lookup takes, so the lookup gives up
+    /// first. Without the timeout the run waits as long as the service does.
+    ///
+    /// This test names no `Mock::assert`. The client drops the connection when
+    /// it gives up, and the count of requests is of no interest here: the URL
+    /// is the URL of the mock service, so the lookup reached no other one.
+    #[test]
+    fn a_service_that_answers_after_the_timeout_gives_no_address() {
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock(GET, ROOT)
+            .with_status(OK)
+            .with_chunked_body(|writer| {
+                std::thread::sleep(SLOW_ANSWER);
+                writer.write_all(PUBLIC_ADDRESS.as_bytes())
+            })
+            .create();
+        let error = public_address(&server.url(), SHORT_TIMEOUT)
+            .expect_err("the lookup gives up before the service answers");
+        assert!(
+            matches!(error, PublicError::Request { .. }),
+            "a request that runs out of time did not complete: {error}"
+        );
+    }
+
+    /// A service that answers `200` with a page of its own, and not with an
+    /// address, gives no address. The message names the text, so a reader of
+    /// the warning line sees what arrived.
+    #[test]
+    fn a_service_that_answers_with_text_that_is_not_an_address_gives_no_address() {
+        let error =
+            answer_of(OK, NOT_AN_ADDRESS).expect_err("the text of the answer is not an address");
+        assert!(
+            matches!(error, PublicError::Answer { .. }),
+            "the request completed and the answer did not parse: {error}"
+        );
+        assert!(
+            error.to_string().contains(NOT_AN_ADDRESS),
+            "the message names the text that arrived: {error}"
+        );
+    }
+
+    /// A service that answers with a whole page writes that whole page to the
+    /// warning line of the run, unless the message cuts it.
+    ///
+    /// The answer repeats a character of three bytes, so a cut that reads bytes
+    /// lands inside a character and panics. The cut reads characters, so the
+    /// message ends with the ellipsis and the test does not panic.
+    #[test]
+    fn an_answer_that_is_not_an_address_and_holds_many_characters_gives_a_short_message() {
+        let body = LONG_ANSWER_CHARACTER
+            .to_string()
+            .repeat(LONG_ANSWER_LENGTH);
+        let error = answer_of(OK, &body).expect_err("a page of text is not an address");
+        let message = error.to_string();
+        assert!(
+            message.ends_with(ELLIPSIS),
+            "the message cut the answer and said so: {message}"
+        );
+        assert!(
+            message.chars().count() < body.chars().count(),
+            "the message is shorter than the answer: {message}"
+        );
     }
 }

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -260,10 +260,6 @@ pub(crate) struct Discovery {
     ///
     /// `main` writes it to standard error before the display starts. A search
     /// that needed no fallback carries none.
-    #[allow(
-        dead_code,
-        reason = "main() writes this line in the next slice of issue #368"
-    )]
     pub(crate) note: Option<String>,
 }
 

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -194,19 +194,75 @@ const PUBLIC_TIMEOUT: Duration = Duration::from_secs(3);
 ///
 /// A service that answers with a page of HTML, and not with an address, writes
 /// that whole page to the warning line of the run without this limit. Sixty
-/// characters name the service and the trouble, and they fit one line.
+/// characters name the service and the trouble.
+///
+/// These sixty characters are the characters of one line, because [`shorten`]
+/// makes the answer one line before it counts them. A count of the characters
+/// of the raw answer bounds no line: the first sixty characters of a page of
+/// HTML hold three line breaks, so the warning breaks across lines and
+/// [`PUBLIC_FALLBACK`] stands on a line of its own, away from the reason.
 const ANSWER_LIMIT: usize = 60;
 
 /// The character that marks an answer that the message cut.
 const ELLIPSIS: &str = "…";
 
-/// The start of an answer, short enough for one line of a warning.
+/// The character that stands in the place of every run of whitespace.
+const SPACE: char = ' ';
+
+/// The answer as one line, with no character that paints a terminal.
+///
+/// The answer is the text of a remote service, and the warning line goes
+/// straight to the standard error of the user. Two kinds of character
+/// therefore leave the answer here.
+///
+/// Every run of whitespace becomes one space. The line break is the character
+/// that matters most: a page of HTML holds three of them inside its first
+/// sixty characters, so an answer that keeps them breaks the warning across
+/// lines. One space also spends less of [`ANSWER_LIMIT`] than a run of padding
+/// does, so the limit buys words and not whitespace.
+///
+/// Every other control character goes. A line break is a control character and
+/// a whitespace character both, and the rule of the whitespace wins, so a line
+/// break becomes a space and not nothing. The escape character starts every
+/// sequence that paints a terminal, and this walk drops that character alone.
+/// The parameter letters of such a sequence stay as ordinary text. The warning
+/// therefore paints nothing, and the reader still sees what arrived.
+///
+/// The result starts with no space and ends with no space.
+///
+/// The walk reads characters and never bytes, so a character of more than one
+/// byte survives whole. `char::is_whitespace` reads the whole Unicode table,
+/// as [`sanitize`] in this file does, so a space such as U+3000 IDEOGRAPHIC
+/// SPACE collapses as an ASCII space does.
+fn one_line(answer: &str) -> String {
+    let mut cleaned = String::new();
+    let mut space_is_due = false;
+    for character in answer.chars() {
+        if character.is_whitespace() {
+            space_is_due = !cleaned.is_empty();
+        } else if !character.is_control() {
+            if space_is_due {
+                cleaned.push(SPACE);
+                space_is_due = false;
+            }
+            cleaned.push(character);
+        }
+    }
+    cleaned
+}
+
+/// The start of an answer, as one line of a warning.
+///
+/// The answer becomes one line first, and the cut comes second, so
+/// [`ANSWER_LIMIT`] counts the characters of one line and the ellipsis marks a
+/// cut of the cleaned text. [`one_line`] says what the clean takes out.
 ///
 /// The walk reads characters and never bytes, so a character of more than one
 /// byte survives whole. An answer that the walk cut ends with an ellipsis, so a
 /// reader sees that more of it exists.
 fn shorten(answer: &str) -> String {
-    let mut characters = answer.chars();
+    let cleaned = one_line(answer);
+    let mut characters = cleaned.chars();
     let start: String = characters.by_ref().take(ANSWER_LIMIT).collect();
     if characters.next().is_some() {
         format!("{start}{ELLIPSIS}")
@@ -234,7 +290,10 @@ enum PublicError {
     /// The answer is not an address.
     #[error("the public address service answered with text that is not an address: {answer}")]
     Answer {
-        /// The start of the text that the service answered.
+        /// The start of the text that the service answered, as one line.
+        ///
+        /// [`shorten`] makes that one line, so the message of this variant
+        /// stays on the one warning line of the run and paints no terminal.
         answer: String,
     },
     /// The answer is an address of the family that the target is not of.

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -141,13 +141,43 @@ fn egress_address(target: IpAddr) -> std::io::Result<IpAddr> {
     Ok(socket.local_addr()?.ip())
 }
 
-/// The service that answers with the address that the internet sees.
+/// The service that answers with the address that the internet sees, for a
+/// target of IP version 4.
 ///
 /// The service answers a plain GET with the address as text and nothing else,
 /// so the answer needs no parser of a format and the request needs no key of an
 /// account. A service that goes away, or that starts to limit the rate of a
 /// caller, costs this one line to change.
-const PUBLIC_SERVICE: &str = "https://api.ipify.org";
+///
+/// The host holds records of type A only, so the name resolves to an address of
+/// IP version 4 and the request leaves on that family.
+const PUBLIC_SERVICE_V4: &str = "https://api.ipify.org";
+
+/// The service that answers with the address that the internet sees, for a
+/// target of IP version 6.
+///
+/// The host holds records of type AAAA only, so the name resolves to an address
+/// of IP version 6 and the request leaves on that family. It answers the same
+/// plain GET with the address as text, as the service of IP version 4 does.
+#[allow(
+    dead_code,
+    reason = "public_service() picks this in the green half of this fix"
+)]
+const PUBLIC_SERVICE_V6: &str = "https://api6.ipify.org";
+
+/// The service that answers with the address of the family of the target.
+///
+/// A record of one family that carries a source of the other reads as a fault
+/// of the tool, and it derives the file name that the run of the other family
+/// derives, so the pick reads the family of the target and never guesses it.
+///
+/// The pick is a best effort, because it holds only while each host keeps the
+/// records of one family. The check that [`public_address`] makes on the answer
+/// is the guarantee.
+fn public_service(target: IpAddr) -> &'static str {
+    let _ = target;
+    PUBLIC_SERVICE_V4
+}
 
 /// How long the lookup of the public address waits before it gives up.
 ///
@@ -208,6 +238,20 @@ enum PublicError {
         /// The start of the text that the service answered.
         answer: String,
     },
+    /// The answer is an address of the family that the target is not of.
+    #[error(
+        "the public address service answered with {answer}, which is not of the family of {target}"
+    )]
+    #[allow(
+        dead_code,
+        reason = "public_address() raises this in the green half of this fix"
+    )]
+    Family {
+        /// The address that the service answered with.
+        answer: IpAddr,
+        /// The address of the target of the run.
+        target: IpAddr,
+    },
 }
 
 /// The address that the internet sees, from one GET of a public service.
@@ -232,7 +276,8 @@ enum PublicError {
 /// request does not complete inside the timeout, when the service answers with
 /// the status of an error, and when the answer does not read as text. Returns
 /// [`PublicError::Answer`] when the answer is not an address.
-fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicError> {
+fn public_address(service: &str, target: IpAddr, timeout: Duration) -> Result<IpAddr, PublicError> {
+    let _ = target;
     let answer = reqwest::blocking::Client::builder()
         .timeout(timeout)
         .build()
@@ -284,14 +329,14 @@ pub(crate) struct Discovery {
 /// read. A run that names a source raises none of these, and neither does a run
 /// that reads a public address, because neither one opens a socket.
 pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result<Discovery> {
-    discover_at(named, target, PUBLIC_SERVICE, PUBLIC_TIMEOUT)
+    discover_at(named, target, public_service(target), PUBLIC_TIMEOUT)
 }
 
 /// Finds the source address against the service and the timeout of the caller.
 ///
 /// [`discover`] names the service and the timeout of a run. A test names a
 /// service of its own, which runs on this machine, so no test of this module
-/// reaches the service that `PUBLIC_SERVICE` names.
+/// reaches a public address service of the internet.
 ///
 /// # Errors
 ///
@@ -312,7 +357,7 @@ fn discover_at(
             note: None,
         });
     }
-    match public_address(service, timeout) {
+    match public_address(service, target, timeout) {
         Ok(addr) => Ok(Discovery {
             label: SourceLabel {
                 addr,
@@ -334,7 +379,8 @@ fn discover_at(
 mod tests {
     use super::{
         bind_address, derive_name, discover_at, egress_address, output_path, public_address,
-        Discovery, PublicError, ANSWER_LIMIT, ELLIPSIS, PUBLIC_FALLBACK,
+        public_service, Discovery, PublicError, ANSWER_LIMIT, ELLIPSIS, PUBLIC_FALLBACK,
+        PUBLIC_SERVICE_V4, PUBLIC_SERVICE_V6,
     };
     use crate::record::SourceKind;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -527,11 +573,58 @@ mod tests {
         );
     }
 
+    /// The lookup reads the family of the target and never guesses it.
+    ///
+    /// The host of the service of IP version 4 holds records of type A only, so
+    /// a request to it leaves on IP version 4. A run of IP version 6 that asks
+    /// that host reads the address of IP version 4 of the machine, and it
+    /// writes that address into a record that names IP version 6.
+    #[test]
+    fn a_target_of_ip_version_4_asks_the_service_of_that_family() {
+        assert_eq!(public_service(address(SOURCE)), PUBLIC_SERVICE_V4);
+    }
+
+    /// The lookup reads the family of the target and never guesses it.
+    ///
+    /// The host of the service of IP version 6 holds records of type AAAA only,
+    /// so a request to it leaves on IP version 6. This test is pure, so it
+    /// holds on a machine that has turned IP version 6 off.
+    #[test]
+    fn a_target_of_ip_version_6_asks_the_service_of_that_family() {
+        assert_eq!(public_service(address(SOURCE_VERSION_6)), PUBLIC_SERVICE_V6);
+    }
+
+    /// The two families ask two hosts.
+    ///
+    /// One host for both families reads as a pick and is none, and a test of
+    /// each family alone passes when the two constants hold one host. The two
+    /// tests above also pass when the two constants swap, and this one fails
+    /// with them.
+    #[test]
+    fn the_service_of_each_family_is_a_service_of_its_own() {
+        assert_ne!(PUBLIC_SERVICE_V4, PUBLIC_SERVICE_V6);
+    }
+
     /// The address that a mock service answers with.
     ///
     /// 203.0.113.0/24 is TEST-NET-3, which the registries hold for
     /// documentation, so no machine of the internet carries this address.
     const PUBLIC_ADDRESS: &str = "203.0.113.7";
+
+    /// The address of IP version 6 that a mock service answers with.
+    ///
+    /// 2001:db8::/32 is the range that the registries hold for documentation,
+    /// so no machine of the internet carries this address. Every test that
+    /// reads it names a target of IP version 4, so the two families disagree.
+    const PUBLIC_ADDRESS_VERSION_6: &str = "2001:db8::7";
+
+    /// The target of every test that reads the lookup on its own.
+    ///
+    /// The lookup opens no socket, so this address only names a family.
+    /// 198.51.100.0/24 is TEST-NET-2, which the registries hold for
+    /// documentation, so the number tells a reader that it names no machine of
+    /// the internet, and it stands apart from the answers of TEST-NET-3.
+    const TARGET: IpAddr = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
 
     /// The name that the public address and the plain destination derive.
     const PUBLIC_NAME: &str = "203.0.113.7-example.com.jsonl";
@@ -596,18 +689,22 @@ mod tests {
     const LONG_ANSWER_LENGTH: usize = ANSWER_LIMIT * 4;
 
     /// Reads a mock service that answers one GET of its root with a status and
-    /// a body.
+    /// a body, for a target that the caller names.
+    ///
+    /// The target names the family that the answer must be of. A caller that
+    /// names a target of one family and a body of the other reads the check of
+    /// the family.
     ///
     /// `mockito::Server` binds the loopback and asks the operating system for a
     /// port, so two copies of one test that run at the same time take two ports
     /// and never collide. The service is a local one, so no test of the lookup
-    /// reaches the service that `PUBLIC_SERVICE` names.
+    /// reaches a public address service of the internet.
     ///
     /// The guard of the server stays alive until the lookup has its answer, and
     /// the server stops when the guard drops. `Mock::assert` then reads the
     /// count of requests, which proves that the lookup asked the mock service
     /// and asked it once.
-    fn answer_of(status: usize, body: &str) -> Result<IpAddr, PublicError> {
+    fn answer_of(status: usize, body: &str, target: IpAddr) -> Result<IpAddr, PublicError> {
         let mut server = mockito::Server::new();
         let mock = server
             .mock(GET, ROOT)
@@ -615,7 +712,7 @@ mod tests {
             .with_body(body)
             .expect(ONE_REQUEST)
             .create();
-        let found = public_address(&server.url(), TEST_TIMEOUT);
+        let found = public_address(&server.url(), target, TEST_TIMEOUT);
         mock.assert();
         found
     }
@@ -623,7 +720,8 @@ mod tests {
     /// The address that a service which answers at once gives.
     #[test]
     fn a_service_that_answers_with_an_address_gives_that_address() {
-        let found = answer_of(OK, PUBLIC_ADDRESS).expect("the mock service answers an address");
+        let found =
+            answer_of(OK, PUBLIC_ADDRESS, TARGET).expect("the mock service answers an address");
         assert_eq!(found, address(PUBLIC_ADDRESS));
     }
 
@@ -632,7 +730,8 @@ mod tests {
     #[test]
     fn a_service_that_answers_with_an_address_and_whitespace_gives_that_address() {
         let body = format!("  {PUBLIC_ADDRESS}\r\n");
-        let found = answer_of(OK, &body).expect("the answer loses the whitespace of both ends");
+        let found =
+            answer_of(OK, &body, TARGET).expect("the answer loses the whitespace of both ends");
         assert_eq!(found, address(PUBLIC_ADDRESS));
     }
 
@@ -641,7 +740,7 @@ mod tests {
     /// takes that page for an answer.
     #[test]
     fn a_service_that_answers_with_the_status_of_an_error_gives_no_address() {
-        let error = answer_of(SERVER_ERROR, PUBLIC_ADDRESS)
+        let error = answer_of(SERVER_ERROR, PUBLIC_ADDRESS, TARGET)
             .expect_err("the status of an error gives no address");
         assert!(
             matches!(error, PublicError::Request { .. }),
@@ -669,7 +768,7 @@ mod tests {
                 writer.write_all(PUBLIC_ADDRESS.as_bytes())
             })
             .create();
-        let error = public_address(&server.url(), SHORT_TIMEOUT)
+        let error = public_address(&server.url(), TARGET, SHORT_TIMEOUT)
             .expect_err("the lookup gives up before the service answers");
         assert!(
             matches!(error, PublicError::Request { .. }),
@@ -682,8 +781,8 @@ mod tests {
     /// the warning line sees what arrived.
     #[test]
     fn a_service_that_answers_with_text_that_is_not_an_address_gives_no_address() {
-        let error =
-            answer_of(OK, NOT_AN_ADDRESS).expect_err("the text of the answer is not an address");
+        let error = answer_of(OK, NOT_AN_ADDRESS, TARGET)
+            .expect_err("the text of the answer is not an address");
         assert!(
             matches!(error, PublicError::Answer { .. }),
             "the request completed and the answer did not parse: {error}"
@@ -703,7 +802,7 @@ mod tests {
     #[test]
     fn an_answer_that_is_not_an_address_and_holds_many_characters_gives_a_short_message() {
         let body = LONG_ANSWER_CHARACTER.to_string().repeat(LONG_ANSWER_LENGTH);
-        let error = answer_of(OK, &body).expect_err("a page of text is not an address");
+        let error = answer_of(OK, &body, TARGET).expect_err("a page of text is not an address");
         let message = error.to_string();
         assert!(
             message.ends_with(ELLIPSIS),
@@ -712,6 +811,36 @@ mod tests {
         assert!(
             message.chars().count() < body.chars().count(),
             "the message is shorter than the answer: {message}"
+        );
+    }
+
+    /// A service that answers with an address of the other family gives no
+    /// address.
+    ///
+    /// The pick of the host by the family of the target is a best effort, and
+    /// this check is the guarantee. A record of one family that carries a
+    /// source of the other reads as a fault of the tool, and it derives the
+    /// file name that the run of the other family derives, so two traces of two
+    /// families append to one file.
+    ///
+    /// The message names both addresses, because a reader of the warning line
+    /// needs to see which two families disagreed.
+    #[test]
+    fn a_service_that_answers_with_an_address_of_the_other_family_gives_no_address() {
+        let error = answer_of(OK, PUBLIC_ADDRESS_VERSION_6, TARGET)
+            .expect_err("an address of the other family is not the source of this run");
+        assert!(
+            matches!(error, PublicError::Family { .. }),
+            "the answer parses and its family disagrees with the target: {error}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains(PUBLIC_ADDRESS_VERSION_6),
+            "the message names the address that arrived: {message}"
+        );
+        assert!(
+            message.contains(&TARGET.to_string()),
+            "the message names the target of the run: {message}"
         );
     }
 
@@ -729,8 +858,8 @@ mod tests {
     /// address opens a socket of the loopback and touches no network. The mock
     /// service binds the loopback too, and it asks the operating system for a
     /// port, so two copies of one test that run at the same time take two ports
-    /// and never collide. No test of the search reaches the service that
-    /// `PUBLIC_SERVICE` names.
+    /// and never collide. No test of the search reaches a public address
+    /// service of the internet.
     fn search_of(
         named: Option<IpAddr>,
         status: usize,
@@ -817,6 +946,39 @@ mod tests {
         assert!(
             note.contains(NOT_AN_ADDRESS),
             "the note names the reason: {note}"
+        );
+        assert!(
+            note.contains(PUBLIC_FALLBACK),
+            "the note names what the run recorded in its place: {note}"
+        );
+    }
+
+    /// A run that reads an address of the other family falls back to the local
+    /// egress address, and it says why.
+    ///
+    /// The target of this test is the loopback of IP version 4, and the mock
+    /// service answers an address of IP version 6, so the two families
+    /// disagree. The mock service binds the loopback of IP version 4, and the
+    /// check reads the address that arrived and not the address of the
+    /// transport, so the test needs no route of IP version 6.
+    ///
+    /// Without the fallback the run writes an address of one family into a
+    /// record that names the other, and it derives the file name that the run
+    /// of that other family derives.
+    #[test]
+    fn a_service_that_answers_an_address_of_the_other_family_falls_back_and_says_why() {
+        let found = search_of(None, OK, PUBLIC_ADDRESS_VERSION_6, ONE_REQUEST)
+            .expect("every machine holds a loopback route");
+        assert_eq!(found.label.addr, LOOPBACK);
+        assert_eq!(found.label.kind, SourceKind::Local);
+        let note = found.note.expect("a search that fell back carries a note");
+        assert!(
+            note.contains(PUBLIC_ADDRESS_VERSION_6),
+            "the note names the address that arrived: {note}"
+        );
+        assert!(
+            note.contains(&LOOPBACK.to_string()),
+            "the note names the target of the run: {note}"
         );
         assert!(
             note.contains(PUBLIC_FALLBACK),

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -238,9 +238,18 @@ enum PublicError {
     reason = "discover() calls this in the next slice of issue #368; the tests of this module cover it now"
 )]
 fn public_address(service: &str, timeout: Duration) -> Result<IpAddr, PublicError> {
-    let _ = (service, timeout);
-    Err(PublicError::Answer {
-        answer: String::new(),
+    let answer = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .build()
+        .and_then(|client| client.get(service).send())
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .and_then(reqwest::blocking::Response::text)
+        .map_err(|error| PublicError::Request {
+            reason: error.to_string(),
+        })?;
+    let trimmed = answer.trim();
+    trimmed.parse().map_err(|_| PublicError::Answer {
+        answer: shorten(trimmed),
     })
 }
 
@@ -274,11 +283,10 @@ pub(crate) fn discover(named: Option<IpAddr>, target: IpAddr) -> std::io::Result
 #[cfg(test)]
 mod tests {
     use super::{
-        ANSWER_LIMIT, ELLIPSIS, PublicError, bind_address, derive_name, discover, egress_address,
-        output_path, public_address,
+        bind_address, derive_name, discover, egress_address, output_path, public_address,
+        PublicError, ANSWER_LIMIT, ELLIPSIS,
     };
     use crate::record::SourceKind;
-    use std::io::Write;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::path::{Path, PathBuf};
     use std::time::Duration;
@@ -656,9 +664,7 @@ mod tests {
     /// message ends with the ellipsis and the test does not panic.
     #[test]
     fn an_answer_that_is_not_an_address_and_holds_many_characters_gives_a_short_message() {
-        let body = LONG_ANSWER_CHARACTER
-            .to_string()
-            .repeat(LONG_ANSWER_LENGTH);
+        let body = LONG_ANSWER_CHARACTER.to_string().repeat(LONG_ANSWER_LENGTH);
         let error = answer_of(OK, &body).expect_err("a page of text is not an address");
         let message = error.to_string();
         assert!(

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -86,6 +86,15 @@ const AN_IPV4_ADDRESS: &str = "1.2.3.4";
 /// The loopback address of ip version 4. Every machine holds a route to it.
 const LOOPBACK: &str = "127.0.0.1";
 
+/// The flag that names the address the probes leave from.
+///
+/// A run that names no source asks a public service for the address that the
+/// internet sees, and that request reaches the internet. The search takes the
+/// address of this flag at its first step, so it asks no service and opens no
+/// socket. Every test that drives a whole trace therefore names this flag, and
+/// a test that forgets it reaches the internet without saying so.
+const FLAG_SOURCE: &str = "--source";
+
 /// The flag that asks for ip version 6.
 const FLAG_VERSION_6: &str = "-6";
 
@@ -303,12 +312,23 @@ fn temp_path(name: &str) -> PathBuf {
     env::temp_dir().join(format!("{name}-{}-{moment}", process::id()))
 }
 
+/// A recorded file that will not open stops the run, and the run makes no
+/// directory of its own.
+///
+/// `FLAG_SOURCE` is not incidental to what this test covers. It is what keeps
+/// the test offline: the destination is the loopback, so the probes of this
+/// trace leave from the loopback, and the flag hands the search that address at
+/// its first step. Without the flag the run asks a public service for the
+/// address that the internet sees, and every `cargo test` then reaches the
+/// internet.
 #[cfg(target_os = "macos")]
 #[test]
 fn a_recorded_file_that_will_not_open_stops_the_run() {
     let missing = temp_path("krt-no-such-directory");
     let path = missing.join(A_RECORDED_FILE);
     let result = run(&[
+        LOOPBACK,
+        FLAG_SOURCE,
         LOOPBACK,
         "--output",
         path.to_str().expect("the temporary path must be text"),
@@ -331,11 +351,21 @@ fn a_recorded_file_that_will_not_open_stops_the_run() {
     );
 }
 
+/// A TTL that `krt` takes and the tracer refuses stops the run.
+///
+/// `FLAG_SOURCE` is not incidental to what this test covers. It is what keeps
+/// the test offline: the destination is the loopback, so the probes of this
+/// trace leave from the loopback, and the flag hands the search that address at
+/// its first step. Without the flag the run asks a public service for the
+/// address that the internet sees, and every `cargo test` then reaches the
+/// internet.
 #[cfg(target_os = "macos")]
 #[test]
 fn a_ttl_above_what_the_tracer_takes_stops_the_run() {
     let path = temp_path("krt-ttl-above-the-limit");
     let result = run(&[
+        LOOPBACK,
+        FLAG_SOURCE,
         LOOPBACK,
         "--max-ttl",
         TTL_ABOVE_THE_TRACER,


### PR DESCRIPTION
Closes #368.

`krt` now names the source by where the machine sits on the internet, not by where it sits on the LAN.

## What changed

`krt` picks the source label in this order:

1. The `--source` value, when given. The `run` record marks the source `"kind":"override"`.
2. One HTTPS GET to a public IP service at startup, with a 3-second timeout. A success marks the source `"kind":"public"`.
3. The local egress address. A fallback marks the source `"kind":"local"`.

A failed, slow, or refused lookup does not stop the run. The tool falls back to the local egress address and prints one warning line before the display starts. The warning prints once for each run, never once for each round.

The service URL is a named constant, so a service that goes away costs one line to change.

The HTTPS GET uses the blocking client of `reqwest`. The client keeps its `tokio` runtime private and drops it when the call returns, so `krt` starts no runtime of its own and stays free of async code. The `blocking` feature is local to the `krt` manifest, because cargo features are additive.

The derived filename uses whichever source label wins.

## Tests

No test reaches the real service. The tests drive a local `mockito` server, and they cover a success, a timeout, and an error status. Every temporary path keys on the process id plus a nanosecond timestamp, and the mock server binds a port that the operating system assigns.

Every step went red first, then green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
