### PR TITLE
feat(krt): the aggregate fold over rounds

### DIFF
--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -913,10 +913,10 @@ fn time_fields(stats: &stats::HopStats) -> [String; 6] {
 /// The host field of the line of one TTL.
 ///
 /// The field names the address that the TTL first answered from. A TTL that
-/// answered from more addresses adds the count of the other ones, so the line
-/// of a TTL stays one line however many routers answer at it. The line of each
-/// address then carries the numbers of that address. A TTL that never answered
-/// names no host.
+/// answered from more addresses adds the count of the other ones it tracks, so
+/// the line of a TTL stays one line however many routers answer at it. The line
+/// of each address then carries the numbers of that address. A TTL that never
+/// answered names no host.
 fn host_of(row: &stats::TtlRow) -> String {
     let others = row.addresses().len().saturating_sub(1);
     let Some(first) = row.addresses().next() else {
@@ -933,6 +933,12 @@ fn host_of(row: &stats::TtlRow) -> String {
 /// The line holds the TTL, the host, the loss, the count of the probes, the
 /// count of the answers, and the six round-trip times. A TTL that no round
 /// probed holds no loss, and the field then takes the word of an absent number.
+///
+/// A TTL that answered from more addresses than it tracks ends the line with
+/// the count of the answers that no tracked address holds. The shares of the
+/// printed addresses of such a TTL sum to less than the whole, and this field
+/// is what names the rest of it. A TTL that tracks every address that answered
+/// prints no such field, so the line of that TTL reads as it always did.
 fn ttl_line(row: &stats::TtlRow) -> String {
     let loss = row
         .loss()
@@ -945,6 +951,9 @@ fn ttl_line(row: &stats::TtlRow) -> String {
         format!("{RECV} {}", row.stats().recv()),
     ];
     fields.extend(time_fields(row.stats()));
+    if row.untracked() > 0 {
+        fields.push(format!("{UNTRACKED} {}", row.untracked()));
+    }
     format!("{TTL_INDENT}{}", fields.join(SUMMARY_SEPARATOR))
 }
 
@@ -955,6 +964,9 @@ fn ttl_line(row: &stats::TtlRow) -> String {
 /// them. The line carries no count of the probes, because a probe reaches a
 /// TTL and not a router: the run asks the TTL, and whichever router answers
 /// takes that answer.
+///
+/// An address that its TTL does not track takes no line, and the `UNTRACKED`
+/// field of the line of that TTL counts the answers of every such address.
 fn address_line(address: stats::Address<'_>) -> String {
     let mut fields = vec![
         address.addr().to_string(),
@@ -968,8 +980,9 @@ fn address_line(address: stats::Address<'_>) -> String {
 /// The lines that a replay prints for the aggregate of one run.
 ///
 /// One line holds one TTL of the path, in TTL order. A TTL that saw more than
-/// one address adds one line for each of those addresses, under the line of
-/// the TTL. Two spaces separate the fields, as they do on the summary line.
+/// one address adds one line for each of the addresses it tracks, under the
+/// line of the TTL, so a TTL of any number of routers prints a bounded number
+/// of lines. Two spaces separate the fields, as they do on the summary line.
 ///
 /// The design puts the fold in `stats.rs` and the render in `ui.rs`. This
 /// slice builds no `ui.rs`, so the render lives here. A later slice replaces
@@ -2751,7 +2764,8 @@ resolved configuration:
     /// The address of the other router of a TTL that two of them answer at.
     const ANOTHER_ROUTER: &str = "10.0.0.2";
 
-    /// The whole of a percentage, for the sum of the shares of one TTL.
+    /// The whole of a percentage, for the sum of the shares of one TTL that
+    /// tracks every address that answered at it.
     const WHOLE_PERCENT: f64 = 100.0;
 
     /// The largest difference that a comparison of two percentages admits.

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -2912,10 +2912,24 @@ resolved configuration:
         );
     }
 
-    /// A run that folded nothing prints nothing.
+    /// A run that folded nothing prints nothing, and a run that folded one
+    /// round prints a line.
+    ///
+    /// The second half is what gives the first half meaning. A render that
+    /// returned no line for every table, folded or not, would satisfy the
+    /// empty case on its own, so the empty case is pinned here against a table
+    /// that does print.
     #[test]
-    fn an_empty_table_prints_no_line() {
-        assert!(aggregate_lines(&HopTable::new()).is_empty());
+    fn only_an_empty_table_prints_no_line() {
+        assert!(
+            aggregate_lines(&HopTable::new()).is_empty(),
+            "a table that folded no round holds no TTL to print"
+        );
+        let folded = lines_of(&[round(1, 1, &[(1, ONE_ROUTER, 10.0)])]);
+        assert!(
+            !folded.is_empty(),
+            "a table that folded one round prints the TTL of it: {folded:?}"
+        );
     }
 
     /// The number of routers that answer at one TTL of the crowded run.

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -851,8 +851,8 @@ fn counted(count: usize, name: &str) -> String {
 /// below the length of the path.
 ///
 /// The design puts the fold in `stats.rs` and the render in `ui.rs`. This
-/// slice builds neither module, so the summary lives here. A later slice
-/// replaces this line with the aggregate table.
+/// slice builds no `ui.rs`, so the summary lives here. A later slice replaces
+/// this line with the aggregate table.
 fn summarize(run: &Run<'_>) -> String {
     let target = run.start().map_or_else(
         || UNKNOWN.to_owned(),

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -15,6 +15,7 @@
 mod record;
 mod run;
 mod source;
+mod stats;
 mod trace;
 
 use buildinfo::version_string;

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -868,6 +868,94 @@ fn summarize(run: &Run<'_>) -> String {
     .join(SUMMARY_SEPARATOR)
 }
 
+/// Writes one round-trip time, to `DECIMALS` decimal places.
+///
+/// A key that holds no such time takes one word in its place. A TTL that
+/// answered no probe holds none of the times, and a key of one answer holds no
+/// jitter.
+fn render_time(value: Option<f64>) -> String {
+    value.map_or_else(
+        || NO_NUMBER.to_owned(),
+        |value| format!("{value:.DECIMALS$}"),
+    )
+}
+
+/// Writes one percentage, to `DECIMALS` decimal places.
+fn render_percent(value: f64) -> String {
+    format!("{value:.DECIMALS$}{PERCENT_SIGN}")
+}
+
+/// The six round-trip time fields that end the line of one TTL and the line of
+/// one address.
+///
+/// Both lines carry the same six times, in the same order, so a reader compares
+/// one address against the whole of its TTL by column.
+fn time_fields(stats: &stats::HopStats) -> [String; 6] {
+    [
+        format!("{LAST} {}", render_time(stats.last())),
+        format!("{MIN} {}", render_time(stats.min())),
+        format!("{AVG} {}", render_time(stats.avg())),
+        format!("{MAX} {}", render_time(stats.max())),
+        format!("{STDDEV} {}", render_time(stats.stddev())),
+        format!("{JITTER} {}", render_time(stats.jitter())),
+    ]
+}
+
+/// The host field of the line of one TTL.
+///
+/// The field names the address that the TTL first answered from. A TTL that
+/// answered from more addresses adds the count of the other ones, so the line
+/// of a TTL stays one line however many routers answer at it. The line of each
+/// address then carries the numbers of that address. A TTL that never answered
+/// names no host.
+fn host_of(row: &stats::TtlRow) -> String {
+    let others = row.addresses().len().saturating_sub(1);
+    let Some(first) = row.addresses().next() else {
+        return NO_HOST.to_owned();
+    };
+    if others == 0 {
+        return first.addr().to_string();
+    }
+    format!("{} (+{others})", first.addr())
+}
+
+/// Writes the line of one TTL of the path.
+///
+/// The line holds the TTL, the host, the loss, the count of the probes, the
+/// count of the answers, and the six round-trip times. A TTL that no round
+/// probed holds no loss, and the field then takes the word of an absent number.
+fn ttl_line(row: &stats::TtlRow) -> String {
+    let loss = row
+        .loss()
+        .map_or_else(|| NO_NUMBER.to_owned(), render_percent);
+    let mut fields = vec![
+        row.ttl().to_string(),
+        host_of(row),
+        format!("{LOSS} {loss}"),
+        format!("{SENT} {}", row.sent()),
+        format!("{RECV} {}", row.stats().recv()),
+    ];
+    fields.extend(time_fields(row.stats()));
+    format!("{TTL_INDENT}{}", fields.join(SUMMARY_SEPARATOR))
+}
+
+/// Writes the line of one address of a TTL.
+///
+/// The line holds the address, the share of the answers of the TTL that the
+/// address took, the count of those answers, and the six round-trip times of
+/// them. The line carries no count of the probes, because a probe reaches a
+/// TTL and not a router: the run asks the TTL, and whichever router answers
+/// takes that answer.
+fn address_line(address: stats::Address<'_>) -> String {
+    let mut fields = vec![
+        address.addr().to_string(),
+        format!("{SHARE} {}", render_percent(address.share())),
+        format!("{RECV} {}", address.stats().recv()),
+    ];
+    fields.extend(time_fields(address.stats()));
+    format!("{ADDRESS_INDENT}{}", fields.join(SUMMARY_SEPARATOR))
+}
+
 /// The lines that a replay prints for the aggregate of one run.
 ///
 /// One line holds one TTL of the path, in TTL order. A TTL that saw more than
@@ -877,8 +965,17 @@ fn summarize(run: &Run<'_>) -> String {
 /// The design puts the fold in `stats.rs` and the render in `ui.rs`. This
 /// slice builds no `ui.rs`, so the render lives here. A later slice replaces
 /// these lines with the aggregate table.
-fn aggregate_lines(_table: &stats::HopTable) -> Vec<String> {
-    Vec::new()
+fn aggregate_lines(table: &stats::HopTable) -> Vec<String> {
+    let mut lines = Vec::new();
+    for row in table.rows() {
+        lines.push(ttl_line(row));
+        // The one address of a TTL is already the host of the line of that
+        // TTL, and a second line of the same numbers tells a reader nothing.
+        if row.addresses().len() > 1 {
+            lines.extend(row.addresses().map(address_line));
+        }
+    }
+    lines
 }
 
 /// Writes the reason of a file that holds no run to fold.

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -4,9 +4,9 @@
 //! A command line that names a destination prints the configuration that it
 //! resolved, opens the recorded file, starts the tracer, and appends one record
 //! for each round until a limit stops the run. It prints one status line for
-//! each round. The `replay` command reads a recorded file and prints one
-//! summary line for one run of it. A later slice replaces the status lines with
-//! the live table.
+//! each round. The `replay` command reads a recorded file, prints one summary
+//! line for one run of it, and prints the aggregate numbers of that run under
+//! it. A later slice replaces the status lines with the live table.
 
 // Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -522,7 +522,7 @@ impl Cli {
 /// The block names no `replay` and no `run`. `main` prints the block only when
 /// the command line names no `replay`, and `resolve` fills the run only inside
 /// a `replay`, so neither field can reach the block with a value. A replay
-/// prints its own summary line in the place of the block.
+/// prints its own summary line and aggregate in the place of the block.
 impl fmt::Display for ResolvedConfig {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let path_or = |path: Option<&PathBuf>, absent: &str| {
@@ -2353,8 +2353,8 @@ resolved configuration:
     ///
     /// `main` prints the block only when the command line names no `replay`,
     /// and `resolve` fills the run only inside a `replay`, so neither field can
-    /// reach the block with a value. A replay prints its own summary line in
-    /// the place of the block.
+    /// reach the block with a value. A replay prints its own summary line and
+    /// aggregate in the place of the block.
     #[test]
     fn the_block_names_neither_the_replay_nor_the_run() {
         let config = resolve(&[

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -145,6 +145,63 @@ const REACHED: &str = "reached";
 /// The last field of a summary line, when no round reached the target.
 const NEVER_REACHED: &str = "never reached";
 
+/// The text that starts the line of one TTL of the aggregate.
+const TTL_INDENT: &str = "  ";
+
+/// The text that starts the line of one address of a TTL.
+///
+/// The line of an address stands under the line of its TTL, so a reader tells
+/// the two apart by the width of the indent alone.
+const ADDRESS_INDENT: &str = "      ";
+
+/// The name of the field that holds the loss of one TTL, as a percentage.
+const LOSS: &str = "loss";
+
+/// The name of the field that holds the share of one address, as a percentage.
+///
+/// A TTL carries a loss and an address carries a share, and the two words
+/// differ because the two measures differ. Two routers that split the traffic
+/// of one TTL evenly each answer half of the probes of that TTL, and a loss per
+/// address would report 50 percent for a pair that loses nothing.
+const SHARE: &str = "share";
+
+/// The name of the field that counts the probes of one TTL.
+const SENT: &str = "sent";
+
+/// The name of the field that counts the answers.
+const RECV: &str = "recv";
+
+/// The name of the field that holds the most recent round-trip time.
+const LAST: &str = "last";
+
+/// The name of the field that holds the smallest round-trip time.
+const MIN: &str = "min";
+
+/// The name of the field that holds the mean round-trip time.
+const AVG: &str = "avg";
+
+/// The name of the field that holds the largest round-trip time.
+const MAX: &str = "max";
+
+/// The name of the field that holds the standard deviation of the round-trip
+/// times.
+const STDDEV: &str = "stddev";
+
+/// The name of the field that holds the jitter.
+const JITTER: &str = "jitter";
+
+/// The host of a TTL that never answered.
+const NO_HOST: &str = "???";
+
+/// The value of a number that the run holds none of.
+const NO_NUMBER: &str = "-";
+
+/// The sign that ends a percentage.
+const PERCENT_SIGN: &str = "%";
+
+/// The number of decimal places of every round-trip time and every percentage.
+const DECIMALS: usize = 1;
+
 /// The reason of a file that holds no run.
 ///
 /// A file that holds no run at all stops the message here. A `--run` that names
@@ -811,6 +868,19 @@ fn summarize(run: &Run<'_>) -> String {
     .join(SUMMARY_SEPARATOR)
 }
 
+/// The lines that a replay prints for the aggregate of one run.
+///
+/// One line holds one TTL of the path, in TTL order. A TTL that saw more than
+/// one address adds one line for each of those addresses, under the line of
+/// the TTL. Two spaces separate the fields, as they do on the summary line.
+///
+/// The design puts the fold in `stats.rs` and the render in `ui.rs`. This
+/// slice builds no `ui.rs`, so the render lives here. A later slice replaces
+/// these lines with the aggregate table.
+fn aggregate_lines(_table: &stats::HopTable) -> Vec<String> {
+    Vec::new()
+}
+
 /// Writes the reason of a file that holds no run to fold.
 ///
 /// A `--run` that names a run the file does not hold adds that identifier and
@@ -864,7 +934,16 @@ fn replay(path: &Path, wanted: Option<&str>) -> Replay {
         None => recording.last_run(),
     };
     let outcome = match found {
-        Some(run) => Ok(summarize(&run)),
+        Some(run) => {
+            let mut table = stats::HopTable::new();
+            for round in run.rounds() {
+                table.observe(round);
+            }
+            Ok(Folded {
+                summary: summarize(&run),
+                aggregate: aggregate_lines(&table),
+            })
+        }
         None => Err(no_run_message(path, wanted, &recording.run_ids())),
     };
     Replay { warning, outcome }
@@ -874,8 +953,19 @@ fn replay(path: &Path, wanted: Option<&str>) -> Replay {
 struct Replay {
     /// The warning about the file, when the file holds a cut final line.
     warning: Option<String>,
-    /// The one line that names the run, or the reason that no run folds.
-    outcome: Result<String, String>,
+    /// What the replay folded, or the reason that no run folds.
+    outcome: Result<Folded, String>,
+}
+
+/// What a replay folded out of one run.
+///
+/// The summary and the aggregate travel together, so one replay reads the file
+/// once and every line of the answer comes from the same run.
+struct Folded {
+    /// The one line that names the run.
+    summary: String,
+    /// The lines of the aggregate of the run.
+    aggregate: Vec<String>,
 }
 
 /// The fault that stopped a trace, and the code that names its kind.
@@ -1109,7 +1199,13 @@ fn main() {
         eprintln!("{PROGRAM}: {warning}");
     }
     match result.outcome {
-        Ok(summary) => println!("{summary}"),
+        Ok(folded) => {
+            // The summary names the run, and the aggregate stands under it.
+            println!("{}", folded.summary);
+            for line in folded.aggregate {
+                println!("{line}");
+            }
+        }
         Err(reason) => {
             eprintln!("{PROGRAM}: {reason}");
             std::process::exit(EXIT_FAILURE);
@@ -1120,13 +1216,17 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        closing_line, host_name_or, parse_duration, pick_address, render_duration, resolve_target,
-        source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family,
-        Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT,
-        SOURCE_FALLBACK, UNKNOWN,
+        aggregate_lines, closing_line, host_name_or, parse_duration, pick_address, render_duration,
+        resolve_target, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command,
+        EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind,
+        SourceLabel, ADDRESS_INDENT, PERCENT_SIGN, RESOLVE_PORT, SHARE, SOURCE_FALLBACK,
+        SUMMARY_SEPARATOR, UNKNOWN,
     };
+    use crate::record::{Hop, RoundRecord, RunId, TtlRange};
     use crate::run::Outcome;
     use crate::source::Discovery;
+    use crate::stats::HopTable;
+    use chrono::{DateTime, Utc};
     use clap::error::{ContextKind, ContextValue, ErrorKind};
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -2525,5 +2625,176 @@ resolved configuration:
             warning.contains(SOURCE_FALLBACK),
             "the warning names what the run recorded in its place: {warning}"
         );
+    }
+
+    /// The identifier of the run of every round of an aggregate test.
+    const AGGREGATE_RUN: &str = "2026-08-20T00:00:00.000Z";
+
+    /// The moment of every round of an aggregate test.
+    const AGGREGATE_MOMENT: &str = "2026-08-20T00:00:01.000Z";
+
+    /// The time that every round of an aggregate test took, in milliseconds.
+    const AGGREGATE_DURATION: u64 = 1000;
+
+    /// The name of the ICMP message of every hop of an aggregate test.
+    const TIME_EXCEEDED: &str = "time_exceeded";
+
+    /// The address of the router that answers first at a TTL.
+    const ONE_ROUTER: &str = "10.0.0.1";
+
+    /// The address of the other router of a TTL that two of them answer at.
+    const ANOTHER_ROUTER: &str = "10.0.0.2";
+
+    /// The whole of a percentage, for the sum of the shares of one TTL.
+    const WHOLE_PERCENT: f64 = 100.0;
+
+    /// The largest difference that a comparison of two percentages admits.
+    ///
+    /// The two shares of this test are 33.3 and 66.7, which sum to exactly 100
+    /// in decimal. A read of each printed decimal into a number with a
+    /// fraction loses a little. The sum then misses the whole by about 1e-14,
+    /// and this tolerance covers that loss. A pair of shares that rounds the
+    /// other way misses the whole by a tenth, and this test names no such
+    /// pair.
+    const PERCENT_TOLERANCE: f64 = 1e-9;
+
+    /// One round that probed the TTLs of the range, and that the named hops
+    /// answered.
+    ///
+    /// Each hop is a TTL, the address that answered at it, and the round-trip
+    /// time of that answer.
+    fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecord {
+        RoundRecord {
+            run: RunId::from(AGGREGATE_RUN),
+            seq: 1,
+            ts: DateTime::parse_from_rfc3339(AGGREGATE_MOMENT)
+                .expect("the test moment must parse")
+                .with_timezone(&Utc),
+            dur_ms: AGGREGATE_DURATION,
+            ttl_range: TtlRange::new(first, last).expect("the test range must hold"),
+            reached: false,
+            hops: hops
+                .iter()
+                .map(|(ttl, addr, rtt_ms)| Hop {
+                    ttl: *ttl,
+                    addr: address(addr),
+                    rtt_ms: *rtt_ms,
+                    icmp: TIME_EXCEEDED.to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The lines of the aggregate of every round, in one table.
+    fn lines_of(rounds: &[RoundRecord]) -> Vec<String> {
+        let mut table = HopTable::new();
+        for round in rounds {
+            table.observe(round);
+        }
+        aggregate_lines(&table)
+    }
+
+    /// Reads the share that one address line printed.
+    fn share_of(line: &str) -> f64 {
+        let prefix = format!("{SHARE} ");
+        let field = line
+            .split(SUMMARY_SEPARATOR)
+            .find_map(|field| field.strip_prefix(&prefix))
+            .unwrap_or_else(|| panic!("an address line holds a share field: {line}"));
+        field
+            .strip_suffix(PERCENT_SIGN)
+            .unwrap_or_else(|| panic!("a share ends with the percent sign: {line}"))
+            .parse()
+            .unwrap_or_else(|_| panic!("a share reads as a number: {line}"))
+    }
+
+    /// A TTL that answered every round loses nothing.
+    ///
+    /// The two answers are 10.0 and 20.0. The sum is 30.0, so the mean is
+    /// 30 / 2 = 15.0. The distances from the mean are -5.0 and 5.0, and the
+    /// squares of them sum to 50.0. The population variance is 50 / 2 = 25.0,
+    /// so the standard deviation is 5.0. The jitter is the absolute difference
+    /// of the last two answers, which is 10.0.
+    #[test]
+    fn a_ttl_that_answered_every_round_prints_no_loss_and_every_number() {
+        let lines = lines_of(&[
+            round(1, 1, &[(1, ONE_ROUTER, 10.0)]),
+            round(1, 1, &[(1, ONE_ROUTER, 20.0)]),
+        ]);
+        assert_eq!(
+            lines,
+            ["  1  10.0.0.1  loss 0.0%  sent 2  recv 2  last 20.0  min 10.0  avg 15.0  max 20.0  stddev 5.0  jitter 10.0"]
+        );
+    }
+
+    /// A TTL that never answered names no host and holds no number.
+    ///
+    /// Both rounds probed TTL 2 and neither one answered at it, so the loss is
+    /// 2 / 2 * 100 = 100.0 percent.
+    #[test]
+    fn a_ttl_that_never_answered_prints_no_host_and_no_number() {
+        let lines = lines_of(&[
+            round(1, 2, &[(1, ONE_ROUTER, 10.0)]),
+            round(1, 2, &[(1, ONE_ROUTER, 20.0)]),
+        ]);
+        assert_eq!(lines.len(), 2, "two TTLs took a probe: {lines:?}");
+        assert_eq!(
+            lines[1],
+            "  2  ???  loss 100.0%  sent 2  recv 0  last -  min -  avg -  max -  stddev -  jitter -"
+        );
+    }
+
+    /// One address is the host of the TTL line, so it takes no line of its own.
+    #[test]
+    fn a_ttl_of_one_address_prints_no_address_line() {
+        let lines = lines_of(&[round(1, 1, &[(1, ONE_ROUTER, 10.0)])]);
+        assert_eq!(lines.len(), 1, "one TTL is one line: {lines:?}");
+        assert!(
+            !lines[0].starts_with(ADDRESS_INDENT),
+            "the one line is the line of the TTL: {lines:?}"
+        );
+    }
+
+    /// A TTL that two routers answer at names both of them.
+    ///
+    /// The first router answers one round of the three, and the second router
+    /// answers the other two. The shares are therefore 1 / 3 * 100 = 33.3 and
+    /// 2 / 3 * 100 = 66.7 percent, to one decimal place.
+    ///
+    /// The three answers of the TTL are 10.0, 20.0, and 30.0. The sum is 60.0,
+    /// so the mean is 60 / 3 = 20.0. The distances from the mean are -10.0,
+    /// 0.0, and 10.0, and the squares of them sum to 200.0. The population
+    /// variance is 200 / 3 = 66.667, so the standard deviation is 8.165, which
+    /// prints as 8.2.
+    ///
+    /// The second router answered 20.0 and 30.0. The mean of the two is 25.0,
+    /// the distances are -5.0 and 5.0, and the squares sum to 50.0. The
+    /// variance is 50 / 2 = 25.0, so the standard deviation is 5.0.
+    #[test]
+    fn a_ttl_of_two_addresses_prints_one_line_for_each_of_them() {
+        let lines = lines_of(&[
+            round(1, 1, &[(1, ONE_ROUTER, 10.0)]),
+            round(1, 1, &[(1, ANOTHER_ROUTER, 20.0)]),
+            round(1, 1, &[(1, ANOTHER_ROUTER, 30.0)]),
+        ]);
+        assert_eq!(
+            lines,
+            [
+                "  1  10.0.0.1 (+1)  loss 0.0%  sent 3  recv 3  last 30.0  min 10.0  avg 20.0  max 30.0  stddev 8.2  jitter 10.0",
+                "      10.0.0.1  share 33.3%  recv 1  last 10.0  min 10.0  avg 10.0  max 10.0  stddev 0.0  jitter -",
+                "      10.0.0.2  share 66.7%  recv 2  last 30.0  min 20.0  avg 25.0  max 30.0  stddev 5.0  jitter 10.0",
+            ]
+        );
+        let total = share_of(&lines[1]) + share_of(&lines[2]);
+        assert!(
+            (total - WHOLE_PERCENT).abs() < PERCENT_TOLERANCE,
+            "the printed shares of one TTL sum to {WHOLE_PERCENT}, and they sum to {total}"
+        );
+    }
+
+    /// A run that folded nothing prints nothing.
+    #[test]
+    fn an_empty_table_prints_no_line() {
+        assert!(aggregate_lines(&HopTable::new()).is_empty());
     }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -190,6 +190,15 @@ const STDDEV: &str = "stddev";
 /// The name of the field that holds the jitter.
 const JITTER: &str = "jitter";
 
+/// The name of the field that counts the answers of one TTL that no tracked
+/// address holds.
+///
+/// One TTL keeps an entry for a bounded number of addresses, so a TTL that
+/// answered from more of them prints this field and no line for the addresses
+/// past that bound. Without the field, the shares of the printed addresses sum
+/// to less than the whole and nothing on the line says why.
+const UNTRACKED: &str = "untracked";
+
 /// The host of a TTL that never answered.
 const NO_HOST: &str = "???";
 
@@ -1317,7 +1326,7 @@ mod tests {
         resolve_target, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command,
         EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind,
         SourceLabel, ADDRESS_INDENT, PERCENT_SIGN, RESOLVE_PORT, SHARE, SOURCE_FALLBACK,
-        SUMMARY_SEPARATOR, UNKNOWN,
+        SUMMARY_SEPARATOR, UNKNOWN, UNTRACKED,
     };
     use crate::record::{Hop, RoundRecord, RunId, TtlRange};
     use crate::run::Outcome;
@@ -2893,5 +2902,73 @@ resolved configuration:
     #[test]
     fn an_empty_table_prints_no_line() {
         assert!(aggregate_lines(&HopTable::new()).is_empty());
+    }
+
+    /// The number of routers that answer at one TTL of the crowded run.
+    ///
+    /// The count stands above the number of addresses that one TTL tracks, so
+    /// the row of that TTL counts the answers it keeps no entry for.
+    const MANY_ROUTERS: u32 = 40;
+
+    /// The round-trip time of every answer of the crowded run.
+    ///
+    /// One time for every answer makes every number of the TTL line that time,
+    /// so the line stays hand-computed however many routers answer.
+    const SAME_RTT: f64 = 10.0;
+
+    /// The lines that the crowded run prints.
+    ///
+    /// The line of the TTL stands first, and one line for each of the 32
+    /// tracked addresses stands under it, so 1 + 32 = 33 lines.
+    const CROWDED_LINES: usize = 33;
+
+    /// One round for each router of a TTL that answers from more routers than
+    /// it tracks.
+    ///
+    /// The addresses run upward from `10.0.0.1`, one for each round, and every
+    /// answer carries the same round-trip time.
+    fn crowded_rounds() -> Vec<RoundRecord> {
+        (1..=MANY_ROUTERS)
+            .map(|host| round(1, 1, &[(1, &format!("10.0.0.{host}"), SAME_RTT)]))
+            .collect()
+    }
+
+    /// A TTL that answered from more routers than it tracks names the answers
+    /// that no tracked address holds.
+    ///
+    /// Each of the 40 rounds probed TTL 1 and answered from a router of its
+    /// own, so the loss is 0 / 40 * 100 = 0.0 percent. The row tracks 32 of the
+    /// 40 addresses, so the host names the first one and the other 31 tracked
+    /// ones, and 40 - 32 = 8 answers hold no tracked address. Every answer is
+    /// 10.0, so the last, the smallest, the mean, and the largest are all 10.0,
+    /// the deviation is 0.0, and the jitter is |10.0 - 10.0| = 0.0.
+    #[test]
+    fn a_ttl_past_the_tracked_addresses_prints_the_untracked_answers() {
+        let lines = lines_of(&crowded_rounds());
+        assert_eq!(
+            lines.len(),
+            CROWDED_LINES,
+            "the line of the TTL and one line for each tracked address: {lines:?}"
+        );
+        assert_eq!(
+            lines[0],
+            "  1  10.0.0.1 (+31)  loss 0.0%  sent 40  recv 40  last 10.0  min 10.0  avg 10.0  max 10.0  stddev 0.0  jitter 0.0  untracked 8"
+        );
+    }
+
+    /// A TTL that tracks every router that answered at it names no untracked
+    /// answer, so the line of the common case reads as it always did.
+    #[test]
+    fn a_ttl_below_the_tracked_addresses_prints_no_untracked_field() {
+        let lines = lines_of(&[
+            round(1, 1, &[(1, ONE_ROUTER, 10.0)]),
+            round(1, 1, &[(1, ANOTHER_ROUTER, 20.0)]),
+        ]);
+        for line in &lines {
+            assert!(
+                !line.contains(UNTRACKED),
+                "the TTL tracks both of its routers, so no line names an untracked answer: {line}"
+            );
+        }
     }
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -16,6 +16,8 @@ mod record;
 mod run;
 mod source;
 mod stats;
+#[cfg(test)]
+mod testing;
 mod trace;
 
 use buildinfo::version_string;
@@ -1341,11 +1343,11 @@ mod tests {
         SourceLabel, ADDRESS_INDENT, PERCENT_SIGN, RESOLVE_PORT, SHARE, SOURCE_FALLBACK,
         SUMMARY_SEPARATOR, UNKNOWN, UNTRACKED,
     };
-    use crate::record::{Hop, RoundRecord, RunId, TtlRange};
+    use crate::record::RoundRecord;
     use crate::run::Outcome;
     use crate::source::Discovery;
     use crate::stats::HopTable;
-    use chrono::{DateTime, Utc};
+    use crate::testing::{address, round};
     use clap::error::{ContextKind, ContextValue, ErrorKind};
     use clap::{CommandFactory, Parser};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -2397,18 +2399,13 @@ resolved configuration:
         AddressFamily::Version6,
     ];
 
-    /// Reads a literal address that a test names.
+    /// Builds the socket address of one literal address that a test names.
     ///
     /// Every test of the resolution names a literal address. `to_socket_addrs`
     /// reads a literal address inside the machine and asks no resolver, so
     /// every such test runs offline. A host name in the place of a literal
     /// reaches a name server, and the test then answers for the network of the
     /// machine and not for this code.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
-    }
-
-    /// Builds the socket address of one literal address that a test names.
     fn socket(text: &str) -> SocketAddr {
         SocketAddr::new(address(text), RESOLVE_PORT)
     }
@@ -2746,18 +2743,6 @@ resolved configuration:
         );
     }
 
-    /// The identifier of the run of every round of an aggregate test.
-    const AGGREGATE_RUN: &str = "2026-08-20T00:00:00.000Z";
-
-    /// The moment of every round of an aggregate test.
-    const AGGREGATE_MOMENT: &str = "2026-08-20T00:00:01.000Z";
-
-    /// The time that every round of an aggregate test took, in milliseconds.
-    const AGGREGATE_DURATION: u64 = 1000;
-
-    /// The name of the ICMP message of every hop of an aggregate test.
-    const TIME_EXCEEDED: &str = "time_exceeded";
-
     /// The address of the router that answers first at a TTL.
     const ONE_ROUTER: &str = "10.0.0.1";
 
@@ -2777,33 +2762,6 @@ resolved configuration:
     /// other way misses the whole by a tenth, and this test names no such
     /// pair.
     const PERCENT_TOLERANCE: f64 = 1e-9;
-
-    /// One round that probed the TTLs of the range, and that the named hops
-    /// answered.
-    ///
-    /// Each hop is a TTL, the address that answered at it, and the round-trip
-    /// time of that answer.
-    fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecord {
-        RoundRecord {
-            run: RunId::from(AGGREGATE_RUN),
-            seq: 1,
-            ts: DateTime::parse_from_rfc3339(AGGREGATE_MOMENT)
-                .expect("the test moment must parse")
-                .with_timezone(&Utc),
-            dur_ms: AGGREGATE_DURATION,
-            ttl_range: TtlRange::new(first, last).expect("the test range must hold"),
-            reached: false,
-            hops: hops
-                .iter()
-                .map(|(ttl, addr, rtt_ms)| Hop {
-                    ttl: *ttl,
-                    addr: address(addr),
-                    rtt_ms: *rtt_ms,
-                    icmp: TIME_EXCEEDED.to_owned(),
-                })
-                .collect(),
-        }
-    }
 
     /// The lines of the aggregate of every round, in one table.
     fn lines_of(rounds: &[RoundRecord]) -> Vec<String> {

--- a/src/krt/src/record.rs
+++ b/src/krt/src/record.rs
@@ -766,10 +766,10 @@ mod tests {
         RoundRecord, Run, RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange,
         Writer,
     };
+    use crate::testing::address;
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::fs;
-    use std::net::IpAddr;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -836,11 +836,6 @@ mod tests {
 
     /// Two bytes that no UTF-8 text holds.
     const NOT_TEXT: [u8; 2] = [0xff, 0xfe];
-
-    /// Reads an address that a test names.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
-    }
 
     /// Reads a moment that a test names, and converts it to UTC.
     fn moment(text: &str) -> DateTime<Utc> {

--- a/src/krt/src/record.rs
+++ b/src/krt/src/record.rs
@@ -357,18 +357,6 @@ impl TtlRange {
     pub(crate) fn last(self) -> u8 {
         self.last
     }
-
-    /// True when the round probed this TTL.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the aggregate fold walks the range from its first TTL to its last one, so no caller asks about one TTL today, and the tests of this module are the one reader"
-        )
-    )]
-    pub(crate) fn contains(self, ttl: u8) -> bool {
-        (self.first..=self.last).contains(&ttl)
-    }
 }
 
 impl TryFrom<[u8; 2]> for TtlRange {
@@ -1056,14 +1044,8 @@ mod tests {
     }
 
     #[test]
-    fn a_range_holds_every_ttl_from_the_first_one_to_the_last_one() {
+    fn a_range_keeps_the_first_ttl_and_the_last_one_it_was_made_with() {
         let range = TtlRange::new(1, 30).expect("the test range must hold");
-        for held in [1, 15, 30] {
-            assert!(range.contains(held), "the range holds {held}");
-        }
-        for outside in [0, 31] {
-            assert!(!range.contains(outside), "the range holds no {outside}");
-        }
         assert_eq!(range.first(), 1);
         assert_eq!(range.last(), 30);
     }
@@ -2005,8 +1987,11 @@ mod tests {
         assert_eq!(round.seq, 2);
         assert_eq!(round.hops.len(), 1, "one hop of the round answered");
         assert_eq!(round.ttl_range.first(), 1);
-        assert_eq!(round.ttl_range.last(), 3);
-        assert!(round.ttl_range.contains(3), "the round probed ttl 3");
+        assert_eq!(
+            round.ttl_range.last(),
+            3,
+            "the round probed ttl 3, the last ttl of its range"
+        );
         assert!(
             !round.hops.iter().any(|answer| answer.ttl == 3),
             "the hop at ttl 3 did not answer, so the round holds no hop at ttl 3"

--- a/src/krt/src/record.rs
+++ b/src/krt/src/record.rs
@@ -349,25 +349,11 @@ impl TtlRange {
     }
 
     /// The first TTL of the round.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the aggregate fold builds a row for every TTL that the round probed, and the fold arrives in a later slice of issue #369"
-        )
-    )]
     pub(crate) fn first(self) -> u8 {
         self.first
     }
 
     /// The last TTL of the round.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the aggregate fold builds a row for every TTL that the round probed, and the fold arrives in a later slice of issue #369"
-        )
-    )]
     pub(crate) fn last(self) -> u8 {
         self.last
     }
@@ -377,7 +363,7 @@ impl TtlRange {
         not(test),
         expect(
             dead_code,
-            reason = "the aggregate fold asks whether a round probed a TTL, to part a hop that did not answer from a hop the round never probed, and the fold arrives in a later slice of issue #369"
+            reason = "the aggregate fold walks the range from its first TTL to its last one, so no caller asks about one TTL today, and the tests of this module are the one reader"
         )
     )]
     pub(crate) fn contains(self, ttl: u8) -> bool {

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -218,12 +218,12 @@ mod tests {
         EndReason, EndRecord, Family, Hop, Privilege, Record, Recording, RoundRecord, RunConfig,
         RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
+    use crate::testing::address;
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::cell::{Cell, RefCell};
     use std::fs;
     use std::io::{self, Write};
-    use std::net::IpAddr;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::sync::mpsc::{self, Receiver};
@@ -313,11 +313,6 @@ mod tests {
 
     /// The byte that ends one record.
     const NEWLINE: u8 = b'\n';
-
-    /// Reads an address that a test names.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
-    }
 
     /// Reads a moment that a test names, and converts it to UTC.
     fn moment(text: &str) -> DateTime<Utc> {

--- a/src/krt/src/source.rs
+++ b/src/krt/src/source.rs
@@ -454,6 +454,7 @@ mod tests {
         PUBLIC_SERVICE_V4, PUBLIC_SERVICE_V6,
     };
     use crate::record::SourceKind;
+    use crate::testing::address;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::path::{Path, PathBuf};
     use std::time::Duration;
@@ -478,11 +479,6 @@ mod tests {
 
     /// The file that a test names on the command line.
     const NAMED_FILE: &str = "elsewhere/trace.jsonl";
-
-    /// Reads an address that a test names.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
-    }
 
     /// The name that a source and a destination of a test derive.
     fn name_of(source: &str, destination: &str) -> String {

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -2,11 +2,17 @@
 //!
 //! A round record names the TTLs that the round probed, and it holds one hop
 //! for each TTL that answered. This module folds those rounds into one row for
-//! each TTL, and one entry for each address that answered at a TTL. Every row
-//! carries the count of the probes, the count of the answers, and the
-//! statistics of the round trip times. The fold reads the records of the run
+//! each TTL, and one entry for each of the first `TRACKED_ADDRESSES` addresses
+//! that answered at a TTL. Every row carries the count of the probes, the count
+//! of the answers, the statistics of the round trip times, and the count of the
+//! answers that no tracked address holds. The fold reads the records of the run
 //! and nothing else, so a test drives it without a network and without a
 //! privilege.
+//!
+//! Every part of the fold holds a bounded amount of memory, so a run of any
+//! length over a path of any shape holds the same amount: one row for each TTL
+//! of the path, `TRACKED_ADDRESSES` entries for each row, and
+//! `RECENT_CAPACITY` round-trip times for each entry.
 
 use crate::record;
 use std::collections::{BTreeMap, VecDeque};
@@ -170,9 +176,14 @@ impl HopTable {
     ///
     /// Every TTL that the round probed takes one more probe, whether it
     /// answered or not, so the loss of a TTL counts the rounds that reached it.
-    /// Every hop of the round then folds its round-trip time twice: once into
-    /// the statistics of the TTL, and once into the statistics of the address
-    /// that answered.
+    /// Every hop of the round then folds its round-trip time into the
+    /// statistics of its TTL, and into the statistics of the address that
+    /// answered when the row of that TTL tracks the address.
+    ///
+    /// The statistics of the TTL take every answer, whether the row tracks the
+    /// address or not, so the bound of `TRACKED_ADDRESSES` takes no answer away
+    /// from the numbers of the TTL. An answer that no tracked address holds
+    /// counts in [`TtlRow::untracked`].
     pub(crate) fn observe(&mut self, round: &record::RoundRecord) {
         for ttl in round.ttl_range.first()..=round.ttl_range.last() {
             self.row_mut(ttl).sent += 1;
@@ -180,7 +191,9 @@ impl HopTable {
         for hop in &round.hops {
             let row = self.row_mut(hop.ttl);
             row.stats.observe(hop.rtt_ms);
-            row.address_mut(hop.addr).observe(hop.rtt_ms);
+            if let Some(stats) = row.address_mut(hop.addr) {
+                stats.observe(hop.rtt_ms);
+            }
         }
     }
 
@@ -217,11 +230,13 @@ pub(crate) struct TtlRow {
     sent: u64,
     /// The statistics over every answer at this TTL.
     stats: HopStats,
-    /// Every address that answered at this TTL, in the order the TTL first saw
-    /// them, each with the statistics of its own answers.
+    /// The first `TRACKED_ADDRESSES` addresses that answered at this TTL, in
+    /// the order the TTL saw them, each with the statistics of its own answers.
     ///
     /// One TTL sees a handful of routers, so a scan of the whole list costs
-    /// less than a map that keeps the order beside the keys.
+    /// less than a map that keeps the order beside the keys. The bound holds
+    /// that scan short over a path where the count of the routers is no handful
+    /// at all.
     addresses: Vec<(IpAddr, HopStats)>,
     /// The number of answers of this TTL that no tracked address holds.
     ///
@@ -244,18 +259,32 @@ impl TtlRow {
     }
 
     /// The statistics of one address of this row. The entry of an address that
-    /// this row never saw is made here.
-    fn address_mut(&mut self, addr: IpAddr) -> &mut HopStats {
+    /// this row never saw is made here, while the row holds fewer than
+    /// `TRACKED_ADDRESSES` of them.
+    ///
+    /// An address that is new to a row that holds that many gives `None`: the
+    /// answer counts as an untracked one of the row, and it takes no entry.
+    fn address_mut(&mut self, addr: IpAddr) -> Option<&mut HopStats> {
         let found = self.addresses.iter().position(|(held, _)| *held == addr);
-        let index = if let Some(index) = found {
-            index
-        } else {
-            // The address is new to this TTL, so its entry goes at the end.
-            // The order of the list then stays the order of the first answers.
-            self.addresses.push((addr, HopStats::default()));
-            self.addresses.len() - 1
+        let index = match found {
+            Some(index) => index,
+            None if self.addresses.len() < TRACKED_ADDRESSES => {
+                // The address is new to this TTL, so its entry goes at the end.
+                // The order of the list then stays the order of the first answers.
+                self.addresses.push((addr, HopStats::default()));
+                self.addresses.len() - 1
+            }
+            None => {
+                // The list is full, so this answer counts here and takes no
+                // entry of its own. The count is of the answers, because a
+                // count of the addresses that gave them needs a set of every
+                // one of those addresses, and that set is what grows without
+                // limit.
+                self.untracked += 1;
+                return None;
+            }
         };
-        &mut self.addresses[index].1
+        Some(&mut self.addresses[index].1)
     }
 
     /// The TTL of the row.
@@ -279,7 +308,7 @@ impl TtlRow {
     /// every later answer here, so the answers of the tracked addresses and
     /// this count together account for every answer of the row.
     pub(crate) fn untracked(&self) -> u64 {
-        todo!("the count of the untracked answers arrives with the green step")
+        self.untracked
     }
 
     /// The loss of this position, as a percentage. A TTL that no round probed
@@ -295,8 +324,12 @@ impl TtlRow {
         Some(count_as_f64(lost) / count_as_f64(self.sent) * PERCENT)
     }
 
-    /// Every address that answered at this TTL, in the order the TTL first saw
-    /// them, each with the share of the answers it took.
+    /// The addresses that this TTL tracks, in the order the TTL saw them, each
+    /// with the share of the answers it took.
+    ///
+    /// A TTL that answered from more than `TRACKED_ADDRESSES` addresses tracks
+    /// the ones it saw first, and [`TtlRow::untracked`] counts the answers of
+    /// the rest.
     pub(crate) fn addresses(&self) -> impl ExactSizeIterator<Item = Address<'_>> {
         let answers = self.stats.recv();
         self.addresses.iter().map(move |(addr, stats)| Address {
@@ -315,7 +348,8 @@ pub(crate) struct Address<'a> {
     addr: IpAddr,
     /// The statistics over the answers of this address.
     stats: &'a HopStats,
-    /// The number of answers of the whole TTL, from every address of it.
+    /// The number of answers of the whole TTL, whichever address gave them and
+    /// whether the row tracks that address or not.
     answers: u64,
 }
 
@@ -332,6 +366,11 @@ impl Address<'_> {
 
     /// The share of the answers of the TTL that this address took, as a
     /// percentage.
+    ///
+    /// The shares of one TTL sum to the whole while the TTL tracks every
+    /// address that answered at it. A TTL that answered from more addresses
+    /// than it tracks leaves the rest of the whole to the answers that
+    /// [`TtlRow::untracked`] counts.
     ///
     /// The divisor is never zero. This entry exists because the address
     /// answered at the TTL, so the TTL holds one answer at least.

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -20,6 +20,25 @@ use std::collections::VecDeque;
 )]
 const RECENT_CAPACITY: usize = 60;
 
+/// Reads a count as the number that an arithmetic of this module takes.
+///
+/// The mean, the loss, and the share each divide by a count, so each of them
+/// needs the count as a number with a fraction.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "an `f64` holds every whole number below 2^53, and a probe run counts one answer for one TTL of one round, so no count of a run reaches that point"
+)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+fn count_as_f64(count: u64) -> f64 {
+    count as f64
+}
+
 /// The statistics of one key, over the round-trip times it observed.
 ///
 /// A key is one TTL of the path, or one address that answered at a TTL.
@@ -52,6 +71,13 @@ pub(crate) struct HopStats {
 
 impl HopStats {
     /// Folds one more round-trip time into the statistics.
+    ///
+    /// The mean and the standard deviation come from Welford's online
+    /// algorithm. The algorithm holds the mean and the sum of the squared
+    /// distances in constant memory, and it stays stable over millions of
+    /// samples. A naive sum of the squares loses precision on a long run,
+    /// because that sum grows large while the distances between the samples
+    /// stay small.
     #[cfg_attr(
         not(test),
         expect(
@@ -60,7 +86,27 @@ impl HopStats {
         )
     )]
     fn observe(&mut self, rtt_ms: f64) {
-        todo!("the fold of one round-trip time arrives with the green step: {rtt_ms}")
+        self.recv += 1;
+        self.previous = self.last;
+        self.last = Some(rtt_ms);
+        self.min = Some(self.min.map_or(rtt_ms, |min| min.min(rtt_ms)));
+        self.max = Some(self.max.map_or(rtt_ms, |max| max.max(rtt_ms)));
+
+        // Welford's online algorithm. The mean moves toward the new sample by
+        // one part in the count, and the sum of the squared distances takes the
+        // product of the distance from the old mean and the distance from the
+        // new one.
+        let count = count_as_f64(self.recv);
+        let from_old_mean = rtt_ms - self.mean;
+        self.mean += from_old_mean / count;
+        self.m2 += from_old_mean * (rtt_ms - self.mean);
+
+        // The buffer holds a bounded amount of memory, so a run of any length
+        // holds the same amount.
+        if self.recent.len() == RECENT_CAPACITY {
+            self.recent.pop_front();
+        }
+        self.recent.push_back(rtt_ms);
     }
 
     /// The number of round-trip times that the key observed.
@@ -72,7 +118,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn recv(&self) -> u64 {
-        todo!("the count arrives with the green step")
+        self.recv
     }
 
     /// The most recent round-trip time. A key with no sample holds none.
@@ -84,7 +130,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn last(&self) -> Option<f64> {
-        todo!("the most recent round-trip time arrives with the green step")
+        self.last
     }
 
     /// The smallest round-trip time. A key with no sample holds none.
@@ -96,7 +142,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn min(&self) -> Option<f64> {
-        todo!("the smallest round-trip time arrives with the green step")
+        self.min
     }
 
     /// The arithmetic mean of the round-trip times. A key with no sample holds
@@ -109,7 +155,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn avg(&self) -> Option<f64> {
-        todo!("the mean arrives with the green step")
+        (self.recv > 0).then_some(self.mean)
     }
 
     /// The largest round-trip time. A key with no sample holds none.
@@ -121,7 +167,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn max(&self) -> Option<f64> {
-        todo!("the largest round-trip time arrives with the green step")
+        self.max
     }
 
     /// The population standard deviation of the round-trip times. A key with no
@@ -134,7 +180,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn stddev(&self) -> Option<f64> {
-        todo!("the standard deviation arrives with the green step")
+        (self.recv > 0).then(|| (self.m2 / count_as_f64(self.recv)).sqrt())
     }
 
     /// The absolute difference between the last two round-trip times. A key
@@ -147,7 +193,9 @@ impl HopStats {
         )
     )]
     pub(crate) fn jitter(&self) -> Option<f64> {
-        todo!("the jitter arrives with the green step")
+        let last = self.last?;
+        let previous = self.previous?;
+        Some((last - previous).abs())
     }
 
     /// The last `RECENT_CAPACITY` round-trip times, oldest first.
@@ -159,7 +207,7 @@ impl HopStats {
         )
     )]
     pub(crate) fn recent(&self) -> impl ExactSizeIterator<Item = f64> + '_ {
-        self.recent.iter().skip(self.recent.len()).copied()
+        self.recent.iter().copied()
     }
 }
 

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -370,8 +370,8 @@ impl Address<'_> {
 #[cfg(test)]
 mod tests {
     use super::{Address, HopStats, HopTable, TtlRow, RECENT_CAPACITY, TRACKED_ADDRESSES};
-    use crate::record::{Hop, RoundRecord, RunId, TtlRange};
-    use chrono::{DateTime, Utc};
+    use crate::record::RoundRecord;
+    use crate::testing::{address, round};
     use std::net::IpAddr;
 
     /// The largest difference that a comparison of two round-trip times admits.
@@ -491,18 +491,6 @@ mod tests {
         assert_eq!(history, expected, "the history keeps the last samples");
     }
 
-    /// The identifier of the run that every test round belongs to.
-    const RUN: &str = "2026-08-18T12:00:00.000Z";
-
-    /// The moment of every test round.
-    const MOMENT: &str = "2026-08-18T12:00:01.000Z";
-
-    /// The time that every test round took, in milliseconds.
-    const ROUND_DURATION: u64 = 1000;
-
-    /// The name of the ICMP message of every test hop.
-    const TIME_EXCEEDED: &str = "time_exceeded";
-
     /// The address of the first router of the test path.
     const FIRST_HOP: &str = "192.168.1.1";
 
@@ -517,38 +505,6 @@ mod tests {
 
     /// The round-trip time of a hop that a test does not read.
     const ANY_RTT: f64 = 1.5;
-
-    /// Reads an address that a test names.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
-    }
-
-    /// One round that probed the TTLs of the range, and that the named hops
-    /// answered.
-    ///
-    /// Each hop is a TTL, the address that answered at it, and the round-trip
-    /// time of that answer.
-    fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecord {
-        RoundRecord {
-            run: RunId::from(RUN),
-            seq: 1,
-            ts: DateTime::parse_from_rfc3339(MOMENT)
-                .expect("the test moment must parse")
-                .with_timezone(&Utc),
-            dur_ms: ROUND_DURATION,
-            ttl_range: TtlRange::new(first, last).expect("the test range must hold"),
-            reached: false,
-            hops: hops
-                .iter()
-                .map(|(ttl, addr, rtt_ms)| Hop {
-                    ttl: *ttl,
-                    addr: address(addr),
-                    rtt_ms: *rtt_ms,
-                    icmp: TIME_EXCEEDED.to_owned(),
-                })
-                .collect(),
-        }
-    }
 
     /// Folds every round into one table.
     fn table_of(rounds: &[RoundRecord]) -> HopTable {

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -1,0 +1,335 @@
+//! The aggregate fold of a run: every round of a recorded file, in one table.
+//!
+//! A round record names the TTLs that the round probed, and it holds one hop
+//! for each TTL that answered. This module folds those rounds into one row for
+//! each TTL, and one entry for each address that answered at a TTL. Every row
+//! carries the count of the probes, the count of the answers, and the
+//! statistics of the round trip times. The fold reads the records of the run
+//! and nothing else, so a test drives it without a network and without a
+//! privilege.
+
+use std::collections::VecDeque;
+
+/// The number of round-trip times that one key keeps.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+const RECENT_CAPACITY: usize = 60;
+
+/// The statistics of one key, over the round-trip times it observed.
+///
+/// A key is one TTL of the path, or one address that answered at a TTL.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HopStats {
+    /// The number of round-trip times that the key observed.
+    recv: u64,
+    /// The most recent round-trip time.
+    last: Option<f64>,
+    /// The round-trip time before the most recent one.
+    previous: Option<f64>,
+    /// The smallest round-trip time.
+    min: Option<f64>,
+    /// The largest round-trip time.
+    max: Option<f64>,
+    /// The arithmetic mean of every round-trip time.
+    mean: f64,
+    /// The sum of the squared distances from the mean, as Welford keeps it.
+    m2: f64,
+    /// The last `RECENT_CAPACITY` round-trip times, oldest first.
+    recent: VecDeque<f64>,
+}
+
+impl HopStats {
+    /// Folds one more round-trip time into the statistics.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn observe(&mut self, rtt_ms: f64) {
+        todo!("the fold of one round-trip time arrives with the green step: {rtt_ms}")
+    }
+
+    /// The number of round-trip times that the key observed.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn recv(&self) -> u64 {
+        todo!("the count arrives with the green step")
+    }
+
+    /// The most recent round-trip time. A key with no sample holds none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn last(&self) -> Option<f64> {
+        todo!("the most recent round-trip time arrives with the green step")
+    }
+
+    /// The smallest round-trip time. A key with no sample holds none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn min(&self) -> Option<f64> {
+        todo!("the smallest round-trip time arrives with the green step")
+    }
+
+    /// The arithmetic mean of the round-trip times. A key with no sample holds
+    /// none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn avg(&self) -> Option<f64> {
+        todo!("the mean arrives with the green step")
+    }
+
+    /// The largest round-trip time. A key with no sample holds none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn max(&self) -> Option<f64> {
+        todo!("the largest round-trip time arrives with the green step")
+    }
+
+    /// The population standard deviation of the round-trip times. A key with no
+    /// sample holds none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn stddev(&self) -> Option<f64> {
+        todo!("the standard deviation arrives with the green step")
+    }
+
+    /// The absolute difference between the last two round-trip times. A key
+    /// with one sample or none holds none.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn jitter(&self) -> Option<f64> {
+        todo!("the jitter arrives with the green step")
+    }
+
+    /// The last `RECENT_CAPACITY` round-trip times, oldest first.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn recent(&self) -> impl ExactSizeIterator<Item = f64> + '_ {
+        self.recent.iter().skip(self.recent.len()).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HopStats, RECENT_CAPACITY};
+
+    /// The largest difference that a comparison of two round-trip times admits.
+    ///
+    /// Every number of these tests is a small decimal, and the fold adds and
+    /// divides them, so the answer lands within a few units of the last place.
+    const TOLERANCE: f64 = 1e-9;
+
+    /// A sample set whose hand-computed statistics the tests state.
+    ///
+    /// The minimum is 10.0, the maximum is 40.0, and the sum is
+    /// 10 + 20 + 30 + 40 = 100. The mean is therefore 100 / 4 = 25.0.
+    const FOUR_SAMPLES: [f64; 4] = [10.0, 20.0, 30.0, 40.0];
+
+    /// A sample set whose population standard deviation is exactly 2.0.
+    ///
+    /// The sum is 2 + 4 + 4 + 4 + 5 + 5 + 7 + 9 = 40, so the mean is
+    /// 40 / 8 = 5.0. The distances from the mean are -3, -1, -1, -1, 0, 0, 2,
+    /// and 4. The squares of them are 9, 1, 1, 1, 0, 0, 4, and 16, and they
+    /// sum to 32. The population variance is 32 / 8 = 4.0, so the standard
+    /// deviation is the square root of 4.0, which is 2.0.
+    const EIGHT_SAMPLES: [f64; 8] = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
+
+    /// The number of samples that the ring buffer test folds.
+    const MANY: u32 = 100;
+
+    /// Folds every sample into one set of statistics.
+    fn stats_of(samples: &[f64]) -> HopStats {
+        let mut stats = HopStats::default();
+        for sample in samples {
+            stats.observe(*sample);
+        }
+        stats
+    }
+
+    /// Asserts that a statistic holds a value, and that the value is the one
+    /// the test computed by hand.
+    fn holds(actual: Option<f64>, expected: f64, name: &str) {
+        let actual = actual.unwrap_or_else(|| panic!("the {name} must hold a value"));
+        assert!(
+            (actual - expected).abs() < TOLERANCE,
+            "the {name} is {expected}, and the fold gives {actual}"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn a_key_with_no_sample_holds_no_statistic() {
+        let stats = HopStats::default();
+        assert_eq!(stats.recv(), 0, "no sample is no answer");
+        assert_eq!(stats.last(), None, "no sample is no last time");
+        assert_eq!(stats.min(), None, "no sample is no smallest time");
+        assert_eq!(stats.avg(), None, "no sample is no mean");
+        assert_eq!(stats.max(), None, "no sample is no largest time");
+        assert_eq!(stats.stddev(), None, "no sample is no deviation");
+        assert_eq!(stats.jitter(), None, "no sample is no jitter");
+        assert_eq!(stats.recent().len(), 0, "no sample is no history");
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn the_statistics_of_a_known_sample_set_are_the_hand_computed_ones() {
+        let stats = stats_of(&FOUR_SAMPLES);
+        assert_eq!(stats.recv(), 4, "the fold took four samples");
+        holds(stats.min(), 10.0, "smallest time");
+        holds(stats.avg(), 25.0, "mean");
+        holds(stats.max(), 40.0, "largest time");
+        holds(stats.last(), 40.0, "last time");
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn the_deviation_of_a_known_sample_set_is_the_population_one() {
+        let stats = stats_of(&EIGHT_SAMPLES);
+        assert_eq!(stats.recv(), 8, "the fold took eight samples");
+        holds(stats.avg(), 5.0, "mean");
+        holds(stats.stddev(), 2.0, "population standard deviation");
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn one_sample_holds_a_deviation_of_zero() {
+        let stats = stats_of(&[12.5]);
+        assert_eq!(stats.recv(), 1, "the fold took one sample");
+        holds(stats.stddev(), 0.0, "standard deviation of one sample");
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn the_jitter_is_the_absolute_difference_of_the_last_two_samples() {
+        holds(stats_of(&[10.0, 15.0]).jitter(), 5.0, "jitter of a rise");
+        holds(stats_of(&[15.0, 10.0]).jitter(), 5.0, "jitter of a fall");
+        holds(
+            stats_of(&[10.0, 40.0, 42.0]).jitter(),
+            2.0,
+            "jitter of the last two of three samples",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn one_sample_holds_no_jitter() {
+        let stats = stats_of(&[12.5]);
+        assert_eq!(
+            stats.jitter(),
+            None,
+            "one sample names no last two round-trip times"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    fn the_history_holds_the_last_sixty_samples_in_order() {
+        let samples: Vec<f64> = (1..=MANY).map(f64::from).collect();
+        let stats = stats_of(&samples);
+        assert_eq!(stats.recv(), u64::from(MANY), "the fold took every sample");
+        let history: Vec<f64> = stats.recent().collect();
+        assert_eq!(
+            history.len(),
+            RECENT_CAPACITY,
+            "the history keeps {RECENT_CAPACITY} samples"
+        );
+        let expected: Vec<f64> = samples[samples.len() - RECENT_CAPACITY..].to_vec();
+        assert_eq!(history, expected, "the history keeps the last samples");
+    }
+}

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -207,18 +207,6 @@ impl HopTable {
     pub(crate) fn rows(&self) -> impl ExactSizeIterator<Item = &TtlRow> {
         self.rows.values()
     }
-
-    /// The row of one TTL. A TTL the table never saw gives `None`.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the render walks every row in TTL order, so the tests of this module are the one reader of the row of one TTL today"
-        )
-    )]
-    pub(crate) fn row(&self, ttl: u8) -> Option<&TtlRow> {
-        self.rows.get(&ttl)
-    }
 }
 
 /// One hop position on the path, over every answer it gave.
@@ -574,7 +562,8 @@ mod tests {
     /// The row of one TTL that the table must hold.
     fn row_of(table: &HopTable, ttl: u8) -> &TtlRow {
         table
-            .row(ttl)
+            .rows()
+            .find(|row| row.ttl() == ttl)
             .unwrap_or_else(|| panic!("the table must hold the row of ttl {ttl}"))
     }
 
@@ -593,7 +582,7 @@ mod tests {
             assert_eq!(row_of(&table, ttl).sent(), sent, "the probes of ttl {ttl}");
         }
         assert!(
-            table.row(6).is_none(),
+            table.rows().all(|row| row.ttl() != 6),
             "no round probed ttl 6, so the table holds no row of it"
         );
     }

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -12,6 +12,12 @@ use crate::record;
 use std::collections::{BTreeMap, VecDeque};
 use std::net::IpAddr;
 
+/// The whole of a percentage.
+///
+/// The loss and the share are both a part of a whole, and both of them report
+/// that part as a percentage.
+const PERCENT: f64 = 100.0;
+
 /// The number of round-trip times that one key keeps.
 #[cfg_attr(
     not(test),
@@ -256,10 +262,20 @@ impl HopTable {
         )
     )]
     pub(crate) fn observe(&mut self, round: &record::RoundRecord) {
-        todo!(
-            "the fold of one round arrives with the green step: round {}",
-            round.seq
-        )
+        for ttl in round.ttl_range.first()..=round.ttl_range.last() {
+            self.row_mut(ttl).sent += 1;
+        }
+        for hop in &round.hops {
+            let row = self.row_mut(hop.ttl);
+            row.stats.observe(hop.rtt_ms);
+            row.address_mut(hop.addr).observe(hop.rtt_ms);
+        }
+    }
+
+    /// The row of one TTL. The row of a TTL that the table never saw is made
+    /// here.
+    fn row_mut(&mut self, ttl: u8) -> &mut TtlRow {
+        self.rows.entry(ttl).or_insert_with(|| TtlRow::new(ttl))
     }
 
     /// Every TTL row, in TTL order.
@@ -313,6 +329,13 @@ pub(crate) struct TtlRow {
 
 impl TtlRow {
     /// Builds the row of one TTL, before any round reaches it.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
     fn new(ttl: u8) -> Self {
         Self {
             ttl,
@@ -324,14 +347,22 @@ impl TtlRow {
 
     /// The statistics of one address of this row. The entry of an address that
     /// this row never saw is made here.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
     fn address_mut(&mut self, addr: IpAddr) -> &mut HopStats {
         let found = self.addresses.iter().position(|(held, _)| *held == addr);
-        let index = match found {
-            Some(index) => index,
-            None => {
-                self.addresses.push((addr, HopStats::default()));
-                self.addresses.len() - 1
-            }
+        let index = if let Some(index) = found {
+            index
+        } else {
+            // The address is new to this TTL, so its entry goes at the end.
+            // The order of the list then stays the order of the first answers.
+            self.addresses.push((addr, HopStats::default()));
+            self.addresses.len() - 1
         };
         &mut self.addresses[index].1
     }
@@ -382,10 +413,14 @@ impl TtlRow {
         )
     )]
     pub(crate) fn loss(&self) -> Option<f64> {
-        todo!(
-            "the loss of one position arrives with the green step: ttl {}",
-            self.ttl
-        )
+        if self.sent == 0 {
+            return None;
+        }
+        // A TTL that answered more times than it was probed floors at no loss.
+        // No fold of a well formed file reaches that state, and a percentage
+        // below zero would read as a defect of the tool.
+        let lost = self.sent.saturating_sub(self.stats.recv());
+        Some(count_as_f64(lost) / count_as_f64(self.sent) * PERCENT)
     }
 
     /// Every address that answered at this TTL, in the order the TTL first saw
@@ -464,10 +499,7 @@ impl Address<'_> {
         )
     )]
     pub(crate) fn share(&self) -> f64 {
-        todo!(
-            "the share of one address arrives with the green step: {}",
-            self.addr
-        )
+        count_as_f64(self.stats.recv()) / count_as_f64(self.answers) * PERCENT
     }
 }
 

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -8,7 +8,9 @@
 //! and nothing else, so a test drives it without a network and without a
 //! privilege.
 
-use std::collections::VecDeque;
+use crate::record;
+use std::collections::{BTreeMap, VecDeque};
+use std::net::IpAddr;
 
 /// The number of round-trip times that one key keeps.
 #[cfg_attr(
@@ -211,9 +213,270 @@ impl HopStats {
     }
 }
 
+/// The aggregate view of every hop seen so far, keyed and ordered by TTL.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HopTable {
+    /// One row for each TTL that a round probed, and for each TTL that a hop
+    /// answered at. The map holds the rows in TTL order.
+    rows: BTreeMap<u8, TtlRow>,
+}
+
+impl HopTable {
+    /// Builds a table that holds no row.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Folds one more round into the table.
+    ///
+    /// Every TTL that the round probed takes one more probe, whether it
+    /// answered or not, so the loss of a TTL counts the rounds that reached it.
+    /// Every hop of the round then folds its round-trip time twice: once into
+    /// the statistics of the TTL, and once into the statistics of the address
+    /// that answered.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn observe(&mut self, round: &record::RoundRecord) {
+        todo!(
+            "the fold of one round arrives with the green step: round {}",
+            round.seq
+        )
+    }
+
+    /// Every TTL row, in TTL order.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn rows(&self) -> impl ExactSizeIterator<Item = &TtlRow> {
+        self.rows.values()
+    }
+
+    /// The row of one TTL. A TTL the table never saw gives `None`.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn row(&self, ttl: u8) -> Option<&TtlRow> {
+        self.rows.get(&ttl)
+    }
+}
+
+/// One hop position on the path, over every answer it gave.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+#[derive(Debug, Clone)]
+pub(crate) struct TtlRow {
+    /// The TTL of the row.
+    ttl: u8,
+    /// The number of rounds whose range covered this TTL.
+    sent: u64,
+    /// The statistics over every answer at this TTL.
+    stats: HopStats,
+    /// Every address that answered at this TTL, in the order the TTL first saw
+    /// them, each with the statistics of its own answers.
+    ///
+    /// One TTL sees a handful of routers, so a scan of the whole list costs
+    /// less than a map that keeps the order beside the keys.
+    addresses: Vec<(IpAddr, HopStats)>,
+}
+
+impl TtlRow {
+    /// Builds the row of one TTL, before any round reaches it.
+    fn new(ttl: u8) -> Self {
+        Self {
+            ttl,
+            sent: 0,
+            stats: HopStats::default(),
+            addresses: Vec::new(),
+        }
+    }
+
+    /// The statistics of one address of this row. The entry of an address that
+    /// this row never saw is made here.
+    fn address_mut(&mut self, addr: IpAddr) -> &mut HopStats {
+        let found = self.addresses.iter().position(|(held, _)| *held == addr);
+        let index = match found {
+            Some(index) => index,
+            None => {
+                self.addresses.push((addr, HopStats::default()));
+                self.addresses.len() - 1
+            }
+        };
+        &mut self.addresses[index].1
+    }
+
+    /// The TTL of the row.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn ttl(&self) -> u8 {
+        self.ttl
+    }
+
+    /// The rounds whose `ttl_range` covered this TTL.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn sent(&self) -> u64 {
+        self.sent
+    }
+
+    /// The statistics over every answer at this TTL, whichever address gave it.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn stats(&self) -> &HopStats {
+        &self.stats
+    }
+
+    /// The loss of this position, as a percentage. A TTL that no round probed
+    /// gives `None`.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn loss(&self) -> Option<f64> {
+        todo!(
+            "the loss of one position arrives with the green step: ttl {}",
+            self.ttl
+        )
+    }
+
+    /// Every address that answered at this TTL, in the order the TTL first saw
+    /// them, each with the share of the answers it took.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn addresses(&self) -> impl ExactSizeIterator<Item = Address<'_>> {
+        let answers = self.stats.recv();
+        self.addresses.iter().map(move |(addr, stats)| Address {
+            addr: *addr,
+            stats,
+            answers,
+        })
+    }
+}
+
+/// One router that answered at a TTL, and the share of that TTL's answers it
+/// took.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+    )
+)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Address<'a> {
+    /// The address that answered.
+    addr: IpAddr,
+    /// The statistics over the answers of this address.
+    stats: &'a HopStats,
+    /// The number of answers of the whole TTL, from every address of it.
+    answers: u64,
+}
+
+impl Address<'_> {
+    /// The address that answered.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn addr(&self) -> IpAddr {
+        self.addr
+    }
+
+    /// The statistics over the answers of this address.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn stats(&self) -> &HopStats {
+        self.stats
+    }
+
+    /// The share of the answers of the TTL that this address took, as a
+    /// percentage.
+    ///
+    /// The divisor is never zero. This entry exists because the address
+    /// answered at the TTL, so the TTL holds one answer at least.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn share(&self) -> f64 {
+        todo!(
+            "the share of one address arrives with the green step: {}",
+            self.addr
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{HopStats, RECENT_CAPACITY};
+    use super::{HopStats, HopTable, TtlRow, RECENT_CAPACITY};
+    use crate::record::{Hop, RoundRecord, RunId, TtlRange};
+    use chrono::{DateTime, Utc};
+    use std::net::IpAddr;
 
     /// The largest difference that a comparison of two round-trip times admits.
     ///
@@ -379,5 +642,227 @@ mod tests {
         );
         let expected: Vec<f64> = samples[samples.len() - RECENT_CAPACITY..].to_vec();
         assert_eq!(history, expected, "the history keeps the last samples");
+    }
+
+    /// The identifier of the run that every test round belongs to.
+    const RUN: &str = "2026-08-18T12:00:00.000Z";
+
+    /// The moment of every test round.
+    const MOMENT: &str = "2026-08-18T12:00:01.000Z";
+
+    /// The time that every test round took, in milliseconds.
+    const ROUND_DURATION: u64 = 1000;
+
+    /// The name of the ICMP message of every test hop.
+    const TIME_EXCEEDED: &str = "time_exceeded";
+
+    /// The address of the first router of the test path.
+    const FIRST_HOP: &str = "192.168.1.1";
+
+    /// The address of one of the two routers that answer at one TTL.
+    const LEFT_ROUTER: &str = "10.0.0.1";
+
+    /// The address of the other of the two routers that answer at one TTL.
+    const RIGHT_ROUTER: &str = "10.0.0.2";
+
+    /// The address of the target of the test path.
+    const TARGET: &str = "93.184.216.34";
+
+    /// The round-trip time of a hop that a test does not read.
+    const ANY_RTT: f64 = 1.5;
+
+    /// Reads an address that a test names.
+    fn address(text: &str) -> IpAddr {
+        text.parse().expect("the test address must parse")
+    }
+
+    /// One round that probed the TTLs of the range, and that the named hops
+    /// answered.
+    ///
+    /// Each hop is a TTL, the address that answered at it, and the round-trip
+    /// time of that answer.
+    fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecord {
+        RoundRecord {
+            run: RunId::from(RUN),
+            seq: 1,
+            ts: DateTime::parse_from_rfc3339(MOMENT)
+                .expect("the test moment must parse")
+                .with_timezone(&Utc),
+            dur_ms: ROUND_DURATION,
+            ttl_range: TtlRange::new(first, last).expect("the test range must hold"),
+            reached: false,
+            hops: hops
+                .iter()
+                .map(|(ttl, addr, rtt_ms)| Hop {
+                    ttl: *ttl,
+                    addr: address(addr),
+                    rtt_ms: *rtt_ms,
+                    icmp: TIME_EXCEEDED.to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Folds every round into one table.
+    fn table_of(rounds: &[RoundRecord]) -> HopTable {
+        let mut table = HopTable::new();
+        for round in rounds {
+            table.observe(round);
+        }
+        table
+    }
+
+    /// The row of one TTL that the table must hold.
+    fn row_of(table: &HopTable, ttl: u8) -> &TtlRow {
+        table
+            .row(ttl)
+            .unwrap_or_else(|| panic!("the table must hold the row of ttl {ttl}"))
+    }
+
+    /// The TTL of every row of the table, in the order the table gives them.
+    fn ttls_of(table: &HopTable) -> Vec<u8> {
+        table.rows().map(TtlRow::ttl).collect()
+    }
+
+    #[test]
+    fn the_probes_of_a_ttl_count_the_rounds_that_covered_it() {
+        // Round one covers TTL 1 to 3, round two covers TTL 1 to 5, and round
+        // three covers TTL 2 to 4. TTL 1 is therefore in two rounds, TTL 2 and
+        // TTL 3 are in three, TTL 4 is in two, and TTL 5 is in one.
+        let table = table_of(&[round(1, 3, &[]), round(1, 5, &[]), round(2, 4, &[])]);
+        for (ttl, sent) in [(1, 2), (2, 3), (3, 3), (4, 2), (5, 1)] {
+            assert_eq!(row_of(&table, ttl).sent(), sent, "the probes of ttl {ttl}");
+        }
+        assert!(
+            table.row(6).is_none(),
+            "no round probed ttl 6, so the table holds no row of it"
+        );
+    }
+
+    /// A run whose target moves closer shrinks the range of its rounds. A TTL
+    /// that falls outside the new range takes no probe, so its loss stays where
+    /// the earlier rounds left it.
+    #[test]
+    fn a_ttl_outside_the_range_of_a_round_takes_no_probe_from_it() {
+        let table = table_of(&[
+            round(1, 5, &[(5, TARGET, ANY_RTT)]),
+            round(1, 3, &[(3, FIRST_HOP, ANY_RTT)]),
+        ]);
+        let five = row_of(&table, 5);
+        assert_eq!(five.sent(), 1, "one round of the two covered ttl 5");
+        assert_eq!(five.stats().recv(), 1, "ttl 5 answered its one probe");
+        holds(five.loss(), 0.0, "loss of ttl 5");
+    }
+
+    #[test]
+    fn a_ttl_that_never_answers_reaches_a_loss_of_one_hundred_percent() {
+        let table = table_of(&[
+            round(1, 3, &[(1, FIRST_HOP, ANY_RTT)]),
+            round(1, 3, &[(1, FIRST_HOP, ANY_RTT)]),
+        ]);
+        let two = row_of(&table, 2);
+        assert_eq!(two.sent(), 2, "both rounds probed ttl 2");
+        assert_eq!(two.stats().recv(), 0, "ttl 2 answered no probe");
+        holds(two.loss(), 100.0, "loss of ttl 2");
+    }
+
+    #[test]
+    fn a_ttl_that_answers_nine_rounds_of_ten_reaches_a_loss_of_ten_percent() {
+        let mut rounds: Vec<RoundRecord> = (0..9)
+            .map(|_| round(1, 1, &[(1, FIRST_HOP, ANY_RTT)]))
+            .collect();
+        rounds.push(round(1, 1, &[]));
+        let table = table_of(&rounds);
+        let one = row_of(&table, 1);
+        assert_eq!(one.sent(), 10, "ten rounds probed ttl 1");
+        assert_eq!(one.stats().recv(), 9, "nine rounds of the ten answered");
+        // One round of the ten answered nothing, so the loss is
+        // 1 / 10 * 100 = 10.0 percent.
+        holds(one.loss(), 10.0, "loss of ttl 1");
+    }
+
+    #[test]
+    fn two_addresses_at_one_ttl_share_the_answers_of_that_ttl() {
+        // The left router answers three of the four rounds, and the right
+        // router answers the other one. The shares are therefore
+        // 3 / 4 * 100 = 75.0 and 1 / 4 * 100 = 25.0.
+        let table = table_of(&[
+            round(1, 2, &[(2, LEFT_ROUTER, 10.0)]),
+            round(1, 2, &[(2, RIGHT_ROUTER, 20.0)]),
+            round(1, 2, &[(2, LEFT_ROUTER, 30.0)]),
+            round(1, 2, &[(2, LEFT_ROUTER, 50.0)]),
+        ]);
+        let two = row_of(&table, 2);
+        assert_eq!(
+            two.stats().recv(),
+            4,
+            "the row of the ttl holds every answer of it"
+        );
+        holds(two.stats().avg(), 27.5, "mean of ttl 2");
+
+        let addresses: Vec<_> = two.addresses().collect();
+        assert_eq!(addresses.len(), 2, "two routers answered at ttl 2");
+        assert_eq!(
+            addresses[0].addr(),
+            address(LEFT_ROUTER),
+            "the left router answered first"
+        );
+        assert_eq!(
+            addresses[1].addr(),
+            address(RIGHT_ROUTER),
+            "the right router answered second"
+        );
+        assert_eq!(addresses[0].stats().recv(), 3, "the left router answered 3");
+        assert_eq!(
+            addresses[1].stats().recv(),
+            1,
+            "the right router answered 1"
+        );
+        assert_eq!(
+            addresses[0].stats().recv() + addresses[1].stats().recv(),
+            two.stats().recv(),
+            "every answer of the ttl belongs to one address of it"
+        );
+        holds(Some(addresses[0].share()), 75.0, "share of the left router");
+        holds(
+            Some(addresses[1].share()),
+            25.0,
+            "share of the right router",
+        );
+        let total: f64 = two.addresses().map(|address| address.share()).sum();
+        holds(Some(total), 100.0, "sum of the shares of ttl 2");
+    }
+
+    #[test]
+    fn a_ttl_that_stops_answering_keeps_its_history_and_loses_the_later_rounds() {
+        // Three rounds answer with 10, 20, and 30, and two more rounds probe
+        // the TTL and get nothing. The sum is 60, so the mean is 60 / 3 = 20.0.
+        // Two probes of the five got no answer, so the loss is
+        // 2 / 5 * 100 = 40.0 percent.
+        let table = table_of(&[
+            round(1, 1, &[(1, FIRST_HOP, 10.0)]),
+            round(1, 1, &[(1, FIRST_HOP, 20.0)]),
+            round(1, 1, &[(1, FIRST_HOP, 30.0)]),
+            round(1, 1, &[]),
+            round(1, 1, &[]),
+        ]);
+        let one = row_of(&table, 1);
+        assert_eq!(one.sent(), 5, "five rounds probed ttl 1");
+        assert_eq!(one.stats().recv(), 3, "three rounds of the five answered");
+        holds(one.stats().min(), 10.0, "smallest time of ttl 1");
+        holds(one.stats().avg(), 20.0, "mean of ttl 1");
+        holds(one.stats().max(), 30.0, "largest time of ttl 1");
+        holds(one.stats().last(), 30.0, "last time of ttl 1");
+        holds(one.loss(), 40.0, "loss of ttl 1");
+    }
+
+    #[test]
+    fn the_rows_come_back_in_ttl_order() {
+        let table = table_of(&[
+            round(3, 3, &[(3, TARGET, ANY_RTT)]),
+            round(1, 2, &[(2, FIRST_HOP, ANY_RTT)]),
+        ]);
+        assert_eq!(table.rows().len(), 3, "the table holds three rows");
+        assert_eq!(ttls_of(&table), [1, 2, 3], "the rows run in ttl order");
     }
 }

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -19,13 +19,6 @@ use std::net::IpAddr;
 const PERCENT: f64 = 100.0;
 
 /// The number of round-trip times that one key keeps.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 const RECENT_CAPACITY: usize = 60;
 
 /// Reads a count as the number that an arithmetic of this module takes.
@@ -36,13 +29,6 @@ const RECENT_CAPACITY: usize = 60;
     clippy::cast_precision_loss,
     reason = "an `f64` holds every whole number below 2^53, and a probe run counts one answer for one TTL of one round, so no count of a run reaches that point"
 )]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 fn count_as_f64(count: u64) -> f64 {
     count as f64
 }
@@ -50,13 +36,6 @@ fn count_as_f64(count: u64) -> f64 {
 /// The statistics of one key, over the round-trip times it observed.
 ///
 /// A key is one TTL of the path, or one address that answered at a TTL.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct HopStats {
     /// The number of round-trip times that the key observed.
@@ -86,13 +65,6 @@ impl HopStats {
     /// samples. A naive sum of the squares loses precision on a long run,
     /// because that sum grows large while the distances between the samples
     /// stay small.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn observe(&mut self, rtt_ms: f64) {
         self.recv += 1;
         self.previous = self.last;
@@ -118,88 +90,39 @@ impl HopStats {
     }
 
     /// The number of round-trip times that the key observed.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn recv(&self) -> u64 {
         self.recv
     }
 
     /// The most recent round-trip time. A key with no sample holds none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn last(&self) -> Option<f64> {
         self.last
     }
 
     /// The smallest round-trip time. A key with no sample holds none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn min(&self) -> Option<f64> {
         self.min
     }
 
     /// The arithmetic mean of the round-trip times. A key with no sample holds
     /// none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn avg(&self) -> Option<f64> {
         (self.recv > 0).then_some(self.mean)
     }
 
     /// The largest round-trip time. A key with no sample holds none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn max(&self) -> Option<f64> {
         self.max
     }
 
     /// The population standard deviation of the round-trip times. A key with no
     /// sample holds none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn stddev(&self) -> Option<f64> {
         (self.recv > 0).then(|| (self.m2 / count_as_f64(self.recv)).sqrt())
     }
 
     /// The absolute difference between the last two round-trip times. A key
     /// with one sample or none holds none.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn jitter(&self) -> Option<f64> {
         let last = self.last?;
         let previous = self.previous?;
@@ -211,7 +134,7 @@ impl HopStats {
         not(test),
         expect(
             dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+            reason = "the sparkline of one hop reads the history, and that sparkline arrives in issue #370, so the tests of this module are the one reader of it today"
         )
     )]
     pub(crate) fn recent(&self) -> impl ExactSizeIterator<Item = f64> + '_ {
@@ -220,13 +143,6 @@ impl HopStats {
 }
 
 /// The aggregate view of every hop seen so far, keyed and ordered by TTL.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct HopTable {
     /// One row for each TTL that a round probed, and for each TTL that a hop
@@ -236,13 +152,6 @@ pub(crate) struct HopTable {
 
 impl HopTable {
     /// Builds a table that holds no row.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -254,13 +163,6 @@ impl HopTable {
     /// Every hop of the round then folds its round-trip time twice: once into
     /// the statistics of the TTL, and once into the statistics of the address
     /// that answered.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn observe(&mut self, round: &record::RoundRecord) {
         for ttl in round.ttl_range.first()..=round.ttl_range.last() {
             self.row_mut(ttl).sent += 1;
@@ -279,13 +181,6 @@ impl HopTable {
     }
 
     /// Every TTL row, in TTL order.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn rows(&self) -> impl ExactSizeIterator<Item = &TtlRow> {
         self.rows.values()
     }
@@ -295,7 +190,7 @@ impl HopTable {
         not(test),
         expect(
             dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
+            reason = "the render walks every row in TTL order, so the tests of this module are the one reader of the row of one TTL today"
         )
     )]
     pub(crate) fn row(&self, ttl: u8) -> Option<&TtlRow> {
@@ -304,13 +199,6 @@ impl HopTable {
 }
 
 /// One hop position on the path, over every answer it gave.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 #[derive(Debug, Clone)]
 pub(crate) struct TtlRow {
     /// The TTL of the row.
@@ -329,13 +217,6 @@ pub(crate) struct TtlRow {
 
 impl TtlRow {
     /// Builds the row of one TTL, before any round reaches it.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn new(ttl: u8) -> Self {
         Self {
             ttl,
@@ -347,13 +228,6 @@ impl TtlRow {
 
     /// The statistics of one address of this row. The entry of an address that
     /// this row never saw is made here.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn address_mut(&mut self, addr: IpAddr) -> &mut HopStats {
         let found = self.addresses.iter().position(|(held, _)| *held == addr);
         let index = if let Some(index) = found {
@@ -368,50 +242,22 @@ impl TtlRow {
     }
 
     /// The TTL of the row.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn ttl(&self) -> u8 {
         self.ttl
     }
 
     /// The rounds whose `ttl_range` covered this TTL.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn sent(&self) -> u64 {
         self.sent
     }
 
     /// The statistics over every answer at this TTL, whichever address gave it.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn stats(&self) -> &HopStats {
         &self.stats
     }
 
     /// The loss of this position, as a percentage. A TTL that no round probed
     /// gives `None`.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn loss(&self) -> Option<f64> {
         if self.sent == 0 {
             return None;
@@ -425,13 +271,6 @@ impl TtlRow {
 
     /// Every address that answered at this TTL, in the order the TTL first saw
     /// them, each with the share of the answers it took.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn addresses(&self) -> impl ExactSizeIterator<Item = Address<'_>> {
         let answers = self.stats.recv();
         self.addresses.iter().map(move |(addr, stats)| Address {
@@ -444,13 +283,6 @@ impl TtlRow {
 
 /// One router that answered at a TTL, and the share of that TTL's answers it
 /// took.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-    )
-)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Address<'a> {
     /// The address that answered.
@@ -463,25 +295,11 @@ pub(crate) struct Address<'a> {
 
 impl Address<'_> {
     /// The address that answered.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn addr(&self) -> IpAddr {
         self.addr
     }
 
     /// The statistics over the answers of this address.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn stats(&self) -> &HopStats {
         self.stats
     }
@@ -491,13 +309,6 @@ impl Address<'_> {
     ///
     /// The divisor is never zero. This entry exists because the address
     /// answered at the TTL, so the TTL holds one answer at least.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn share(&self) -> f64 {
         count_as_f64(self.stats.recv()) / count_as_f64(self.answers) * PERCENT
     }

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -365,13 +365,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn a_key_with_no_sample_holds_no_statistic() {
         let stats = HopStats::default();
         assert_eq!(stats.recv(), 0, "no sample is no answer");
@@ -385,13 +378,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn the_statistics_of_a_known_sample_set_are_the_hand_computed_ones() {
         let stats = stats_of(&FOUR_SAMPLES);
         assert_eq!(stats.recv(), 4, "the fold took four samples");
@@ -402,13 +388,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn the_deviation_of_a_known_sample_set_is_the_population_one() {
         let stats = stats_of(&EIGHT_SAMPLES);
         assert_eq!(stats.recv(), 8, "the fold took eight samples");
@@ -417,13 +396,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn one_sample_holds_a_deviation_of_zero() {
         let stats = stats_of(&[12.5]);
         assert_eq!(stats.recv(), 1, "the fold took one sample");
@@ -431,13 +403,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn the_jitter_is_the_absolute_difference_of_the_last_two_samples() {
         holds(stats_of(&[10.0, 15.0]).jitter(), 5.0, "jitter of a rise");
         holds(stats_of(&[15.0, 10.0]).jitter(), 5.0, "jitter of a fall");
@@ -449,13 +414,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn one_sample_holds_no_jitter() {
         let stats = stats_of(&[12.5]);
         assert_eq!(
@@ -466,13 +424,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the replay slice of issue #369 wires the fold into `krt replay`, so the tests of this module are the one reader today"
-        )
-    )]
     fn the_history_holds_the_last_sixty_samples_in_order() {
         let samples: Vec<f64> = (1..=MANY).map(f64::from).collect();
         let stats = stats_of(&samples);

--- a/src/krt/src/stats.rs
+++ b/src/krt/src/stats.rs
@@ -21,6 +21,16 @@ const PERCENT: f64 = 100.0;
 /// The number of round-trip times that one key keeps.
 const RECENT_CAPACITY: usize = 60;
 
+/// The number of addresses that one TTL keeps an entry for.
+///
+/// A load-balanced path and a flapping path both answer one TTL from many
+/// routers. Without this bound, a long run over such a path would hold one
+/// entry for every router it ever saw at every TTL, so the memory of the fold,
+/// the scan of the address list, and the printed lines of one TTL would all
+/// grow with the length of the run. The row counts the answers past this bound
+/// and keeps no entry for them.
+const TRACKED_ADDRESSES: usize = 32;
+
 /// Reads a count as the number that an arithmetic of this module takes.
 ///
 /// The mean, the loss, and the share each divide by a count, so each of them
@@ -213,6 +223,12 @@ pub(crate) struct TtlRow {
     /// One TTL sees a handful of routers, so a scan of the whole list costs
     /// less than a map that keeps the order beside the keys.
     addresses: Vec<(IpAddr, HopStats)>,
+    /// The number of answers of this TTL that no tracked address holds.
+    ///
+    /// The count is of the answers and not of the addresses that gave them. A
+    /// count of those addresses would need a set of every one of them, and that
+    /// set is the unbounded memory that `TRACKED_ADDRESSES` removes.
+    untracked: u64,
 }
 
 impl TtlRow {
@@ -223,6 +239,7 @@ impl TtlRow {
             sent: 0,
             stats: HopStats::default(),
             addresses: Vec::new(),
+            untracked: 0,
         }
     }
 
@@ -254,6 +271,15 @@ impl TtlRow {
     /// The statistics over every answer at this TTL, whichever address gave it.
     pub(crate) fn stats(&self) -> &HopStats {
         &self.stats
+    }
+
+    /// The answers of this TTL that no tracked address holds.
+    ///
+    /// A TTL that answered from more than `TRACKED_ADDRESSES` addresses counts
+    /// every later answer here, so the answers of the tracked addresses and
+    /// this count together account for every answer of the row.
+    pub(crate) fn untracked(&self) -> u64 {
+        todo!("the count of the untracked answers arrives with the green step")
     }
 
     /// The loss of this position, as a percentage. A TTL that no round probed
@@ -316,7 +342,7 @@ impl Address<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{HopStats, HopTable, TtlRow, RECENT_CAPACITY};
+    use super::{Address, HopStats, HopTable, TtlRow, RECENT_CAPACITY, TRACKED_ADDRESSES};
     use crate::record::{Hop, RoundRecord, RunId, TtlRange};
     use chrono::{DateTime, Utc};
     use std::net::IpAddr;
@@ -658,5 +684,121 @@ mod tests {
         ]);
         assert_eq!(table.rows().len(), 3, "the table holds three rows");
         assert_eq!(ttls_of(&table), [1, 2, 3], "the rows run in ttl order");
+    }
+
+    /// The TTL that the addresses of the bound tests answer at.
+    const CROWDED_TTL: u8 = 1;
+
+    /// The number of addresses that the bound tests answer from.
+    ///
+    /// The count stands above `TRACKED_ADDRESSES`, so the row of the TTL fills
+    /// its address list and then meets addresses it has no room for.
+    const MANY_ADDRESSES: u32 = 40;
+
+    /// The answers of the crowded TTL that no tracked address holds.
+    ///
+    /// Each of the `MANY_ADDRESSES` addresses answers one round, so the TTL
+    /// takes 40 answers from 40 distinct routers. The row tracks the first 32
+    /// of them, so 40 - 32 = 8 answers hold no tracked address.
+    const UNTRACKED_ANSWERS: u64 = 8;
+
+    /// The addresses of a TTL that answers from more of them than it tracks.
+    ///
+    /// The addresses run upward from `10.0.0.1`, one for each answer, so no two
+    /// answers of the set come from the same router.
+    fn many_addresses() -> Vec<String> {
+        (1..=MANY_ADDRESSES)
+            .map(|host| format!("10.0.0.{host}"))
+            .collect()
+    }
+
+    /// A table of one round for each address of [`many_addresses`], each of
+    /// them answering at `CROWDED_TTL`.
+    fn crowded_table() -> HopTable {
+        let addresses = many_addresses();
+        let rounds: Vec<RoundRecord> = addresses
+            .iter()
+            .map(|addr| {
+                round(
+                    CROWDED_TTL,
+                    CROWDED_TTL,
+                    &[(CROWDED_TTL, addr.as_str(), ANY_RTT)],
+                )
+            })
+            .collect();
+        table_of(&rounds)
+    }
+
+    /// A TTL that answers from more addresses than it tracks keeps the first
+    /// `TRACKED_ADDRESSES` of them, and counts the answers of the rest.
+    ///
+    /// The 40 answers come from 40 distinct addresses, so the row tracks the
+    /// first 32 and the other 40 - 32 = 8 answers hold no tracked address.
+    #[test]
+    fn a_ttl_tracks_a_bounded_number_of_addresses() {
+        let table = crowded_table();
+        let row = row_of(&table, CROWDED_TTL);
+        let held: Vec<_> = row.addresses().collect();
+        assert_eq!(
+            held.len(),
+            TRACKED_ADDRESSES,
+            "the row tracks {TRACKED_ADDRESSES} addresses of the {MANY_ADDRESSES}"
+        );
+        assert_eq!(
+            row.untracked(),
+            UNTRACKED_ANSWERS,
+            "the answers past the tracked addresses count as untracked ones"
+        );
+        let tracked: Vec<IpAddr> = held.iter().map(Address::addr).collect();
+        let first_seen: Vec<IpAddr> = many_addresses()
+            .iter()
+            .take(TRACKED_ADDRESSES)
+            .map(|text| address(text))
+            .collect();
+        assert_eq!(
+            tracked, first_seen,
+            "the row keeps the addresses that answered first"
+        );
+    }
+
+    /// The row of a TTL counts every answer of that TTL, whether a tracked
+    /// address holds the answer or not.
+    ///
+    /// Each of the 40 rounds probed the TTL once and each one answered, so the
+    /// row holds 40 probes and 40 answers, and the loss is 0 / 40 * 100 = 0.0
+    /// percent. The bound stops at the address list, and it takes nothing away
+    /// from the numbers of the TTL itself.
+    #[test]
+    fn the_row_of_a_ttl_counts_the_answers_past_the_tracked_addresses() {
+        let table = crowded_table();
+        let row = row_of(&table, CROWDED_TTL);
+        assert_eq!(
+            row.sent(),
+            u64::from(MANY_ADDRESSES),
+            "each of the rounds probed the crowded ttl"
+        );
+        assert_eq!(
+            row.stats().recv(),
+            u64::from(MANY_ADDRESSES),
+            "the row counts every answer of the ttl, tracked or not"
+        );
+        holds(row.loss(), 0.0, "loss of the crowded ttl");
+    }
+
+    /// A TTL that answers from fewer addresses than it tracks counts no
+    /// untracked answer, so the shares of its addresses cover the whole of it.
+    #[test]
+    fn a_ttl_below_the_bound_counts_no_untracked_answer() {
+        let table = table_of(&[
+            round(1, 2, &[(2, LEFT_ROUTER, ANY_RTT)]),
+            round(1, 2, &[(2, RIGHT_ROUTER, ANY_RTT)]),
+        ]);
+        let two = row_of(&table, 2);
+        assert_eq!(two.addresses().len(), 2, "two routers answered at ttl 2");
+        assert_eq!(
+            two.untracked(),
+            0,
+            "the row holds an entry for both of the addresses"
+        );
     }
 }

--- a/src/krt/src/testing.rs
+++ b/src/krt/src/testing.rs
@@ -1,0 +1,68 @@
+//! The fixtures that the tests of more than one module of this crate build on.
+//!
+//! A test of the fold, and a test of the lines that the fold prints, both need
+//! a round record to read. The record carries a run, a moment, and a duration
+//! that no such test asserts on, so one set of values serves every one of them
+//! and each test names only the part it cares about: the TTLs that the round
+//! probed, and the hops that answered.
+//!
+//! This module compiles under `cfg(test)` alone, so nothing it holds reaches
+//! the binary.
+
+use crate::record::{Hop, RoundRecord, RunId, TtlRange};
+use chrono::{DateTime, Utc};
+use std::net::IpAddr;
+
+/// The identifier of the run that every test round belongs to.
+const RUN: &str = "2026-08-18T12:00:00.000Z";
+
+/// The moment of every test round.
+const MOMENT: &str = "2026-08-18T12:00:01.000Z";
+
+/// The time that every test round took, in milliseconds.
+const ROUND_DURATION: u64 = 1000;
+
+/// The name of the ICMP message of every test hop.
+const TIME_EXCEEDED: &str = "time_exceeded";
+
+/// Reads an address that a test names.
+///
+/// # Panics
+///
+/// Panics on text that holds no address. Such text is a mistake in the test,
+/// not an answer the code under test can give.
+pub(crate) fn address(text: &str) -> IpAddr {
+    text.parse().expect("the test address must parse")
+}
+
+/// One round that probed the TTLs of the range, and that the named hops
+/// answered.
+///
+/// Each hop is a TTL, the address that answered at it, and the round-trip time
+/// of that answer.
+///
+/// # Panics
+///
+/// Panics on a range that no TTL pair holds, and on an address that no text
+/// holds. Both are mistakes in the test.
+pub(crate) fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecord {
+    RoundRecord {
+        run: RunId::from(RUN),
+        seq: 1,
+        ts: DateTime::parse_from_rfc3339(MOMENT)
+            .expect("the test moment must parse")
+            .with_timezone(&Utc),
+        dur_ms: ROUND_DURATION,
+        ttl_range: TtlRange::new(first, last).expect("the test range must hold"),
+        reached: false,
+        hops: hops
+            .iter()
+            .map(|(ttl, addr, rtt_ms)| Hop {
+                ttl: *ttl,
+                addr: address(addr),
+                rtt_ms: *rtt_ms,
+                icmp: TIME_EXCEEDED.to_owned(),
+            })
+            .collect(),
+    }
+}

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -478,9 +478,9 @@ mod tests {
         PrivilegeError, TraceConfig, TraceError,
     };
     use crate::record::{Privilege, Record, RoundRecord, RunId};
+    use crate::testing::address;
     use crate::{Multipath, Protocol, PROGRAM};
     use chrono::{DateTime, Utc};
-    use std::net::IpAddr;
     use std::sync::atomic::AtomicU64;
     use std::time::{Duration, SystemTime};
     use trippy_core::{
@@ -669,11 +669,6 @@ this platform needs raw socket privileges to send probes.
     /// The same moment, as the clock of the operating system reads it.
     fn clock(text: &str) -> SystemTime {
         SystemTime::from(utc(text))
-    }
-
-    /// Reads an address that a test names.
-    fn address(text: &str) -> IpAddr {
-        text.parse().expect("the test address must parse")
     }
 
     /// A probe that the round sent and that answered.

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -11,8 +11,8 @@
 //! The rest of the file covers the resolved configuration. A command line that
 //! names a destination prints the block and exits with success. A command line
 //! that contradicts itself prints the reason on standard error and exits with a
-//! failure. The `replay` command prints one summary line in the place of the
-//! block, and `tests/replay.rs` covers that line.
+//! failure. The `replay` command prints one summary line and the aggregate of
+//! the run in the place of the block, and `tests/replay.rs` covers those lines.
 
 // Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -440,8 +440,8 @@ fn a_destination_beside_a_replay_fails_and_names_both() {
 
 /// A replay takes no destination, and the parser asks for none.
 ///
-/// The summary line that the replay prints belongs to `tests/replay.rs`, so
-/// this test reads the exit status only.
+/// The lines that the replay prints belong to `tests/replay.rs`, so this test
+/// reads the exit status only.
 #[test]
 fn a_replay_needs_no_destination() {
     let result = run(&[REPLAY, FIXTURE]);

--- a/src/krt/tests/replay.rs
+++ b/src/krt/tests/replay.rs
@@ -1,8 +1,13 @@
 //! Black-box coverage for `krt replay`, driving the real binary.
 //!
-//! A replay reads a recorded file and prints one summary line for one run. The
-//! tests read the line that the binary printed, so they cover the whole path
-//! from the command line to standard output.
+//! A replay reads a recorded file, prints one summary line for one run, and
+//! prints the aggregate numbers of that run under it. The tests read the lines
+//! that the binary printed, so they cover the whole path from the command line
+//! to standard output.
+//!
+//! Every number of an expected constant is computed by hand, and the
+//! arithmetic stands beside the constant. A constant that copies what the
+//! binary printed proves nothing.
 //!
 //! The committed fixture holds two runs. It covers the default selection of the
 //! last run, and the selection of the other run by `--run`. Every other file is
@@ -47,16 +52,49 @@ const SECOND_RUN: &str = "2026-08-19T09:30:00.000Z";
 /// An identifier that the fixture does not hold.
 const ABSENT_RUN: &str = "1999-01-01T00:00:00.000Z";
 
-/// The summary of the first run of the fixture.
+/// What a replay prints for the first run of the fixture.
 ///
-/// The run makes two rounds. The first round answers at TTL 1 and TTL 3, and
-/// the second round answers at TTL 1, so two TTLs answered in all.
-const FIRST_RUN_SUMMARY: &str =
-    "2026-08-18T12:00:00.123Z  example.com (93.184.216.34)  2 rounds  2 hops  reached\n";
+/// The run makes two rounds. Both rounds carry the TTL range 1 to 3, so every
+/// one of those three TTLs took two probes. The first round answers at TTL 1
+/// from 192.168.1.1 at 1.23, and at TTL 3 from 93.184.216.34 at 24.1. The
+/// second round answers at TTL 1 from 192.168.1.1 at 1.41. Two TTLs answered
+/// in all.
+///
+/// TTL 1 answered both probes, so it loses nothing. The two answers are 1.23
+/// and 1.41. The sum is 2.64, so the mean is 2.64 / 2 = 1.32, which prints as
+/// 1.3. The distances from the mean are -0.09 and 0.09, and the squares of
+/// them sum to 0.0162. The population variance is 0.0162 / 2 = 0.0081, so the
+/// standard deviation is 0.09, which prints as 0.1. The jitter is the absolute
+/// difference of the last two answers, 1.41 - 1.23 = 0.18, which prints as
+/// 0.2.
+///
+/// TTL 2 answered no probe of the two, so its loss is 2 / 2 * 100 = 100.0
+/// percent, it names no host, and it holds no number.
+///
+/// TTL 3 answered one probe of the two, so its loss is 1 / 2 * 100 = 50.0
+/// percent. One answer is its own smallest, mean, and largest time, and the
+/// population standard deviation of one sample is 0.0. One sample names no
+/// last two answers, so it holds no jitter.
+const FIRST_RUN_OUTPUT: &str = "\
+2026-08-18T12:00:00.123Z  example.com (93.184.216.34)  2 rounds  2 hops  reached
+  1  192.168.1.1  loss 0.0%  sent 2  recv 2  last 1.4  min 1.2  avg 1.3  max 1.4  stddev 0.1  jitter 0.2
+  2  ???  loss 100.0%  sent 2  recv 0  last -  min -  avg -  max -  stddev -  jitter -
+  3  93.184.216.34  loss 50.0%  sent 2  recv 1  last 24.1  min 24.1  avg 24.1  max 24.1  stddev 0.0  jitter -
+";
 
-/// The summary of the second run of the fixture.
-const SECOND_RUN_SUMMARY: &str =
-    "2026-08-19T09:30:00.000Z  example.org (93.184.216.35)  1 round  2 hops  reached\n";
+/// What a replay prints for the second run of the fixture.
+///
+/// The run makes one round of the TTL range 1 to 2, and it answers at both
+/// TTLs. TTL 1 answers from 10.0.0.1 at 0.87, which prints as 0.9, and TTL 2
+/// answers from 93.184.216.35 at 12.5. Each TTL took one probe and answered
+/// it, so each one loses nothing. One answer is its own smallest, mean, and
+/// largest time, the population standard deviation of one sample is 0.0, and
+/// one sample holds no jitter.
+const SECOND_RUN_OUTPUT: &str = "\
+2026-08-19T09:30:00.000Z  example.org (93.184.216.35)  1 round  2 hops  reached
+  1  10.0.0.1  loss 0.0%  sent 1  recv 1  last 0.9  min 0.9  avg 0.9  max 0.9  stddev 0.0  jitter -
+  2  93.184.216.35  loss 0.0%  sent 1  recv 1  last 12.5  min 12.5  avg 12.5  max 12.5  stddev 0.0  jitter -
+";
 
 /// The `run` line of every file that a test builds.
 const BUILT_RUN_LINE: &str = r#"{"type":"run","run":"2026-08-20T00:00:00.000Z","krt":"0.1.0 (abc1234, clean)","source":{"addr":"1.2.3.4","kind":"public"},"target":{"arg":"example.net","addr":"198.51.100.7","family":"ipv4"},"config":{"interval_ms":1000,"protocol":"icmp","first_ttl":1,"max_ttl":30,"multipath":"classic","privilege":"unprivileged","dns":true},"host":"tims-mac"}"#;
@@ -65,6 +103,20 @@ const BUILT_RUN_LINE: &str = r#"{"type":"run","run":"2026-08-20T00:00:00.000Z","
 ///
 /// Two TTLs answered, and the round reached the target.
 const BUILT_ROUND_LINE: &str = r#"{"type":"round","run":"2026-08-20T00:00:00.000Z","seq":1,"ts":"2026-08-20T00:00:01.000Z","dur_ms":1000,"ttl_range":[1,2],"reached":true,"hops":[{"ttl":1,"addr":"10.0.0.1","rtt_ms":0.5,"icmp":"time_exceeded"},{"ttl":2,"addr":"198.51.100.7","rtt_ms":9.5,"icmp":"echo_reply"}]}"#;
+
+/// The aggregate of a built file that holds the one round.
+///
+/// The round carries the TTL range 1 to 2, so each of the two TTLs took one
+/// probe. Both TTLs answered, so neither one loses anything. One answer is its
+/// own smallest, mean, and largest time, the population standard deviation of
+/// one sample is 0.0, and one sample names no last two answers, so it holds no
+/// jitter.
+// A backslash at the end of a line of a string literal takes the newline and
+// every space that follows it, so a text whose first line is indented starts on
+// the line of the opening quotation mark.
+const BUILT_AGGREGATE: &str = "  1  10.0.0.1  loss 0.0%  sent 1  recv 1  last 0.5  min 0.5  avg 0.5  max 0.5  stddev 0.0  jitter -
+  2  198.51.100.7  loss 0.0%  sent 1  recv 1  last 9.5  min 9.5  avg 9.5  max 9.5  stddev 0.0  jitter -
+";
 
 /// The summary of a built file that holds the `run` record.
 const BUILT_SUMMARY: &str =
@@ -79,9 +131,80 @@ const BUILT_SUMMARY_WITHOUT_A_TARGET: &str =
 /// One TTL answered, so the summary of this round holds the singular `1 hop`.
 const BUILT_MISSED_ROUND_LINE: &str = r#"{"type":"round","run":"2026-08-20T00:00:00.000Z","seq":1,"ts":"2026-08-20T00:00:01.000Z","dur_ms":1000,"ttl_range":[1,2],"reached":false,"hops":[{"ttl":1,"addr":"10.0.0.1","rtt_ms":0.5,"icmp":"time_exceeded"}]}"#;
 
-/// The summary of a built file whose run did not reach the target.
-const BUILT_SUMMARY_NEVER_REACHED: &str =
-    "2026-08-20T00:00:00.000Z  example.net (198.51.100.7)  1 round  1 hop  never reached\n";
+/// What a replay prints for a built file whose run did not reach the target.
+///
+/// The round carries the TTL range 1 to 2, so each of the two TTLs took one
+/// probe. TTL 1 answered its probe, so it loses nothing. TTL 2 answered no
+/// probe of the one, so its loss is 1 / 1 * 100 = 100.0 percent, it names no
+/// host, and it holds no number.
+const BUILT_OUTPUT_NEVER_REACHED: &str = "\
+2026-08-20T00:00:00.000Z  example.net (198.51.100.7)  1 round  1 hop  never reached
+  1  10.0.0.1  loss 0.0%  sent 1  recv 1  last 0.5  min 0.5  avg 0.5  max 0.5  stddev 0.0  jitter -
+  2  ???  loss 100.0%  sent 1  recv 0  last -  min -  avg -  max -  stddev -  jitter -
+";
+
+/// The `round` lines of a run whose TTL 1 two routers answer at.
+///
+/// The first router answers round one at 1.0. The second router answers round
+/// two at 2.0 and round three at 3.0. TTL 2 answers every round at 10.0.
+const BUILT_SPLIT_ROUND_LINES: [&str; 3] = [
+    r#"{"type":"round","run":"2026-08-20T00:00:00.000Z","seq":1,"ts":"2026-08-20T00:00:01.000Z","dur_ms":1000,"ttl_range":[1,2],"reached":true,"hops":[{"ttl":1,"addr":"10.0.0.1","rtt_ms":1.0,"icmp":"time_exceeded"},{"ttl":2,"addr":"198.51.100.7","rtt_ms":10.0,"icmp":"echo_reply"}]}"#,
+    r#"{"type":"round","run":"2026-08-20T00:00:00.000Z","seq":2,"ts":"2026-08-20T00:00:02.000Z","dur_ms":1000,"ttl_range":[1,2],"reached":true,"hops":[{"ttl":1,"addr":"10.0.0.2","rtt_ms":2.0,"icmp":"time_exceeded"},{"ttl":2,"addr":"198.51.100.7","rtt_ms":10.0,"icmp":"echo_reply"}]}"#,
+    r#"{"type":"round","run":"2026-08-20T00:00:00.000Z","seq":3,"ts":"2026-08-20T00:00:03.000Z","dur_ms":1000,"ttl_range":[1,2],"reached":true,"hops":[{"ttl":1,"addr":"10.0.0.2","rtt_ms":3.0,"icmp":"time_exceeded"},{"ttl":2,"addr":"198.51.100.7","rtt_ms":10.0,"icmp":"echo_reply"}]}"#,
+];
+
+/// What a replay prints for the file of the split TTL.
+///
+/// Every one of the three rounds carries the TTL range 1 to 2, so each of the
+/// two TTLs took three probes, and every probe answered. Neither TTL loses
+/// anything.
+///
+/// TTL 1 saw two addresses, so its host field names the first one and the
+/// count of the other one. The three answers of the TTL are 1.0, 2.0, and 3.0.
+/// The sum is 6.0, so the mean is 6 / 3 = 2.0. The distances from the mean are
+/// -1.0, 0.0, and 1.0, and the squares of them sum to 2.0. The population
+/// variance is 2 / 3 = 0.667, so the standard deviation is 0.816, which prints
+/// as 0.8. The jitter is 3.0 - 2.0 = 1.0.
+///
+/// The first router answered one of the three answers of TTL 1, so its share
+/// is 1 / 3 * 100 = 33.3 percent. The second router answered the other two, so
+/// its share is 2 / 3 * 100 = 66.7 percent. The two answers of the second
+/// router are 2.0 and 3.0. The mean of them is 5 / 2 = 2.5, the distances are
+/// -0.5 and 0.5, and the squares sum to 0.5. The variance is 0.5 / 2 = 0.25,
+/// so the standard deviation is 0.5.
+///
+/// TTL 2 saw one address, so it takes no address line. Its three answers are
+/// all 10.0, so the mean is 10.0 and the standard deviation is 0.0. The jitter
+/// is 10.0 - 10.0 = 0.0.
+const BUILT_SPLIT_OUTPUT: &str = "\
+2026-08-20T00:00:00.000Z  example.net (198.51.100.7)  3 rounds  2 hops  reached
+  1  10.0.0.1 (+1)  loss 0.0%  sent 3  recv 3  last 3.0  min 1.0  avg 2.0  max 3.0  stddev 0.8  jitter 1.0
+      10.0.0.1  share 33.3%  recv 1  last 1.0  min 1.0  avg 1.0  max 1.0  stddev 0.0  jitter -
+      10.0.0.2  share 66.7%  recv 2  last 3.0  min 2.0  avg 2.5  max 3.0  stddev 0.5  jitter 1.0
+  2  198.51.100.7  loss 0.0%  sent 3  recv 3  last 10.0  min 10.0  avg 10.0  max 10.0  stddev 0.0  jitter 0.0
+";
+
+/// The text between two fields of a line that a replay prints.
+const FIELD_SEPARATOR: &str = "  ";
+
+/// The name of the field that holds the share of one address.
+const SHARE: &str = "share";
+
+/// The sign that ends a percentage.
+const PERCENT_SIGN: &str = "%";
+
+/// The whole of a percentage, which the shares of one TTL sum to.
+const WHOLE_PERCENT: f64 = 100.0;
+
+/// The largest difference that a comparison of two percentages admits.
+///
+/// The two shares of this test are 33.3 and 66.7, which sum to exactly 100
+/// in decimal. A read of each printed decimal into a number with a
+/// fraction loses a little. The sum then misses the whole by about 1e-14,
+/// and this tolerance covers that loss. A pair of shares that rounds the
+/// other way misses the whole by a tenth, and this test names no such
+/// pair.
+const PERCENT_TOLERANCE: f64 = 1e-9;
 
 /// The start of a `round` line that a `kill -9` cut short.
 const CUT_CHUNK: &str = r#"{"type":"round""#;
@@ -217,10 +340,24 @@ fn file_of(lines: &[&str]) -> String {
     text
 }
 
+/// Reads the share that one address line printed.
+fn share_of(line: &str) -> f64 {
+    let prefix = format!("{SHARE} ");
+    let field = line
+        .split(FIELD_SEPARATOR)
+        .find_map(|field| field.strip_prefix(&prefix))
+        .unwrap_or_else(|| panic!("an address line holds a share field: {line}"));
+    field
+        .strip_suffix(PERCENT_SIGN)
+        .unwrap_or_else(|| panic!("a share ends with the percent sign: {line}"))
+        .parse()
+        .unwrap_or_else(|_| panic!("a share reads as a number: {line}"))
+}
+
 #[test]
-fn a_replay_prints_the_summary_of_the_last_run() {
+fn a_replay_prints_the_summary_and_the_aggregate_of_the_last_run() {
     let result = success(&[REPLAY, FIXTURE]);
-    assert_eq!(result.stdout, SECOND_RUN_SUMMARY);
+    assert_eq!(result.stdout, SECOND_RUN_OUTPUT);
     assert_eq!(
         result.stderr, "",
         "a whole file writes nothing to standard error"
@@ -228,12 +365,39 @@ fn a_replay_prints_the_summary_of_the_last_run() {
 }
 
 #[test]
-fn a_named_run_prints_the_summary_of_that_run() {
+fn a_named_run_prints_the_summary_and_the_aggregate_of_that_run() {
     let result = success(&[REPLAY, FIXTURE, RUN_FLAG, FIRST_RUN]);
-    assert_eq!(result.stdout, FIRST_RUN_SUMMARY);
+    assert_eq!(result.stdout, FIRST_RUN_OUTPUT);
     assert_eq!(
         result.stderr, "",
         "a whole file writes nothing to standard error"
+    );
+}
+
+/// A TTL that two routers answer at names both of them, and the two shares of
+/// that TTL sum to the whole.
+///
+/// A share per address is the measure that a TTL of two routers needs. A loss
+/// per address would report 50 percent for a pair that splits the traffic
+/// evenly and loses nothing.
+#[test]
+fn a_ttl_that_two_routers_answer_at_prints_one_line_for_each_of_them() {
+    let mut lines = vec![BUILT_RUN_LINE];
+    lines.extend(BUILT_SPLIT_ROUND_LINES);
+    let file = TempFile::new("split", &file_of(&lines));
+    let path = file.arg();
+    let result = success(&[REPLAY, path.as_str()]);
+    assert_eq!(result.stdout, BUILT_SPLIT_OUTPUT);
+    assert_eq!(
+        result.stderr, "",
+        "a whole file writes nothing to standard error"
+    );
+
+    let printed: Vec<&str> = result.stdout.lines().collect();
+    let total = share_of(printed[2]) + share_of(printed[3]);
+    assert!(
+        (total - WHOLE_PERCENT).abs() < PERCENT_TOLERANCE,
+        "the printed shares of one TTL sum to {WHOLE_PERCENT}, and they sum to {total}"
     );
 }
 
@@ -291,7 +455,7 @@ fn a_final_line_that_is_cut_short_warns_and_still_prints_the_summary() {
     let file = TempFile::new("cut", &text);
     let path = file.arg();
     let result = success(&[REPLAY, path.as_str()]);
-    assert_eq!(result.stdout, BUILT_SUMMARY);
+    assert_eq!(result.stdout, format!("{BUILT_SUMMARY}{BUILT_AGGREGATE}"));
     assert!(
         result.stderr.contains(path.as_str()),
         "the warning names the path: {}",
@@ -310,7 +474,10 @@ fn a_file_without_a_run_record_prints_no_target() {
     let file = TempFile::new("no-run-record", &file_of(&[BUILT_ROUND_LINE]));
     let path = file.arg();
     let result = success(&[REPLAY, path.as_str()]);
-    assert_eq!(result.stdout, BUILT_SUMMARY_WITHOUT_A_TARGET);
+    assert_eq!(
+        result.stdout,
+        format!("{BUILT_SUMMARY_WITHOUT_A_TARGET}{BUILT_AGGREGATE}")
+    );
     assert_eq!(
         result.stderr, "",
         "a whole file writes nothing to standard error"
@@ -324,7 +491,7 @@ fn a_run_that_did_not_reach_the_target_says_so() {
     let file = TempFile::new("missed", &text);
     let path = file.arg();
     let result = success(&[REPLAY, path.as_str()]);
-    assert_eq!(result.stdout, BUILT_SUMMARY_NEVER_REACHED);
+    assert_eq!(result.stdout, BUILT_OUTPUT_NEVER_REACHED);
     assert_eq!(
         result.stderr, "",
         "a whole file writes nothing to standard error"

--- a/src/krt/tests/replay.rs
+++ b/src/krt/tests/replay.rs
@@ -193,7 +193,8 @@ const SHARE: &str = "share";
 /// The sign that ends a percentage.
 const PERCENT_SIGN: &str = "%";
 
-/// The whole of a percentage, which the shares of one TTL sum to.
+/// The whole of a percentage, which the shares of one TTL sum to while that
+/// TTL tracks every address that answered at it.
 const WHOLE_PERCENT: f64 = 100.0;
 
 /// The largest difference that a comparison of two percentages admits.


### PR DESCRIPTION
Closes #369.

## Why

`trippy_core::State` already computes loss, best, worst, average, and standard
deviation. `krt` cannot use it. The replay mode reads rounds back out of a
recorded file, and a recorded file carries no tracer state. A second
implementation for replay would drift away from the live one.

This branch adds one fold. The channel feeds the fold live, and the file reader
feeds the same fold offline. Both directions give identical numbers.

## What it adds

- `src/krt/src/stats.rs` — `HopTable::observe` folds one `RoundRecord` into the
  table. Welford's online algorithm keeps the mean and the standard deviation in
  constant memory, so a run of millions of samples stays numerically stable.
- Two levels of key. A TTL row covers every answer at that hop position. An
  address row sits under a TTL that saw more than one address.
- Two loss columns, because the difference is not cosmetic. A TTL row shows
  `Loss%`, which is the true loss of that position. An address row shows
  `Share%`. A loss percentage for one address misleads the reader, because two
  routers that split the traffic evenly each look like 50 percent loss when they
  lose nothing.
- The replay prints the aggregate. `krt --replay <file>` prints one line for
  each TTL, and one line for each address under a TTL that saw more than one.
- `record::TtlRange::first` and `record::TtlRange::last` lose their `dead_code`
  expectations. The fold is the caller they waited for.

## Tests

The branch is test-first throughout, one red commit and one green commit for
each slice. `cargo test -p krt` passes 252 unit tests, 12 CLI tests, and 12
replay tests.

The full gates pass over the workspace: `cargo fmt --all -- --check`,
`cargo machete`, `cargo clippy --workspace --all-targets`, and
`cargo test --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
