### PR TITLE
feat(krt): the run loop folds a reverse DNS name over each address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +1957,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5597a4b7fe5275fc9dcf88ce26326bc8e4cb87d0130f33752d4c5f717793cf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.6.5",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2042,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3661,6 +3702,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.7",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.7",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,6 +4312,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,6 +4573,7 @@ dependencies = [
  "termsize",
  "thiserror 2.0.20",
  "trippy-core",
+ "trippy-dns",
  "trippy-privilege",
  "unicode-width",
 ]
@@ -4596,6 +4696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,6 +4777,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -6514,6 +6629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7852,6 +7973,20 @@ dependencies = [
  "trippy-privilege",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "trippy-dns"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199065919ab40574006383853f7fd3a0bc80a09954d4a43283a287f62651871a"
+dependencies = [
+ "crossbeam",
+ "dns-lookup",
+ "hickory-resolver",
+ "itertools 0.14.0",
+ "parking_lot",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ percent-encoding = "2.3"
 # every mention of a trippy type in one module, and `repo_guards::trippy_wall`
 # keeps it there, so an upgrade breaks one file.
 trippy-core = "=0.13.0"
+trippy-dns = "0.13.0"
 trippy-privilege = "0.13.0"
 
 # Date/time

--- a/README.md
+++ b/README.md
@@ -631,10 +631,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - A run resolves the name of each address it sees through the system resolver of the platform.
     The file takes one `name` record for each name, and one record for each address at most,
     however many rounds that address answers in. An address that resolves to no name keeps its raw
-    address, and the file holds no record for it. A lookup holds up no round, and a run waits up to
-    2 seconds after its last round for the names that its lookups have not given yet. `--no-dns`
-    skips every lookup, so the file then holds no `name` record and the `run` record says
-    `"dns":false`.
+    address, and the file holds no record for it. A lookup holds up no round, and a run waits after
+    its last round for the names that its lookups have not given yet. That wait ends the moment
+    that every lookup settles, and its ceiling is the timeout of the system resolver, which is 5
+    seconds. `--no-dns` skips every lookup, so the file then holds no `name` record and the `run`
+    record says `"dns":false`.
   - `krt replay` prints one table of the path. A header line names the destination, the address it
     resolved to, the source, the count of the rounds, the period of one round, and the recorded
     file with its size. Under it stands one row for each TTL, with the columns `TTL`, `Host`,

--- a/README.md
+++ b/README.md
@@ -628,6 +628,13 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     time. Each of the two writes the record that closes the run. On macOS and Linux, Ctrl-C also
     stops the run at once and writes that record. Windows gets that key with the table that a
     later build adds.
+  - A run resolves the name of each address it sees through the system resolver of the platform.
+    The file takes one `name` record for each name, and one record for each address at most,
+    however many rounds that address answers in. An address that resolves to no name keeps its raw
+    address, and the file holds no record for it. A lookup holds up no round, and a run waits up to
+    2 seconds after its last round for the names that its lookups have not given yet. `--no-dns`
+    skips every lookup, so the file then holds no `name` record and the `run` record says
+    `"dns":false`.
   - `krt replay` prints one table of the path. A header line names the destination, the address it
     resolved to, the source, the count of the rounds, the period of one round, and the recorded
     file with its size. Under it stands one row for each TTL, with the columns `TTL`, `Host`,
@@ -657,7 +664,8 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - macOS sends the probes without privileges. Linux needs `CAP_NET_RAW`, and Windows needs an
     elevated prompt. A platform that needs privileges and does not hold them prints the remedy and
     stops, and `krt` never falls back to a degraded trace without saying so.
-  - `krt` takes its tracer from [`trippy-core`](https://trippy.rs), which is Apache-2.0.
+  - `krt` takes its tracer from [`trippy-core`](https://trippy.rs) and its resolver from
+    [`trippy-dns`](https://trippy.rs), and both of them are Apache-2.0.
   - Usage: `krt example.com`, `krt example.com --rounds 3`, `krt example.com --duration 1h`,
     `krt example.com --interval 500ms --protocol udp --multipath paris`,
     `krt replay trace.jsonl`, `krt replay trace.jsonl --run 2026-08-19T12:00:00.000Z`

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -17,6 +17,7 @@ sysinfo.workspace = true
 termsize.workspace = true
 thiserror.workspace = true
 trippy-core.workspace = true
+trippy-dns.workspace = true
 trippy-privilege.workspace = true
 unicode-width.workspace = true
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1054,6 +1054,21 @@ fn resolver_of(reverse_dns: bool) -> std::io::Result<Box<dyn names::Resolver>> {
     }
 }
 
+/// Reads the configuration that one run records, out of the command line that
+/// the run resolved and the privilege mode that the platform gave.
+///
+/// The `run` record states what the run does, and a reader of a recorded file
+/// takes that statement as the truth. So every field here reads one field of
+/// the resolved command line, and nothing here holds a value of its own.
+///
+/// The `dns` field is the one that a reader is most likely to doubt, because
+/// a file that holds no `name` record reads the same whether `--no-dns` turned
+/// the lookups off or whether no address of the run resolved. The field
+/// separates the two.
+fn run_config(config: &ResolvedConfig, privilege: record::Privilege) -> RunConfig {
+    todo!("the configuration that one run records arrives with the green step: {config:?} {privilege:?}")
+}
+
 /// Records one trace, from the destination of the command line to the record
 /// that closes the run.
 ///
@@ -1120,15 +1135,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         krt: version_string!().to_owned(),
         source,
         target,
-        config: RunConfig {
-            interval_ms: interval_millis(config.interval),
-            protocol: config.protocol,
-            first_ttl: config.first_ttl,
-            max_ttl: config.max_ttl,
-            multipath: config.multipath,
-            privilege,
-            dns: config.reverse_dns,
-        },
+        config: run_config(config, privilege),
         host: host_name(),
     };
 
@@ -1211,11 +1218,12 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        closing_line, host_name_or, parse_duration, pick_address, resolve_target, source_from,
-        stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family, Multipath,
-        Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT,
+        closing_line, host_name_or, parse_duration, pick_address, resolve_target, run_config,
+        source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family,
+        Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT,
         SOURCE_FALLBACK, UNKNOWN,
     };
+    use crate::record::{Privilege, RunConfig};
     use crate::run::Outcome;
     use crate::source::Discovery;
     use crate::testing::address;
@@ -1249,6 +1257,61 @@ mod tests {
         parse(arguments)
             .resolve()
             .expect("the command line must resolve")
+    }
+
+    /// The configuration that a command line records, under the privilege that
+    /// a probe of this run needs.
+    fn recorded_config(arguments: &[&str], privilege: Privilege) -> RunConfig {
+        run_config(&resolve(arguments), privilege)
+    }
+
+    #[test]
+    fn a_run_that_reads_names_records_that_it_reads_them() {
+        assert!(
+            recorded_config(&["krt", "example.com"], Privilege::Unprivileged).dns,
+            "reverse DNS is on by default, and the record must say so"
+        );
+    }
+
+    #[test]
+    fn the_no_dns_flag_reaches_the_dns_field_of_the_record() {
+        assert!(
+            !recorded_config(&["krt", "example.com", "--no-dns"], Privilege::Unprivileged).dns,
+            "`--no-dns` turns the lookups off, and the record must say so"
+        );
+    }
+
+    #[test]
+    fn every_field_of_the_recorded_config_reads_the_command_line_that_set_it() {
+        let recorded = recorded_config(
+            &[
+                "krt",
+                "example.com",
+                "--interval",
+                "2s",
+                "--first-ttl",
+                "3",
+                "--max-ttl",
+                "9",
+                "--protocol",
+                "udp",
+                "--multipath",
+                "paris",
+            ],
+            Privilege::Privileged,
+        );
+        assert_eq!(
+            recorded,
+            RunConfig {
+                interval_ms: 2000,
+                protocol: Protocol::Udp,
+                first_ttl: 3,
+                max_ttl: 9,
+                multipath: Multipath::Paris,
+                privilege: Privilege::Privileged,
+                dns: true,
+            }
+        );
     }
 
     /// Reads the message of a command line that contradicts itself.

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1107,12 +1107,16 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         rounds: config.rounds,
         deadline: deadline_of(config.duration),
     };
+    // Every run of this slice looks nothing up. The slice that follows reads
+    // `--no-dns` and picks the resolver of the run from it.
+    let mut namer = names::Namer::new(Box::new(names::NoLookups), start.run.clone());
     let mut status = std::io::stdout();
     let outcome = run::record(
         &start,
         &rounds,
         &limits,
         &|| user_stopped(&flag),
+        &mut namer,
         &mut writer,
         &mut status,
     )

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1054,6 +1054,11 @@ fn resolver_of(reverse_dns: bool) -> std::io::Result<Box<dyn names::Resolver>> {
     }
 }
 
+/// The grace that a run gives its names after its last round.
+fn name_grace() -> Duration {
+    run::NAME_GRACE
+}
+
 /// Reads the configuration that one run records, out of the command line that
 /// the run resolved and the privilege mode that the platform gave.
 ///
@@ -1156,7 +1161,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
     let limits = run::Limits {
         rounds: config.rounds,
         deadline: deadline_of(config.duration),
-        name_grace: run::NAME_GRACE,
+        name_grace: name_grace(),
     };
     let mut namer = names::Namer::new(resolver, start.run.clone());
     let mut status = std::io::stdout();
@@ -1227,10 +1232,10 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        closing_line, host_name_or, parse_duration, pick_address, resolve_target, run_config,
-        source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason, Family,
-        Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT,
-        SOURCE_FALLBACK, UNKNOWN,
+        closing_line, host_name_or, name_grace, parse_duration, pick_address, resolve_target,
+        run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason,
+        Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel,
+        RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
     };
     use crate::record::{Privilege, RunConfig};
     use crate::run::Outcome;
@@ -1320,6 +1325,22 @@ mod tests {
                 privilege: Privilege::Privileged,
                 dns: true,
             }
+        );
+    }
+
+    /// The grace that a run gives its names is never shorter than the longest
+    /// that one lookup takes.
+    ///
+    /// A grace below the timeout of the resolver drops the name of a hop whose
+    /// name server answers slowly and truly, and the file of the run then holds
+    /// the raw address of that hop.
+    #[test]
+    fn the_grace_of_the_names_outlives_every_lookup_that_can_still_answer() {
+        let grace = name_grace();
+        let timeout = crate::trace::resolver_timeout();
+        assert!(
+            grace >= timeout,
+            "the run gives its names {grace:?}, and one lookup takes up to {timeout:?}"
         );
     }
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -869,8 +869,9 @@ fn replay(path: &Path, wanted: Option<&str>, width: u16) -> Replay {
             }
             // A `name` record names one address, and one address answers at any
             // number of TTLs, so the map is keyed by the address and not by the
-            // hop. No run writes such a record yet, and a file that a later
-            // build recorded holds them.
+            // hop. A run of this build writes such a record. A file that an
+            // older build recorded holds none, and the map then leaves the
+            // address raw.
             let names: BTreeMap<IpAddr, String> = run
                 .names()
                 .iter()
@@ -1037,11 +1038,10 @@ fn closing_line(outcome: &run::Outcome, path: &Path) -> String {
 /// platform.
 ///
 /// A resolver that does not start stops the run, and that is a decision. The
-/// start of the system resolver fails when the platform gives it no thread, and
-/// the tracer of the same run needs threads of its own, so a run that cannot
-/// start a resolver cannot record either. A fatal start also keeps the `dns`
-/// field of the `run` record true by construction: a run that reaches the loop
-/// holds the resolver that the user asked for.
+/// crate reports a start failure as an `io::Error`, and `krt` treats one as
+/// fatal. A fatal start also keeps the `dns` field of the `run` record true by
+/// construction: a run that reaches the loop holds the resolver that the user
+/// asked for.
 ///
 /// # Errors
 ///

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1156,6 +1156,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
     let limits = run::Limits {
         rounds: config.rounds,
         deadline: deadline_of(config.duration),
+        name_grace: run::NAME_GRACE,
     };
     let mut namer = names::Namer::new(resolver, start.run.clone());
     let mut status = std::io::stdout();

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1066,7 +1066,15 @@ fn resolver_of(reverse_dns: bool) -> std::io::Result<Box<dyn names::Resolver>> {
 /// the lookups off or whether no address of the run resolved. The field
 /// separates the two.
 fn run_config(config: &ResolvedConfig, privilege: record::Privilege) -> RunConfig {
-    todo!("the configuration that one run records arrives with the green step: {config:?} {privilege:?}")
+    RunConfig {
+        interval_ms: interval_millis(config.interval),
+        protocol: config.protocol,
+        first_ttl: config.first_ttl,
+        max_ttl: config.max_ttl,
+        multipath: config.multipath,
+        privilege,
+        dns: config.reverse_dns,
+    }
 }
 
 /// Records one trace, from the destination of the command line to the record

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1055,8 +1055,14 @@ fn resolver_of(reverse_dns: bool) -> std::io::Result<Box<dyn names::Resolver>> {
 }
 
 /// The grace that a run gives its names after its last round.
+///
+/// The grace is the timeout of the reverse resolver. Every lookup settles when
+/// that time runs out, so this grace outlives every lookup that can still
+/// answer, and a hop whose name server answers slowly still takes a `name`
+/// record. The wait ends at the moment that no address waits, so a run whose
+/// addresses settled pays none of it.
 fn name_grace() -> Duration {
-    run::NAME_GRACE
+    trace::resolver_timeout()
 }
 
 /// Reads the configuration that one run records, out of the command line that

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -13,6 +13,7 @@
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+mod names;
 mod record;
 mod run;
 mod source;

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1030,6 +1030,30 @@ fn closing_line(outcome: &run::Outcome, path: &Path) -> String {
     .join(SUMMARY_SEPARATOR)
 }
 
+/// The reverse resolver of one run.
+///
+/// `--no-dns` gives the resolver that looks nothing up, so no lookup of such a
+/// run leaves the machine. Every other run takes the system resolver of the
+/// platform.
+///
+/// A resolver that does not start stops the run, and that is a decision. The
+/// start of the system resolver fails when the platform gives it no thread, and
+/// the tracer of the same run needs threads of its own, so a run that cannot
+/// start a resolver cannot record either. A fatal start also keeps the `dns`
+/// field of the `run` record true by construction: a run that reaches the loop
+/// holds the resolver that the user asked for.
+///
+/// # Errors
+///
+/// Returns the reason when the system resolver does not start.
+fn resolver_of(reverse_dns: bool) -> std::io::Result<Box<dyn names::Resolver>> {
+    if reverse_dns {
+        trace::resolver()
+    } else {
+        Ok(Box::new(names::NoLookups))
+    }
+}
+
 /// Records one trace, from the destination of the command line to the record
 /// that closes the run.
 ///
@@ -1037,8 +1061,10 @@ fn closing_line(outcome: &run::Outcome, path: &Path) -> String {
 /// run before the next one spends anything. The resolution comes first, because
 /// it needs no privilege and touches no file. The privilege gate comes next, so
 /// a platform that cannot probe says so before the run makes a file. The
-/// recorded file opens before the tracer starts, so no probe leaves the machine
-/// for a run that cannot record it.
+/// reverse resolver starts after the gate and before the recorded file opens,
+/// so a run that cannot start its resolver makes no file and prints no path.
+/// The recorded file opens before the tracer starts, so no probe leaves the
+/// machine for a run that cannot record it.
 ///
 /// # Errors
 ///
@@ -1052,6 +1078,15 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         .map_err(|error| TraceFailure::new(&error, EXIT_FAILURE))?;
     let privilege = trace::acquire_privilege()
         .map_err(|error| TraceFailure::new(&error, EXIT_NO_PRIVILEGES))?;
+    // The resolver starts here, before the run makes a file and before it
+    // prints the path of that file, so no message of a run that stops misleads
+    // a reader.
+    let resolver = resolver_of(config.reverse_dns).map_err(|error| {
+        TraceFailure::new(
+            &format!("the reverse resolver did not start: {error}"),
+            EXIT_FAILURE,
+        )
+    })?;
 
     // The search runs here, and it runs once. The warning of a fallback
     // therefore reaches standard error once a run and never once a round, and
@@ -1107,9 +1142,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         rounds: config.rounds,
         deadline: deadline_of(config.duration),
     };
-    // Every run of this slice looks nothing up. The slice that follows reads
-    // `--no-dns` and picks the resolver of the run from it.
-    let mut namer = names::Namer::new(Box::new(names::NoLookups), start.run.clone());
+    let mut namer = names::Namer::new(resolver, start.run.clone());
     let mut status = std::io::stdout();
     let outcome = run::record(
         &start,

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -17,13 +17,6 @@ use std::collections::{BTreeSet, HashSet};
 use std::net::IpAddr;
 
 /// What a reverse lookup of one address holds now.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the binary of this slice looks nothing up, so it builds `Nameless` alone. The resolver of the slice that follows builds `Named` and `Pending`, and the tests of this module build them today"
-    )
-)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Lookup {
     /// The lookup finished, and the address carries this name.

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -123,6 +123,18 @@ impl Namer {
 
         records
     }
+
+    /// Answers whether any address still waits for its lookup.
+    ///
+    /// The first ask of an address starts the lookup of that address, so a name
+    /// arrives on a later turn than the round that first reported it. A run that
+    /// is about to close reads this to learn whether a name is still on its way.
+    ///
+    /// The answer is `false` when every address that the run saw carries a name
+    /// or carries none, and `false` also before the run sees its first address.
+    pub(crate) fn waits(&self) -> bool {
+        !self.waiting.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -141,11 +141,8 @@ impl Namer {
 mod tests {
     use super::{Lookup, Namer, NoLookups, Resolver};
     use crate::record::{Hop, NameRecord, RunId};
-    use crate::testing::{address, round};
+    use crate::testing::{address, named, round, FakeResolver};
     use chrono::{DateTime, Utc};
-    use std::cell::{Cell, RefCell};
-    use std::collections::{HashMap, VecDeque};
-    use std::net::IpAddr;
     use std::rc::Rc;
 
     /// The identifier of the run that every test of this module folds.
@@ -204,11 +201,6 @@ mod tests {
         round(FIRST_TTL, LAST_TTL, &answers).hops
     }
 
-    /// The answer of a lookup that finished with a name.
-    fn named(host: &str) -> Lookup {
-        Lookup::Named(host.to_owned())
-    }
-
     /// The record that the name of one address takes at one moment.
     fn record(ts: &str, addr: &str, host: &str) -> NameRecord {
         NameRecord {
@@ -216,64 +208,6 @@ mod tests {
             ts: moment(ts),
             addr: address(addr),
             host: host.to_owned(),
-        }
-    }
-
-    /// A resolver that a test programs: one answer for each ask of one address,
-    /// and the last answer of the list for every ask after the list runs out.
-    ///
-    /// An address that the test named no answer for answers `Nameless`.
-    ///
-    /// The counts and the answers sit behind a `Cell` and a `RefCell`, because
-    /// [`Resolver::lookup`] takes the resolver by reference. The fake stays on
-    /// one thread.
-    struct FakeResolver {
-        /// The answers that each address holds, the next answer first.
-        answers: RefCell<HashMap<IpAddr, VecDeque<Lookup>>>,
-        /// The number of asks that the resolver took.
-        asks: Cell<usize>,
-    }
-
-    impl FakeResolver {
-        /// A resolver that answers each address with the answers of its list.
-        fn new(answers: &[(&str, &[Lookup])]) -> Rc<Self> {
-            Rc::new(Self {
-                answers: RefCell::new(
-                    answers
-                        .iter()
-                        .map(|(addr, list)| (address(addr), list.iter().cloned().collect()))
-                        .collect(),
-                ),
-                asks: Cell::new(0),
-            })
-        }
-
-        /// The number of asks that the resolver took.
-        fn asks(&self) -> usize {
-            self.asks.get()
-        }
-
-        /// The answer of one ask, and one step along the list of that address.
-        fn answer(&self, addr: IpAddr) -> Lookup {
-            self.asks.set(self.asks.get() + 1);
-            let mut answers = self.answers.borrow_mut();
-            let Some(queue) = answers.get_mut(&addr) else {
-                return Lookup::Nameless;
-            };
-            // The last answer of a list stands for every ask after it, so the
-            // list keeps that answer in the place of a step.
-            let answer = if queue.len() > 1 {
-                queue.pop_front()
-            } else {
-                queue.front().cloned()
-            };
-            answer.unwrap_or(Lookup::Nameless)
-        }
-    }
-
-    impl Resolver for Rc<FakeResolver> {
-        fn lookup(&self, addr: IpAddr) -> Lookup {
-            self.answer(addr)
         }
     }
 

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -21,7 +21,7 @@ use std::net::IpAddr;
     not(test),
     expect(
         dead_code,
-        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+        reason = "the binary of this slice looks nothing up, so it builds `Nameless` alone. The resolver of the slice that follows builds `Named` and `Pending`, and the tests of this module build them today"
     )
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,13 +37,6 @@ pub(crate) enum Lookup {
 }
 
 /// A reverse resolver that never blocks its caller.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
-    )
-)]
 pub(crate) trait Resolver {
     /// Asks for the name of one address, and answers with whatever the resolver
     /// holds now.
@@ -57,13 +50,6 @@ pub(crate) trait Resolver {
 ///
 /// `--no-dns` becomes this resolver, so no branch of the run loop reads the
 /// switch and no lookup leaves the machine.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
-    )
-)]
 pub(crate) struct NoLookups;
 
 impl Resolver for NoLookups {
@@ -73,13 +59,6 @@ impl Resolver for NoLookups {
 }
 
 /// Turns the addresses that a run reports into `name` records.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
-    )
-)]
 pub(crate) struct Namer {
     /// The resolver that every ask of this namer goes to.
     resolver: Box<dyn Resolver>,
@@ -95,13 +74,6 @@ pub(crate) struct Namer {
 
 impl Namer {
     /// A namer that asks this resolver and stamps every record with this run.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn new(resolver: Box<dyn Resolver>, run: RunId) -> Self {
         Self {
             resolver,
@@ -120,13 +92,6 @@ impl Namer {
     ///
     /// One address takes one record in one run, whatever the number of TTLs it
     /// answers at and whatever the number of rounds it appears in.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
-        )
-    )]
     pub(crate) fn names(&mut self, hops: &[Hop], now: DateTime<Utc>) -> Vec<NameRecord> {
         // An address that settled needs no further ask, so no round puts it
         // back into the set of the addresses that wait. One address arrives at

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -341,6 +341,43 @@ mod tests {
         );
     }
 
+    /// The answer of the namer about the lookups that are still on their way.
+    ///
+    /// A namer that saw no address waits for nothing. An address whose lookup
+    /// has not finished holds the namer. An address that took a name, and an
+    /// address that took none, hold it no longer.
+    #[test]
+    fn the_namer_waits_only_while_an_address_waits_for_its_lookup() {
+        let resolver = FakeResolver::new(&[
+            (FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)]),
+            (TARGET, &[Lookup::Pending, Lookup::Nameless]),
+        ]);
+        let mut namer = namer(&resolver);
+        assert!(
+            !namer.waits(),
+            "a namer that saw no address waits for nothing"
+        );
+        let first = namer.names(&hops(&[(1, FIRST_HOP), (3, TARGET)]), moment(FIRST_MOMENT));
+        assert!(
+            first.is_empty(),
+            "neither lookup finished on the first turn"
+        );
+        assert!(
+            namer.waits(),
+            "the two addresses that wait for their lookups hold the namer"
+        );
+        let later = namer.names(&[], moment(LATER_MOMENT));
+        assert_eq!(
+            later,
+            vec![record(LATER_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "the address that took a name gives its record on the later turn"
+        );
+        assert!(
+            !namer.waits(),
+            "an address that took a name, and an address that took none, hold the namer no longer"
+        );
+    }
+
     #[test]
     fn two_addresses_that_resolve_on_one_turn_give_two_records_in_address_order() {
         let resolver = FakeResolver::new(&[

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -1,0 +1,450 @@
+//! The reverse DNS fold of one run: every address that a round reports, in one
+//! `name` record each.
+//!
+//! A run sees the same address at many TTLs and in many rounds, and a reverse
+//! lookup of an address takes a time that no round waits for. This module holds
+//! the two sets that answer both of those facts: the addresses whose lookups
+//! have not finished, and the addresses that need no further ask. A turn of the
+//! run hands the hops of a round to the fold, and the fold answers with one
+//! record for each name that arrived since the turn before it.
+//!
+//! The fold asks a resolver and reads nothing else, so a test drives it without
+//! a network and without a name server.
+
+use crate::record::{Hop, NameRecord, RunId};
+use chrono::{DateTime, Utc};
+use std::collections::{BTreeSet, HashSet};
+use std::net::IpAddr;
+
+/// What a reverse lookup of one address holds now.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+    )
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Lookup {
+    /// The lookup finished, and the address carries this name.
+    Named(String),
+    /// The lookup finished, and the address carries no name. A lookup that
+    /// failed and a lookup that timed out both land here, because the run shows
+    /// the raw address for each of them and asks no second time.
+    Nameless,
+    /// The lookup has not finished. The caller asks again on a later turn.
+    Pending,
+}
+
+/// A reverse resolver that never blocks its caller.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+    )
+)]
+pub(crate) trait Resolver {
+    /// Asks for the name of one address, and answers with whatever the resolver
+    /// holds now.
+    ///
+    /// The first ask starts the lookup, and every ask after it reads the
+    /// answer. No ask waits for the network.
+    fn lookup(&self, addr: IpAddr) -> Lookup;
+}
+
+/// A resolver that looks nothing up.
+///
+/// `--no-dns` becomes this resolver, so no branch of the run loop reads the
+/// switch and no lookup leaves the machine.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+    )
+)]
+pub(crate) struct NoLookups;
+
+impl Resolver for NoLookups {
+    fn lookup(&self, addr: IpAddr) -> Lookup {
+        todo!(
+            "the answer of the resolver that looks nothing up arrives with the green step: {addr}"
+        )
+    }
+}
+
+/// Turns the addresses that a run reports into `name` records.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+    )
+)]
+pub(crate) struct Namer {
+    /// The resolver that every ask of this namer goes to.
+    resolver: Box<dyn Resolver>,
+    /// The identifier that every record of this namer carries.
+    run: RunId,
+    /// The addresses whose lookups have not finished. The set is ordered, so
+    /// the records of one turn come out in one order whatever the run.
+    waiting: BTreeSet<IpAddr>,
+    /// The addresses that need no further ask, whether they carry a name or
+    /// not.
+    settled: HashSet<IpAddr>,
+}
+
+impl Namer {
+    /// A namer that asks this resolver and stamps every record with this run.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn new(resolver: Box<dyn Resolver>, run: RunId) -> Self {
+        todo!("the namer of one run arrives with the green step: {run}")
+    }
+
+    /// Reads the addresses that a round reported, asks the resolver about every
+    /// address whose lookup has not finished, and answers with one record for
+    /// each name that arrived.
+    ///
+    /// A turn that saw no round passes an empty slice, so a lookup that
+    /// finishes between two rounds still lands.
+    ///
+    /// One address takes one record in one run, whatever the number of TTLs it
+    /// answers at and whatever the number of rounds it appears in.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the run loop of issue #371 writes these records; the tests of this module are the one reader today"
+        )
+    )]
+    pub(crate) fn names(&mut self, hops: &[Hop], now: DateTime<Utc>) -> Vec<NameRecord> {
+        todo!(
+            "the records of one turn arrive with the green step: {} hops at {now}",
+            hops.len()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Lookup, Namer, NoLookups, Resolver};
+    use crate::record::{Hop, NameRecord, RunId};
+    use crate::testing::{address, round};
+    use chrono::{DateTime, Utc};
+    use std::cell::{Cell, RefCell};
+    use std::collections::{HashMap, VecDeque};
+    use std::net::IpAddr;
+    use std::rc::Rc;
+
+    /// The identifier of the run that every test of this module folds.
+    const RUN: &str = "2026-08-23T12:00:00.000Z";
+
+    /// The moment of the first turn of a test.
+    const FIRST_MOMENT: &str = "2026-08-23T12:00:01.000Z";
+
+    /// The moment of the turn after the first one.
+    const LATER_MOMENT: &str = "2026-08-23T12:00:02.000Z";
+
+    /// The first TTL that every test round probes.
+    const FIRST_TTL: u8 = 1;
+
+    /// The last TTL that every test round probes.
+    const LAST_TTL: u8 = 3;
+
+    /// The round-trip time of a hop that no test of this module reads.
+    const ANY_RTT: f64 = 1.5;
+
+    /// The address of the first router of the test path.
+    const FIRST_HOP: &str = "192.168.1.1";
+
+    /// The name of the first router of the test path.
+    const FIRST_HOP_NAME: &str = "gateway.example.com";
+
+    /// The address of one more router of the test path.
+    ///
+    /// The address stands below `TARGET` in address order, and a test of the
+    /// order of the records reads that.
+    const LEFT_ROUTER: &str = "10.0.0.1";
+
+    /// The name of that router.
+    const LEFT_ROUTER_NAME: &str = "left.example.com";
+
+    /// The address of the target of the test path.
+    const TARGET: &str = "93.184.216.34";
+
+    /// The name of the target of the test path.
+    const TARGET_NAME: &str = "example.com";
+
+    /// Reads a moment that a test names.
+    fn moment(text: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(text)
+            .expect("the test moment must parse")
+            .with_timezone(&Utc)
+    }
+
+    /// The hops of one round: each one a TTL, and the address that answered at
+    /// that TTL.
+    fn hops(answers: &[(u8, &str)]) -> Vec<Hop> {
+        let answers: Vec<(u8, &str, f64)> = answers
+            .iter()
+            .map(|(ttl, addr)| (*ttl, *addr, ANY_RTT))
+            .collect();
+        round(FIRST_TTL, LAST_TTL, &answers).hops
+    }
+
+    /// The answer of a lookup that finished with a name.
+    fn named(host: &str) -> Lookup {
+        Lookup::Named(host.to_owned())
+    }
+
+    /// The record that the name of one address takes at one moment.
+    fn record(ts: &str, addr: &str, host: &str) -> NameRecord {
+        NameRecord {
+            run: RunId::from(RUN),
+            ts: moment(ts),
+            addr: address(addr),
+            host: host.to_owned(),
+        }
+    }
+
+    /// A resolver that a test programs: one answer for each ask of one address,
+    /// and the last answer of the list for every ask after the list runs out.
+    ///
+    /// An address that the test named no answer for answers `Nameless`.
+    ///
+    /// The counts and the answers sit behind a `Cell` and a `RefCell`, because
+    /// [`Resolver::lookup`] takes the resolver by reference. The fake stays on
+    /// one thread.
+    struct FakeResolver {
+        /// The answers that each address holds, the next answer first.
+        answers: RefCell<HashMap<IpAddr, VecDeque<Lookup>>>,
+        /// The number of asks that the resolver took.
+        asks: Cell<usize>,
+    }
+
+    impl FakeResolver {
+        /// A resolver that answers each address with the answers of its list.
+        fn new(answers: &[(&str, &[Lookup])]) -> Rc<Self> {
+            Rc::new(Self {
+                answers: RefCell::new(
+                    answers
+                        .iter()
+                        .map(|(addr, list)| (address(addr), list.iter().cloned().collect()))
+                        .collect(),
+                ),
+                asks: Cell::new(0),
+            })
+        }
+
+        /// The number of asks that the resolver took.
+        fn asks(&self) -> usize {
+            self.asks.get()
+        }
+
+        /// The answer of one ask, and one step along the list of that address.
+        fn answer(&self, addr: IpAddr) -> Lookup {
+            self.asks.set(self.asks.get() + 1);
+            let mut answers = self.answers.borrow_mut();
+            let Some(queue) = answers.get_mut(&addr) else {
+                return Lookup::Nameless;
+            };
+            // The last answer of a list stands for every ask after it, so the
+            // list keeps that answer in the place of a step.
+            let answer = if queue.len() > 1 {
+                queue.pop_front()
+            } else {
+                queue.front().cloned()
+            };
+            answer.unwrap_or(Lookup::Nameless)
+        }
+    }
+
+    impl Resolver for Rc<FakeResolver> {
+        fn lookup(&self, addr: IpAddr) -> Lookup {
+            self.answer(addr)
+        }
+    }
+
+    /// A namer of the test run that asks this resolver.
+    fn namer(resolver: &Rc<FakeResolver>) -> Namer {
+        Namer::new(Box::new(Rc::clone(resolver)), RunId::from(RUN))
+    }
+
+    #[test]
+    fn an_address_that_resolves_gives_one_record_of_the_run() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        let records = namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        assert_eq!(
+            records,
+            vec![record(FIRST_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "the record carries the run, the moment, the address, and the name"
+        );
+    }
+
+    #[test]
+    fn an_address_with_no_name_gives_no_record_and_the_run_goes_on() {
+        let resolver = FakeResolver::new(&[
+            (FIRST_HOP, &[Lookup::Nameless]),
+            (TARGET, &[named(TARGET_NAME)]),
+        ]);
+        let mut namer = namer(&resolver);
+        let first = namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        assert!(first.is_empty(), "an address with no name takes no record");
+        let later = namer.names(&hops(&[(3, TARGET)]), moment(LATER_MOMENT));
+        assert_eq!(
+            later,
+            vec![record(LATER_MOMENT, TARGET, TARGET_NAME)],
+            "the run names the addresses that follow an address with no name"
+        );
+    }
+
+    #[test]
+    fn an_address_that_answers_late_gives_its_record_on_the_later_turn() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        let first = namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        assert!(
+            first.is_empty(),
+            "a lookup that has not finished takes no record"
+        );
+        let later = namer.names(&hops(&[(1, FIRST_HOP)]), moment(LATER_MOMENT));
+        assert_eq!(
+            later,
+            vec![record(LATER_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "the record carries the moment that the name arrived"
+        );
+    }
+
+    #[test]
+    fn an_address_in_two_rounds_gives_one_record() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        let first = namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        assert_eq!(
+            first,
+            vec![record(FIRST_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "the first round of the address takes the record"
+        );
+        let later = namer.names(&hops(&[(1, FIRST_HOP)]), moment(LATER_MOMENT));
+        assert!(
+            later.is_empty(),
+            "the second round of the address takes no second record"
+        );
+    }
+
+    #[test]
+    fn an_address_at_two_ttls_of_one_round_gives_one_record() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        let records = namer.names(
+            &hops(&[(1, FIRST_HOP), (2, FIRST_HOP)]),
+            moment(FIRST_MOMENT),
+        );
+        assert_eq!(
+            records,
+            vec![record(FIRST_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "one address takes one record, whatever the number of TTLs it answers at"
+        );
+    }
+
+    #[test]
+    fn an_address_that_holds_a_name_is_never_asked_again() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        let asks = resolver.asks();
+        assert_eq!(asks, 1, "the first turn asked the resolver once");
+        namer.names(&hops(&[(1, FIRST_HOP)]), moment(LATER_MOMENT));
+        assert_eq!(
+            resolver.asks(),
+            asks,
+            "an address that holds a name takes no further ask"
+        );
+    }
+
+    #[test]
+    fn an_address_that_holds_no_name_is_never_asked_again() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Nameless])]);
+        let mut namer = namer(&resolver);
+        namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        let asks = resolver.asks();
+        assert_eq!(asks, 1, "the first turn asked the resolver once");
+        namer.names(&hops(&[(1, FIRST_HOP)]), moment(LATER_MOMENT));
+        assert_eq!(
+            resolver.asks(),
+            asks,
+            "an address that holds no name takes no further ask"
+        );
+    }
+
+    #[test]
+    fn a_turn_that_saw_no_round_still_asks_about_the_addresses_that_wait() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        let mut namer = namer(&resolver);
+        let first = namer.names(&hops(&[(1, FIRST_HOP)]), moment(FIRST_MOMENT));
+        assert!(
+            first.is_empty(),
+            "a lookup that has not finished takes no record"
+        );
+        let later = namer.names(&[], moment(LATER_MOMENT));
+        assert_eq!(
+            later,
+            vec![record(LATER_MOMENT, FIRST_HOP, FIRST_HOP_NAME)],
+            "a lookup that finishes between two rounds lands on the turn that saw no round"
+        );
+    }
+
+    #[test]
+    fn two_addresses_that_resolve_on_one_turn_give_two_records_in_address_order() {
+        let resolver = FakeResolver::new(&[
+            (TARGET, &[named(TARGET_NAME)]),
+            (LEFT_ROUTER, &[named(LEFT_ROUTER_NAME)]),
+        ]);
+        let mut namer = namer(&resolver);
+        // The target answers at the lower TTL, so the hops name it first. The
+        // records must still run in address order, because `10.0.0.1` stands
+        // below `93.184.216.34`.
+        let records = namer.names(
+            &hops(&[(1, TARGET), (2, LEFT_ROUTER)]),
+            moment(FIRST_MOMENT),
+        );
+        assert_eq!(
+            records,
+            vec![
+                record(FIRST_MOMENT, LEFT_ROUTER, LEFT_ROUTER_NAME),
+                record(FIRST_MOMENT, TARGET, TARGET_NAME),
+            ],
+            "the records of one turn run in address order"
+        );
+    }
+
+    #[test]
+    fn the_resolver_that_looks_nothing_up_gives_no_record_for_any_round() {
+        assert_eq!(
+            NoLookups.lookup(address(FIRST_HOP)),
+            Lookup::Nameless,
+            "the resolver that looks nothing up names no address"
+        );
+        let mut namer = Namer::new(Box::new(NoLookups), RunId::from(RUN));
+        assert!(
+            namer
+                .names(&hops(&[(1, FIRST_HOP), (3, TARGET)]), moment(FIRST_MOMENT))
+                .is_empty(),
+            "no address of the first round takes a record"
+        );
+        assert!(
+            namer
+                .names(&hops(&[(1, FIRST_HOP)]), moment(LATER_MOMENT))
+                .is_empty(),
+            "no address of a later round takes a record"
+        );
+    }
+}

--- a/src/krt/src/names.rs
+++ b/src/krt/src/names.rs
@@ -67,10 +67,8 @@ pub(crate) trait Resolver {
 pub(crate) struct NoLookups;
 
 impl Resolver for NoLookups {
-    fn lookup(&self, addr: IpAddr) -> Lookup {
-        todo!(
-            "the answer of the resolver that looks nothing up arrives with the green step: {addr}"
-        )
+    fn lookup(&self, _addr: IpAddr) -> Lookup {
+        Lookup::Nameless
     }
 }
 
@@ -105,7 +103,12 @@ impl Namer {
         )
     )]
     pub(crate) fn new(resolver: Box<dyn Resolver>, run: RunId) -> Self {
-        todo!("the namer of one run arrives with the green step: {run}")
+        Self {
+            resolver,
+            run,
+            waiting: BTreeSet::new(),
+            settled: HashSet::new(),
+        }
     }
 
     /// Reads the addresses that a round reported, asks the resolver about every
@@ -125,10 +128,42 @@ impl Namer {
         )
     )]
     pub(crate) fn names(&mut self, hops: &[Hop], now: DateTime<Utc>) -> Vec<NameRecord> {
-        todo!(
-            "the records of one turn arrive with the green step: {} hops at {now}",
-            hops.len()
-        )
+        // An address that settled needs no further ask, so no round puts it
+        // back into the set of the addresses that wait. One address arrives at
+        // many TTLs of one round and in many rounds of one run, and the two
+        // sets together hold one entry for it.
+        for hop in hops {
+            if !self.settled.contains(&hop.addr) {
+                self.waiting.insert(hop.addr);
+            }
+        }
+
+        let mut records = Vec::new();
+        let mut settled_now = Vec::new();
+        for addr in &self.waiting {
+            match self.resolver.lookup(*addr) {
+                Lookup::Named(host) => {
+                    records.push(NameRecord {
+                        run: self.run.clone(),
+                        ts: now,
+                        addr: *addr,
+                        host,
+                    });
+                    settled_now.push(*addr);
+                }
+                Lookup::Nameless => settled_now.push(*addr),
+                Lookup::Pending => {}
+            }
+        }
+
+        // The loop above reads the set of the addresses that wait, so the moves
+        // between the two sets come after it.
+        for addr in settled_now {
+            self.waiting.remove(&addr);
+            self.settled.insert(addr);
+        }
+
+        records
     }
 }
 

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -5,7 +5,9 @@
 //! A reverse lookup takes a time that no round waits for, so the loop asks the
 //! namer of `names.rs` on every turn and writes whatever the namer hands back.
 //! A turn that saw no round asks too, so a name that arrives between two rounds
-//! still reaches the file.
+//! still reaches the file. The run also asks one last time before it closes,
+//! because the name of an address that a round reports arrives after that
+//! round, and the last round of a run has no turn behind it.
 //!
 //! The tracer of `trace.rs` carries no limit of its own. It sends one round
 //! after another until the process ends, and this module owns the number of
@@ -104,6 +106,12 @@ pub(crate) enum RunError {
 /// finishes between two rounds still reaches the file. The `name` records of a
 /// turn stand before the `round` record of that turn.
 ///
+/// The run asks the namer one last time before it writes the `end` record, and
+/// again until no address waits or `limits.name_grace` runs out. The first ask
+/// of an address starts the lookup of that address, so the name of an address
+/// that the last round reported arrives after that round, and this last ask is
+/// what puts it in the file.
+///
 /// Each round that the run records also prints one status line to `status`.
 ///
 /// A failed write of any record stops the run. The recording is the whole
@@ -129,6 +137,7 @@ pub(crate) fn record<W: Write, S: Write>(
     let mut recorded: u64 = 0;
     loop {
         if let Some(reason) = stopped(recorded, limits, stop) {
+            drain_names(writer, namer, limits.name_grace)?;
             close(writer, &start.run, recorded, reason)?;
             return Ok(Outcome {
                 rounds: recorded,
@@ -138,9 +147,10 @@ pub(crate) fn record<W: Write, S: Write>(
         match rounds.recv_timeout(wait(limits.deadline)) {
             Ok(round) => {
                 let line = status_line(&round);
-                // The names of the round stand before the round, so a reader of
-                // the file holds the name of every address of a round by the
-                // time the round arrives.
+                // The names that arrived stand before the round of the same
+                // turn. A name always lands on a later turn than the round that
+                // first reported its address, because the first ask of an
+                // address starts the lookup of that address.
                 write_names(writer, namer.names(&round.hops, Utc::now()))?;
                 writer
                     .write(&Record::Round(round))
@@ -167,6 +177,11 @@ pub(crate) fn record<W: Write, S: Write>(
                 // `end` record will not write reports that fault and not the
                 // dead tracer, because a file that takes no record names the
                 // fault that stops the tool from doing its job at all.
+                //
+                // The grace of this drain is zero. The names that already
+                // arrived still reach the file, and a run that is already
+                // failing waits for nothing.
+                drain_names(writer, namer, Duration::ZERO)?;
                 close(writer, &start.run, recorded, EndReason::Error)?;
                 return Err(RunError::Tracer { rounds: recorded });
             }
@@ -184,6 +199,40 @@ fn write_names<W: Write>(writer: &mut Writer<W>, names: Vec<NameRecord>) -> Resu
         writer.write(&Record::Name(name)).map_err(RunError::Write)?;
     }
     Ok(())
+}
+
+/// Asks the namer one last time, and again until no address waits or the grace
+/// runs out. Each name that arrives becomes one record.
+///
+/// The first ask of an address starts the lookup of that address, so the name of
+/// an address that a round reports arrives on a later turn. A run whose last
+/// turn is its stopping turn therefore holds names that no turn wrote, and this
+/// drain is the turn that writes them.
+///
+/// The drain asks once whatever the grace, so a grace of zero still writes the
+/// names that already arrived. Between two asks it sleeps for [`POLL`] at the
+/// longest, and never past the end of the grace.
+///
+/// # Errors
+///
+/// Returns [`RunError::Write`] when a record does not reach the file.
+fn drain_names<W: Write>(
+    writer: &mut Writer<W>,
+    namer: &mut Namer,
+    grace: Duration,
+) -> Result<(), RunError> {
+    let end = Instant::now() + grace;
+    loop {
+        write_names(writer, namer.names(&[], Utc::now()))?;
+        if !namer.waits() {
+            return Ok(());
+        }
+        let left = end.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            return Ok(());
+        }
+        std::thread::sleep(left.min(POLL));
+    }
 }
 
 /// Writes the one line that a run prints for one round.

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -37,6 +37,17 @@ use std::time::{Duration, Instant};
 /// because the wait ends after this time and the loop takes another turn.
 const POLL: Duration = Duration::from_millis(100);
 
+/// The longest that a run waits, after its last round, for the names that its
+/// lookups have not given yet.
+///
+/// The value is a trade. A warm system resolver answers in milliseconds, so the
+/// common short run pays about that much and not this whole time. The wait ends
+/// at the moment that no address waits, so a long run whose addresses settled
+/// many rounds ago pays nothing at all. And a hop whose name server answers
+/// nothing holds its lookup open for longer than any bounded value, so a larger
+/// value catches that name no better than this one does.
+pub(crate) const NAME_GRACE: Duration = Duration::from_secs(2);
+
 /// The limits that stop a run.
 #[derive(Debug)]
 pub(crate) struct Limits {
@@ -45,6 +56,9 @@ pub(crate) struct Limits {
     pub(crate) rounds: Option<u64>,
     /// The moment that stops the run. No moment runs until the user stops it.
     pub(crate) deadline: Option<Instant>,
+    /// The longest that the run waits, after its last round, for the names that
+    /// its lookups have not given yet.
+    pub(crate) name_grace: Duration,
 }
 
 /// What a run produced.
@@ -340,10 +354,18 @@ mod tests {
     /// The status line of a round that answered one hop and reached nothing.
     const A_LOST_ROUND_LINE: &str = "round 2  1 hop  never reached  1004ms";
 
+    /// The grace that every test run gives its names.
+    ///
+    /// The fake resolver of a test answers at once, so no test waits for a
+    /// lookup. The run still asks one last time before it closes, whatever this
+    /// value, so a name that arrived after the last round still lands.
+    const NO_GRACE: Duration = Duration::ZERO;
+
     /// The limits of a run that stops on nothing.
     const NO_LIMIT: Limits = Limits {
         rounds: None,
         deadline: None,
+        name_grace: NO_GRACE,
     };
 
     /// The number of turns that a run takes before the user stops it.
@@ -351,6 +373,13 @@ mod tests {
     /// The loop asks the stop closure once at the top of each turn, so the
     /// third question follows the second turn.
     const STOP_AFTER: u64 = 2;
+
+    /// The number of turns that a run takes before the user stops it right
+    /// after its one round.
+    ///
+    /// The second question follows the first turn, so the run stops on the turn
+    /// that comes straight after the round it recorded.
+    const STOP_AFTER_ONE_TURN: u64 = 1;
 
     /// The fault of a sink that takes no more records.
     const THE_SINK_IS_FULL: &str = "the sink takes no more records";
@@ -489,6 +518,7 @@ mod tests {
         Limits {
             rounds: Some(rounds),
             deadline: None,
+            name_grace: NO_GRACE,
         }
     }
 
@@ -501,6 +531,7 @@ mod tests {
                     .checked_sub(Duration::from_secs(1))
                     .expect("the clock must stand one second after the start of the process"),
             ),
+            name_grace: NO_GRACE,
         }
     }
 
@@ -1185,6 +1216,68 @@ mod tests {
             FIRST_HOP_NAME,
             "the record holds the name that arrived"
         );
+    }
+
+    /// The first ask of an address starts its lookup, so the name of the one
+    /// round of a one round run arrives on the turn that stops the run. The run
+    /// asks one last time before it closes, so the name still reaches the file.
+    #[test]
+    fn a_run_that_stops_after_its_last_round_still_writes_the_name_that_arrived() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "name-drain-rounds",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds(1),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "name", "end"],
+            "the name that arrived after the last round stands before the end"
+        );
+        assert_eq!(
+            names_of(&ran.recording)[0].host,
+            FIRST_HOP_NAME,
+            "the record holds the name that arrived"
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Rounds);
+        assert_eq!(outcome_of(&ran).rounds, 1);
+    }
+
+    /// A run that the user stops takes the same last ask, so a name that
+    /// arrives on the stopping turn reaches the file.
+    #[test]
+    fn a_run_that_the_user_stops_still_writes_the_name_that_arrived() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        // The sender stands for the whole run, so the loop stops on the user
+        // and reads no closed channel.
+        let (_sender, stream) = a_held_stream(&rounds_of(&[1]));
+        let asked = Cell::new(0_u64);
+        let stop = || {
+            let asked_before = asked.get();
+            asked.set(asked_before + 1);
+            asked_before >= STOP_AFTER_ONE_TURN
+        };
+        let ran = ran_with(
+            "name-drain-quit",
+            &stream,
+            &NO_LIMIT,
+            &stop,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "name", "end"],
+            "the name that arrived on the stopping turn stands before the end"
+        );
+        assert_eq!(
+            names_of(&ran.recording)[0].host,
+            FIRST_HOP_NAME,
+            "the record holds the name that arrived"
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Quit);
+        assert_eq!(outcome_of(&ran).rounds, 1);
     }
 
     // The status line of one round. A later slice replaces this line with the

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -314,19 +314,17 @@ fn close<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{record, Limits, Outcome, RunError};
-    use crate::names::{Lookup, Namer, NoLookups, Resolver};
+    use crate::names::{Lookup, Namer, NoLookups};
     use crate::record::{
         EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
         RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
-    use crate::testing::address;
+    use crate::testing::{address, named, FakeResolver};
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::cell::{Cell, RefCell};
-    use std::collections::{HashMap, VecDeque};
     use std::fs;
     use std::io::{self, Write};
-    use std::net::IpAddr;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::sync::mpsc::{self, Receiver, Sender};
@@ -690,69 +688,6 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
-    }
-
-    /// A resolver that a test programs: one answer for each ask of one address,
-    /// and the last answer of the list for every ask after the list runs out.
-    ///
-    /// An address that the test named no answer for answers `Nameless`.
-    ///
-    /// The count and the answers sit behind a `Cell` and a `RefCell`, because
-    /// [`Resolver::lookup`] takes the resolver by reference. The fake stays on
-    /// one thread.
-    struct FakeResolver {
-        /// The answers that each address holds, the next answer first.
-        answers: RefCell<HashMap<IpAddr, VecDeque<Lookup>>>,
-        /// The number of asks that the resolver took.
-        asks: Cell<usize>,
-    }
-
-    impl FakeResolver {
-        /// A resolver that answers each address with the answers of its list.
-        fn new(answers: &[(&str, &[Lookup])]) -> Rc<Self> {
-            Rc::new(Self {
-                answers: RefCell::new(
-                    answers
-                        .iter()
-                        .map(|(addr, list)| (address(addr), list.iter().cloned().collect()))
-                        .collect(),
-                ),
-                asks: Cell::new(0),
-            })
-        }
-
-        /// The number of asks that the resolver took.
-        fn asks(&self) -> usize {
-            self.asks.get()
-        }
-
-        /// The answer of one ask, and one step along the list of that address.
-        fn answer(&self, addr: IpAddr) -> Lookup {
-            self.asks.set(self.asks.get() + 1);
-            let mut answers = self.answers.borrow_mut();
-            let Some(queue) = answers.get_mut(&addr) else {
-                return Lookup::Nameless;
-            };
-            // The last answer of a list stands for every ask after it, so the
-            // list keeps that answer in the place of a step.
-            let answer = if queue.len() > 1 {
-                queue.pop_front()
-            } else {
-                queue.front().cloned()
-            };
-            answer.unwrap_or(Lookup::Nameless)
-        }
-    }
-
-    impl Resolver for Rc<FakeResolver> {
-        fn lookup(&self, addr: IpAddr) -> Lookup {
-            self.answer(addr)
-        }
-    }
-
-    /// The answer of a lookup that finished with a name.
-    fn named(host: &str) -> Lookup {
-        Lookup::Named(host.to_owned())
     }
 
     /// A namer of the test run that asks this resolver.

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -1,5 +1,11 @@
-//! The run loop: the record that opens a run, one record for each round, the
-//! record that closes it, and one status line for each round.
+//! The run loop: the record that opens a run, one record for each name that a
+//! reverse lookup gave, one record for each round, the record that closes it,
+//! and one status line for each round.
+//!
+//! A reverse lookup takes a time that no round waits for, so the loop asks the
+//! namer of `names.rs` on every turn and writes whatever the namer hands back.
+//! A turn that saw no round asks too, so a name that arrives between two rounds
+//! still reaches the file.
 //!
 //! The tracer of `trace.rs` carries no limit of its own. It sends one round
 //! after another until the process ends, and this module owns the number of
@@ -14,7 +20,10 @@
 //! recording is the whole purpose of the tool, and a run that keeps a display
 //! while it silently records nothing is worse than a run that stops.
 
-use crate::record::{EndReason, EndRecord, Record, RoundRecord, RunId, RunRecord, Writer};
+use crate::names::Namer;
+use crate::record::{
+    EndReason, EndRecord, NameRecord, Record, RoundRecord, RunId, RunRecord, Writer,
+};
 use crate::ui::render_duration;
 use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
 use chrono::Utc;
@@ -75,6 +84,12 @@ pub(crate) enum RunError {
 /// anything. Each round that arrives becomes one `round` record. The `end`
 /// record names the number of rounds that the run recorded and why it stopped.
 ///
+/// Every turn also asks `namer` for the names that arrived, and each name
+/// becomes one `name` record. The turn hands the namer the hops of the round it
+/// read, and a turn that read no round hands it nothing, so a lookup that
+/// finishes between two rounds still reaches the file. The `name` records of a
+/// turn stand before the `round` record of that turn.
+///
 /// Each round that the run records also prints one status line to `status`.
 ///
 /// A failed write of any record stops the run. The recording is the whole
@@ -90,6 +105,7 @@ pub(crate) fn record<W: Write, S: Write>(
     rounds: &Receiver<RoundRecord>,
     limits: &Limits,
     stop: &dyn Fn() -> bool,
+    namer: &mut Namer,
     writer: &mut Writer<W>,
     status: &mut S,
 ) -> Result<Outcome, RunError> {
@@ -134,6 +150,15 @@ pub(crate) fn record<W: Write, S: Write>(
             }
         }
     }
+}
+
+/// Appends one record for each name that arrived.
+///
+/// # Errors
+///
+/// Returns [`RunError::Write`] when a record does not reach the file.
+fn write_names<W: Write>(_writer: &mut Writer<W>, _names: Vec<NameRecord>) -> Result<(), RunError> {
+    todo!("the write of the name records arrives with the green step")
 }
 
 /// Writes the one line that a run prints for one round.
@@ -215,19 +240,22 @@ fn close<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{record, Limits, Outcome, RunError};
+    use crate::names::{Lookup, Namer, NoLookups, Resolver};
     use crate::record::{
-        EndReason, EndRecord, Family, Hop, Privilege, Record, Recording, RoundRecord, RunConfig,
-        RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
+        EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
+        RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
     use crate::testing::address;
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::cell::{Cell, RefCell};
+    use std::collections::{HashMap, VecDeque};
     use std::fs;
     use std::io::{self, Write};
+    use std::net::IpAddr;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
-    use std::sync::mpsc::{self, Receiver};
+    use std::sync::mpsc::{self, Receiver, Sender};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     /// The identifier of the run that every test record belongs to.
@@ -242,8 +270,14 @@ mod tests {
     /// The address of the first hop of a test round.
     const FIRST_HOP: &str = "192.168.1.1";
 
+    /// The name that a reverse lookup gives the first hop of a test round.
+    const FIRST_HOP_NAME: &str = "gateway.example.com";
+
     /// The address of the target of a test run.
     const TARGET_ADDRESS: &str = "93.184.216.34";
+
+    /// The name that a reverse lookup gives the target of a test run.
+    const TARGET_NAME: &str = "target.example.com";
 
     /// The destination of a test run, as the user typed it.
     const TARGET_ARG: &str = "example.com";
@@ -301,12 +335,10 @@ mod tests {
         deadline: None,
     };
 
-    /// The number of turns that the run of one test takes before the user stops
-    /// it.
+    /// The number of turns that a run takes before the user stops it.
     ///
-    /// The loop asks the stop closure once at the top of each turn, and each
-    /// turn of that test records one round, so the third question follows the
-    /// second round.
+    /// The loop asks the stop closure once at the top of each turn, so the
+    /// third question follows the second turn.
     const STOP_AFTER: u64 = 2;
 
     /// The fault of a sink that takes no more records.
@@ -393,6 +425,19 @@ mod tests {
         }
     }
 
+    /// One round that no hop answered.
+    fn a_silent_round(seq: u64) -> RoundRecord {
+        RoundRecord {
+            run: RunId::from(RUN),
+            seq,
+            ts: moment(ROUND_START),
+            dur_ms: LOST_ROUND_MS,
+            ttl_range: TtlRange::new(FIRST_TTL, TARGET_TTL).expect("the test range must hold"),
+            reached: false,
+            hops: Vec::new(),
+        }
+    }
+
     /// The rounds of a test, in the order the tracer sends them.
     fn rounds_of(seqs: &[u64]) -> Vec<RoundRecord> {
         seqs.iter().copied().map(a_round).collect()
@@ -411,6 +456,21 @@ mod tests {
                 .expect("the receiver of the test must stand");
         }
         receiver
+    }
+
+    /// A channel that holds these rounds and whose sender the caller keeps.
+    ///
+    /// The loop reads a closed channel as a tracer that died, so a test whose
+    /// run must reach a limit holds the sender for the whole run. The tracer
+    /// holds its own sender the same way.
+    fn a_held_stream(rounds: &[RoundRecord]) -> (Sender<RoundRecord>, Receiver<RoundRecord>) {
+        let (sender, receiver) = mpsc::channel();
+        for round in rounds {
+            sender
+                .send(round.clone())
+                .expect("the receiver of the test must stand");
+        }
+        (sender, receiver)
     }
 
     /// The limits of a run that stops after this many rounds.
@@ -541,6 +601,79 @@ mod tests {
         }
     }
 
+    /// A resolver that a test programs: one answer for each ask of one address,
+    /// and the last answer of the list for every ask after the list runs out.
+    ///
+    /// An address that the test named no answer for answers `Nameless`.
+    ///
+    /// The count and the answers sit behind a `Cell` and a `RefCell`, because
+    /// [`Resolver::lookup`] takes the resolver by reference. The fake stays on
+    /// one thread.
+    struct FakeResolver {
+        /// The answers that each address holds, the next answer first.
+        answers: RefCell<HashMap<IpAddr, VecDeque<Lookup>>>,
+        /// The number of asks that the resolver took.
+        asks: Cell<usize>,
+    }
+
+    impl FakeResolver {
+        /// A resolver that answers each address with the answers of its list.
+        fn new(answers: &[(&str, &[Lookup])]) -> Rc<Self> {
+            Rc::new(Self {
+                answers: RefCell::new(
+                    answers
+                        .iter()
+                        .map(|(addr, list)| (address(addr), list.iter().cloned().collect()))
+                        .collect(),
+                ),
+                asks: Cell::new(0),
+            })
+        }
+
+        /// The number of asks that the resolver took.
+        fn asks(&self) -> usize {
+            self.asks.get()
+        }
+
+        /// The answer of one ask, and one step along the list of that address.
+        fn answer(&self, addr: IpAddr) -> Lookup {
+            self.asks.set(self.asks.get() + 1);
+            let mut answers = self.answers.borrow_mut();
+            let Some(queue) = answers.get_mut(&addr) else {
+                return Lookup::Nameless;
+            };
+            // The last answer of a list stands for every ask after it, so the
+            // list keeps that answer in the place of a step.
+            let answer = if queue.len() > 1 {
+                queue.pop_front()
+            } else {
+                queue.front().cloned()
+            };
+            answer.unwrap_or(Lookup::Nameless)
+        }
+    }
+
+    impl Resolver for Rc<FakeResolver> {
+        fn lookup(&self, addr: IpAddr) -> Lookup {
+            self.answer(addr)
+        }
+    }
+
+    /// The answer of a lookup that finished with a name.
+    fn named(host: &str) -> Lookup {
+        Lookup::Named(host.to_owned())
+    }
+
+    /// A namer of the test run that asks this resolver.
+    fn a_namer(resolver: &Rc<FakeResolver>) -> Namer {
+        Namer::new(Box::new(Rc::clone(resolver)), RunId::from(RUN))
+    }
+
+    /// A namer of the test run that looks nothing up.
+    fn a_nameless_namer() -> Namer {
+        Namer::new(Box::new(NoLookups), RunId::from(RUN))
+    }
+
     /// What one recorded run produced.
     struct Ran {
         /// What the run loop gave back.
@@ -551,18 +684,37 @@ mod tests {
         status: String,
     }
 
-    /// Records one run to a real file, and reads the file back.
+    /// Records one run that looks nothing up to a real file, and reads the file
+    /// back.
     fn ran(label: &str, rounds: &[RoundRecord], limits: &Limits, stop: &dyn Fn() -> bool) -> Ran {
+        ran_with(
+            label,
+            &a_stream(rounds),
+            limits,
+            stop,
+            &mut a_nameless_namer(),
+        )
+    }
+
+    /// Records one run that asks this namer to a real file, and reads the file
+    /// back.
+    fn ran_with(
+        label: &str,
+        rounds: &Receiver<RoundRecord>,
+        limits: &Limits,
+        stop: &dyn Fn() -> bool,
+        namer: &mut Namer,
+    ) -> Ran {
         let file = TempFile::absent(label);
-        let stream = a_stream(rounds);
         let mut status: Vec<u8> = Vec::new();
         let outcome = {
             let mut writer = Writer::append(file.path()).expect("the test file must open");
             record(
                 &a_run_record(),
-                &stream,
+                rounds,
                 limits,
                 stop,
+                namer,
                 &mut writer,
                 &mut status,
             )
@@ -604,6 +756,30 @@ mod tests {
             Some(Record::End(end)) => end,
             other => panic!("the file must end with an `end` record: {other:?}"),
         }
+    }
+
+    /// The `type` value of every record that reached a sink, in write order.
+    fn kinds_in(text: &str) -> Vec<&'static str> {
+        text.lines()
+            .map(|line| {
+                let written = Record::from_line(line)
+                    .expect("the record must parse")
+                    .expect("the record must name a type that this build knows");
+                kind_of(&written)
+            })
+            .collect()
+    }
+
+    /// The `name` record of every name of a recording, in file order.
+    fn names_of(recording: &Recording) -> Vec<&NameRecord> {
+        recording
+            .records()
+            .iter()
+            .filter_map(|record| match record {
+                Record::Name(name) => Some(name),
+                _ => None,
+            })
+            .collect()
     }
 
     /// The number of every round of a recording, in file order.
@@ -746,6 +922,7 @@ mod tests {
             &a_stream(&rounds_of(&[1])),
             &after_rounds(1),
             &|| false,
+            &mut a_nameless_namer(),
             &mut writer,
             &mut Vec::new(),
         );
@@ -769,6 +946,7 @@ mod tests {
             &a_stream(&rounds_of(&[1])),
             &after_rounds(3),
             &|| false,
+            &mut a_nameless_namer(),
             &mut writer,
             &mut Vec::new(),
         );
@@ -783,6 +961,213 @@ mod tests {
             .expect("the record must parse")
             .expect("the record must name a type that this build knows");
         assert_eq!(kind_of(&written), "run");
+    }
+
+    // The `name` record of each address that a run sees.
+
+    #[test]
+    fn an_address_that_resolves_writes_one_name_record_of_the_run() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "name-one",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds(1),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "name", "round", "end"],
+            "the name of the round stands before the round"
+        );
+        let names = names_of(&ran.recording);
+        assert_eq!(names.len(), 1, "the run named one address: {names:?}");
+        assert_eq!(names[0].run, RunId::from(RUN), "the record names the run");
+        assert_eq!(
+            names[0].addr,
+            address(FIRST_HOP),
+            "the record names the address"
+        );
+        assert_eq!(names[0].host, FIRST_HOP_NAME, "the record holds the name");
+    }
+
+    #[test]
+    fn an_address_in_every_round_writes_one_name_record_for_the_whole_run() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "name-once",
+            &a_stream(&rounds_of(&[1, 2, 3])),
+            &after_rounds(3),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(seqs_of(&ran.recording), [1, 2, 3]);
+        let names = names_of(&ran.recording);
+        assert_eq!(
+            names.len(),
+            1,
+            "one address takes one record in one run: {names:?}"
+        );
+        assert_eq!(names[0].addr, address(FIRST_HOP));
+    }
+
+    /// The acceptance of the reverse DNS work: a lookup that takes its time
+    /// holds up no round of the run.
+    ///
+    /// The resolver answers `Pending` for the first two asks of the first hop
+    /// and gives the name on the third, so the name lands on the third turn.
+    /// Every round still reaches the file, and in its own turn.
+    #[test]
+    fn a_slow_lookup_holds_up_no_round_of_the_run() {
+        let resolver = FakeResolver::new(&[(
+            FIRST_HOP,
+            &[Lookup::Pending, Lookup::Pending, named(FIRST_HOP_NAME)],
+        )]);
+        // The sender stands for the whole run, so the loop reaches its limit
+        // and reads no closed channel.
+        let (_sender, stream) = a_held_stream(&rounds_of(&[1, 2, 3]));
+        let ran = ran_with(
+            "name-slow",
+            &stream,
+            &after_rounds(3),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            seqs_of(&ran.recording),
+            [1, 2, 3],
+            "the slow lookup held up no round"
+        );
+        let names = names_of(&ran.recording);
+        assert_eq!(names.len(), 1, "the slow lookup landed once: {names:?}");
+        assert_eq!(names[0].addr, address(FIRST_HOP));
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "round", "name", "round", "end"],
+            "the name stands after the rounds that ran before it arrived"
+        );
+    }
+
+    #[test]
+    fn a_lookup_that_never_finishes_still_records_every_round_and_closes_the_run() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending])]);
+        let (_sender, stream) = a_held_stream(&rounds_of(&[1, 2, 3]));
+        let ran = ran_with(
+            "name-never",
+            &stream,
+            &after_rounds(3),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "round", "round", "end"]
+        );
+        assert!(
+            names_of(&ran.recording).is_empty(),
+            "a lookup that never finishes writes no record"
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Rounds);
+        assert_eq!(end_of(&ran.recording).rounds, 3);
+    }
+
+    #[test]
+    fn a_run_that_looks_nothing_up_writes_no_name_record() {
+        let ran = ran(
+            "name-none",
+            &rounds_of(&[1, 2, 3]),
+            &after_rounds(3),
+            &|| false,
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "round", "round", "end"]
+        );
+        assert!(
+            names_of(&ran.recording).is_empty(),
+            "the resolver that looks nothing up names no address"
+        );
+    }
+
+    /// The sink takes the `run` record, the name of the target, and the first
+    /// round. The next write is the name of the first hop, which the second
+    /// turn reads, so the write that fails is a `name` record.
+    #[test]
+    fn a_failed_write_of_a_name_record_stops_the_run() {
+        let resolver = FakeResolver::new(&[
+            (TARGET_ADDRESS, &[named(TARGET_NAME)]),
+            (FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)]),
+        ]);
+        let sink = Sink::that_takes(3);
+        let mut writer = Writer::to_sink(sink.clone());
+        let outcome = record(
+            &a_run_record(),
+            &a_stream(&rounds_of(&[1, 2])),
+            &after_rounds(2),
+            &|| false,
+            &mut a_namer(&resolver),
+            &mut writer,
+            &mut Vec::new(),
+        );
+        assert!(
+            matches!(outcome, Err(RunError::Write(_))),
+            "a failed write of a name stops the run: {outcome:?}"
+        );
+        let text = sink.text();
+        assert_eq!(
+            kinds_in(&text),
+            ["run", "name", "round"],
+            "the run stopped on the name of the second turn: {text}"
+        );
+    }
+
+    #[test]
+    fn a_round_that_reports_no_hop_writes_no_name_record() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "name-no-hop",
+            &a_stream(&[a_silent_round(1)]),
+            &after_rounds(1),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(kinds_of(&ran.recording), ["run", "round", "end"]);
+        assert!(
+            names_of(&ran.recording).is_empty(),
+            "a round that reports no hop names no address"
+        );
+        assert_eq!(
+            resolver.asks(),
+            0,
+            "a round that reports no hop asks the resolver nothing"
+        );
+    }
+
+    /// A lookup that finishes between two rounds lands on the turn that saw no
+    /// round, so the name reaches the file whatever the period of the rounds.
+    #[test]
+    fn a_name_that_arrives_between_two_rounds_reaches_the_file_on_the_turn_that_saw_no_round() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        // The channel holds one round and the sender stands, so the second turn
+        // of the loop waits out its poll and reads no round.
+        let (_sender, stream) = a_held_stream(&rounds_of(&[1]));
+        let asked = Cell::new(0_u64);
+        let stop = || {
+            let asked_before = asked.get();
+            asked.set(asked_before + 1);
+            asked_before >= STOP_AFTER
+        };
+        let ran = ran_with("name-late", &stream, &NO_LIMIT, &stop, &mut a_namer(&resolver));
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "name", "end"],
+            "the name stands after the one round that the run recorded"
+        );
+        assert_eq!(
+            names_of(&ran.recording)[0].host,
+            FIRST_HOP_NAME,
+            "the record holds the name that arrived"
+        );
     }
 
     // The status line of one round. A later slice replaces this line with the

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -124,6 +124,10 @@ pub(crate) fn record<W: Write, S: Write>(
         match rounds.recv_timeout(wait(limits.deadline)) {
             Ok(round) => {
                 let line = status_line(&round);
+                // The names of the round stand before the round, so a reader of
+                // the file holds the name of every address of a round by the
+                // time the round arrives.
+                write_names(writer, namer.names(&round.hops, Utc::now()))?;
                 writer
                     .write(&Record::Round(round))
                     .map_err(RunError::Write)?;
@@ -135,8 +139,12 @@ pub(crate) fn record<W: Write, S: Write>(
                 recorded += 1;
             }
             // No round arrived inside the wait. The loop takes another turn, so
-            // it reads the stop flag and the deadline again.
-            Err(RecvTimeoutError::Timeout) => {}
+            // it reads the stop flag and the deadline again. A lookup that
+            // finished inside the wait lands here, so a name that arrives
+            // between two rounds reaches the file at the moment it arrives.
+            Err(RecvTimeoutError::Timeout) => {
+                write_names(writer, namer.names(&[], Utc::now()))?;
+            }
             Err(RecvTimeoutError::Disconnected) => {
                 // The tracer holds the sender for as long as it lives, so a
                 // closed channel names a tracer thread that died.
@@ -157,8 +165,11 @@ pub(crate) fn record<W: Write, S: Write>(
 /// # Errors
 ///
 /// Returns [`RunError::Write`] when a record does not reach the file.
-fn write_names<W: Write>(_writer: &mut Writer<W>, _names: Vec<NameRecord>) -> Result<(), RunError> {
-    todo!("the write of the name records arrives with the green step")
+fn write_names<W: Write>(writer: &mut Writer<W>, names: Vec<NameRecord>) -> Result<(), RunError> {
+    for name in names {
+        writer.write(&Record::Name(name)).map_err(RunError::Write)?;
+    }
+    Ok(())
 }
 
 /// Writes the one line that a run prints for one round.
@@ -1157,7 +1168,13 @@ mod tests {
             asked.set(asked_before + 1);
             asked_before >= STOP_AFTER
         };
-        let ran = ran_with("name-late", &stream, &NO_LIMIT, &stop, &mut a_namer(&resolver));
+        let ran = ran_with(
+            "name-late",
+            &stream,
+            &NO_LIMIT,
+            &stop,
+            &mut a_namer(&resolver),
+        );
         assert_eq!(
             kinds_of(&ran.recording),
             ["run", "round", "name", "end"],

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -39,17 +39,6 @@ use std::time::{Duration, Instant};
 /// because the wait ends after this time and the loop takes another turn.
 const POLL: Duration = Duration::from_millis(100);
 
-/// The longest that a run waits, after its last round, for the names that its
-/// lookups have not given yet.
-///
-/// The value is a trade. A warm system resolver answers in milliseconds, so the
-/// common short run pays about that much and not this whole time. The wait ends
-/// at the moment that no address waits, so a long run whose addresses settled
-/// many rounds ago pays nothing at all. And a hop whose name server answers
-/// nothing holds its lookup open for longer than any bounded value, so a larger
-/// value catches that name no better than this one does.
-pub(crate) const NAME_GRACE: Duration = Duration::from_secs(2);
-
 /// The limits that stop a run.
 #[derive(Debug)]
 pub(crate) struct Limits {
@@ -60,6 +49,12 @@ pub(crate) struct Limits {
     pub(crate) deadline: Option<Instant>,
     /// The longest that the run waits, after its last round, for the names that
     /// its lookups have not given yet.
+    ///
+    /// The wait ends at the moment that every lookup settles, so a run whose
+    /// addresses already gave their names pays nothing here. The ceiling of the
+    /// value is the timeout of the resolver, because every lookup settles when
+    /// that time runs out. A grace of that length therefore outlives every
+    /// lookup that can still answer.
     pub(crate) name_grace: Duration,
 }
 

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -408,6 +408,20 @@ mod tests {
     /// value, so a name that arrived after the last round still lands.
     const NO_GRACE: Duration = Duration::ZERO;
 
+    /// The grace of a run whose name arrives after its last round.
+    ///
+    /// The drain sleeps for one hundred milliseconds at the longest between two
+    /// asks, so this value holds a few asks. The name arrives on the second ask
+    /// of the drain, and the run closes there, so the test pays one sleep and
+    /// not this whole time.
+    const A_GRACE: Duration = Duration::from_millis(300);
+
+    /// The grace of a run whose lookup never finishes.
+    ///
+    /// The drain asks until this time runs out, so this value is the whole cost
+    /// of the test that reads it.
+    const A_SHORT_GRACE: Duration = Duration::from_millis(200);
+
     /// The limits of a run that stops on nothing.
     const NO_LIMIT: Limits = Limits {
         rounds: None,
@@ -562,10 +576,16 @@ mod tests {
 
     /// The limits of a run that stops after this many rounds.
     fn after_rounds(rounds: u64) -> Limits {
+        after_rounds_with_grace(rounds, NO_GRACE)
+    }
+
+    /// The limits of a run that stops after this many rounds and that gives its
+    /// names this grace.
+    fn after_rounds_with_grace(rounds: u64, grace: Duration) -> Limits {
         Limits {
             rounds: Some(rounds),
             deadline: None,
-            name_grace: NO_GRACE,
+            name_grace: grace,
         }
     }
 
@@ -1261,6 +1281,70 @@ mod tests {
             "the record holds the name that arrived"
         );
         assert_eq!(outcome_of(&ran).reason, EndReason::Quit);
+        assert_eq!(outcome_of(&ran).rounds, 1);
+    }
+
+    /// One ask of the drain is not always enough. The drain asks again until
+    /// the name arrives, and the grace holds the run open for it.
+    ///
+    /// The resolver answers `Pending` for the first two asks of the first hop.
+    /// The round takes the first ask and the drain takes the second, so the
+    /// name arrives on the third ask, which is the second ask of the drain. The
+    /// drain sleeps between those two asks.
+    #[test]
+    fn a_name_that_the_first_ask_of_the_drain_does_not_reach_arrives_on_the_second() {
+        let resolver = FakeResolver::new(&[(
+            FIRST_HOP,
+            &[Lookup::Pending, Lookup::Pending, named(FIRST_HOP_NAME)],
+        )]);
+        let ran = ran_with(
+            "name-drain-again",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds_with_grace(1, A_GRACE),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "name", "end"],
+            "the name of the second ask of the drain stands before the end"
+        );
+        assert_eq!(
+            names_of(&ran.recording)[0].host,
+            FIRST_HOP_NAME,
+            "the record holds the name that the drain waited for"
+        );
+        assert_eq!(
+            resolver.asks(),
+            4,
+            "the round asked about the two hops, and the drain asked twice more about the first one"
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Rounds);
+        assert_eq!(outcome_of(&ran).rounds, 1);
+    }
+
+    /// The grace bounds the drain. A lookup that never finishes holds the run
+    /// open for the grace and no longer, and the run closes with no name.
+    #[test]
+    fn a_lookup_that_never_finishes_lets_the_grace_close_the_run() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending])]);
+        let ran = ran_with(
+            "name-drain-grace",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds_with_grace(1, A_SHORT_GRACE),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "end"],
+            "the run closed after the grace ran out"
+        );
+        assert!(
+            names_of(&ran.recording).is_empty(),
+            "a lookup that never finishes writes no record"
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Rounds);
         assert_eq!(outcome_of(&ran).rounds, 1);
     }
 

--- a/src/krt/src/testing.rs
+++ b/src/krt/src/testing.rs
@@ -7,10 +7,10 @@
 //! probed, and the hops that answered.
 //!
 //! The module also holds the fake resolver that a test of the fold and a test
-//! of the run loop both program. The fake stands for one contract: the first
-//! ask of an address starts the lookup, and every ask after it reads the
-//! answer. One copy of the fake holds one statement of that contract, so a
-//! correction to the contract reaches every test of it.
+//! of the run loop both program. The fake is a queue of answers for each
+//! address, not a contract. The first ask of a real resolver starts the
+//! lookup and answers no name, so a test that wants that behavior programs
+//! `Lookup::Pending` first. A test of the fold programs a name first.
 //!
 //! This module compiles under `cfg(test)` alone, so nothing it holds reaches
 //! the binary.

--- a/src/krt/src/testing.rs
+++ b/src/krt/src/testing.rs
@@ -6,12 +6,22 @@
 //! and each test names only the part it cares about: the TTLs that the round
 //! probed, and the hops that answered.
 //!
+//! The module also holds the fake resolver that a test of the fold and a test
+//! of the run loop both program. The fake stands for one contract: the first
+//! ask of an address starts the lookup, and every ask after it reads the
+//! answer. One copy of the fake holds one statement of that contract, so a
+//! correction to the contract reaches every test of it.
+//!
 //! This module compiles under `cfg(test)` alone, so nothing it holds reaches
 //! the binary.
 
+use crate::names::{Lookup, Resolver};
 use crate::record::{Hop, RoundRecord, RunId, TtlRange};
 use chrono::{DateTime, Utc};
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
+use std::rc::Rc;
 
 /// The identifier of the run that every test round belongs to.
 const RUN: &str = "2026-08-18T12:00:00.000Z";
@@ -64,5 +74,68 @@ pub(crate) fn round(first: u8, last: u8, hops: &[(u8, &str, f64)]) -> RoundRecor
                 icmp: TIME_EXCEEDED.to_owned(),
             })
             .collect(),
+    }
+}
+
+/// The answer of a lookup that finished with a name.
+pub(crate) fn named(host: &str) -> Lookup {
+    Lookup::Named(host.to_owned())
+}
+
+/// A resolver that a test programs: one answer for each ask of one address,
+/// and the last answer of the list for every ask after the list runs out.
+///
+/// An address that the test named no answer for answers `Nameless`.
+///
+/// The count and the answers sit behind a `Cell` and a `RefCell`, because
+/// [`Resolver::lookup`] takes the resolver by reference. The fake stays on
+/// one thread.
+pub(crate) struct FakeResolver {
+    /// The answers that each address holds, the next answer first.
+    answers: RefCell<HashMap<IpAddr, VecDeque<Lookup>>>,
+    /// The number of asks that the resolver took.
+    asks: Cell<usize>,
+}
+
+impl FakeResolver {
+    /// A resolver that answers each address with the answers of its list.
+    pub(crate) fn new(answers: &[(&str, &[Lookup])]) -> Rc<Self> {
+        Rc::new(Self {
+            answers: RefCell::new(
+                answers
+                    .iter()
+                    .map(|(addr, list)| (address(addr), list.iter().cloned().collect()))
+                    .collect(),
+            ),
+            asks: Cell::new(0),
+        })
+    }
+
+    /// The number of asks that the resolver took.
+    pub(crate) fn asks(&self) -> usize {
+        self.asks.get()
+    }
+
+    /// The answer of one ask, and one step along the list of that address.
+    fn answer(&self, addr: IpAddr) -> Lookup {
+        self.asks.set(self.asks.get() + 1);
+        let mut answers = self.answers.borrow_mut();
+        let Some(queue) = answers.get_mut(&addr) else {
+            return Lookup::Nameless;
+        };
+        // The last answer of a list stands for every ask after it, so the
+        // list keeps that answer in the place of a step.
+        let answer = if queue.len() > 1 {
+            queue.pop_front()
+        } else {
+            queue.front().cloned()
+        };
+        answer.unwrap_or(Lookup::Nameless)
+    }
+}
+
+impl Resolver for Rc<FakeResolver> {
+    fn lookup(&self, addr: IpAddr) -> Lookup {
+        self.answer(addr)
     }
 }

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -502,22 +502,34 @@ impl crate::names::Resolver for SystemNames {
 /// # Errors
 ///
 /// Returns the reason when the resolver does not start.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the command line of the slice that follows picks this resolver from `--no-dns`; the tests of this module are the one reader today"
-    )
-)]
 pub(crate) fn resolver() -> std::io::Result<Box<dyn crate::names::Resolver>> {
     let names = DnsResolver::start(trippy_dns::Config::default())?;
     Ok(Box::new(SystemNames { names }))
 }
 
 /// Reads what one reverse lookup holds now, in the words that `krt` owns.
+///
+/// An address that carries more than one name takes the first name of the
+/// answer, because one record of the schema holds one name. The iterator of
+/// that crate gives its first name again at every step, so this conversion
+/// reads one name from it and collects nothing.
+///
+/// A lookup that timed out settles the address, and it does not wait. The
+/// resolver puts a timed-out address back into its queue on every ask, and the
+/// run loop asks ten times a second, so an address that waited on a timeout
+/// would probe a name server that does not answer, without end. The design of
+/// `krt` says that a failed lookup stops no run, and that the display shows the
+/// raw address of such a hop. One ask for each address of one run is the
+/// bounded reading of that rule.
 fn to_lookup(entry: &DnsEntry) -> Lookup {
-    let _ = entry;
-    todo!("the reading of one reverse lookup arrives with the green step")
+    match entry {
+        DnsEntry::Pending(_) => Lookup::Pending,
+        DnsEntry::Resolved(_) => entry
+            .hostnames()
+            .next()
+            .map_or(Lookup::Nameless, |host| Lookup::Named(host.to_owned())),
+        DnsEntry::NotFound(_) | DnsEntry::Failed(_) | DnsEntry::Timeout(_) => Lookup::Nameless,
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -13,9 +13,11 @@
 //! that needs them and holds none stops, and the message names the remedy of
 //! each platform.
 //!
-//! The interface of the wall is one type and one function. [`TraceConfig`]
+//! The interface of the wall is one type and two functions. [`TraceConfig`]
 //! states one run in the words that `krt` owns, and [`spawn`] starts the
-//! tracer of that run and gives back a receiver of completed rounds. A caller
+//! tracer of that run and gives back a receiver of completed rounds.
+//! [`resolver`] gives the reverse resolver of the platform as a
+//! [`crate::names::Resolver`], which is a type that `krt` owns. A caller
 //! outside this module therefore names no type of a trippy crate.
 //!
 //! The conversion is the wall itself. The tracer hands one round over as a
@@ -25,6 +27,7 @@
 //! this file alone. The run loop that reads the receiver arrives in a later
 //! slice.
 
+use crate::names::Lookup;
 use crate::record::{self, Hop, RoundRecord, RunId, TtlRange};
 use chrono::{DateTime, Utc};
 use std::net::IpAddr;
@@ -32,6 +35,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver};
 use std::time::{Duration, SystemTime};
 use trippy_core::{CompletionReason, IcmpPacketType, ProbeStatus, Round};
+use trippy_dns::{DnsEntry, DnsResolver, Resolver as _};
 
 /// The remedy of a platform that needs raw socket privileges and holds none.
 ///
@@ -471,12 +475,58 @@ fn rtt_millis(sent: SystemTime, received: SystemTime) -> f64 {
         * MILLIS_PER_SECOND
 }
 
+/// The reverse resolver of the platform, behind the interface that `krt` owns.
+///
+/// The resolver holds a counted reference that no thread can move, so it stays
+/// on the thread that built it. That thread is the thread of the run loop,
+/// which is the one thread that asks it.
+struct SystemNames {
+    /// The resolver that every ask of this run goes to.
+    names: DnsResolver,
+}
+
+impl crate::names::Resolver for SystemNames {
+    fn lookup(&self, addr: IpAddr) -> Lookup {
+        to_lookup(&self.names.lazy_reverse_lookup(addr))
+    }
+}
+
+/// A reverse resolver over the system resolver of the platform.
+///
+/// The configuration is the one that the crate holds by default: the system
+/// resolver, the address families in the order IPv4 and then IPv6, a timeout of
+/// five seconds, and a cache of five minutes. `krt` asks for the system
+/// resolver, so a lookup of a run reads the same names as every other program
+/// of the machine.
+///
+/// # Errors
+///
+/// Returns the reason when the resolver does not start.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the command line of the slice that follows picks this resolver from `--no-dns`; the tests of this module are the one reader today"
+    )
+)]
+pub(crate) fn resolver() -> std::io::Result<Box<dyn crate::names::Resolver>> {
+    let names = DnsResolver::start(trippy_dns::Config::default())?;
+    Ok(Box::new(SystemNames { names }))
+}
+
+/// Reads what one reverse lookup holds now, in the words that `krt` owns.
+fn to_lookup(entry: &DnsEntry) -> Lookup {
+    let _ = entry;
+    todo!("the reading of one reverse lookup arrives with the green step")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        choose_privilege, icmp_kind, next_seq, to_round_record, tracer_of, IcmpKind,
+        choose_privilege, icmp_kind, next_seq, to_lookup, to_round_record, tracer_of, IcmpKind,
         PrivilegeError, TraceConfig, TraceError,
     };
+    use crate::names::Lookup;
     use crate::record::{Privilege, Record, RoundRecord, RunId};
     use crate::testing::address;
     use crate::{Multipath, Protocol, PROGRAM};
@@ -487,6 +537,7 @@ mod tests {
         CompletionReason, Flags, IcmpPacketType, Port, Probe, ProbeComplete, ProbeStatus, Round,
         RoundId, Sequence, TimeToLive, TraceId,
     };
+    use trippy_dns::{DnsEntry, Resolved, Unresolved};
 
     /// The remedy, exactly as the design writes it.
     ///
@@ -1188,5 +1239,84 @@ this platform needs raw socket privileges to send probes.
         let counter = AtomicU64::new(0);
         assert_eq!(next_seq(&counter), 1);
         assert_eq!(next_seq(&counter), 2);
+    }
+
+    // The reading of one reverse lookup. No test below touches the network, and
+    // none of them starts a resolver. Each one builds the answer of a lookup by
+    // hand.
+    //
+    // Every answer below is a `Normal` answer. `krt` asks for no autonomous
+    // system information, so the resolver of this module never gives a
+    // `WithAsInfo` answer and no test builds one.
+
+    /// The address that every lookup of these tests reads.
+    const A_HOP: &str = "192.168.1.1";
+
+    /// The name that a lookup of that address finds.
+    const A_HOP_NAME: &str = "router.lan";
+
+    /// One more name of the same address, after the first one.
+    const ONE_MORE_NAME: &str = "gateway.lan";
+
+    /// The answer of a lookup that found these names.
+    fn found(names: &[&str]) -> DnsEntry {
+        DnsEntry::Resolved(Resolved::Normal(
+            address(A_HOP),
+            names.iter().map(|name| (*name).to_owned()).collect(),
+        ))
+    }
+
+    /// The name that one lookup holds.
+    fn name(host: &str) -> Lookup {
+        Lookup::Named(host.to_owned())
+    }
+
+    #[test]
+    fn a_lookup_that_has_not_finished_gives_a_wait() {
+        assert_eq!(
+            to_lookup(&DnsEntry::Pending(address(A_HOP))),
+            Lookup::Pending
+        );
+    }
+
+    #[test]
+    fn a_lookup_that_finished_gives_the_first_name_it_holds() {
+        assert_eq!(
+            to_lookup(&found(&[A_HOP_NAME, ONE_MORE_NAME])),
+            name(A_HOP_NAME)
+        );
+    }
+
+    #[test]
+    fn a_lookup_that_finished_with_no_name_gives_a_nameless_address() {
+        assert_eq!(to_lookup(&found(&[])), Lookup::Nameless);
+    }
+
+    #[test]
+    fn a_lookup_that_matched_no_record_gives_a_nameless_address() {
+        assert_eq!(
+            to_lookup(&DnsEntry::NotFound(Unresolved::Normal(address(A_HOP)))),
+            Lookup::Nameless
+        );
+    }
+
+    #[test]
+    fn a_lookup_that_failed_gives_a_nameless_address() {
+        assert_eq!(
+            to_lookup(&DnsEntry::Failed(address(A_HOP))),
+            Lookup::Nameless
+        );
+    }
+
+    /// A timeout settles the address, and it does not wait. The resolver puts a
+    /// timed-out address back into its queue on every ask, and the run loop asks
+    /// ten times a second, so an address that waited on a timeout would probe a
+    /// name server that does not answer, without end.
+    #[test]
+    fn a_lookup_that_timed_out_gives_a_nameless_address_and_the_run_asks_no_second_time() {
+        assert_eq!(
+            to_lookup(&DnsEntry::Timeout(address(A_HOP))),
+            Lookup::Nameless
+        );
     }
 }

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -13,12 +13,14 @@
 //! that needs them and holds none stops, and the message names the remedy of
 //! each platform.
 //!
-//! The interface of the wall is one type and two functions. [`TraceConfig`]
+//! The interface of the wall is one type and three functions. [`TraceConfig`]
 //! states one run in the words that `krt` owns, and [`spawn`] starts the
 //! tracer of that run and gives back a receiver of completed rounds.
 //! [`resolver`] gives the reverse resolver of the platform as a
-//! [`crate::names::Resolver`], which is a type that `krt` owns. A caller
-//! outside this module therefore names no type of a trippy crate.
+//! [`crate::names::Resolver`], which is a type that `krt` owns, and
+//! [`resolver_timeout`] gives the longest that one lookup of that resolver
+//! takes, as a [`Duration`]. A caller outside this module therefore names no
+//! type of a trippy crate.
 //!
 //! The conversion is the wall itself. The tracer hands one round over as a
 //! borrowed value that lives for the length of one call, and
@@ -491,7 +493,7 @@ impl crate::names::Resolver for SystemNames {
     }
 }
 
-/// A reverse resolver over the system resolver of the platform.
+/// The configuration of the reverse resolver of a run.
 ///
 /// The configuration is the one that the crate holds by default: the system
 /// resolver, the address families in the order IPv4 and then IPv6, a timeout of
@@ -499,11 +501,31 @@ impl crate::names::Resolver for SystemNames {
 /// resolver, so a lookup of a run reads the same names as every other program
 /// of the machine.
 ///
+/// [`resolver`] and [`resolver_timeout`] both read this one configuration, so a
+/// change of a field moves the resolver and the timeout that `krt` reports
+/// together.
+fn resolver_config() -> trippy_dns::Config {
+    trippy_dns::Config::default()
+}
+
+/// The longest that one reverse lookup of a run takes.
+///
+/// The resolver settles an address when this time runs out, and a settled
+/// address gives its name or gives none. No lookup of a run therefore stays
+/// open past this time.
+pub(crate) fn resolver_timeout() -> Duration {
+    resolver_config().timeout
+}
+
+/// A reverse resolver over the system resolver of the platform.
+///
+/// [`resolver_config`] states the configuration of the resolver.
+///
 /// # Errors
 ///
 /// Returns the reason when the resolver does not start.
 pub(crate) fn resolver() -> std::io::Result<Box<dyn crate::names::Resolver>> {
-    let names = DnsResolver::start(trippy_dns::Config::default())?;
+    let names = DnsResolver::start(resolver_config())?;
     Ok(Box::new(SystemNames { names }))
 }
 


### PR DESCRIPTION
Toward #371.

The run loop of `krt` now folds a name over each address it reports, and writes
one `name` record for each address that resolves.

## What this branch adds

- `src/krt/src/names.rs` — a `Namer` that holds one lookup per address for the
  length of a run. A `Lookups` trait stands between the fold and the resolver,
  so a test drives a fake. `NoLookups` answers nothing, which is the shape that
  `--no-dns` takes in the slice that follows.
- `src/krt/src/run.rs` — the run loop passes each address of a round through the
  `Namer`, and writes a `name` record the first time an address resolves. An
  address that resolves twice writes one record. An address that fails to
  resolve writes none, and the display keeps the raw address.
- `src/krt/src/main.rs` — the trace path builds a `Namer` and gives it to
  `run::record`.

## What is not here yet

This branch wires the fold and the record. It does not yet wire a real resolver.
`trace` builds the `Namer` on `NoLookups`, so a run of this branch looks nothing
up. The slice that follows reads `--no-dns`, picks `trippy-dns` or `NoLookups`
from it, and makes the `dns` field of the `run` record tell the truth. The
comment at the call site in `main.rs` says so.

The replay path reads `name` records already, through `record.rs`. Showing the
name beside the address in the replay display belongs to the same following
slice.

## Tests

Every commit is a red/green pair. The tests drive a fake resolver and cover a
hit, a miss, a repeat, and a slow answer. No test touches the network.
