### PR TITLE
feat(krt): the live table and the keys of a run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,6 +4565,7 @@ dependencies = [
  "clap",
  "crossterm",
  "mockito",
+ "portable-pty",
  "ratatui",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,6 +4563,7 @@ dependencies = [
  "buildinfo",
  "chrono",
  "clap",
+ "crossterm",
  "mockito",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ indicatif = "0.18"
 dialoguer = "0.11"
 terminal_size = "0.4"
 termion = "4.0"
+portable-pty = "0.9.0"
 
 # Clipboard
 arboard = "3.6"

--- a/README.md
+++ b/README.md
@@ -654,7 +654,10 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     measures no terminal draws every line of the frame. The table folds every round that arrives and
     draws the frame of that fold, so the count of the rounds in its header line is the count that
     the table folded, and the size in that same line is the size the recorded file holds at that
-    draw.
+    draw. The first frame draws at the moment the run takes the terminal, in front of the first
+    round. It counts no round, and its header line already names the destination, the address, the
+    source, the period, and the recorded file, so a run of `--interval 2m` says that it started and
+    holds no empty screen for those two minutes.
   - Five keys drive the live table. `q` and Ctrl-C stop the run, write the record that closes it,
     give the terminal back, and exit with success. `p` holds the table where it stands, and a
     second press lets it move again. A held table holds the display alone: the file still takes

--- a/README.md
+++ b/README.md
@@ -625,9 +625,11 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - The default name therefore carries the public address of the machine, and a file you share
     carries it too. `--source` avoids the lookup, and `--output` avoids the name.
   - `--rounds` stops the run after that many rounds, and `--duration` stops it after that much
-    time. Each of the two writes the record that closes the run. On macOS and Linux, Ctrl-C also
-    stops the run at once and writes that record. Windows gets that key with the table that a
-    later build adds.
+    time. Each of the two writes the record that closes the run, whatever screen that run shows. On
+    macOS and Linux, Ctrl-C also stops the run at once and writes that record. A run that draws the
+    live table takes Ctrl-C as a key, and a run that draws no table takes it as a signal. On
+    Windows, the live table is what reads that key, and a Windows run that draws no table stops at
+    a limit of the command line alone.
   - A run resolves the name of each address it sees through the system resolver of the platform.
     The file takes one `name` record for each name, and one record for each address at most,
     however many rounds that address answers in. An address that resolves to no name keeps its raw
@@ -636,6 +638,37 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     that every lookup settles, and its ceiling is the timeout of the system resolver, which is 5
     seconds. `--no-dns` skips every lookup, so the file then holds no `name` record and the `run`
     record says `"dns":false`.
+  - A run draws the live table of the path when standard output is a terminal and `--headless` is
+    off. Every other run prints one status line at its first round, and one more each minute: a run
+    of `--headless`, a run whose output goes to a pipe or to a file, and a run under a `nohup`, a
+    `launchd` job, or a `systemd` unit. Such a run holds no terminal, and no key of it reaches
+    `krt`. A table there writes one whole frame into that pipe or that file for each round, and one
+    line each minute says what the run is doing and leaves that file readable.
+  - The live table is the table of `krt replay` below. It holds the same header line, the same
+    columns, the same marks, and the same rule for a terminal too narrow for every column. It takes
+    the width of the terminal at the start of the run, and a window that changes size while the run
+    stands leaves the frame at that width. The table folds every round that arrives and draws the
+    frame of that fold, so the count of the rounds in its header line is the count that the table
+    folded, and the size in that same line is the size the recorded file holds at that draw.
+  - Five keys drive the live table. `q` and Ctrl-C stop the run, write the record that closes it,
+    give the terminal back, and exit with success. `p` holds the table where it stands, and a
+    second press lets it move again. A held table holds the display alone: the file still takes
+    every round, and the table still folds every round into its numbers, so the frame that follows
+    the pause holds every round of that pause. `n` shows the names of the hosts, and a second press
+    shows the raw addresses. `r` empties the table and counts its rounds from zero, and it touches
+    neither the recorded file nor the count of the rounds that the closing record carries. `?`
+    shows the list of the keys under the table, and a second press hides it.
+  - Ctrl-C reaches the live table as a key and not as a signal. The table holds the terminal in raw
+    mode, which clears `ISIG`, so the terminal sends the byte to `krt` and the process takes no
+    `SIGINT`. A run that draws no table keeps the signal handler of the platform.
+  - The terminal always comes back. The live table draws on the alternate screen, and a guard gives
+    the terminal back on every way out of the run: the key that stopped it, a write that failed
+    (exit code 3), a tracer that died (exit code 4), and a panic that nobody asked for. A panic
+    hook gives the terminal back ahead of the message of the panic, so that message lands on the
+    screen the reader keeps. The line that closes the run prints there too, under the lines that
+    stood in the terminal before the run. A destination that resolves to no address (exit code 1)
+    and a platform that withholds the privilege of a raw socket (exit code 2) both print before the
+    run takes the terminal at all.
   - `krt replay` prints one table of the path. A header line names the destination, the address it
     resolved to, the source, the count of the rounds, the period of one round, and the recorded
     file with its size. Under it stands one row for each TTL, with the columns `TTL`, `Host`,
@@ -661,7 +694,6 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - A host too wide for the `Host` column loses the tail of its name, and it keeps its `★` and its
     `(+N)`. A name with its address fills that column of a run that resolves names, and the two
     marks say what no other column of the row says.
-  - A live run still prints one status line for each round. A later build gives it the table.
   - macOS sends the probes without privileges. Linux needs `CAP_NET_RAW`, and Windows needs an
     elevated prompt. A platform that needs privileges and does not hold them prints the remedy and
     stops, and `krt` never falls back to a degraded trace without saying so.

--- a/README.md
+++ b/README.md
@@ -646,10 +646,15 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     line each minute says what the run is doing and leaves that file readable.
   - The live table is the table of `krt replay` below. It holds the same header line, the same
     columns, the same marks, and the same rule for a terminal too narrow for every column. It takes
-    the width of the terminal at the start of the run, and a window that changes size while the run
-    stands leaves the frame at that width. The table folds every round that arrives and draws the
-    frame of that fold, so the count of the rounds in its header line is the count that the table
-    folded, and the size in that same line is the size the recorded file holds at that draw.
+    the width and the height of the terminal at the start of the run, and a window that changes size
+    while the run stands leaves the frame at the size it started with. A frame taller than that
+    window keeps its header line, its column header, the mark of the pause, and the list of the
+    keys. The rows of the path take the lines that those leave, first hop first, and one line under
+    the last row of them counts the rows that went out of the frame, as in `+12 rows`. A run that
+    measures no terminal draws every line of the frame. The table folds every round that arrives and
+    draws the frame of that fold, so the count of the rounds in its header line is the count that
+    the table folded, and the size in that same line is the size the recorded file holds at that
+    draw.
   - Five keys drive the live table. `q` and Ctrl-C stop the run, write the record that closes it,
     give the terminal back, and exit with success. `p` holds the table where it stands, and a
     second press lets it move again. A held table holds the display alone: the file still takes

--- a/TLDR.md
+++ b/TLDR.md
@@ -34,7 +34,7 @@ A one-line description of every program documented in the [README](./README.md),
 | `inscribe` | Generates git commit messages from staged changes using Claude AI. |
 | `jsonboard` | Pretty-prints JSON on the clipboard and puts it back. |
 | `kitchen-sync` | Installs every Rust binary from a git repo with one command. |
-| `krt` | Knights of the Round Trip — records the network path to a destination, hop by hop, into an append-only JSONL file. `krt replay` folds one run of a recorded file into one table of the path. |
+| `krt` | Knights of the Round Trip — records the network path to a destination, hop by hop, into an append-only JSONL file, and draws the live table of that path under a terminal. `krt replay` folds one run of a recorded file into one table of the path. |
 | `localnext` | Serves statically exported Next.js apps locally. |
 | `ng` | Navel-Gaze — watches JS/TS files and re-runs `pnpm lint` (or `--typecheck`) on change. |
 | `nodenuke` | Removes `node_modules` directories and lock files throughout a repo. |

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -8,6 +8,7 @@ description = "Knights of the Round Trip: a Rust tool that records the network p
 buildinfo.workspace = true
 chrono.workspace = true
 clap.workspace = true
+crossterm.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true

--- a/src/krt/Cargo.toml
+++ b/src/krt/Cargo.toml
@@ -24,6 +24,7 @@ unicode-width.workspace = true
 
 [dev-dependencies]
 mockito.workspace = true
+portable-pty.workspace = true
 
 [lints]
 workspace = true

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -1204,6 +1204,25 @@ mod tests {
     }
 
     #[test]
+    fn a_headless_screen_shows_no_name() {
+        // A name belongs to a row of a table, and a headless run draws no
+        // table. The name record reaches the recorded file whatever the screen
+        // does, so a replay of that file names every address that a lookup
+        // answered.
+        let clock = FakeClock::new();
+        let mut screen = headless(&clock);
+        screen.round(&a_whole_path_round());
+        screen.sink.clear();
+
+        screen.names(&[name(ROUTER, ROUTER_NAME)]);
+        assert!(
+            screen.sink.is_empty(),
+            "the names that arrived print nothing: {:?}",
+            printed(&screen.sink)
+        );
+    }
+
+    #[test]
     fn the_q_key_asks_for_a_quit() {
         assert_eq!(classify(press(KeyCode::Char('q'))), Some(Command::Quit));
     }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -589,11 +589,17 @@ fn install_panic_hook() -> PanicHook {
     previous
 }
 
+/// Puts a hook back.
+fn restore_panic_hook(previous: PanicHook) {
+    drop(previous);
+    drop(std::panic::take_hook());
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        classify, install_panic_hook, status_line, Clock, Command, Headless, Keys, NoKeys,
-        PanicHook, RunFacts, Screen, SystemClock, Table,
+        classify, install_panic_hook, restore_panic_hook, status_line, Clock, Command, Headless,
+        Keys, NoKeys, PanicHook, RunFacts, Screen, SystemClock, Table,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round, FakeKeys};
@@ -1450,6 +1456,34 @@ mod tests {
         assert!(
             restored_first,
             "and it puts the terminal back first, so the message of the panic lands on the screen that the reader keeps"
+        );
+    }
+
+    #[test]
+    fn a_live_run_puts_back_the_hook_that_stood_before_it() {
+        // The panic hook is one setting of the whole process. A live run that
+        // ended and left its own hook standing puts a terminal back for every
+        // panic of every part of the process that follows it, and no part of
+        // that process holds a terminal.
+        let hooks = HookGuard::take();
+        let marked = mark();
+
+        let previous = install_panic_hook();
+        restore_panic_hook(previous);
+        let before = restorations();
+        let outcome = std::panic::catch_unwind(|| panic!("{THE_TEST_PANIC}"));
+        let read = marked.read.load(Ordering::SeqCst);
+        let after = restorations();
+        drop(hooks);
+
+        assert!(outcome.is_err(), "the body of the test raised its panic");
+        assert!(
+            read,
+            "the hook that stood in front of the live run reads the panic on its own"
+        );
+        assert_eq!(
+            after, before,
+            "and the hook of the live run puts back no terminal, because that hook no longer stands"
         );
     }
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -7,16 +7,17 @@
 //! reason this module classifies the keys itself: it is the one part of the
 //! live run that can stop a run that the user asked to stop.
 
-// Nothing outside this module names any item of it. The run loop takes a
-// screen in the next step of this work, and every item below is then live. One
-// attribute stands here, and not one attribute for each item, because the
-// items are dead for one reason: no caller. The expectation fails once the
-// whole module is live, which takes this attribute back off.
+// The run loop reads the headless screen of this module. The live table waits
+// for the caller that chooses between the two screens, and that caller joins
+// in the next step of this work. One attribute stands here, and not one
+// attribute for each item of the table, because those items are dead for one
+// reason: no caller. The expectation fails once that caller stands, which
+// takes this attribute back off.
 #![cfg_attr(
     not(test),
     expect(
         dead_code,
-        reason = "the run loop joins this module in the next step of this work"
+        reason = "the caller that picks the live table joins this module in the next step of this work"
     )
 )]
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -391,15 +391,24 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// The clear comes first, so a frame of fewer lines than the frame before
     /// it leaves none of the older lines on the screen.
     ///
+    /// The whole frame stands in one buffer, and that buffer reaches the sink
+    /// in one call. The sink of a live run is `std::io::Stdout`, which is a
+    /// `LineWriter`, and such a writer flushes at every line feed. One call for
+    /// each line of the frame is therefore one `write(2)` for each line of it,
+    /// and the terminal draws what arrives, so the reader sees a half-drawn
+    /// frame between two of those writes.
+    ///
     /// # Errors
     ///
     /// Answers the fault that the sink raised. The caller of this function
     /// drops that fault, for the reason that [`Table::draw`] states.
     fn paint(&mut self, lines: &[String]) -> std::io::Result<()> {
-        queue!(self.sink, Clear(ClearType::All), MoveTo(0, 0))?;
+        let mut frame: Vec<u8> = Vec::new();
+        queue!(frame, Clear(ClearType::All), MoveTo(0, 0))?;
         for line in lines {
-            write!(self.sink, "{line}{LINE_END}")?;
+            write!(frame, "{line}{LINE_END}")?;
         }
+        self.sink.write_all(&frame)?;
         self.sink.flush()
     }
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -332,7 +332,9 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
 #[cfg(test)]
 mod tests {
     use super::{classify, Command, Keys, RunFacts, Screen, Table};
+    use crate::record::{NameRecord, RunId};
     use crate::testing::{address, round};
+    use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use std::collections::VecDeque;
     use std::path::PathBuf;
@@ -365,11 +367,23 @@ mod tests {
     /// The address of the one router that answers the rounds below.
     const ROUTER: &str = "10.0.0.1";
 
+    /// The name that a name record gives that router.
+    const ROUTER_NAME: &str = "router.lan";
+
+    /// The host of the row of that router, while the names stand.
+    ///
+    /// The address stays beside the name, because a name is what a resolver
+    /// said and an address is what answered.
+    const NAMED_ROUTER: &str = "router.lan (10.0.0.1)";
+
     /// The round-trip time of the answer of that router, in milliseconds.
     const RTT: f64 = 0.87;
 
     /// The first TTL of every round below, which is also the last one.
     const TTL: u8 = 1;
+
+    /// The identifier of the run that every name record below belongs to.
+    const RUN: &str = "2026-08-18T12:00:00.000Z";
 
     /// The start of the header line of a table that folded one round.
     ///
@@ -497,6 +511,21 @@ mod tests {
         round(TTL, TTL, &[(TTL, ROUTER, RTT)])
     }
 
+    /// The record of one name that a lookup answered.
+    ///
+    /// The identifier of the run and the moment of the record take the values
+    /// of the moment of the test. No frame reads either of them: the map of the
+    /// names is keyed by the address, because one address answers at any number
+    /// of TTLs.
+    fn name(addr: &str, host: &str) -> NameRecord {
+        NameRecord {
+            run: RunId::from(RUN),
+            ts: Utc::now(),
+            addr: address(addr),
+            host: host.to_owned(),
+        }
+    }
+
     /// The word that a table which holds where it stands writes under its
     /// table.
     ///
@@ -558,6 +587,38 @@ mod tests {
             screen.sink.is_empty(),
             "a round of a table that holds draws nothing: {:?}",
             painted(&screen.sink)
+        );
+    }
+
+    #[test]
+    fn the_names_key_swaps_a_name_for_the_address_of_it_and_back() {
+        let mut screen = table(&[&[Command::Names], &[Command::Names]]);
+        screen.round(&one_round());
+        screen.names(&[name(ROUTER, ROUTER_NAME)]);
+        let named = painted(&screen.sink);
+        assert!(
+            named.iter().any(|line| line.contains(NAMED_ROUTER)),
+            "the name that arrived stands in the host of the row: {named:?}"
+        );
+
+        screen.sink.clear();
+        screen.poll();
+        let raw = painted(&screen.sink);
+        assert!(
+            !raw.iter().any(|line| line.contains(ROUTER_NAME)),
+            "the key takes the names off the table: {raw:?}"
+        );
+        assert!(
+            raw.iter().any(|line| line.contains(ROUTER)),
+            "the host of the row then reads as the address that answered: {raw:?}"
+        );
+
+        screen.sink.clear();
+        screen.poll();
+        let again = painted(&screen.sink);
+        assert!(
+            again.iter().any(|line| line.contains(NAMED_ROUTER)),
+            "a second press puts the names back, so the table keeps them: {again:?}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -624,6 +624,14 @@ fn restore_terminal() {
 /// hook of the machine prints the message of a panic, and a test binary holds a
 /// hook that collects one. A hook that replaced either of them takes the report
 /// of every panic away from the reader who needs it most.
+///
+/// # Panics
+///
+/// Panics on a thread that is already panicking, because
+/// `std::panic::take_hook` refuses such a thread. The guard of a live run takes
+/// the terminal at the start of that run, where no panic of the run stands.
+/// [`restore_panic_hook`] reads the thread for the same rule, because the drop
+/// of that guard does stand on the path of a panic.
 fn install_panic_hook() -> PanicHook {
     let previous: PanicHook = Arc::from(std::panic::take_hook());
     let chained = Arc::clone(&previous);

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -94,6 +94,43 @@ pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
 /// front of them. One word answers that.
 const PAUSED: &str = "paused";
 
+/// The number of keys that a live table reads.
+const KEY_COUNT: usize = 5;
+
+/// Each key of a live table, and what that key does.
+///
+/// This list is the one place that says what a key does, and the help builds
+/// its lines out of it. A second list would name a key that [`classify`] no
+/// longer holds, and a reader who pressed that key would then read a screen
+/// which says that nothing happened.
+const KEYS: [(&str, &str); KEY_COUNT] = [
+    ("q, Ctrl-C", "stop the run"),
+    ("p", "hold the table, or let it move"),
+    ("n", "show the names, or show the addresses"),
+    ("r", "empty the table"),
+    ("?", "show these keys, or hide them"),
+];
+
+/// The text between a key and what that key does.
+///
+/// Two spaces, so the widest key of the list stands clear of its own text.
+const KEY_GAP: &str = "  ";
+
+/// The lines of the list of the keys.
+///
+/// Every key takes the columns of the widest key, so the text of each of them
+/// starts at one column and the list reads as two columns.
+fn key_lines() -> Vec<String> {
+    let width = KEYS
+        .iter()
+        .map(|(key, _)| ui::display_width(key))
+        .max()
+        .unwrap_or(0);
+    KEYS.iter()
+        .map(|(key, does)| format!("{key:<width$}{KEY_GAP}{does}"))
+        .collect()
+}
+
 /// The end of every line that a draw writes.
 ///
 /// Raw mode returns no carriage on a bare line feed, so a frame of bare line
@@ -264,6 +301,10 @@ impl<W: Write, K: Keys> Table<W, K> {
             lines.push(String::new());
             lines.push(PAUSED.to_owned());
         }
+        if self.help {
+            lines.push(String::new());
+            lines.extend(key_lines());
+        }
         lines
     }
 
@@ -280,9 +321,9 @@ impl<W: Write, K: Keys> Table<W, K> {
                 self.table = HopTable::new();
                 self.rounds = 0;
             }
-            // Each command below takes an arm of this table with the test of
-            // that command.
-            Command::Quit | Command::Help => {}
+            Command::Help => self.help = !self.help,
+            // The stop takes an arm of this table with the test of it.
+            Command::Quit => {}
         }
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -27,7 +27,7 @@ use crate::ui;
 use crate::ui::render_duration;
 use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
 use crossterm::cursor::{MoveTo, Show};
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, Clear, ClearType, LeaveAlternateScreen};
 use crossterm::{execute, queue};
 use std::collections::BTreeMap;
@@ -159,6 +159,49 @@ pub(crate) struct NoKeys;
 impl Keys for NoKeys {
     fn presses(&mut self) -> Vec<Command> {
         Vec::new()
+    }
+}
+
+/// The key source of a run that holds a terminal.
+///
+/// The source takes every key event that already arrived, and it waits for
+/// none. The run loop asks ten times each second, and an ask that waited for a
+/// key holds the recording where it stands until the user presses one.
+///
+/// No test of this file builds this source. `crossterm` reads the keys of a
+/// terminal, and `cargo test` hands the test binary a pipe. A source that read
+/// the keys of the terminal of `cargo test` takes the keys of the reader who
+/// started it. The pseudo terminal of a later step of this work is what drives
+/// this source.
+#[expect(
+    dead_code,
+    reason = "the caller that picks the live table joins this module in the next step of this work"
+)]
+pub(crate) struct Keyboard;
+
+impl Keys for Keyboard {
+    fn presses(&mut self) -> Vec<Command> {
+        let mut commands = Vec::new();
+        // A poll of no time answers whether an event stands ready now, and it
+        // waits for no event to arrive.
+        //
+        // A poll that fails, and a read that fails, end the gathering and leave
+        // the commands that the gathering already holds. A terminal that will
+        // not answer is no reason to stop the recording, which is the purpose
+        // of the tool.
+        while event::poll(Duration::ZERO).unwrap_or(false) {
+            let Ok(arrived) = event::read() else {
+                break;
+            };
+            // A resize of the window and a paste of text arrive at this same
+            // reader, and neither of them is a key. The gathering goes on past
+            // each of them, because the events behind one of them still hold
+            // the keys of the user.
+            if let Event::Key(key) = arrived {
+                commands.extend(classify(key));
+            }
+        }
+        commands
     }
 }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -595,7 +595,17 @@ fn install_panic_hook() -> PanicHook {
 /// the live run that installed it. The hook of a live run puts a terminal back,
 /// and no part of the process that follows that run holds one, so a hook that
 /// outlived its run acts on a panic that it knows nothing about.
+///
+/// A thread that panics puts no hook back. `std::panic::set_hook` refuses such
+/// a thread, and it refuses with a panic of its own, which aborts the process
+/// on the spot. The guard of a live run reaches this call on the path of every
+/// panic of that run, and the hook of the live run already put the terminal
+/// back by then. That hook therefore stands on for the little of the process
+/// that is left, and the message of the panic reaches the reader.
 fn restore_panic_hook(previous: PanicHook) {
+    if std::thread::panicking() {
+        return;
+    }
     std::panic::set_hook(Box::new(move |info| (*previous)(info)));
 }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -398,7 +398,7 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
 
 #[cfg(test)]
 mod tests {
-    use super::{classify, Command, Keys, RunFacts, Screen, Table};
+    use super::{classify, Command, Keys, NoKeys, RunFacts, Screen, Table};
     use crate::record::{NameRecord, RunId};
     use crate::testing::{address, round};
     use chrono::Utc;
@@ -766,6 +766,24 @@ mod tests {
             "a turn that took no key asks for no stop of the run"
         );
         assert!(screen.poll(), "the quit key asks for the stop of the run");
+    }
+
+    #[test]
+    fn a_turn_that_took_no_key_draws_nothing() {
+        // The run loop polls ten times each second. A poll that drew every
+        // turn would clear the screen and paint it again ten times each
+        // second, and the table would flicker for nothing.
+        let mut screen = table_at(temp_path("no-key"), NoKeys);
+        screen.round(&one_round());
+        let drawn = screen.sink.len();
+
+        screen.poll();
+        assert_eq!(
+            screen.sink.len(),
+            drawn,
+            "a turn of no key leaves the frame that stands: {:?}",
+            painted(&screen.sink)
+        );
     }
 
     #[test]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -33,7 +33,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// What one key press asks for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -436,9 +436,30 @@ pub(crate) fn status_line(round: &RoundRecord) -> String {
     .join(SUMMARY_SEPARATOR)
 }
 
+/// The clock that times the lines of a run which draws no table.
+///
+/// Such a run writes one line each minute. A test of that minute must not wait
+/// one, so the clock comes from the caller and a test hands the screen a clock
+/// that it moves by hand.
+pub(crate) trait Clock {
+    /// The moment now.
+    fn now(&self) -> Instant;
+}
+
+/// The clock of a run, which reads the clock of the machine.
+pub(crate) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        todo!("the clock of a run reads the clock of the machine")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{classify, status_line, Command, Keys, NoKeys, RunFacts, Screen, Table};
+    use super::{
+        classify, status_line, Clock, Command, Keys, NoKeys, RunFacts, Screen, SystemClock, Table,
+    };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round};
     use chrono::Utc;
@@ -446,7 +467,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     /// Builds the press of a key that no modifier holds.
     fn press(code: KeyCode) -> KeyEvent {
@@ -955,6 +976,17 @@ mod tests {
                 .first()
                 .is_some_and(|line| line.ends_with(&size_of(SECOND_BYTES))),
             "and the next draw names the size that the file holds then: {second:?}"
+        );
+    }
+
+    #[test]
+    fn the_clock_of_a_run_reads_the_moment_now() {
+        let before = Instant::now();
+        let read = SystemClock.now();
+        let after = Instant::now();
+        assert!(
+            read >= before && read <= after,
+            "the clock of a run reads the clock of the machine"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -412,7 +412,8 @@ mod tests {
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use std::collections::VecDeque;
-    use std::path::PathBuf;
+    use std::fs;
+    use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     /// Builds the press of a key that no modifier holds.
@@ -459,6 +460,22 @@ mod tests {
 
     /// The identifier of the run that every name record below belongs to.
     const RUN: &str = "2026-08-18T12:00:00.000Z";
+
+    /// The number of bytes of the recorded file at the first draw of the test
+    /// of the size.
+    ///
+    /// A size below one kilobyte reads as whole bytes, so the header names the
+    /// count itself and no unit above the byte.
+    const FIRST_BYTES: usize = 100;
+
+    /// The number of bytes of that same file at the second draw.
+    const SECOND_BYTES: usize = 142;
+
+    /// The byte that fills that file.
+    ///
+    /// The header names the size of the recorded file and reads no line of it,
+    /// so one byte serves as well as a record.
+    const FILLER: u8 = b'x';
 
     /// The start of the header line of a table that folded one round.
     ///
@@ -524,6 +541,43 @@ mod tests {
             .as_nanos();
         let process = std::process::id();
         std::env::temp_dir().join(format!("krt-live-{label}-{process}-{nanos}.jsonl"))
+    }
+
+    /// A file that one test makes. The file goes away when the test ends, and
+    /// also when the test panics.
+    struct TempFile {
+        /// The path of the file.
+        path: PathBuf,
+    }
+
+    impl TempFile {
+        /// Holds a path that no file uses yet, and that no other run reaches.
+        fn absent(label: &str) -> Self {
+            Self {
+                path: temp_path(label),
+            }
+        }
+
+        /// The path of the file.
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        /// Writes a file of `bytes` bytes at that path.
+        ///
+        /// # Panics
+        ///
+        /// Panics on a write that fails. Such a fault is a fault of the
+        /// machine, not an answer of the code under test.
+        fn of(&self, bytes: usize) {
+            fs::write(&self.path, vec![FILLER; bytes]).expect("the test file must write");
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 
     /// A table that draws into bytes, reads `keys`, and heads its frames with
@@ -791,6 +845,32 @@ mod tests {
             drawn,
             "a turn of no key leaves the frame that stands: {:?}",
             painted(&screen.sink)
+        );
+    }
+
+    #[test]
+    fn the_header_names_the_size_of_the_recorded_file_at_the_moment_of_the_draw() {
+        let file = TempFile::absent("size");
+        file.of(FIRST_BYTES);
+        let mut screen = table_at(file.path().to_owned(), FakeKeys::of(&[]));
+
+        screen.round(&one_round());
+        let first = painted(&screen.sink);
+        assert!(
+            first.first().is_some_and(|line| line.ends_with("(100 B)")),
+            "the header line names the size that the file holds: {first:?}"
+        );
+
+        // The run appends one record for each round, so the file grows while
+        // the table stands. A header that measured the file one time would
+        // name the size of an empty file for the whole of a long run.
+        file.of(SECOND_BYTES);
+        screen.sink.clear();
+        screen.round(&one_round());
+        let second = painted(&screen.sink);
+        assert!(
+            second.first().is_some_and(|line| line.ends_with("(142 B)")),
+            "and the next draw names the size that the file holds then: {second:?}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -271,9 +271,10 @@ impl<W: Write, K: Keys> Table<W, K> {
     fn apply(&mut self, command: Command) {
         match command {
             Command::Pause => self.paused = !self.paused,
+            Command::Names => self.named = !self.named,
             // Each command below takes an arm of this table with the test of
             // that command.
-            Command::Quit | Command::Names | Command::Reset | Command::Help => {}
+            Command::Quit | Command::Reset | Command::Help => {}
         }
     }
 
@@ -326,7 +327,16 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
         }
     }
 
-    fn names(&mut self, _names: &[NameRecord]) {}
+    fn names(&mut self, names: &[NameRecord]) {
+        for name in names {
+            // The map is keyed by the address, and not by the hop, because one
+            // address answers at any number of TTLs.
+            self.names.insert(name.addr, name.host.clone());
+        }
+        if !self.paused {
+            self.draw();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -7,7 +7,14 @@
 //! reason this module classifies the keys itself: it is the one part of the
 //! live run that can stop a run that the user asked to stop.
 
+use crate::record::{NameRecord, RoundRecord};
+use crate::stats::HopTable;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::time::Duration;
 
 /// What one key press asks for.
 #[cfg_attr(
@@ -76,14 +83,326 @@ pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
     }
 }
 
+/// The end of every line that a draw writes.
+///
+/// Raw mode returns no carriage on a bare line feed, so a frame of bare line
+/// feeds walks down the screen one column further to the right for each line
+/// of it.
+const LINE_END: &str = "\r\n";
+
+/// A source of key presses.
+pub(crate) trait Keys {
+    /// The commands of the keys that arrived since the last ask.
+    ///
+    /// The ask never waits. A run that waited for a key would take no round
+    /// while it waited, and the table would then stand still while the path
+    /// moved.
+    fn presses(&mut self) -> Vec<Command>;
+}
+
+/// The key source of a run that reads no key.
+pub(crate) struct NoKeys;
+
+impl Keys for NoKeys {
+    fn presses(&mut self) -> Vec<Command> {
+        Vec::new()
+    }
+}
+
+/// What a live run shows.
+pub(crate) trait Screen {
+    /// Takes the key presses that arrived. Answers whether the user asked the
+    /// run to stop.
+    fn poll(&mut self) -> bool;
+    /// One round arrived.
+    fn round(&mut self, round: &RoundRecord);
+    /// The names that arrived.
+    fn names(&mut self, names: &[NameRecord]);
+}
+
+/// The facts of a run that every frame of that run repeats.
+///
+/// The header line names them, and no round changes any of them, so the table
+/// takes them one time at the start of the run. They travel as one value
+/// because a constructor of eight parameters says nothing about which
+/// parameter is which.
+pub(crate) struct RunFacts {
+    /// The destination as the command line named it.
+    pub(crate) destination: String,
+    /// The address that the destination resolved to.
+    pub(crate) address: IpAddr,
+    /// The source address of the run.
+    pub(crate) source: IpAddr,
+    /// The period of one round.
+    pub(crate) interval: Duration,
+    /// The path of the recorded file.
+    ///
+    /// The header line names the size of that file, and the file grows with
+    /// every round, so each draw reads the size again.
+    pub(crate) path: PathBuf,
+}
+
+/// The live table of a run.
+///
+/// The table folds every round that arrives, and it draws the frame of that
+/// fold. It holds the terminal in raw mode on the alternate screen, so each
+/// draw clears the screen and moves the cursor to the origin first, and every
+/// line ends with a carriage return and a line feed. Raw mode returns no
+/// carriage on a bare line feed, and a frame of bare line feeds walks down the
+/// screen one column further to the right for each line of it.
+pub(crate) struct Table<W: Write, K: Keys> {
+    /// The facts of the run that the header line names.
+    facts: RunFacts,
+    /// The name of the recorded file, without its directory.
+    file: String,
+    /// The fold of every round that arrived.
+    table: HopTable,
+    /// The host name of each address that a name record named.
+    names: BTreeMap<IpAddr, String>,
+    /// The map that a table of the raw addresses hands the frame.
+    ///
+    /// One empty map that stands beside the names, and not a map that a draw
+    /// builds: a run draws one frame for each round, and each of those draws
+    /// would build the same empty map and drop it again.
+    nameless: BTreeMap<IpAddr, String>,
+    /// The number of rounds that the table folded.
+    ///
+    /// This is the counter of the display, and not the counter of the run. The
+    /// `end` record counts what the file holds, and a reader of the table asks
+    /// how many rounds the picture in front of them stands on. The reset
+    /// command therefore zeroes this counter and touches no file.
+    rounds: usize,
+    /// Whether the table holds where it stands.
+    paused: bool,
+    /// Whether the hosts read as names.
+    named: bool,
+    /// Whether the list of the keys stands under the table.
+    help: bool,
+    /// Where the frames go.
+    sink: W,
+    /// Where the commands come from.
+    keys: K,
+    /// The number of terminal columns that a frame draws in.
+    width: u16,
+}
+
+impl<W: Write, K: Keys> Table<W, K> {
+    /// A table of one run, which draws into `sink` and reads `keys`.
+    ///
+    /// The names start on. A reader who wants the raw addresses asks for them
+    /// with a key, and a run that resolves no name shows the addresses anyway,
+    /// because the map of the names then stays empty.
+    pub(crate) fn new(facts: RunFacts, sink: W, keys: K, width: u16) -> Self {
+        Self {
+            file: crate::file_name(&facts.path),
+            facts,
+            table: HopTable::new(),
+            names: BTreeMap::new(),
+            nameless: BTreeMap::new(),
+            rounds: 0,
+            paused: false,
+            named: true,
+            help: false,
+            sink,
+            keys,
+            width,
+        }
+    }
+}
+
+impl<W: Write, K: Keys> Screen for Table<W, K> {
+    fn poll(&mut self) -> bool {
+        false
+    }
+
+    fn round(&mut self, _round: &RoundRecord) {}
+
+    fn names(&mut self, _names: &[NameRecord]) {}
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{classify, Command};
+    use super::{classify, Command, Keys, RunFacts, Screen, Table};
+    use crate::testing::{address, round};
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     /// Builds the press of a key that no modifier holds.
     fn press(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// The number of terminal columns that every table below draws in.
+    ///
+    /// The nominal frame is 97 columns wide: every column of the table, with a
+    /// Host column of 30. The rows of `tests/replay.rs` stand at that same
+    /// width, so a row of this file reads as a row of that one.
+    const WIDTH: u16 = 97;
+
+    /// The destination of every table below.
+    const DESTINATION: &str = "example.com";
+
+    /// The address that the destination resolved to.
+    const DESTINATION_ADDRESS: &str = "93.184.216.34";
+
+    /// The source address of every run below.
+    const SOURCE: &str = "1.2.3.4";
+
+    /// The period of one round of every run below.
+    const INTERVAL: Duration = Duration::from_secs(1);
+
+    /// The address of the one router that answers the rounds below.
+    const ROUTER: &str = "10.0.0.1";
+
+    /// The round-trip time of the answer of that router, in milliseconds.
+    const RTT: f64 = 0.87;
+
+    /// The first TTL of every round below, which is also the last one.
+    const TTL: u8 = 1;
+
+    /// The start of the header line of a table that folded one round.
+    ///
+    /// The name of the recorded file ends that line, and each test builds a
+    /// path of its own, so the assertion reads the start of the line and not
+    /// the whole of it.
+    const ONE_ROUND_HEADER: &str = " krt  example.com → 93.184.216.34   src 1.2.3.4   round 1   1s   ";
+
+    /// The row of a table that folded one round of one TTL.
+    ///
+    /// The round answers at TTL 1 from 10.0.0.1 at 0.87, which one decimal
+    /// place writes as 0.9. One answer is its own last, smallest, mean, and
+    /// largest time, and the population standard deviation of one sample is
+    /// 0.0. The TTL answered the one probe it took, so it loses nothing. One
+    /// sample draws one bar, and a window of one sample varies by nothing, so
+    /// that bar is the lowest one.
+    const ONE_ROUND_ROW: &str =
+        "   1  10.0.0.1                          0.0%      1    0.9    0.9    0.9    0.9    0.0  ▁";
+
+    /// The escape character that starts every control sequence of a draw.
+    const ESCAPE: char = '\u{1b}';
+
+    /// A key source that hands back one list of commands for each turn.
+    ///
+    /// A turn past the end of the script took no key.
+    struct FakeKeys {
+        /// The commands of each turn, the next turn first.
+        turns: VecDeque<Vec<Command>>,
+    }
+
+    impl FakeKeys {
+        /// A key source of one script.
+        fn of(script: &[&[Command]]) -> Self {
+            Self {
+                turns: script.iter().map(|turn| turn.to_vec()).collect(),
+            }
+        }
+    }
+
+    impl Keys for FakeKeys {
+        fn presses(&mut self) -> Vec<Command> {
+            self.turns.pop_front().unwrap_or_default()
+        }
+    }
+
+    /// Builds a path under the temporary directory that no other run reaches.
+    ///
+    /// Two runs of one test can overlap, because `cargo test` runs on many
+    /// threads and more than one `cargo test` can run at once. The process
+    /// identifier and the nanosecond keep the two runs apart.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a clock that stands before the epoch. Such a clock is a fault
+    /// of the machine, not an answer of the code under test.
+    fn temp_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("the clock must stand after the epoch")
+            .as_nanos();
+        let process = std::process::id();
+        std::env::temp_dir().join(format!("krt-live-{label}-{process}-{nanos}.jsonl"))
+    }
+
+    /// A table that draws into bytes, reads `keys`, and heads its frames with
+    /// the recorded file at `path`.
+    fn table_at<K: Keys>(path: PathBuf, keys: K) -> Table<Vec<u8>, K> {
+        Table::new(
+            RunFacts {
+                destination: DESTINATION.to_owned(),
+                address: address(DESTINATION_ADDRESS),
+                source: address(SOURCE),
+                interval: INTERVAL,
+                path,
+            },
+            Vec::new(),
+            keys,
+            WIDTH,
+        )
+    }
+
+    /// A table that draws into bytes and takes the keys of a script.
+    ///
+    /// The path of its recorded file names no file, so the header line of it
+    /// names no size. The one test that reads a size writes a file of its own.
+    fn table(script: &[&[Command]]) -> Table<Vec<u8>, FakeKeys> {
+        table_at(temp_path("frame"), FakeKeys::of(script))
+    }
+
+    /// The text that a terminal prints for what the draws wrote, with the
+    /// control sequences taken out.
+    ///
+    /// Every sequence of a draw starts with the escape character and ends with
+    /// a letter: the clear of the screen ends `J`, and the move of the cursor
+    /// ends `H`. The reader therefore drops from one escape to the letter that
+    /// closes it, and what stays is what a reader of the terminal sees.
+    fn glyphs(painted: &[u8]) -> String {
+        let text = String::from_utf8_lossy(painted);
+        let mut kept = String::new();
+        let mut characters = text.chars();
+        while let Some(character) = characters.next() {
+            if character != ESCAPE {
+                kept.push(character);
+                continue;
+            }
+            for inside in characters.by_ref() {
+                if inside.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        }
+        kept
+    }
+
+    /// The lines that the draws wrote into a sink, in the order they arrived.
+    fn painted(sink: &[u8]) -> Vec<String> {
+        glyphs(sink)
+            .split_terminator(super::LINE_END)
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// One round of one TTL, which the router answered.
+    fn one_round() -> crate::record::RoundRecord {
+        round(TTL, TTL, &[(TTL, ROUTER, RTT)])
+    }
+
+    #[test]
+    fn one_round_reaches_the_sink_as_a_row_of_the_table() {
+        let mut screen = table(&[]);
+        screen.round(&one_round());
+        let lines = painted(&screen.sink);
+        assert!(
+            lines
+                .first()
+                .is_some_and(|line| line.starts_with(ONE_ROUND_HEADER)),
+            "the header line names the target, the source, the one round, and the interval: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == ONE_ROUND_ROW),
+            "the row of the TTL stands under that header: {lines:?}"
+        );
     }
 
     #[test]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -480,8 +480,12 @@ impl<W: Write, C: Clock> Screen for Headless<W, C> {
         todo!("a headless screen reads no key")
     }
 
-    fn round(&mut self, _round: &RoundRecord) {
-        todo!("a headless screen writes the status line of a round")
+    fn round(&mut self, round: &RoundRecord) {
+        // A line that does not print stops nothing. The recording is the
+        // purpose of the tool, and the line is one view of it, so a reader who
+        // closes the pipe of the display loses the display and keeps the
+        // recording.
+        drop(writeln!(self.sink, "{}", status_line(round)));
     }
 
     fn names(&mut self, _names: &[NameRecord]) {

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -455,11 +455,21 @@ impl Clock for SystemClock {
     }
 }
 
+/// The time between two lines of a run that draws no table.
+///
+/// A run of one round each second writes one line each second, and an hour of
+/// such a run fills a terminal with 3600 lines that say almost the same thing.
+/// One line for each minute of the run says the same thing and leaves the
+/// window of the terminal to the work of the reader.
+const LINE_PERIOD: Duration = Duration::from_secs(60);
+
 /// The display of a run that draws no table.
 ///
 /// A run whose standard output is a pipe or a file holds no terminal. Such a
-/// run clears no screen and reads no key, so it writes one status line for a
-/// round and nothing else.
+/// run clears no screen and reads no key. It writes one status line at its
+/// first round, and one more each time a whole [`LINE_PERIOD`] passed since the
+/// line before it. The first round stands on its own reason: a run that printed
+/// nothing for a whole minute reads as a run that died.
 pub(crate) struct Headless<W: Write, C: Clock> {
     /// Where the lines go.
     sink: W,
@@ -479,6 +489,15 @@ impl<W: Write, C: Clock> Headless<W, C> {
             last: None,
         }
     }
+
+    /// Whether the line of a round that arrives at `now` reaches the sink.
+    ///
+    /// The first round of a run prints, and every round after it prints when a
+    /// whole [`LINE_PERIOD`] passed since the last line.
+    fn due(&self, now: Instant) -> bool {
+        self.last
+            .is_none_or(|last| now.duration_since(last) >= LINE_PERIOD)
+    }
 }
 
 impl<W: Write, C: Clock> Screen for Headless<W, C> {
@@ -487,10 +506,11 @@ impl<W: Write, C: Clock> Screen for Headless<W, C> {
     }
 
     fn round(&mut self, round: &RoundRecord) {
-        if self.last.is_some() {
+        let now = self.clock.now();
+        if !self.due(now) {
             return;
         }
-        self.last = Some(self.clock.now());
+        self.last = Some(now);
         // A line that does not print stops nothing. The recording is the
         // purpose of the tool, and the line is one view of it, so a reader who
         // closes the pipe of the display loses the display and keeps the

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -26,9 +26,11 @@ use crate::stats::HopTable;
 use crate::ui;
 use crate::ui::render_duration;
 use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
-use crossterm::cursor::{MoveTo, Show};
+use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::terminal::{disable_raw_mode, Clear, ClearType, LeaveAlternateScreen};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use crossterm::{execute, queue};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -650,6 +652,78 @@ fn restore_panic_hook(previous: PanicHook) {
         return;
     }
     std::panic::set_hook(Box::new(move |info| (*previous)(info)));
+}
+
+/// The hold of a live run on the terminal of that run.
+///
+/// The guard takes the terminal at the start of the live run and puts it back
+/// at the end. It is a local of the run, so every way out of that run gives the
+/// terminal back: the stop that the user asked for, the fault that ends the run
+/// early, and the panic that nobody asked for.
+///
+/// No test of this file builds this guard. `crossterm` takes raw mode of the
+/// terminal of the process, and a test that took the terminal of `cargo test`
+/// takes the terminal of the reader who started it. The pseudo terminal of a
+/// later step of this work is what drives the guard. The panic hook of the
+/// guard holds no terminal, and the tests above drive that hook on its own.
+#[expect(
+    dead_code,
+    reason = "the caller that picks the live table joins this module in the next step of this work"
+)]
+pub(crate) struct TerminalGuard {
+    /// The panic hook that stood before [`TerminalGuard::enter`] wrapped it.
+    ///
+    /// An `Option`, so the drop moves the hook out of it and back into the
+    /// process.
+    previous_hook: Option<PanicHook>,
+}
+
+impl TerminalGuard {
+    /// Takes the terminal for a live run.
+    ///
+    /// Raw mode sends the bytes of every key straight to this process, which is
+    /// what lets a key of the reader reach the run. The alternate screen holds
+    /// the frames of the run, so the lines that stood in the terminal come back
+    /// at the end of it. The cursor goes away, because a table that redraws
+    /// itself ten times each second drags a cursor across itself.
+    ///
+    /// The panic hook comes last. A panic of a live run prints its message on
+    /// the alternate screen in raw mode, and the process then dies and takes
+    /// that screen away with it, so the reader reads no message at all. The
+    /// hook puts the terminal back in front of the message.
+    ///
+    /// # Errors
+    ///
+    /// Answers the fault of a terminal that refused raw mode, or that refused
+    /// the alternate screen. A terminal that refused the second of the two
+    /// comes all the way back before the fault answers, so a run that stops
+    /// here leaves no terminal in raw mode.
+    #[expect(
+        dead_code,
+        reason = "the caller that picks the live table joins this module in the next step of this work"
+    )]
+    pub(crate) fn enter() -> std::io::Result<Self> {
+        enable_raw_mode()?;
+        if let Err(fault) = execute!(std::io::stdout(), EnterAlternateScreen, Hide) {
+            restore_terminal();
+            return Err(fault);
+        }
+        Ok(Self {
+            previous_hook: Some(install_panic_hook()),
+        })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        restore_terminal();
+        // The hook of the live run goes off the process with the run that
+        // installed it. A hook that stood on holds a terminal that no part of
+        // the process holds.
+        if let Some(previous) = self.previous_hook.take() {
+            restore_panic_hook(previous);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -7,20 +7,6 @@
 //! reason this module classifies the keys itself: it is the one part of the
 //! live run that can stop a run that the user asked to stop.
 
-// The run loop reads the headless screen of this module. The live table waits
-// for the caller that chooses between the two screens, and that caller joins
-// in the next step of this work. One attribute stands here, and not one
-// attribute for each item of the table, because those items are dead for one
-// reason: no caller. The expectation fails once that caller stands, which
-// takes this attribute back off.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the caller that picks the live table joins this module in the next step of this work"
-    )
-)]
-
 use crate::record::{NameRecord, RoundRecord};
 use crate::stats::HopTable;
 use crate::ui;
@@ -156,8 +142,16 @@ pub(crate) trait Keys {
 }
 
 /// The key source of a run that reads no key.
+///
+/// No run of the tool builds this source. A run that draws the table holds a
+/// terminal and reads the keys of it, and a run that holds no terminal draws no
+/// table and takes no key source at all. The source is therefore a part of a
+/// test build and no part of a build that ships, and the tests of a turn that
+/// took no key are what read it.
+#[cfg(test)]
 pub(crate) struct NoKeys;
 
+#[cfg(test)]
 impl Keys for NoKeys {
     fn presses(&mut self) -> Vec<Command> {
         Vec::new()
@@ -175,10 +169,6 @@ impl Keys for NoKeys {
 /// the keys of the terminal of `cargo test` takes the keys of the reader who
 /// started it. The pseudo terminal of a later step of this work is what drives
 /// this source.
-#[expect(
-    dead_code,
-    reason = "the caller that picks the live table joins this module in the next step of this work"
-)]
 pub(crate) struct Keyboard;
 
 impl Keys for Keyboard {
@@ -674,10 +664,6 @@ fn restore_panic_hook(previous: PanicHook) {
 /// takes the terminal of the reader who started it. The pseudo terminal of a
 /// later step of this work is what drives the guard. The panic hook of the
 /// guard holds no terminal, and the tests above drive that hook on its own.
-#[expect(
-    dead_code,
-    reason = "the caller that picks the live table joins this module in the next step of this work"
-)]
 pub(crate) struct TerminalGuard {
     /// The panic hook that stood before [`TerminalGuard::enter`] wrapped it.
     ///
@@ -706,10 +692,6 @@ impl TerminalGuard {
     /// the alternate screen. A terminal that refused the second of the two
     /// comes all the way back before the fault answers, so a run that stops
     /// here leaves no terminal in raw mode.
-    #[expect(
-        dead_code,
-        reason = "the caller that picks the live table joins this module in the next step of this work"
-    )]
     pub(crate) fn enter() -> std::io::Result<Self> {
         enable_raw_mode()?;
         if let Err(fault) = execute!(std::io::stdout(), EnterAlternateScreen, Hide) {

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -87,6 +87,13 @@ pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
     }
 }
 
+/// The word that a table which holds where it stands writes under itself.
+///
+/// A held table looks like a table of a run that stopped, and a reader who
+/// pressed the key a minute ago does not remember which of the two stands in
+/// front of them. One word answers that.
+const PAUSED: &str = "paused";
+
 /// The end of every line that a draw writes.
 ///
 /// Raw mode returns no carriage on a bare line feed, so a frame of bare line
@@ -223,6 +230,10 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// beside the names. The frame names an address that its map holds none of
     /// by the address itself, so one empty map turns every host of the table
     /// back into the number that answered.
+    ///
+    /// The footer stands under the table, and one blank line holds it off the
+    /// last row of the path: a word directly under the numbers of a hop reads
+    /// as a part of the table.
     fn frame_lines(&self) -> Vec<String> {
         let frame = ui::Frame {
             header: ui::Header {
@@ -248,7 +259,22 @@ impl<W: Write, K: Keys> Table<W, K> {
             },
             destination: Some(self.facts.address),
         };
-        frame.lines(self.width)
+        let mut lines = frame.lines(self.width);
+        if self.paused {
+            lines.push(String::new());
+            lines.push(PAUSED.to_owned());
+        }
+        lines
+    }
+
+    /// Acts on one command.
+    fn apply(&mut self, command: Command) {
+        match command {
+            Command::Pause => self.paused = !self.paused,
+            // Each command below takes an arm of this table with the test of
+            // that command.
+            Command::Quit | Command::Names | Command::Reset | Command::Help => {}
+        }
     }
 
     /// Puts one frame on the screen, over the frame that stands there.
@@ -281,13 +307,23 @@ impl<W: Write, K: Keys> Table<W, K> {
 
 impl<W: Write, K: Keys> Screen for Table<W, K> {
     fn poll(&mut self) -> bool {
+        for command in self.keys.presses() {
+            self.apply(command);
+        }
+        // The draw stands outside the loop, and it draws while the table holds
+        // as well: a table that took the key of the pause must put the mark of
+        // that pause on the screen, and no round draws it while the table
+        // holds.
+        self.draw();
         false
     }
 
     fn round(&mut self, round: &RoundRecord) {
         self.table.observe(round);
         self.rounds += 1;
-        self.draw();
+        if !self.paused {
+            self.draw();
+        }
     }
 
     fn names(&mut self, _names: &[NameRecord]) {}

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -461,6 +461,28 @@ mod tests {
         round(TTL, TTL, &[(TTL, ROUTER, RTT)])
     }
 
+    /// The word that a table which holds where it stands writes under its
+    /// table.
+    ///
+    /// The test spells the word, and the module spells it again. That is on
+    /// purpose: a test that read the constant of the module would agree with
+    /// every word the module ever holds, and this word is what a reader of the
+    /// screen sees.
+    const PAUSED: &str = "paused";
+
+    /// The last `count` lines of a frame, or every line of a frame that holds
+    /// fewer than that.
+    ///
+    /// A frame of too few lines must fail the assertion of the test that reads
+    /// the end of it, and must not stop that test with an index.
+    fn last_lines(lines: &[String], count: usize) -> Vec<&str> {
+        lines
+            .iter()
+            .skip(lines.len().saturating_sub(count))
+            .map(String::as_str)
+            .collect()
+    }
+
     #[test]
     fn one_round_reaches_the_sink_as_a_row_of_the_table() {
         let mut screen = table(&[]);
@@ -475,6 +497,31 @@ mod tests {
         assert!(
             lines.iter().any(|line| line == ONE_ROUND_ROW),
             "the row of the TTL stands under that header: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn the_pause_holds_the_table_and_the_frame_of_it_names_the_pause() {
+        let mut screen = table(&[&[Command::Pause]]);
+        screen.round(&one_round());
+        screen.sink.clear();
+
+        // A poll draws while the table holds as well, so the mark of the pause
+        // reaches the screen of a run that no round moves.
+        screen.poll();
+        let held = painted(&screen.sink);
+        assert_eq!(
+            last_lines(&held, 2),
+            ["", PAUSED],
+            "one blank line and the word of the pause close the frame: {held:?}"
+        );
+
+        screen.sink.clear();
+        screen.round(&one_round());
+        assert!(
+            screen.sink.is_empty(),
+            "a round of a table that holds draws nothing: {:?}",
+            painted(&screen.sink)
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -320,12 +320,13 @@ impl Window {
 /// The live table of a run.
 ///
 /// The table folds every round that arrives, and it draws the frame of that
-/// fold. A run that draws this table holds the terminal in raw mode on the
-/// alternate screen, so each draw clears the screen and moves the cursor to the
-/// origin first, and one carriage return with one line feed stands between two
-/// lines of a frame. Raw mode returns no carriage on a bare line feed, and a
-/// frame of bare line feeds walks down the screen one column further to the
-/// right for each line of it.
+/// fold. It also draws one frame at the moment it is built, in front of every
+/// round, for the reason that [`Table::new`] states. A run that draws this
+/// table holds the terminal in raw mode on the alternate screen, so each draw
+/// clears the screen and moves the cursor to the origin first, and one carriage
+/// return with one line feed stands between two lines of a frame. Raw mode
+/// returns no carriage on a bare line feed, and a frame of bare line feeds
+/// walks down the screen one column further to the right for each line of it.
 ///
 /// The frame fits the window of the terminal. A frame of more lines than that
 /// window holds keeps its head and its footer and drops the rows of the highest
@@ -373,8 +374,22 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// The names start on. A reader who wants the raw addresses asks for them
     /// with a key, and a run that resolves no name shows the addresses anyway,
     /// because the map of the names then stays empty.
+    ///
+    /// The table draws its opening frame here, and not at the first round. The
+    /// caller takes the terminal in front of this call, so the alternate screen
+    /// of the run already stands in front of the reader, and that screen hides
+    /// every line which the run printed under it. A table that drew at the
+    /// first round alone therefore leaves an empty screen for one whole
+    /// period, and `--interval 2m` makes that two minutes with nothing on the
+    /// screen that says the run started. The frame of no round answers it: the
+    /// header line of such a frame names the destination, the address, the
+    /// source, the period of one round, and the recorded file, and the column
+    /// header stands under it.
+    ///
+    /// A table that exists holds a frame, and no caller can forget to ask for
+    /// one.
     pub(crate) fn new(facts: RunFacts, sink: W, keys: K, window: Window) -> Self {
-        Self {
+        let mut table = Self {
             file: crate::file_name(&facts.path),
             facts,
             fold: HopTable::new(),
@@ -387,7 +402,9 @@ impl<W: Write, K: Keys> Table<W, K> {
             sink,
             keys,
             window,
-        }
+        };
+        table.draw();
+        table
     }
 
     /// The lines of one frame of this table.
@@ -1018,13 +1035,19 @@ mod tests {
 
     /// A table that draws into bytes, reads `keys`, and heads its frames with
     /// the recorded file at `path`.
+    ///
+    /// The sink comes back empty. A table draws its opening frame at the moment
+    /// it is built, and every test below reads the frames that its own calls
+    /// drew.
     fn table_at<K: Keys>(path: PathBuf, keys: K) -> Table<Vec<u8>, K> {
-        Table::new(
+        let mut table = Table::new(
             facts_at(path),
             Vec::new(),
             keys,
             Window::new(WIDTH, NO_ROWS),
-        )
+        );
+        table.sink.clear();
+        table
     }
 
     /// A sink that counts the calls of [`Write::write`] that reach it.
@@ -1054,13 +1077,18 @@ mod tests {
 
     /// A table that draws into a sink which counts the calls, and that takes
     /// the keys of an empty script.
+    ///
+    /// The count comes back at zero. A table draws its opening frame at the
+    /// moment it is built, and the test below counts the calls of one draw.
     fn counted_table() -> Table<Counted, FakeKeys> {
-        Table::new(
+        let mut table = Table::new(
             facts_at(temp_path("writes")),
             Counted { writes: 0 },
             FakeKeys::of(&[]),
             Window::new(WIDTH, NO_ROWS),
-        )
+        );
+        table.sink.writes = 0;
+        table
     }
 
     /// A table that draws into bytes and takes the keys of a script.
@@ -1217,13 +1245,17 @@ mod tests {
 
     /// A table that draws into bytes in a window of `rows` rows, and that takes
     /// the keys of a script.
+    ///
+    /// The sink comes back empty, for the reason that [`table_at`] states.
     fn table_in(rows: Option<u16>, script: &[&[Command]]) -> Table<Vec<u8>, FakeKeys> {
-        Table::new(
+        let mut table = Table::new(
             facts_at(temp_path("window")),
             Vec::new(),
             FakeKeys::of(script),
             Window::new(WIDTH, rows),
-        )
+        );
+        table.sink.clear();
+        table
     }
 
     /// A table of the tall path in a window of `rows` rows, which drew the
@@ -1387,6 +1419,36 @@ mod tests {
             .skip(lines.len().saturating_sub(count))
             .map(String::as_str)
             .collect()
+    }
+
+    #[test]
+    fn a_table_draws_a_frame_of_no_round_at_the_moment_it_is_built() {
+        // The run takes the terminal in front of this call, so the alternate
+        // screen of that run already stands in front of the reader, and it
+        // hides every line which the run printed under it. A table that drew at
+        // the first round alone leaves an empty screen for one whole period,
+        // and a period of two minutes is two minutes of nothing that says the
+        // run started.
+        let screen = Table::new(
+            facts_at(temp_path("opening")),
+            Vec::new(),
+            FakeKeys::of(&[]),
+            Window::new(WIDTH, NO_ROWS),
+        );
+        let lines = painted(&screen.sink);
+
+        assert!(
+            lines
+                .first()
+                .is_some_and(|line| line.starts_with(NO_ROUND_HEADER)),
+            "the header line names the target, the source, the interval, and the round that no probe took yet: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.starts_with(COLUMN_HEADER_START)),
+            "and the column header stands under it: {lines:?}"
+        );
     }
 
     #[test]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -574,10 +574,17 @@ fn restore_terminal() {
 /// terminal reads no message at all, and a raw terminal is what stays in front
 /// of them. The hook therefore puts the terminal back first, and the message of
 /// the panic then lands on the screen that the reader keeps.
+///
+/// The hook chains, and it puts the terminal back in front of that chain. The
+/// hook of the machine prints the message of a panic, and a test binary holds a
+/// hook that collects one. A hook that replaced either of them takes the report
+/// of every panic away from the reader who needs it most.
 fn install_panic_hook() -> PanicHook {
     let previous: PanicHook = Arc::from(std::panic::take_hook());
-    std::panic::set_hook(Box::new(move |_info| {
+    let chained = Arc::clone(&previous);
+    std::panic::set_hook(Box::new(move |info| {
         restore_terminal();
+        (*chained)(info);
     }));
     previous
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -26,14 +26,17 @@ use crate::stats::HopTable;
 use crate::ui;
 use crate::ui::render_duration;
 use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
-use crossterm::cursor::MoveTo;
+use crossterm::cursor::{MoveTo, Show};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::queue;
-use crossterm::terminal::{Clear, ClearType};
+use crossterm::terminal::{disable_raw_mode, Clear, ClearType, LeaveAlternateScreen};
+use crossterm::{execute, queue};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::net::IpAddr;
 use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// What one key press asks for.
@@ -530,11 +533,60 @@ impl<W: Write, C: Clock> Screen for Headless<W, C> {
     }
 }
 
+/// A panic hook, of the kind that [`std::panic::take_hook`] answers.
+///
+/// The hook stands in an [`Arc`], because two holders read the one hook: the
+/// hook that a live run installs chains to it, and the guard of that run puts
+/// it back.
+type PanicHook = Arc<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send>;
+
+/// The number of times that this process put the terminal back.
+///
+/// A test holds no terminal, so it reads nothing of what a restoration writes.
+/// This count is what such a test reads in the place of that, and it says
+/// whether the panic hook of a live run still stands. Only the tests of that
+/// hook read the count, and they hold one lock while they do, so no two
+/// readers of it race. The count is a part of a test build and no part of a
+/// build that ships.
+#[cfg(test)]
+static RESTORATIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Puts the terminal back the way it stood before a live run took it.
+///
+/// Each step stands on its own, and a step that fails leaves the steps after it
+/// alone: a terminal that took one part of the entry and refused the next one
+/// must come all the way back anyway. The function also runs two times on the
+/// path of a panic, because the hook of the panic runs it and the unwind then
+/// drops the guard, and each of those two runs is safe.
+fn restore_terminal() {
+    #[cfg(test)]
+    RESTORATIONS.fetch_add(1, Ordering::SeqCst);
+    drop(disable_raw_mode());
+    drop(execute!(std::io::stdout(), Show, LeaveAlternateScreen));
+}
+
+/// Installs the hook that puts the terminal back before a panic message prints,
+/// and answers the hook that stood before it.
+///
+/// A live run holds the terminal in raw mode on the alternate screen. A panic
+/// of such a run prints its message on that alternate screen, and the process
+/// then dies and takes the alternate screen away with it. The reader of that
+/// terminal reads no message at all, and a raw terminal is what stays in front
+/// of them. The hook therefore puts the terminal back first, and the message of
+/// the panic then lands on the screen that the reader keeps.
+fn install_panic_hook() -> PanicHook {
+    let previous: PanicHook = Arc::from(std::panic::take_hook());
+    std::panic::set_hook(Box::new(move |_info| {
+        restore_terminal();
+    }));
+    previous
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        classify, status_line, Clock, Command, Headless, Keys, NoKeys, RunFacts, Screen,
-        SystemClock, Table,
+        classify, install_panic_hook, status_line, Clock, Command, Headless, Keys, NoKeys,
+        PanicHook, RunFacts, Screen, SystemClock, Table,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round, FakeKeys};
@@ -544,6 +596,8 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     /// Builds the press of a key that no modifier holds.
@@ -1265,5 +1319,130 @@ mod tests {
     #[test]
     fn a_key_that_carries_no_letter_asks_for_nothing() {
         assert_eq!(classify(press(KeyCode::Enter)), None);
+    }
+
+    /// The lock of every test that changes the panic hook.
+    ///
+    /// The panic hook is one setting of the whole process, and `cargo test`
+    /// runs the tests of one binary on many threads. A test that set the hook
+    /// while another test held it takes the hook of that test away, and that
+    /// test then reads the answer of a hook it never installed. The lock keeps
+    /// the tests below apart from each other, and it keeps each of them apart
+    /// from a second run of itself. The count of the restorations reads true
+    /// under the same lock, for the same reason.
+    static HOOK_LOCK: Mutex<()> = Mutex::new(());
+
+    /// The message of the panic that each test of the hook raises.
+    const THE_TEST_PANIC: &str = "the panic that a test of the hook raises";
+
+    /// Holds the panic hook of the process while one test changes it.
+    ///
+    /// The guard takes the lock of the hook, and it takes the hook that stood
+    /// in front of the test. The drop puts that hook back and lets the lock go
+    /// after it.
+    ///
+    /// Each test below reads its answers into locals and drops this guard
+    /// before it asserts on them. `std::panic::set_hook` refuses a thread that
+    /// is panicking, and it refuses with a panic of its own, which aborts the
+    /// process and takes the report of every other test with it. A failed
+    /// assertion of a test that still held the guard is such a thread.
+    struct HookGuard {
+        /// The hook that stood before the test. An `Option`, so the drop moves
+        /// the hook out of it.
+        previous: Option<PanicHook>,
+        /// The lock, which the drop lets go last of all.
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl HookGuard {
+        /// Takes the lock, and the hook that stands now.
+        ///
+        /// A poisoned lock still guards. The state under it is the panic hook
+        /// of the process, and this guard puts a whole hook back whatever the
+        /// test in front of it did.
+        fn take() -> Self {
+            let lock = HOOK_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+            Self {
+                previous: Some(Arc::from(std::panic::take_hook())),
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for HookGuard {
+        fn drop(&mut self) {
+            // The panic that no test asked for reaches this drop while the
+            // thread panics, and a hook that goes back there aborts the
+            // process. The hook of the test stands on for that run, which
+            // costs the report of a panic and keeps the report of every test.
+            if std::thread::panicking() {
+                return;
+            }
+            if let Some(previous) = self.previous.take() {
+                std::panic::set_hook(Box::new(move |info| (*previous)(info)));
+            }
+        }
+    }
+
+    /// What the hook of a test read.
+    struct Marked {
+        /// Whether the hook read a panic.
+        read: Arc<AtomicBool>,
+        /// Whether the terminal came back before the hook read that panic.
+        restored_first: Arc<AtomicBool>,
+    }
+
+    /// The number of times that this process put the terminal back.
+    fn restorations() -> usize {
+        super::RESTORATIONS.load(Ordering::SeqCst)
+    }
+
+    /// Installs the hook of a test, and answers what that hook reads.
+    ///
+    /// The hook prints nothing. Each test below raises a panic on purpose, and
+    /// the hook of the machine prints the message of every panic it reads, so a
+    /// test that left that hook standing writes the message of a panic that the
+    /// test asked for.
+    fn mark() -> Marked {
+        let read = Arc::new(AtomicBool::new(false));
+        let restored_first = Arc::new(AtomicBool::new(false));
+        let read_in_hook = Arc::clone(&read);
+        let restored_in_hook = Arc::clone(&restored_first);
+        let before = restorations();
+        std::panic::set_hook(Box::new(move |_info| {
+            restored_in_hook.store(restorations() > before, Ordering::SeqCst);
+            read_in_hook.store(true, Ordering::SeqCst);
+        }));
+        Marked {
+            read,
+            restored_first,
+        }
+    }
+
+    #[test]
+    fn the_panic_hook_of_a_live_run_chains_to_the_hook_it_replaced() {
+        // A hook that replaced the hook of the process takes the report of
+        // every panic away from the reader of it. The hook of a live run
+        // therefore puts the terminal back and hands the panic on.
+        let hooks = HookGuard::take();
+        let marked = mark();
+
+        // The guard of the test puts a whole hook back, so the answer of the
+        // installation goes nowhere here. The test below reads that answer.
+        drop(install_panic_hook());
+        let outcome = std::panic::catch_unwind(|| panic!("{THE_TEST_PANIC}"));
+        let read = marked.read.load(Ordering::SeqCst);
+        let restored_first = marked.restored_first.load(Ordering::SeqCst);
+        drop(hooks);
+
+        assert!(outcome.is_err(), "the body of the test raised its panic");
+        assert!(
+            read,
+            "the hook of a live run chains to the hook that stood before it"
+        );
+        assert!(
+            restored_first,
+            "and it puts the terminal back first, so the message of the panic lands on the screen that the reader keeps"
+        );
     }
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -842,6 +842,14 @@ mod tests {
     /// The number of rounds that arrive inside one minute of the test.
     const ROUNDS_INSIDE_A_MINUTE: usize = 4;
 
+    /// One whole minute.
+    ///
+    /// The test spells the minute, and the module spells it again. That is on
+    /// purpose, as the word of the pause is: a test that read the constant of
+    /// the module would agree with every period the module ever holds, and one
+    /// line each minute is what a reader of a headless run gets.
+    const ONE_MINUTE: Duration = Duration::from_secs(60);
+
     /// The lines that a headless screen wrote, in the order they arrived.
     fn printed(sink: &[u8]) -> Vec<String> {
         String::from_utf8_lossy(sink)
@@ -1138,6 +1146,23 @@ mod tests {
             printed(&screen.sink),
             [A_WHOLE_PATH_LINE],
             "the rounds that follow the first one inside the minute print nothing"
+        );
+    }
+
+    #[test]
+    fn a_headless_screen_prints_a_second_line_after_a_minute() {
+        // The line of each minute is what says that the run still stands, and
+        // it names the round that the file holds now.
+        let clock = FakeClock::new();
+        let mut screen = headless(&clock);
+
+        screen.round(&a_whole_path_round());
+        clock.advance(ONE_MINUTE);
+        screen.round(&a_lost_round());
+        assert_eq!(
+            printed(&screen.sink),
+            [A_WHOLE_PATH_LINE, A_LOST_ROUND_LINE],
+            "the first round of the next minute puts its own line on the screen"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -451,7 +451,7 @@ pub(crate) struct SystemClock;
 
 impl Clock for SystemClock {
     fn now(&self) -> Instant {
-        todo!("the clock of a run reads the clock of the machine")
+        Instant::now()
     }
 }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -1490,4 +1490,64 @@ mod tests {
             "and the hook of the live run puts back no terminal, because that hook no longer stands"
         );
     }
+
+    /// Puts a hook back on the way out, as the guard of a live run does.
+    struct Restorer {
+        /// The hook to put back. An `Option`, so the drop moves it out.
+        previous: Option<PanicHook>,
+        /// Whether the restoration raised a panic of its own.
+        refused: Arc<AtomicBool>,
+    }
+
+    impl Drop for Restorer {
+        fn drop(&mut self) {
+            let Some(previous) = self.previous.take() else {
+                return;
+            };
+            // This drop runs while the thread panics, and a panic of the
+            // restoration on that path ends the whole process. The catch holds
+            // such a panic long enough for the test to read that it happened.
+            // The test asserts that there is nothing to catch.
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                restore_panic_hook(previous);
+            }));
+            self.refused.store(outcome.is_err(), Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn a_live_run_that_panics_puts_back_no_hook_and_the_process_lives() {
+        // `std::panic::set_hook` refuses a thread that panics, and it refuses
+        // with a panic of its own. A second panic on the path of a first one
+        // aborts the process. The guard of a live run reaches its drop on the
+        // path of every panic of that run, so a restoration that reads the
+        // thread of no such panic turns each of them into an abort. The hook
+        // of the live run already put the terminal back by then, and the
+        // message of the panic is what the reader waits for.
+        let hooks = HookGuard::take();
+        let marked = mark();
+        let refused = Arc::new(AtomicBool::new(false));
+        let refused_in_run = Arc::clone(&refused);
+
+        let outcome = std::panic::catch_unwind(move || {
+            let _restorer = Restorer {
+                previous: Some(install_panic_hook()),
+                refused: refused_in_run,
+            };
+            panic!("{THE_TEST_PANIC}");
+        });
+        let read = marked.read.load(Ordering::SeqCst);
+        let refused_now = refused.load(Ordering::SeqCst);
+        drop(hooks);
+
+        assert!(outcome.is_err(), "the body of the test raised its panic");
+        assert!(
+            read,
+            "the hook of the live run read that panic and handed it on"
+        );
+        assert!(
+            !refused_now,
+            "and the restoration of the hook raises no panic of its own on the path of a panic"
+        );
+    }
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -522,7 +522,10 @@ impl<W: Write, C: Clock> Screen for Headless<W, C> {
     }
 
     fn names(&mut self, _names: &[NameRecord]) {
-        todo!("a headless screen shows no name")
+        // A name belongs to a row of a table, and this screen draws no table.
+        // The run writes every name record to the recorded file before it
+        // reaches this call, so a replay of that file names each address that
+        // a lookup answered.
     }
 }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -10,6 +10,13 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 /// What one key press asks for.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the tests of this module read the whole table, and the display that acts on a command joins it in the next step of this work. The expectation fails once that display lands, which takes the attribute back off"
+    )
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Command {
     /// Stop the run.
@@ -25,9 +32,48 @@ pub(crate) enum Command {
 }
 
 /// What one key press means, or nothing.
+///
+/// - A key release means nothing. A kitty terminal and a Windows terminal both
+///   report a release, and only a press acts.
+/// - Ctrl-C stops the run, and `q` stops it too. Raw mode clears `ISIG`, so
+///   Ctrl-C arrives as this key press and the process takes no `SIGINT`. A run
+///   that ignored it would need a second terminal to stop.
+/// - `p` holds the display, `n` turns the names on or off, `r` empties the
+///   table of the display, and `?` shows the list of the keys.
+/// - Every other key means nothing.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the tests of this module read the whole table, and the display that polls the keyboard joins it in the next step of this work. The expectation fails once that display lands, which takes the attribute back off"
+    )
+)]
 pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
-    let _ = key;
-    None
+    let KeyEvent {
+        code,
+        modifiers,
+        kind,
+        ..
+    } = key;
+
+    if kind == KeyEventKind::Release {
+        return None;
+    }
+
+    // Checked in front of the table of the letters, so no mode that a later
+    // display adds can trap the user.
+    if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+        return Some(Command::Quit);
+    }
+
+    match code {
+        KeyCode::Char('q') => Some(Command::Quit),
+        KeyCode::Char('p') => Some(Command::Pause),
+        KeyCode::Char('n') => Some(Command::Names),
+        KeyCode::Char('r') => Some(Command::Reset),
+        KeyCode::Char('?') => Some(Command::Help),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -90,6 +90,15 @@ const PAUSED: &str = "paused";
 /// The number of keys that a live table reads.
 const KEY_COUNT: usize = 5;
 
+/// The key that shows the list of the keys, and hides it again.
+///
+/// The long help of `krt` names this key, and it names no other key of the
+/// table, because a doc comment of `clap` is a string literal that reads
+/// [`KEYS`] at no time. This name therefore stands here, beside the one list,
+/// and `the_long_help_names_the_key_that_lists_the_keys` holds the two of them
+/// together.
+const KEY_THAT_LISTS_THE_KEYS: &str = "?";
+
 /// Each key of a live table, and what that key does.
 ///
 /// This list is the one place that says what a key does, and the help builds
@@ -101,7 +110,7 @@ const KEYS: [(&str, &str); KEY_COUNT] = [
     ("p", "hold the table, or let it move"),
     ("n", "show the names, or show the addresses"),
     ("r", "empty the table"),
-    ("?", "show these keys, or hide them"),
+    (KEY_THAT_LISTS_THE_KEYS, "show these keys, or hide them"),
 ];
 
 /// The text between a key and what that key does.
@@ -858,6 +867,7 @@ mod tests {
     use super::{
         classify, install_panic_hook, restore_panic_hook, status_line, Clock, Command, Headless,
         Keys, NoKeys, PanicHook, RunFacts, Screen, SystemClock, Table, Window,
+        KEY_THAT_LISTS_THE_KEYS,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round, FakeKeys};
@@ -1718,6 +1728,26 @@ mod tests {
                 .iter()
                 .any(|line| HELP_LINES.contains(&line.as_str())),
             "a second press takes the list back off the screen: {hidden:?}"
+        );
+    }
+
+    /// The long help of `krt` names the key that opens the list of the keys.
+    ///
+    /// [`KEYS`] is the one list that says what a key does, and a doc comment
+    /// of `clap` is a string literal that reads that list at no time. The long
+    /// help therefore writes the name of one key by hand. This test holds that
+    /// name and the list together: a list that gives the work to another key
+    /// fails here, and no reader of the help then presses a key which does
+    /// nothing.
+    #[test]
+    fn the_long_help_names_the_key_that_lists_the_keys() {
+        use clap::CommandFactory;
+
+        let help = crate::Cli::command().render_long_help().to_string();
+        let name = format!("`{KEY_THAT_LISTS_THE_KEYS}`");
+        assert!(
+            help.contains(&name),
+            "the long help names the {name} key, which opens the list of the keys: {help}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -167,8 +167,8 @@ impl Keys for NoKeys {
 /// No test of this file builds this source. `crossterm` reads the keys of a
 /// terminal, and `cargo test` hands the test binary a pipe. A source that read
 /// the keys of the terminal of `cargo test` takes the keys of the reader who
-/// started it. The pseudo terminal of a later step of this work is what drives
-/// this source.
+/// started it. The pseudo terminal of `tests/terminal.rs` is what drives this
+/// source.
 pub(crate) struct Keyboard;
 
 impl Keys for Keyboard {
@@ -661,9 +661,9 @@ fn restore_panic_hook(previous: PanicHook) {
 ///
 /// No test of this file builds this guard. `crossterm` takes raw mode of the
 /// terminal of the process, and a test that took the terminal of `cargo test`
-/// takes the terminal of the reader who started it. The pseudo terminal of a
-/// later step of this work is what drives the guard. The panic hook of the
-/// guard holds no terminal, and the tests above drive that hook on its own.
+/// takes the terminal of the reader who started it. The pseudo terminal of
+/// `tests/terminal.rs` is what drives the guard. The panic hook of the guard
+/// holds no terminal, and the tests above drive that hook on its own.
 pub(crate) struct TerminalGuard {
     /// The panic hook that stood before [`TerminalGuard::enter`] wrapped it.
     ///

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -536,11 +536,10 @@ mod tests {
         SystemClock, Table,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
-    use crate::testing::{address, round};
+    use crate::testing::{address, round, FakeKeys};
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use std::cell::Cell;
-    use std::collections::VecDeque;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
@@ -629,29 +628,6 @@ mod tests {
 
     /// The escape character that starts every control sequence of a draw.
     const ESCAPE: char = '\u{1b}';
-
-    /// A key source that hands back one list of commands for each turn.
-    ///
-    /// A turn past the end of the script took no key.
-    struct FakeKeys {
-        /// The commands of each turn, the next turn first.
-        turns: VecDeque<Vec<Command>>,
-    }
-
-    impl FakeKeys {
-        /// A key source of one script.
-        fn of(script: &[&[Command]]) -> Self {
-            Self {
-                turns: script.iter().map(|turn| turn.to_vec()).collect(),
-            }
-        }
-    }
-
-    impl Keys for FakeKeys {
-        fn presses(&mut self) -> Vec<Command> {
-            self.turns.pop_front().unwrap_or_default()
-        }
-    }
 
     /// Builds a path under the temporary directory that no other run reaches.
     ///

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -9,7 +9,11 @@
 
 use crate::record::{NameRecord, RoundRecord};
 use crate::stats::HopTable;
+use crate::ui;
+use crossterm::cursor::MoveTo;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::queue;
+use crossterm::terminal::{Clear, ClearType};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::net::IpAddr;
@@ -208,6 +212,71 @@ impl<W: Write, K: Keys> Table<W, K> {
             width,
         }
     }
+
+    /// The lines of one frame of this table.
+    ///
+    /// The frame stands apart from the draw that puts it on the screen, so a
+    /// reader of the lines reads the glyphs of the table and no control
+    /// sequence of a terminal.
+    ///
+    /// A table of the raw addresses hands the frame the empty map that stands
+    /// beside the names. The frame names an address that its map holds none of
+    /// by the address itself, so one empty map turns every host of the table
+    /// back into the number that answered.
+    fn frame_lines(&self) -> Vec<String> {
+        let frame = ui::Frame {
+            header: ui::Header {
+                destination: Some(&self.facts.destination),
+                address: Some(self.facts.address),
+                source: Some(self.facts.source),
+                rounds: self.rounds,
+                interval: Some(self.facts.interval),
+                file: &self.file,
+                // The file grows with every round, so the size comes off the
+                // file at the moment of the draw. A file that the run cannot
+                // measure still folds, and the header then names the file and
+                // no size.
+                bytes: std::fs::metadata(&self.facts.path)
+                    .ok()
+                    .map(|data| data.len()),
+            },
+            table: &self.table,
+            names: if self.named {
+                &self.names
+            } else {
+                &self.nameless
+            },
+            destination: Some(self.facts.address),
+        };
+        frame.lines(self.width)
+    }
+
+    /// Puts one frame on the screen, over the frame that stands there.
+    ///
+    /// A frame that does not print stops nothing. The recording is the purpose
+    /// of the tool, and the frame is one view of it, so a run whose terminal
+    /// goes away loses the display and keeps the recording.
+    fn draw(&mut self) {
+        let lines = self.frame_lines();
+        drop(self.paint(&lines));
+    }
+
+    /// Writes the lines of one frame.
+    ///
+    /// The clear comes first, so a frame of fewer lines than the frame before
+    /// it leaves none of the older lines on the screen.
+    ///
+    /// # Errors
+    ///
+    /// Answers the fault that the sink raised. The caller of this function
+    /// drops that fault, for the reason that [`Table::draw`] states.
+    fn paint(&mut self, lines: &[String]) -> std::io::Result<()> {
+        queue!(self.sink, Clear(ClearType::All), MoveTo(0, 0))?;
+        for line in lines {
+            write!(self.sink, "{line}{LINE_END}")?;
+        }
+        self.sink.flush()
+    }
 }
 
 impl<W: Write, K: Keys> Screen for Table<W, K> {
@@ -215,7 +284,11 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
         false
     }
 
-    fn round(&mut self, _round: &RoundRecord) {}
+    fn round(&mut self, round: &RoundRecord) {
+        self.table.observe(round);
+        self.rounds += 1;
+        self.draw();
+    }
 
     fn names(&mut self, _names: &[NameRecord]) {}
 }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -465,13 +465,19 @@ pub(crate) struct Headless<W: Write, C: Clock> {
     sink: W,
     /// The clock that times the lines.
     clock: C,
+    /// The moment of the last line, and nothing before the first one.
+    last: Option<Instant>,
 }
 
 impl<W: Write, C: Clock> Headless<W, C> {
     /// A headless screen that writes into `sink` and times its lines by
     /// `clock`.
     pub(crate) fn new(sink: W, clock: C) -> Self {
-        Self { sink, clock }
+        Self {
+            sink,
+            clock,
+            last: None,
+        }
     }
 }
 
@@ -481,6 +487,10 @@ impl<W: Write, C: Clock> Screen for Headless<W, C> {
     }
 
     fn round(&mut self, round: &RoundRecord) {
+        if self.last.is_some() {
+            return;
+        }
+        self.last = Some(self.clock.now());
         // A line that does not print stops nothing. The recording is the
         // purpose of the tool, and the line is one view of it, so a reader who
         // closes the pipe of the display loses the display and keeps the

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -467,9 +467,6 @@ mod tests {
 
     /// The number of bytes of the recorded file at the first draw of the test
     /// of the size.
-    ///
-    /// A size below one kilobyte reads as whole bytes, so the header names the
-    /// count itself and no unit above the byte.
     const FIRST_BYTES: usize = 100;
 
     /// The number of bytes of that same file at the second draw.
@@ -642,6 +639,14 @@ mod tests {
             .split_terminator(super::LINE_END)
             .map(str::to_owned)
             .collect()
+    }
+
+    /// The text that ends a header line whose file holds this many bytes.
+    ///
+    /// A size below one kilobyte reads as whole bytes, so the text names the
+    /// count of the bytes itself and no unit above the byte.
+    fn size_of(bytes: usize) -> String {
+        format!("({bytes} B)")
     }
 
     /// One round of one TTL, which the router answered.
@@ -863,7 +868,9 @@ mod tests {
         screen.round(&one_round());
         let first = painted(&screen.sink);
         assert!(
-            first.first().is_some_and(|line| line.ends_with("(100 B)")),
+            first
+                .first()
+                .is_some_and(|line| line.ends_with(&size_of(FIRST_BYTES))),
             "the header line names the size that the file holds: {first:?}"
         );
 
@@ -875,7 +882,9 @@ mod tests {
         screen.round(&one_round());
         let second = painted(&screen.sink);
         assert!(
-            second.first().is_some_and(|line| line.ends_with("(142 B)")),
+            second
+                .first()
+                .is_some_and(|line| line.ends_with(&size_of(SECOND_BYTES))),
             "and the next draw names the size that the file holds then: {second:?}"
         );
     }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -234,15 +234,46 @@ pub(crate) struct RunFacts {
     pub(crate) path: PathBuf,
 }
 
+/// The window that a live table draws its frames in.
+///
+/// The two numbers travel as one value, because the table reads both of them
+/// for one purpose: a frame stands in the window of the terminal, and a frame
+/// that ran past either edge of that window would lose the part that ran past
+/// it.
+pub(crate) struct Window {
+    /// The number of terminal columns that a frame draws in.
+    columns: u16,
+    /// The number of rows that the window holds, and `None` for a window that
+    /// no probe measured.
+    rows: Option<u16>,
+}
+
+impl Window {
+    /// A window of these columns, and of these rows.
+    ///
+    /// `rows` is `None` for a window that no probe measured. Such a window
+    /// holds every line of a frame, which is the rule of the columns applied to
+    /// the height: a run that cannot measure the terminal draws the whole frame
+    /// and lets the terminal decide what it shows.
+    pub(crate) fn new(columns: u16, rows: Option<u16>) -> Self {
+        Self { columns, rows }
+    }
+}
+
 /// The live table of a run.
 ///
 /// The table folds every round that arrives, and it draws the frame of that
 /// fold. A run that draws this table holds the terminal in raw mode on the
 /// alternate screen, so each draw clears the screen and moves the cursor to the
-/// origin first, and every line ends with a carriage return and a line feed.
-/// Raw mode returns no carriage on a bare line feed, and a frame of bare line
-/// feeds walks down the screen one column further to the right for each line of
-/// it.
+/// origin first, and one carriage return with one line feed stands between two
+/// lines of a frame. Raw mode returns no carriage on a bare line feed, and a
+/// frame of bare line feeds walks down the screen one column further to the
+/// right for each line of it.
+///
+/// The frame fits the window of the terminal. A frame of more lines than that
+/// window holds keeps its head and its footer and drops the rows of the highest
+/// TTLs, because a frame that ran past the foot of the window scrolls its own
+/// header line off the top of an alternate screen that keeps no scrollback.
 pub(crate) struct Table<W: Write, K: Keys> {
     /// The facts of the run that the header line names.
     facts: RunFacts,
@@ -275,8 +306,8 @@ pub(crate) struct Table<W: Write, K: Keys> {
     sink: W,
     /// Where the commands come from.
     keys: K,
-    /// The number of terminal columns that a frame draws in.
-    width: u16,
+    /// The window that the frames draw in.
+    window: Window,
 }
 
 impl<W: Write, K: Keys> Table<W, K> {
@@ -285,7 +316,7 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// The names start on. A reader who wants the raw addresses asks for them
     /// with a key, and a run that resolves no name shows the addresses anyway,
     /// because the map of the names then stays empty.
-    pub(crate) fn new(facts: RunFacts, sink: W, keys: K, width: u16) -> Self {
+    pub(crate) fn new(facts: RunFacts, sink: W, keys: K, window: Window) -> Self {
         Self {
             file: crate::file_name(&facts.path),
             facts,
@@ -298,7 +329,7 @@ impl<W: Write, K: Keys> Table<W, K> {
             help: false,
             sink,
             keys,
-            width,
+            window,
         }
     }
 
@@ -341,7 +372,7 @@ impl<W: Write, K: Keys> Table<W, K> {
             },
             destination: Some(self.facts.address),
         };
-        let mut lines = frame.lines(self.width);
+        let mut lines = frame.lines(self.window.columns);
         if self.paused {
             lines.push(String::new());
             lines.push(PAUSED.to_owned());
@@ -729,7 +760,7 @@ impl Drop for TerminalGuard {
 mod tests {
     use super::{
         classify, install_panic_hook, restore_panic_hook, status_line, Clock, Command, Headless,
-        Keys, NoKeys, PanicHook, RunFacts, Screen, SystemClock, Table,
+        Keys, NoKeys, PanicHook, RunFacts, Screen, SystemClock, Table, Window,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round, FakeKeys};
@@ -755,6 +786,13 @@ mod tests {
     /// Host column of 30. The rows of `tests/replay.rs` stand at that same
     /// width, so a row of this file reads as a row of that one.
     const WIDTH: u16 = 97;
+
+    /// The rows of a window that no probe measured.
+    ///
+    /// Such a window fits a frame to no height, so the table draws every line
+    /// of it. Every table below takes this window, and the tests of the height
+    /// name a window of their own.
+    const NO_ROWS: Option<u16> = None;
 
     /// The destination of every table below.
     const DESTINATION: &str = "example.com";
@@ -901,7 +939,7 @@ mod tests {
     /// A table that draws into bytes, reads `keys`, and heads its frames with
     /// the recorded file at `path`.
     fn table_at<K: Keys>(path: PathBuf, keys: K) -> Table<Vec<u8>, K> {
-        Table::new(facts_at(path), Vec::new(), keys, WIDTH)
+        Table::new(facts_at(path), Vec::new(), keys, Window::new(WIDTH, NO_ROWS))
     }
 
     /// A sink that counts the calls of [`Write::write`] that reach it.
@@ -936,7 +974,7 @@ mod tests {
             facts_at(temp_path("writes")),
             Counted { writes: 0 },
             FakeKeys::of(&[]),
-            WIDTH,
+            Window::new(WIDTH, NO_ROWS),
         )
     }
 
@@ -992,6 +1030,123 @@ mod tests {
     /// One round of one TTL, which the router answered.
     fn one_round() -> RoundRecord {
         round(TTL, TTL, &[(TTL, ROUTER, RTT)])
+    }
+
+    /// The number of lines that stand above the rows of the path: the header
+    /// line, the blank line under it, and the column header.
+    ///
+    /// The test spells the count, and the module reads it off the two
+    /// constants of `ui.rs`. That is on purpose, as the word of the pause is:
+    /// these three lines are what a reader of a clamped frame keeps.
+    const HEAD_LINES: usize = 3;
+
+    /// The start of the column header of every frame.
+    ///
+    /// The TTL column and the Host column never drop, so this text starts the
+    /// column header at every width.
+    const COLUMN_HEADER_START: &str = " TTL  Host";
+
+    /// The number of columns that the TTL of a row takes, with the one column
+    /// that stands to the left of it.
+    const TTL_COLUMNS: usize = 4;
+
+    /// The text between two columns of a frame.
+    const COLUMN_GAP: &str = "  ";
+
+    /// The number of TTLs of the path that the tall table below folds.
+    ///
+    /// The head takes three lines and this path takes twenty, so the frame of
+    /// it stands inside a window of [`WINDOW_ROWS`] rows on its own, and it
+    /// runs past the foot of that window the moment a key asks for the pause
+    /// and the list of the keys.
+    const TALL_PATH: u8 = 20;
+
+    /// The network of the address that answers at each TTL of that path.
+    const TALL_NETWORK: &str = "10.0.0";
+
+    /// The number of rows of a window too short for that path.
+    ///
+    /// The head takes three of these rows, and the line that counts the rows
+    /// which went out of the frame takes one, so six rows of the path stand.
+    const SHORT_ROWS: u16 = 10;
+
+    /// The last TTL of the tall path that a window of [`SHORT_ROWS`] rows
+    /// holds.
+    const LAST_KEPT_TTL: u8 = 6;
+
+    /// The first TTL of that path that such a window leaves out.
+    const FIRST_DROPPED_TTL: u8 = 7;
+
+    /// The line that closes the rows of a frame in a window of [`SHORT_ROWS`]
+    /// rows.
+    ///
+    /// Six of the twenty rows of the path stand, so fourteen of them go out of
+    /// the frame.
+    ///
+    /// The test spells the line, and the module builds the same line out of a
+    /// count and the name of a row. That is on purpose, as the word of the
+    /// pause is: this line is what a reader of the screen sees.
+    const DROPPED_LINE: &str = "+14 rows";
+
+    /// The number of rows of the window of a common terminal.
+    ///
+    /// The head and the tall path take 23 of these 24 rows. The pause and the
+    /// list of the keys take eight lines more, so a frame that carries both of
+    /// them runs past the foot of this window.
+    const WINDOW_ROWS: u16 = 24;
+
+    /// The line that closes the rows of that crowded frame.
+    ///
+    /// The head takes three rows, the pause and the list of the keys take
+    /// eight, and this line takes one, so twelve of the twenty rows of the path
+    /// stand and eight go out of the frame.
+    const CROWDED_LINE: &str = "+8 rows";
+
+    /// The mark that opens the line which counts the rows that a frame left
+    /// out.
+    ///
+    /// No other line of a frame opens with it: the header line opens with the
+    /// name of the tool, and a row of the path opens with the number of a TTL.
+    const MORE_MARK: char = '+';
+
+    /// The address that answers at one TTL of the tall path.
+    fn tall_host(ttl: u8) -> String {
+        format!("{TALL_NETWORK}.{ttl}")
+    }
+
+    /// The start of the row of one TTL of that path: the number of the TTL, and
+    /// the address that answered at it.
+    fn tall_row(ttl: u8) -> String {
+        format!("{ttl:>TTL_COLUMNS$}{COLUMN_GAP}{}", tall_host(ttl))
+    }
+
+    /// One round that answered at every TTL of the tall path.
+    fn a_tall_round() -> RoundRecord {
+        let hosts: Vec<String> = (TTL..=TALL_PATH).map(tall_host).collect();
+        let hops: Vec<(u8, &str, f64)> = (TTL..=TALL_PATH)
+            .zip(hosts.iter())
+            .map(|(ttl, host)| (ttl, host.as_str(), RTT))
+            .collect();
+        round(TTL, TALL_PATH, &hops)
+    }
+
+    /// A table that draws into bytes in a window of `rows` rows, and that takes
+    /// the keys of a script.
+    fn table_in(rows: Option<u16>, script: &[&[Command]]) -> Table<Vec<u8>, FakeKeys> {
+        Table::new(
+            facts_at(temp_path("window")),
+            Vec::new(),
+            FakeKeys::of(script),
+            Window::new(WIDTH, rows),
+        )
+    }
+
+    /// A table of the tall path in a window of `rows` rows, which drew the
+    /// frame of that path already.
+    fn tall_table(rows: Option<u16>, script: &[&[Command]]) -> Table<Vec<u8>, FakeKeys> {
+        let mut screen = table_in(rows, script);
+        screen.round(&a_tall_round());
+        screen
     }
 
     /// The TTL that the destination answered at.
@@ -1163,6 +1318,135 @@ mod tests {
         assert!(
             lines.iter().any(|line| line == ONE_ROUND_ROW),
             "the row of the TTL stands under that header: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_frame_taller_than_the_window_keeps_the_near_hops_and_counts_the_rest() {
+        // The alternate screen keeps no scrollback. A frame of more lines than
+        // the window holds scrolls its own header line off the top of that
+        // window at every draw, and nothing brings the line back.
+        let screen = tall_table(Some(SHORT_ROWS), &[]);
+        let lines = painted(&screen.sink);
+
+        assert!(
+            lines.len() <= usize::from(SHORT_ROWS),
+            "the frame stands inside the {SHORT_ROWS} rows of the window: {lines:?}"
+        );
+        assert!(
+            lines
+                .first()
+                .is_some_and(|line| line.starts_with(ONE_ROUND_HEADER)),
+            "the header line stands, so the reader keeps the destination, the round, and the file: {lines:?}"
+        );
+        assert!(
+            lines
+                .get(HEAD_LINES - 1)
+                .is_some_and(|line| line.starts_with(COLUMN_HEADER_START)),
+            "the column header stands under it, so every row that is left reads: {lines:?}"
+        );
+        for (index, ttl) in (TTL..=LAST_KEPT_TTL).enumerate() {
+            assert!(
+                lines
+                    .get(HEAD_LINES + index)
+                    .is_some_and(|line| line.starts_with(&tall_row(ttl))),
+                "the hops nearest the source stand under that header, in TTL order: {lines:?}"
+            );
+        }
+        for ttl in FIRST_DROPPED_TTL..=TALL_PATH {
+            assert!(
+                !lines.iter().any(|line| line.starts_with(&tall_row(ttl))),
+                "the TTLs that the window does not hold go out of the frame: {lines:?}"
+            );
+        }
+        assert_eq!(
+            last_lines(&lines, 1),
+            [DROPPED_LINE],
+            "and one line says how many rows the frame left out: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_window_that_no_probe_measured_leaves_every_row_standing() {
+        // A run that cannot measure the terminal knows no height to fit a
+        // frame to. It draws the whole frame and lets the terminal decide what
+        // it shows, which is the rule of the columns applied to the height.
+        let screen = tall_table(NO_ROWS, &[]);
+        let lines = painted(&screen.sink);
+
+        for ttl in TTL..=TALL_PATH {
+            assert!(
+                lines.iter().any(|line| line.starts_with(&tall_row(ttl))),
+                "the row of TTL {ttl} stands: {lines:?}"
+            );
+        }
+        assert!(
+            !lines.iter().any(|line| line.starts_with(MORE_MARK)),
+            "and no line counts a row that went out of the frame: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_frame_that_fits_its_window_counts_no_row() {
+        let mut screen = table_in(Some(WINDOW_ROWS), &[]);
+        screen.round(&one_round());
+        let lines = painted(&screen.sink);
+
+        assert!(
+            lines.iter().any(|line| line == ONE_ROUND_ROW),
+            "the one row of the path stands: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|line| line.starts_with(MORE_MARK)),
+            "and a frame that the window holds whole leaves nothing out: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_clamped_frame_keeps_the_pause_and_the_list_of_the_keys() {
+        // The two of them are what the reader asked for with a key. A frame
+        // that dropped them answers that key press with nothing.
+        let mut screen = tall_table(Some(WINDOW_ROWS), &[&[Command::Pause, Command::Help]]);
+        screen.sink.clear();
+
+        screen.poll();
+        let lines = painted(&screen.sink);
+        let mut wanted = vec!["", PAUSED, ""];
+        wanted.extend(HELP_LINES);
+        assert_eq!(
+            last_lines(&lines, wanted.len()),
+            wanted,
+            "the mark of the pause and the list of the keys close the frame: {lines:?}"
+        );
+        assert!(
+            lines.len() <= usize::from(WINDOW_ROWS),
+            "the frame stands inside the {WINDOW_ROWS} rows of the window: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == CROWDED_LINE),
+            "and the rows of the path give up the lines that those two take: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_frame_writes_no_line_end_under_its_last_line() {
+        // A frame of as many lines as the window holds ends with a line feed
+        // on the last row of that window, and the terminal then scrolls the
+        // whole window by one line. The header line goes off the top of an
+        // alternate screen that keeps no scrollback.
+        let mut screen = table(&[]);
+        screen.round(&one_round());
+        let text = glyphs(&screen.sink);
+        let lines = painted(&screen.sink);
+
+        assert!(
+            !text.ends_with(super::LINE_END),
+            "no line end closes the last line of a frame: {text:?}"
+        );
+        assert_eq!(
+            text.matches(super::LINE_END).count(),
+            lines.len().saturating_sub(1),
+            "and one line end stands between two lines of it: {lines:?}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -1,0 +1,107 @@
+//! The live display of a run, and the keys that drive it.
+//!
+//! A live run holds the terminal in raw mode, so the terminal sends the bytes
+//! of every key straight to this process. Raw mode clears `ISIG`, which is the
+//! setting that turns Ctrl-C into a `SIGINT`. Ctrl-C therefore arrives here as
+//! a key press, and the signal handler of `main.rs` never sees it. That is the
+//! reason this module classifies the keys itself: it is the one part of the
+//! live run that can stop a run that the user asked to stop.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+/// What one key press asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Command {
+    /// Stop the run.
+    Quit,
+    /// Hold the display where it stands, or let it move again.
+    Pause,
+    /// Show the names of the addresses, or show the addresses.
+    Names,
+    /// Empty the table of the display, and count the rounds again from zero.
+    Reset,
+    /// Show the list of the keys, or hide it.
+    Help,
+}
+
+/// What one key press means, or nothing.
+pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
+    let _ = key;
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify, Command};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+    /// Builds the press of a key that no modifier holds.
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn the_q_key_asks_for_a_quit() {
+        assert_eq!(classify(press(KeyCode::Char('q'))), Some(Command::Quit));
+    }
+
+    #[test]
+    fn ctrl_c_asks_for_a_quit() {
+        // Raw mode clears `ISIG`, so Ctrl-C arrives as a key press and not as a
+        // signal. A run that ignored it would need a second terminal to stop.
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(classify(ctrl_c), Some(Command::Quit));
+    }
+
+    #[test]
+    fn the_p_key_asks_for_a_pause() {
+        assert_eq!(classify(press(KeyCode::Char('p'))), Some(Command::Pause));
+    }
+
+    #[test]
+    fn the_n_key_asks_for_the_names() {
+        assert_eq!(classify(press(KeyCode::Char('n'))), Some(Command::Names));
+    }
+
+    #[test]
+    fn the_r_key_asks_for_a_reset() {
+        assert_eq!(classify(press(KeyCode::Char('r'))), Some(Command::Reset));
+    }
+
+    #[test]
+    fn the_question_mark_asks_for_the_help() {
+        assert_eq!(classify(press(KeyCode::Char('?'))), Some(Command::Help));
+    }
+
+    #[test]
+    fn a_release_of_a_mapped_key_asks_for_nothing() {
+        // A kitty terminal and a Windows terminal both report a release. Only a
+        // press acts, or one press of `q` stops the run two times.
+        let release = KeyEvent {
+            kind: KeyEventKind::Release,
+            ..press(KeyCode::Char('q'))
+        };
+        assert_eq!(classify(release), None);
+    }
+
+    #[test]
+    fn a_release_of_ctrl_c_asks_for_nothing() {
+        // The check of the release stands in front of the check of Ctrl-C, so
+        // the escape that no table can trap also obeys the rule of the press.
+        let release = KeyEvent {
+            kind: KeyEventKind::Release,
+            ..KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        };
+        assert_eq!(classify(release), None);
+    }
+
+    #[test]
+    fn a_letter_that_the_table_does_not_hold_asks_for_nothing() {
+        assert_eq!(classify(press(KeyCode::Char('x'))), None);
+    }
+
+    #[test]
+    fn a_key_that_carries_no_letter_asks_for_nothing() {
+        assert_eq!(classify(press(KeyCode::Enter)), None);
+    }
+}

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -402,6 +402,9 @@ mod tests {
     /// the whole of it.
     const ONE_ROUND_HEADER: &str = " krt  example.com → 93.184.216.34   src 1.2.3.4   round 1   1s   ";
 
+    /// The start of the header line of a table that folded no round.
+    const NO_ROUND_HEADER: &str = " krt  example.com → 93.184.216.34   src 1.2.3.4   round 0   1s   ";
+
     /// The row of a table that folded one round of one TTL.
     ///
     /// The round answers at TTL 1 from 10.0.0.1 at 0.87, which one decimal
@@ -629,6 +632,34 @@ mod tests {
         assert!(
             again.iter().any(|line| line.contains(NAMED_ROUTER)),
             "a second press puts the names back, so the table keeps them: {again:?}"
+        );
+    }
+
+    #[test]
+    fn the_reset_key_empties_the_table_and_zeroes_the_counter_of_the_display() {
+        let mut screen = table(&[&[Command::Reset]]);
+        screen.round(&one_round());
+
+        screen.sink.clear();
+        screen.poll();
+        let empty = painted(&screen.sink);
+        assert!(
+            empty
+                .first()
+                .is_some_and(|line| line.starts_with(NO_ROUND_HEADER)),
+            "the header line then counts no round: {empty:?}"
+        );
+        assert!(
+            !empty.iter().any(|line| line.contains(ROUTER)),
+            "and no row of the path stands under it: {empty:?}"
+        );
+
+        screen.sink.clear();
+        screen.round(&one_round());
+        let first = painted(&screen.sink);
+        assert!(
+            first.iter().any(|line| line == ONE_ROUND_ROW),
+            "the round that follows the reset counts as the first round: {first:?}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -11,7 +11,7 @@ use crate::record::{NameRecord, RoundRecord};
 use crate::stats::HopTable;
 use crate::ui;
 use crate::ui::render_duration;
-use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
+use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, ROW, SUMMARY_SEPARATOR};
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{
@@ -124,7 +124,64 @@ fn key_lines() -> Vec<String> {
         .collect()
 }
 
-/// The end of every line that a draw writes.
+/// The mark that opens the line which counts the rows that a frame left out.
+///
+/// The mark reads as "and more of the same". The rows behind it are rows of the
+/// table above it, and the count says how many of them the window does not
+/// hold.
+const MORE_MARK: &str = "+";
+
+/// The lines of one frame that fit a window of `rows` rows.
+///
+/// The head and the footer stand at every height. The head names the
+/// destination, the count of the rounds, the size of the recorded file, and
+/// every column of the table, and the footer holds the mark of the pause and
+/// the list of the keys, which are what a key press of the reader asked for.
+/// The rows of the path take the lines that those two leave, and one line then
+/// says how many rows went out of the frame.
+///
+/// The frame drops the TTLs farthest from the source, which is the end that
+/// `traceroute` and `mtr` drop as well. The numbering of the rows then starts
+/// under the column header and runs down the window, so a reader of a short
+/// frame still reads the hops that answer first.
+///
+/// A window that no probe measured holds every line. Such a run knows no height
+/// to fit a frame to, and the terminal decides what it shows.
+///
+/// The last cut holds a window too short even for the head and the footer
+/// together. A frame that ran past the foot of the window would scroll the
+/// window by the lines that ran past it, and the head of the frame goes off the
+/// top of an alternate screen that keeps no scrollback.
+fn fitted(
+    head: Vec<String>,
+    body: Vec<String>,
+    footer: Vec<String>,
+    rows: Option<u16>,
+) -> Vec<String> {
+    let budget = rows.map_or(usize::MAX, usize::from);
+    let mut lines = head;
+    if lines.len() + body.len() + footer.len() <= budget {
+        lines.extend(body);
+        lines.extend(footer);
+        return lines;
+    }
+    // The head, the footer, and the one line that counts the rows which went
+    // out of the frame keep their lines. The rows of the path take what is
+    // left.
+    let kept = budget.saturating_sub(lines.len() + footer.len() + 1);
+    let dropped = body.len() - kept.min(body.len());
+    lines.extend(body.into_iter().take(kept));
+    // A table of no row leaves no row out, and a line that counted zero rows
+    // would name a table the reader can already see the whole of.
+    if dropped > 0 {
+        lines.push(format!("{MORE_MARK}{}", counted(dropped, ROW)));
+    }
+    lines.extend(footer);
+    lines.truncate(budget);
+    lines
+}
+
+/// The text between two lines that a draw writes.
 ///
 /// Raw mode returns no carriage on a bare line feed, so a frame of bare line
 /// feeds walks down the screen one column further to the right for each line
@@ -347,6 +404,9 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// The footer stands under the table, and one blank line holds it off the
     /// last row of the path: a word directly under the numbers of a hop reads
     /// as a part of the table.
+    ///
+    /// The lines then fit the window, in the three parts that [`fitted`] takes:
+    /// the head of the frame, the rows of the path, and that footer.
     fn frame_lines(&self) -> Vec<String> {
         let frame = ui::Frame {
             header: ui::Header {
@@ -372,7 +432,22 @@ impl<W: Write, K: Keys> Table<W, K> {
             },
             destination: Some(self.facts.address),
         };
-        let mut lines = frame.lines(self.window.columns);
+        let mut body = frame.lines(self.window.columns);
+        // The head comes off the front of the frame, because a frame that the
+        // window does not hold keeps the head and drops rows of the path. A
+        // frame holds those lines at every width, and the `min` says so anyway.
+        let head: Vec<String> = body
+            .drain(..usize::from(ui::HEAD_LINES).min(body.len()))
+            .collect();
+        fitted(head, body, self.footer(), self.window.rows)
+    }
+
+    /// The lines that stand under the rows of the path.
+    ///
+    /// The mark of the pause comes first, and the list of the keys comes under
+    /// it. One blank line holds each of them off the lines above.
+    fn footer(&self) -> Vec<String> {
+        let mut lines = Vec::new();
         if self.paused {
             lines.push(String::new());
             lines.push(PAUSED.to_owned());
@@ -429,6 +504,13 @@ impl<W: Write, K: Keys> Table<W, K> {
     /// and the terminal draws what arrives, so the reader sees a half-drawn
     /// frame between two of those writes.
     ///
+    /// One line end stands between two lines, and no line end closes the last
+    /// line. A line end on the last row of the window scrolls the window by one
+    /// line, so a frame of as many lines as the window holds would push its own
+    /// header line off the top of a screen that keeps no scrollback. The
+    /// position of the cursor between two draws says nothing, because every
+    /// draw clears the screen and moves the cursor to the origin first.
+    ///
     /// # Errors
     ///
     /// Answers the fault that the sink raised. The caller of this function
@@ -436,9 +518,7 @@ impl<W: Write, K: Keys> Table<W, K> {
     fn paint(&mut self, lines: &[String]) -> std::io::Result<()> {
         let mut frame: Vec<u8> = Vec::new();
         queue!(frame, Clear(ClearType::All), MoveTo(0, 0))?;
-        for line in lines {
-            write!(frame, "{line}{LINE_END}")?;
-        }
+        write!(frame, "{}", lines.join(LINE_END))?;
         self.sink.write_all(&frame)?;
         self.sink.flush()
     }
@@ -939,7 +1019,12 @@ mod tests {
     /// A table that draws into bytes, reads `keys`, and heads its frames with
     /// the recorded file at `path`.
     fn table_at<K: Keys>(path: PathBuf, keys: K) -> Table<Vec<u8>, K> {
-        Table::new(facts_at(path), Vec::new(), keys, Window::new(WIDTH, NO_ROWS))
+        Table::new(
+            facts_at(path),
+            Vec::new(),
+            keys,
+            Window::new(WIDTH, NO_ROWS),
+        )
     }
 
     /// A sink that counts the calls of [`Write::write`] that reach it.
@@ -1037,7 +1122,7 @@ mod tests {
     ///
     /// The test spells the count, and the module reads it off the two
     /// constants of `ui.rs`. That is on purpose, as the word of the pause is:
-    /// these three lines are what a reader of a clamped frame keeps.
+    /// these three lines are what a reader of a short frame keeps.
     const HEAD_LINES: usize = 3;
 
     /// The start of the column header of every frame.

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -822,6 +822,16 @@ mod tests {
         Headless::new(Vec::new(), Rc::clone(clock))
     }
 
+    /// The step that the clock of the test takes between two rounds.
+    ///
+    /// The rounds of [`ROUNDS_INSIDE_A_MINUTE`] at this step stand inside one
+    /// minute, so a screen that holds to the minute prints one line for the
+    /// whole of them.
+    const ROUND_STEP: Duration = Duration::from_secs(10);
+
+    /// The number of rounds that arrive inside one minute of the test.
+    const ROUNDS_INSIDE_A_MINUTE: usize = 4;
+
     /// The lines that a headless screen wrote, in the order they arrived.
     fn printed(sink: &[u8]) -> Vec<String> {
         String::from_utf8_lossy(sink)
@@ -1100,6 +1110,24 @@ mod tests {
             printed(&screen.sink),
             [A_WHOLE_PATH_LINE],
             "the first round of a run puts its status line on the screen"
+        );
+    }
+
+    #[test]
+    fn a_headless_screen_prints_no_second_line_inside_one_minute() {
+        // A run of one round each second prints one line each second, and an
+        // hour of such a run fills a terminal with the same line 3600 times.
+        let clock = FakeClock::new();
+        let mut screen = headless(&clock);
+
+        for _ in 0..ROUNDS_INSIDE_A_MINUTE {
+            screen.round(&a_whole_path_round());
+            clock.advance(ROUND_STEP);
+        }
+        assert_eq!(
+            printed(&screen.sink),
+            [A_WHOLE_PATH_LINE],
+            "the rounds that follow the first one inside the minute print nothing"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -556,6 +556,20 @@ mod tests {
     /// screen sees.
     const PAUSED: &str = "paused";
 
+    /// The list of the keys, one line for each key.
+    ///
+    /// The test spells every line, and the module builds the same lines out of
+    /// one table of pairs. That is on purpose, as the word of the pause is: a
+    /// test that read the table of the module would agree with every list the
+    /// module ever holds, and this list is what a reader of the screen sees.
+    const HELP_LINES: [&str; 5] = [
+        "q, Ctrl-C  stop the run",
+        "p          hold the table, or let it move",
+        "n          show the names, or show the addresses",
+        "r          empty the table",
+        "?          show these keys, or hide them",
+    ];
+
     /// The last `count` lines of a frame, or every line of a frame that holds
     /// fewer than that.
     ///
@@ -668,6 +682,30 @@ mod tests {
         assert!(
             first.iter().any(|line| line == ONE_ROUND_ROW),
             "the round that follows the reset counts as the first round: {first:?}"
+        );
+    }
+
+    #[test]
+    fn the_help_key_shows_the_list_of_the_keys_and_hides_it_again() {
+        let mut screen = table(&[&[Command::Help], &[Command::Help]]);
+        screen.poll();
+        let shown = painted(&screen.sink);
+        let mut wanted = vec![""];
+        wanted.extend(HELP_LINES);
+        assert_eq!(
+            last_lines(&shown, wanted.len()),
+            wanted,
+            "one blank line and the list of the keys close the frame: {shown:?}"
+        );
+
+        screen.sink.clear();
+        screen.poll();
+        let hidden = painted(&screen.sink);
+        assert!(
+            !hidden
+                .iter()
+                .any(|line| HELP_LINES.contains(&line.as_str())),
+            "a second press takes the list back off the screen: {hidden:?}"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -455,18 +455,55 @@ impl Clock for SystemClock {
     }
 }
 
+/// The display of a run that draws no table.
+///
+/// A run whose standard output is a pipe or a file holds no terminal. Such a
+/// run clears no screen and reads no key, so it writes one status line for a
+/// round and nothing else.
+pub(crate) struct Headless<W: Write, C: Clock> {
+    /// Where the lines go.
+    sink: W,
+    /// The clock that times the lines.
+    clock: C,
+}
+
+impl<W: Write, C: Clock> Headless<W, C> {
+    /// A headless screen that writes into `sink` and times its lines by
+    /// `clock`.
+    pub(crate) fn new(sink: W, clock: C) -> Self {
+        Self { sink, clock }
+    }
+}
+
+impl<W: Write, C: Clock> Screen for Headless<W, C> {
+    fn poll(&mut self) -> bool {
+        todo!("a headless screen reads no key")
+    }
+
+    fn round(&mut self, _round: &RoundRecord) {
+        todo!("a headless screen writes the status line of a round")
+    }
+
+    fn names(&mut self, _names: &[NameRecord]) {
+        todo!("a headless screen shows no name")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        classify, status_line, Clock, Command, Keys, NoKeys, RunFacts, Screen, SystemClock, Table,
+        classify, status_line, Clock, Command, Headless, Keys, NoKeys, RunFacts, Screen,
+        SystemClock, Table,
     };
     use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round};
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+    use std::cell::Cell;
     use std::collections::VecDeque;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::rc::Rc;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     /// Builds the press of a key that no modifier holds.
@@ -744,6 +781,51 @@ mod tests {
         record
     }
 
+    /// A clock that the test moves by hand.
+    ///
+    /// A headless screen writes one line each minute, and a test that waited a
+    /// minute for the second line would take a minute of the suite. The moment
+    /// sits behind a `Cell`, because [`Clock::now`] takes the clock by
+    /// reference. The fake stays on one thread.
+    struct FakeClock {
+        /// The moment that the clock reads now.
+        now: Cell<Instant>,
+    }
+
+    impl FakeClock {
+        /// A clock that stands at the moment of its making.
+        fn new() -> Rc<Self> {
+            Rc::new(Self {
+                now: Cell::new(Instant::now()),
+            })
+        }
+
+        /// Moves the clock forward.
+        fn advance(&self, by: Duration) {
+            self.now.set(self.now.get() + by);
+        }
+    }
+
+    impl Clock for Rc<FakeClock> {
+        fn now(&self) -> Instant {
+            self.now.get()
+        }
+    }
+
+    /// A headless screen that writes into bytes and reads the clock of the
+    /// test.
+    fn headless(clock: &Rc<FakeClock>) -> Headless<Vec<u8>, Rc<FakeClock>> {
+        Headless::new(Vec::new(), Rc::clone(clock))
+    }
+
+    /// The lines that a headless screen wrote, in the order they arrived.
+    fn printed(sink: &[u8]) -> Vec<String> {
+        String::from_utf8_lossy(sink)
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
     /// The record of one name that a lookup answered.
     ///
     /// The identifier of the run and the moment of the record take the values
@@ -1000,6 +1082,21 @@ mod tests {
     #[test]
     fn a_round_that_answered_one_hop_and_reached_nothing_prints_the_singular_name() {
         assert_eq!(status_line(&a_lost_round()), A_LOST_ROUND_LINE);
+    }
+
+    #[test]
+    fn a_headless_screen_prints_a_line_at_its_first_round() {
+        // A run that printed nothing for its first minute reads as a run that
+        // died, so the first round always prints.
+        let clock = FakeClock::new();
+        let mut screen = headless(&clock);
+
+        screen.round(&a_whole_path_round());
+        assert_eq!(
+            printed(&screen.sink),
+            [A_WHOLE_PATH_LINE],
+            "the first round of a run puts its status line on the screen"
+        );
     }
 
     #[test]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -461,7 +461,7 @@ impl Clock for SystemClock {
 /// such a run fills a terminal with 3600 lines that say almost the same thing.
 /// One line for each minute of the run says the same thing and leaves the
 /// window of the terminal to the work of the reader.
-const LINE_PERIOD: Duration = Duration::from_secs(60);
+const LINE_PERIOD: Duration = Duration::from_mins(1);
 
 /// The display of a run that draws no table.
 ///
@@ -874,7 +874,7 @@ mod tests {
     /// purpose, as the word of the pause is: a test that read the constant of
     /// the module would agree with every period the module ever holds, and one
     /// line each minute is what a reader of a headless run gets.
-    const ONE_MINUTE: Duration = Duration::from_secs(60);
+    const ONE_MINUTE: Duration = Duration::from_mins(1);
 
     /// The lines that a headless screen wrote, in the order they arrived.
     fn printed(sink: &[u8]) -> Vec<String> {

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -272,9 +272,17 @@ impl<W: Write, K: Keys> Table<W, K> {
         match command {
             Command::Pause => self.paused = !self.paused,
             Command::Names => self.named = !self.named,
+            Command::Reset => {
+                // A new table, because the fold keeps no way back to the empty
+                // one. The names stay: a name belongs to an address and not to
+                // a round, and a reader who emptied the table did not ask to
+                // resolve every address of the path again.
+                self.table = HopTable::new();
+                self.rounds = 0;
+            }
             // Each command below takes an arm of this table with the test of
             // that command.
-            Command::Quit | Command::Reset | Command::Help => {}
+            Command::Quit | Command::Help => {}
         }
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -751,6 +751,16 @@ mod tests {
     }
 
     #[test]
+    fn the_quit_key_stops_the_run_and_a_turn_of_no_key_stops_nothing() {
+        let mut screen = table(&[&[], &[Command::Quit]]);
+        assert!(
+            !screen.poll(),
+            "a turn that took no key asks for no stop of the run"
+        );
+        assert!(screen.poll(), "the quit key asks for the stop of the run");
+    }
+
+    #[test]
     fn the_q_key_asks_for_a_quit() {
         assert_eq!(classify(press(KeyCode::Char('q'))), Some(Command::Quit));
     }

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -361,8 +361,16 @@ impl<W: Write, K: Keys> Table<W, K> {
 
 impl<W: Write, K: Keys> Screen for Table<W, K> {
     fn poll(&mut self) -> bool {
+        let commands = self.keys.presses();
+        // A turn of no key leaves the frame that stands. The run loop polls
+        // ten times each second, and a draw of every turn would clear the
+        // screen and paint it again at that rate. The table would flicker, and
+        // no key of the reader asked for anything.
+        if commands.is_empty() {
+            return false;
+        }
         let mut quit = false;
-        for command in self.keys.presses() {
+        for command in commands {
             // Every command of the turn acts, and the loop does not stop at
             // the stop: a turn that took `p` and then `q` holds the table and
             // stops the run.

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -590,9 +590,13 @@ fn install_panic_hook() -> PanicHook {
 }
 
 /// Puts a hook back.
+///
+/// The hook that [`install_panic_hook`] answers goes back here, at the end of
+/// the live run that installed it. The hook of a live run puts a terminal back,
+/// and no part of the process that follows that run holds one, so a hook that
+/// outlived its run acts on a panic that it knows nothing about.
 fn restore_panic_hook(previous: PanicHook) {
-    drop(previous);
-    drop(std::panic::take_hook());
+    std::panic::set_hook(Box::new(move |info| (*previous)(info)));
 }
 
 #[cfg(test)]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -23,6 +23,8 @@
 use crate::record::{NameRecord, RoundRecord};
 use crate::stats::HopTable;
 use crate::ui;
+use crate::ui::render_duration;
+use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
 use crossterm::cursor::MoveTo;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::queue;
@@ -408,10 +410,36 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
     }
 }
 
+/// Writes the one line that a run of no live table prints for one round.
+///
+/// The line holds the number of the round, the number of hops that answered,
+/// whether the round reached the target, and the time that the round took. Two
+/// spaces separate the fields, as they do in the closing line of the run.
+///
+/// A hop that did not answer is absent from the record, so the count is the
+/// number of hops that answered and not the length of the path.
+///
+/// This line is the whole picture that a headless run gives of one round. A run
+/// that holds a terminal draws the table above in the place of it.
+pub(crate) fn status_line(round: &RoundRecord) -> String {
+    let reached = if round.reached {
+        REACHED
+    } else {
+        NEVER_REACHED
+    };
+    [
+        format!("{ROUND} {}", round.seq),
+        counted(round.hops.len(), HOP),
+        reached.to_owned(),
+        render_duration(Duration::from_millis(round.dur_ms)),
+    ]
+    .join(SUMMARY_SEPARATOR)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{classify, Command, Keys, NoKeys, RunFacts, Screen, Table};
-    use crate::record::{NameRecord, RunId};
+    use super::{classify, status_line, Command, Keys, NoKeys, RunFacts, Screen, Table};
+    use crate::record::{NameRecord, RoundRecord, RunId};
     use crate::testing::{address, round};
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -650,8 +678,49 @@ mod tests {
     }
 
     /// One round of one TTL, which the router answered.
-    fn one_round() -> crate::record::RoundRecord {
+    fn one_round() -> RoundRecord {
         round(TTL, TTL, &[(TTL, ROUTER, RTT)])
+    }
+
+    /// The TTL that the destination answered at.
+    const TARGET_TTL: u8 = 2;
+
+    /// The round-trip time of the answer of the destination, in milliseconds.
+    const TARGET_RTT: f64 = 4.56;
+
+    /// The number of a round that answered one hop and reached nothing.
+    const LOST_ROUND_SEQ: u64 = 2;
+
+    /// The time that such a round took, in milliseconds.
+    const LOST_ROUND_MS: u64 = 1004;
+
+    /// The status line of the first round of a run that answered the whole
+    /// path.
+    const A_WHOLE_PATH_LINE: &str = "round 1  2 hops  reached  1s";
+
+    /// The status line of a round that answered one hop and reached nothing.
+    const A_LOST_ROUND_LINE: &str = "round 2  1 hop  never reached  1004ms";
+
+    /// One round that answered two hops and reached the target.
+    fn a_whole_path_round() -> RoundRecord {
+        let mut record = round(
+            TTL,
+            TARGET_TTL,
+            &[
+                (TTL, ROUTER, RTT),
+                (TARGET_TTL, DESTINATION_ADDRESS, TARGET_RTT),
+            ],
+        );
+        record.reached = true;
+        record
+    }
+
+    /// One round that answered one hop and reached nothing.
+    fn a_lost_round() -> RoundRecord {
+        let mut record = round(TTL, TARGET_TTL, &[(TTL, ROUTER, RTT)]);
+        record.seq = LOST_ROUND_SEQ;
+        record.dur_ms = LOST_ROUND_MS;
+        record
     }
 
     /// The record of one name that a lookup answered.
@@ -887,6 +956,18 @@ mod tests {
                 .is_some_and(|line| line.ends_with(&size_of(SECOND_BYTES))),
             "and the next draw names the size that the file holds then: {second:?}"
         );
+    }
+
+    #[test]
+    fn a_round_that_answered_two_hops_and_reached_the_target_prints_one_line() {
+        assert_eq!(status_line(&a_whole_path_round()), A_WHOLE_PATH_LINE);
+    }
+
+    /// One hop keeps the singular name, and a round that reached nothing says
+    /// so.
+    #[test]
+    fn a_round_that_answered_one_hop_and_reached_nothing_prints_the_singular_name() {
+        assert_eq!(status_line(&a_lost_round()), A_LOST_ROUND_LINE);
     }
 
     #[test]

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -7,6 +7,19 @@
 //! reason this module classifies the keys itself: it is the one part of the
 //! live run that can stop a run that the user asked to stop.
 
+// Nothing outside this module names any item of it. The run loop takes a
+// screen in the next step of this work, and every item below is then live. One
+// attribute stands here, and not one attribute for each item, because the
+// items are dead for one reason: no caller. The expectation fails once the
+// whole module is live, which takes this attribute back off.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the run loop joins this module in the next step of this work"
+    )
+)]
+
 use crate::record::{NameRecord, RoundRecord};
 use crate::stats::HopTable;
 use crate::ui;
@@ -21,13 +34,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 /// What one key press asks for.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the tests of this module read the whole table, and the display that acts on a command joins it in the next step of this work. The expectation fails once that display lands, which takes the attribute back off"
-    )
-)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Command {
     /// Stop the run.
@@ -52,13 +58,6 @@ pub(crate) enum Command {
 /// - `p` holds the display, `n` turns the names on or off, `r` empties the
 ///   table of the display, and `?` shows the list of the keys.
 /// - Every other key means nothing.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the tests of this module read the whole table, and the display that polls the keyboard joins it in the next step of this work. The expectation fails once that display lands, which takes the attribute back off"
-    )
-)]
 pub(crate) fn classify(key: KeyEvent) -> Option<Command> {
     let KeyEvent {
         code,
@@ -161,6 +160,10 @@ impl Keys for NoKeys {
 pub(crate) trait Screen {
     /// Takes the key presses that arrived. Answers whether the user asked the
     /// run to stop.
+    ///
+    /// A turn that took no key draws nothing. The run loop takes ten turns each
+    /// second, and a draw of every turn would clear the screen and paint it
+    /// again at that rate.
     fn poll(&mut self) -> bool;
     /// One round arrived.
     fn round(&mut self, round: &RoundRecord);
@@ -193,18 +196,19 @@ pub(crate) struct RunFacts {
 /// The live table of a run.
 ///
 /// The table folds every round that arrives, and it draws the frame of that
-/// fold. It holds the terminal in raw mode on the alternate screen, so each
-/// draw clears the screen and moves the cursor to the origin first, and every
-/// line ends with a carriage return and a line feed. Raw mode returns no
-/// carriage on a bare line feed, and a frame of bare line feeds walks down the
-/// screen one column further to the right for each line of it.
+/// fold. A run that draws this table holds the terminal in raw mode on the
+/// alternate screen, so each draw clears the screen and moves the cursor to the
+/// origin first, and every line ends with a carriage return and a line feed.
+/// Raw mode returns no carriage on a bare line feed, and a frame of bare line
+/// feeds walks down the screen one column further to the right for each line of
+/// it.
 pub(crate) struct Table<W: Write, K: Keys> {
     /// The facts of the run that the header line names.
     facts: RunFacts,
     /// The name of the recorded file, without its directory.
     file: String,
     /// The fold of every round that arrived.
-    table: HopTable,
+    fold: HopTable,
     /// The host name of each address that a name record named.
     names: BTreeMap<IpAddr, String>,
     /// The map that a table of the raw addresses hands the frame.
@@ -244,7 +248,7 @@ impl<W: Write, K: Keys> Table<W, K> {
         Self {
             file: crate::file_name(&facts.path),
             facts,
-            table: HopTable::new(),
+            fold: HopTable::new(),
             names: BTreeMap::new(),
             nameless: BTreeMap::new(),
             rounds: 0,
@@ -288,7 +292,7 @@ impl<W: Write, K: Keys> Table<W, K> {
                     .ok()
                     .map(|data| data.len()),
             },
-            table: &self.table,
+            table: &self.fold,
             names: if self.named {
                 &self.names
             } else {
@@ -318,7 +322,7 @@ impl<W: Write, K: Keys> Table<W, K> {
                 // one. The names stay: a name belongs to an address and not to
                 // a round, and a reader who emptied the table did not ask to
                 // resolve every address of the path again.
-                self.table = HopTable::new();
+                self.fold = HopTable::new();
                 self.rounds = 0;
             }
             Command::Help => self.help = !self.help,
@@ -385,7 +389,7 @@ impl<W: Write, K: Keys> Screen for Table<W, K> {
     }
 
     fn round(&mut self, round: &RoundRecord) {
-        self.table.observe(round);
+        self.fold.observe(round);
         self.rounds += 1;
         if !self.paused {
             self.draw();
@@ -482,10 +486,12 @@ mod tests {
     /// The name of the recorded file ends that line, and each test builds a
     /// path of its own, so the assertion reads the start of the line and not
     /// the whole of it.
-    const ONE_ROUND_HEADER: &str = " krt  example.com → 93.184.216.34   src 1.2.3.4   round 1   1s   ";
+    const ONE_ROUND_HEADER: &str =
+        " krt  example.com → 93.184.216.34   src 1.2.3.4   round 1   1s   ";
 
     /// The start of the header line of a table that folded no round.
-    const NO_ROUND_HEADER: &str = " krt  example.com → 93.184.216.34   src 1.2.3.4   round 0   1s   ";
+    const NO_ROUND_HEADER: &str =
+        " krt  example.com → 93.184.216.34   src 1.2.3.4   round 0   1s   ";
 
     /// The row of a table that folded one round of one TTL.
     ///

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -502,7 +502,10 @@ impl<W: Write, C: Clock> Headless<W, C> {
 
 impl<W: Write, C: Clock> Screen for Headless<W, C> {
     fn poll(&mut self) -> bool {
-        todo!("a headless screen reads no key")
+        // A headless run holds no terminal, so no key of it reaches this
+        // process. The signal handler that `main.rs` registers stops such a
+        // run, and the limits of the command line stop it too.
+        false
     }
 
     fn round(&mut self, round: &RoundRecord) {

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -308,8 +308,8 @@ impl<W: Write, K: Keys> Table<W, K> {
         lines
     }
 
-    /// Acts on one command.
-    fn apply(&mut self, command: Command) {
+    /// Acts on one command, and answers whether that command stops the run.
+    fn apply(&mut self, command: Command) -> bool {
         match command {
             Command::Pause => self.paused = !self.paused,
             Command::Names => self.named = !self.named,
@@ -322,9 +322,13 @@ impl<W: Write, K: Keys> Table<W, K> {
                 self.rounds = 0;
             }
             Command::Help => self.help = !self.help,
-            // The stop takes an arm of this table with the test of it.
-            Command::Quit => {}
+            // No field of the table holds the stop. The run loop owns it,
+            // because the loop is what closes the recorded file with its `end`
+            // record, and a display that stopped the process itself would
+            // leave the file without that record.
+            Command::Quit => return true,
         }
+        false
     }
 
     /// Puts one frame on the screen, over the frame that stands there.
@@ -357,15 +361,19 @@ impl<W: Write, K: Keys> Table<W, K> {
 
 impl<W: Write, K: Keys> Screen for Table<W, K> {
     fn poll(&mut self) -> bool {
+        let mut quit = false;
         for command in self.keys.presses() {
-            self.apply(command);
+            // Every command of the turn acts, and the loop does not stop at
+            // the stop: a turn that took `p` and then `q` holds the table and
+            // stops the run.
+            quit = self.apply(command) || quit;
         }
         // The draw stands outside the loop, and it draws while the table holds
         // as well: a table that took the key of the pause must put the mark of
         // that pause on the screen, and no round draws it while the table
         // holds.
         self.draw();
-        false
+        quit
     }
 
     fn round(&mut self, round: &RoundRecord) {

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -728,6 +728,7 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use std::cell::Cell;
     use std::fs;
+    use std::io::Write;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -874,19 +875,58 @@ mod tests {
         }
     }
 
+    /// The facts of a run whose recorded file stands at `path`.
+    ///
+    /// Every table below heads its frames with these facts, and each of those
+    /// tables holds a sink of its own, so the facts stand apart from the sink.
+    fn facts_at(path: PathBuf) -> RunFacts {
+        RunFacts {
+            destination: DESTINATION.to_owned(),
+            address: address(DESTINATION_ADDRESS),
+            source: address(SOURCE),
+            interval: INTERVAL,
+            path,
+        }
+    }
+
     /// A table that draws into bytes, reads `keys`, and heads its frames with
     /// the recorded file at `path`.
     fn table_at<K: Keys>(path: PathBuf, keys: K) -> Table<Vec<u8>, K> {
+        Table::new(facts_at(path), Vec::new(), keys, WIDTH)
+    }
+
+    /// A sink that counts the calls of [`Write::write`] that reach it.
+    ///
+    /// A test holds no terminal, so it reads nothing of how many times a draw
+    /// crossed into the kernel. This count is what such a test reads in the
+    /// place of that. The sink keeps none of the bytes, because the tests that
+    /// read the glyphs of a frame draw into bytes above.
+    struct Counted {
+        /// The number of calls that reached this sink.
+        writes: usize,
+    }
+
+    impl Write for Counted {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            // The whole buffer counts as taken, so `write_all` hands one
+            // buffer over in one call. A sink that took less of it would count
+            // the calls of its own refusal.
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A table that draws into a sink which counts the calls, and that takes
+    /// the keys of an empty script.
+    fn counted_table() -> Table<Counted, FakeKeys> {
         Table::new(
-            RunFacts {
-                destination: DESTINATION.to_owned(),
-                address: address(DESTINATION_ADDRESS),
-                source: address(SOURCE),
-                interval: INTERVAL,
-                path,
-            },
-            Vec::new(),
-            keys,
+            facts_at(temp_path("writes")),
+            Counted { writes: 0 },
+            FakeKeys::of(&[]),
             WIDTH,
         )
     }
@@ -1114,6 +1154,21 @@ mod tests {
         assert!(
             lines.iter().any(|line| line == ONE_ROUND_ROW),
             "the row of the TTL stands under that header: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn one_frame_of_the_live_table_reaches_the_sink_in_one_write() {
+        // The sink of a live run is `std::io::Stdout`, which is a
+        // `LineWriter`. Such a writer flushes at every line feed, so one call
+        // for each line of a frame is one `write(2)` for each line of it. The
+        // terminal draws what arrives, and the reader then sees a half-drawn
+        // frame between two of those writes.
+        let mut screen = counted_table();
+        screen.round(&one_round());
+        assert_eq!(
+            screen.sink.writes, 1,
+            "the whole frame reaches the sink in one call"
         );
     }
 

--- a/src/krt/src/live.rs
+++ b/src/krt/src/live.rs
@@ -1187,6 +1187,20 @@ mod tests {
     }
 
     #[test]
+    fn a_headless_screen_reads_no_key_and_stops_nothing() {
+        // A headless run holds no terminal, so no key of it reaches this
+        // process. The signal handler of `main.rs` stops such a run, and the
+        // limits of the command line stop it too.
+        let clock = FakeClock::new();
+        let mut screen = headless(&clock);
+
+        assert!(
+            !screen.poll(),
+            "a turn of a headless screen asks for no stop of the run"
+        );
+    }
+
+    #[test]
     fn the_q_key_asks_for_a_quit() {
         assert_eq!(classify(press(KeyCode::Char('q'))), Some(Command::Quit));
     }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1089,6 +1089,25 @@ fn run_config(config: &ResolvedConfig, privilege: record::Privilege) -> RunConfi
     }
 }
 
+/// The screen that a run shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Display {
+    /// The live table of the path, which holds the terminal and reads its keys.
+    Table,
+    /// One status line each minute, and no table.
+    Headless,
+}
+
+/// The screen that a run shows, from the `--headless` flag and from whether
+/// standard output is a terminal.
+fn display_of(headless: bool, _is_terminal: bool) -> Display {
+    if headless {
+        Display::Headless
+    } else {
+        Display::Table
+    }
+}
+
 /// Records one trace, from the destination of the command line to the record
 /// that closes the run.
 ///
@@ -1240,9 +1259,9 @@ fn main() {
 mod tests {
     use super::{
         closing_line, host_name_or, name_grace, parse_duration, pick_address, resolve_target,
-        run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command, EndReason,
-        Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind, SourceLabel,
-        RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
+        display_of, run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command,
+        Display, EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind,
+        SourceLabel, RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
     };
     use crate::record::{Privilege, RunConfig};
     use crate::run::Outcome;
@@ -2126,6 +2145,34 @@ resolved configuration:
         let cli = parse(&["krt", "example.com", "--no-dns", "--headless"]);
         assert!(cli.no_dns);
         assert!(cli.headless);
+    }
+
+    #[test]
+    fn a_run_shows_the_table_only_under_a_terminal_that_the_headless_flag_left_alone() {
+        assert_eq!(
+            display_of(false, true),
+            Display::Table,
+            "a run that holds a terminal and took no flag draws the live table"
+        );
+        assert_eq!(
+            display_of(true, true),
+            Display::Headless,
+            "the flag takes the table off a run that does hold a terminal"
+        );
+        // A run whose standard output is a pipe or a file has no terminal to
+        // hold, no key to read, and no screen to clear. A table there writes
+        // one whole frame into that file for each round, where one line each
+        // minute says the same thing in four lines an hour.
+        assert_eq!(
+            display_of(false, false),
+            Display::Headless,
+            "a run that holds no terminal draws no table"
+        );
+        assert_eq!(
+            display_of(true, false),
+            Display::Headless,
+            "and the flag leaves such a run where it stands"
+        );
     }
 
     #[test]

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1256,6 +1256,10 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
 /// The guard comes before the table, because the table draws into the terminal
 /// that the guard takes.
 ///
+/// The table takes the columns and the rows of that terminal one time, at the
+/// start of the run. A window that changes size while the run stands leaves the
+/// frame at the size it started with.
+///
 /// # Errors
 ///
 /// Returns the reason and [`EXIT_FAILURE`] when the terminal refused the hold.
@@ -1285,11 +1289,12 @@ fn screen_of(
         interval: config.interval,
         path: path.to_owned(),
     };
+    let (columns, rows) = ui::frame_size();
     let table = live::Table::new(
         facts,
         std::io::stdout(),
         live::Keyboard,
-        ui::frame_columns(),
+        live::Window::new(columns, rows),
     );
     Ok((Box::new(table), Some(guard)))
 }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1100,12 +1100,22 @@ enum Display {
 
 /// The screen that a run shows, from the `--headless` flag and from whether
 /// standard output is a terminal.
-fn display_of(headless: bool, _is_terminal: bool) -> Display {
-    if headless {
-        Display::Headless
-    } else {
-        Display::Table
+///
+/// The table holds the terminal in raw mode on the alternate screen, and it
+/// draws one whole frame for each round. A run whose standard output is a pipe
+/// or a file has no terminal to hold, no key to read, and no screen to clear,
+/// and a table there writes one whole frame into that file for each round. Such
+/// a run therefore takes the headless screen, which writes one line each
+/// minute. `--headless` asks for that same line from a run that does hold a
+/// terminal.
+///
+/// The read of the terminal stands apart from this decision, so a test names
+/// the answer of a terminal without a terminal to name it with.
+fn display_of(headless: bool, is_terminal: bool) -> Display {
+    if headless || !is_terminal {
+        return Display::Headless;
     }
+    Display::Table
 }
 
 /// Records one trace, from the destination of the command line to the record

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1171,7 +1171,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         name_grace: name_grace(),
     };
     let mut namer = names::Namer::new(resolver, start.run.clone());
-    let mut status = std::io::stdout();
+    let mut screen = live::Headless::new(std::io::stdout(), live::SystemClock);
     let outcome = run::record(
         &start,
         &rounds,
@@ -1179,7 +1179,7 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         &|| user_stopped(&flag),
         &mut namer,
         &mut writer,
-        &mut status,
+        &mut screen,
     )
     .map_err(|error| {
         let code = match error {

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -13,6 +13,7 @@
 #![deny(unsafe_code)]
 #![warn(clippy::pedantic)]
 
+mod live;
 mod names;
 mod record;
 mod run;

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -3,11 +3,13 @@
 //!
 //! A command line that names a destination prints the configuration that it
 //! resolved, opens the recorded file, starts the tracer, and appends one record
-//! for each round until a limit stops the run. It prints one status line for
-//! each round. The `replay` command reads a recorded file, folds one run of it,
-//! and prints the table of that path: a header line that names the run, and one
-//! row for each TTL. A later slice gives the live run that same table in the
-//! place of its status lines.
+//! for each round until a limit stops the run. A run that holds a terminal
+//! draws the live table of that path and takes the keys of the terminal. A run
+//! whose standard output is a pipe or a file, and a run that `--headless`
+//! asked, print one status line each minute in the place of the table. The
+//! `replay` command reads a recorded file, folds one run of it, and prints the
+//! table of that path: a header line that names the run, and one row for each
+//! TTL.
 
 // Stricter than the inherited `[workspace.lints]` set; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -33,6 +35,7 @@ use record::{
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
+use std::io::IsTerminal;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -748,8 +751,9 @@ fn stop_flag() -> std::io::Result<Arc<AtomicBool>> {
 /// A flag that a termination signal sets.
 ///
 /// This platform registers no handler, so nothing sets the flag. The user of
-/// this platform stops a run through the key handler of the table, and the
-/// table arrives in a later slice of issue #372.
+/// this platform stops a run with the `q` key or with Ctrl-C, which the key
+/// handler of the live table reads. A run of this platform that draws no table
+/// reads no key, and only a limit of the command line stops such a run.
 ///
 /// # Errors
 ///
@@ -1130,6 +1134,12 @@ fn display_of(headless: bool, is_terminal: bool) -> Display {
 /// The recorded file opens before the tracer starts, so no probe leaves the
 /// machine for a run that cannot record it.
 ///
+/// The screen comes last of all, after every step that can print a line and
+/// after every step that can stop the run. A live table takes the terminal and
+/// draws on the alternate screen, and a screen that stood in front of those
+/// steps would put each of their lines on a screen that the drop of the guard
+/// then takes away.
+///
 /// # Errors
 ///
 /// Returns the reason and the exit code of the fault that stopped the run.
@@ -1200,25 +1210,86 @@ fn trace(config: &ResolvedConfig) -> Result<run::Outcome, TraceFailure> {
         name_grace: name_grace(),
     };
     let mut namer = names::Namer::new(resolver, start.run.clone());
-    let mut screen = live::Headless::new(std::io::stdout(), live::SystemClock);
-    let outcome = run::record(
-        &start,
-        &rounds,
-        &limits,
-        &|| user_stopped(&flag),
-        &mut namer,
-        &mut writer,
-        &mut screen,
-    )
-    .map_err(|error| {
-        let code = match error {
-            run::RunError::Write(_) => EXIT_WRITE_FAILED,
-            run::RunError::Tracer { .. } => EXIT_TRACER_FAILED,
-        };
-        TraceFailure::new(&error, code)
-    })?;
+
+    // The screen and the guard stand in a scope of their own, and the closing
+    // line stands under it. The guard drops at the end of the scope, which
+    // takes the alternate screen away and puts the lines of the reader back. A
+    // line that printed in front of that drop lands on the alternate screen,
+    // and the drop then takes the screen away with the line on it.
+    let outcome = {
+        // `_guard` is a name, and a name holds the guard for the whole scope.
+        // A bare `_` in its place drops the guard where it stands, which gives
+        // the terminal back before the first frame draws on it. The two spell
+        // almost the same, and one of them is a defect.
+        let (mut screen, _guard) = screen_of(config, &start, &path)?;
+        run::record(
+            &start,
+            &rounds,
+            &limits,
+            &|| user_stopped(&flag),
+            &mut namer,
+            &mut writer,
+            screen.as_mut(),
+        )
+        .map_err(|error| {
+            let code = match error {
+                run::RunError::Write(_) => EXIT_WRITE_FAILED,
+                run::RunError::Tracer { .. } => EXIT_TRACER_FAILED,
+            };
+            TraceFailure::new(&error, code)
+        })?
+    };
     println!("{}", closing_line(&outcome, &path));
     Ok(outcome)
+}
+
+/// The screen of one run, and the hold that screen takes on the terminal.
+///
+/// The table holds the terminal, so it travels with the guard that gives that
+/// terminal back. The headless screen holds nothing, and its guard is `None`.
+/// The caller binds both, and every way out of the run then drops the guard:
+/// the stop that the user asked for, the fault that ends the run early, and the
+/// panic that nobody asked for.
+///
+/// The guard comes before the table, because the table draws into the terminal
+/// that the guard takes.
+///
+/// # Errors
+///
+/// Returns the reason and [`EXIT_FAILURE`] when the terminal refused the hold.
+/// A terminal that will not go into raw mode reads no key of the user, and a
+/// run that drew a table on it would stop for nothing that the user pressed.
+fn screen_of(
+    config: &ResolvedConfig,
+    start: &RunRecord,
+    path: &Path,
+) -> Result<(Box<dyn live::Screen>, Option<live::TerminalGuard>), TraceFailure> {
+    if display_of(config.headless, std::io::stdout().is_terminal()) == Display::Headless {
+        return Ok((
+            Box::new(live::Headless::new(std::io::stdout(), live::SystemClock)),
+            None,
+        ));
+    }
+    let guard = live::TerminalGuard::enter().map_err(|error| {
+        TraceFailure::new(
+            &format!("the live table did not take the terminal: {error}"),
+            EXIT_FAILURE,
+        )
+    })?;
+    let facts = live::RunFacts {
+        destination: start.target.arg.clone(),
+        address: start.target.addr,
+        source: start.source.addr,
+        interval: config.interval,
+        path: path.to_owned(),
+    };
+    let table = live::Table::new(
+        facts,
+        std::io::stdout(),
+        live::Keyboard,
+        ui::frame_columns(),
+    );
+    Ok((Box::new(table), Some(guard)))
 }
 
 fn main() {
@@ -1268,10 +1339,10 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        closing_line, host_name_or, name_grace, parse_duration, pick_address, resolve_target,
-        display_of, run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli, Command,
-        Display, EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig, SourceKind,
-        SourceLabel, RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
+        closing_line, display_of, host_name_or, name_grace, parse_duration, pick_address,
+        resolve_target, run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli,
+        Command, Display, EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig,
+        SourceKind, SourceLabel, RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
     };
     use crate::record::{Privilege, RunConfig};
     use crate::run::Outcome;

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -256,10 +256,18 @@ fn value_name<T: ValueEnum>(value: &T) -> String {
 /// A trace resolves the destination, opens the recorded file, and probes every
 /// hop to the destination once per round. It appends one record for each round.
 /// A run under a terminal draws the live table of that path, and it takes the
-/// keys of the terminal. A run whose standard output is a pipe or a file, and a
-/// run that `--headless` asked, print one status line each minute. The `replay`
-/// command reads a file that an earlier run wrote, so it takes no destination
-/// and no flag of a probe.
+/// keys of the terminal. The `?` key shows the list of those keys under the
+/// table. A run whose standard output is a pipe or a file, and a run that
+/// `--headless` asked, print one status line each minute. The `replay` command
+/// reads a file that an earlier run wrote, so it takes no destination and no
+/// flag of a probe.
+// The help names the `?` key and no other key of the live table, because
+// `live::KEYS` is the one list that says what a key does and a doc comment of
+// `clap` is a string literal that reads that list at no time. A help page that
+// named all five keys would be a second list of them, and the second list
+// drifts. One key name opens the first list from inside the table, and
+// `live::tests::the_long_help_names_the_key_that_lists_the_keys` holds that
+// name and the list together.
 #[derive(Parser, Debug)]
 // `args_conflicts_with_subcommands` rejects a flag of a probe beside a command,
 // because a replay probes nothing. `subcommand_negates_reqs` lifts the demand

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -149,6 +149,10 @@ const ROUND: &str = "round";
 /// The name of one TTL that answered, in the status line of one round.
 const HOP: &str = "hop";
 
+/// The name of one row of a table, in the line that counts the rows which a
+/// window too short left out of a frame.
+const ROW: &str = "row";
+
 /// The last field of the status line of one round that reached the target.
 const REACHED: &str = "reached";
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -250,10 +250,12 @@ fn value_name<T: ValueEnum>(value: &T) -> String {
 /// Knights of the Round Trip: record the network path to a destination.
 ///
 /// A trace resolves the destination, opens the recorded file, and probes every
-/// hop to the destination once per round. It appends one record for each round,
-/// and it prints one status line for that round. The `replay` command reads a
-/// file that an earlier run wrote, so it takes no destination and no flag of a
-/// probe.
+/// hop to the destination once per round. It appends one record for each round.
+/// A run under a terminal draws the live table of that path, and it takes the
+/// keys of the terminal. A run whose standard output is a pipe or a file, and a
+/// run that `--headless` asked, print one status line each minute. The `replay`
+/// command reads a file that an earlier run wrote, so it takes no destination
+/// and no flag of a probe.
 #[derive(Parser, Debug)]
 // `args_conflicts_with_subcommands` rejects a flag of a probe beside a command,
 // because a replay probes nothing. `subcommand_negates_reqs` lifts the demand
@@ -333,7 +335,7 @@ struct Cli {
     #[arg(long, value_name = "IP")]
     source: Option<IpAddr>,
 
-    /// No table. Print one status line per minute.
+    /// No table and no keys. Print one status line per minute.
     #[arg(long)]
     headless: bool,
 

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -86,9 +86,11 @@ pub(crate) enum RunError {
 /// Records one run: the record that opens it, one record for each round, and
 /// the record that closes it.
 ///
-/// `stop` answers whether the user asked the run to stop. The loop asks it once
-/// at the top of each turn, before it reads a round, so a run that the user
-/// stops records no further round.
+/// `stop` answers whether the user asked the run to stop, and the ask of
+/// `screen` answers the same question. The loop asks both once at the top of
+/// each turn, before it reads a round, so a run that the user stops records no
+/// further round. The ask of the screen also draws that screen, which is why one
+/// turn asks one time.
 ///
 /// The `run` record goes first, and a fault there stops the run before it reads
 /// anything. Each round that arrives becomes one `round` record. The `end`
@@ -152,8 +154,8 @@ pub(crate) fn record<W: Write>(
                 show_names(writer, screen, &namer.names(&round.hops, Utc::now()))?;
                 // The recording comes first. The round reaches the file before
                 // it reaches the screen, so a screen that fails loses one frame
-                // and no record, and the file of a run whose display the user
-                // held holds every round of it. The record takes a copy of the
+                // and no record, and a run whose display the user held still
+                // holds every round in its file. The record takes a copy of the
                 // round, because the screen reads the round after the write.
                 writer
                     .write(&Record::Round(round.clone()))

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -149,7 +149,7 @@ pub(crate) fn record<W: Write>(
                 // turn. A name always lands on a later turn than the round that
                 // first reported its address, because the first ask of an
                 // address starts the lookup of that address.
-                write_names(writer, namer.names(&round.hops, Utc::now()))?;
+                show_names(writer, screen, &namer.names(&round.hops, Utc::now()))?;
                 // The recording comes first. The round reaches the file before
                 // it reaches the screen, so a screen that fails loses one frame
                 // and no record, and the file of a run whose display the user
@@ -166,7 +166,7 @@ pub(crate) fn record<W: Write>(
             // finished inside the wait lands here, so a name that arrives
             // between two rounds reaches the file at the moment it arrives.
             Err(RecvTimeoutError::Timeout) => {
-                write_names(writer, namer.names(&[], Utc::now()))?;
+                show_names(writer, screen, &namer.names(&[], Utc::now()))?;
             }
             Err(RecvTimeoutError::Disconnected) => {
                 // The tracer holds the sender for as long as it lives, so a
@@ -188,14 +188,43 @@ pub(crate) fn record<W: Write>(
     }
 }
 
-/// Appends one record for each name that arrived.
+/// Appends one record for each name that arrived, and then shows the names.
+///
+/// The record comes first, for the reason that the round of a turn does: the
+/// file is the purpose of the tool, and the screen is one view of it.
+///
+/// A turn of no name shows nothing. The loop takes ten turns each second, and a
+/// live table that took an empty list on each of them would clear the screen and
+/// paint it again at that rate.
 ///
 /// # Errors
 ///
 /// Returns [`RunError::Write`] when a record does not reach the file.
-fn write_names<W: Write>(writer: &mut Writer<W>, names: Vec<NameRecord>) -> Result<(), RunError> {
+fn show_names<W: Write>(
+    writer: &mut Writer<W>,
+    screen: &mut dyn Screen,
+    names: &[NameRecord],
+) -> Result<(), RunError> {
+    write_names(writer, names)?;
+    if !names.is_empty() {
+        screen.names(names);
+    }
+    Ok(())
+}
+
+/// Appends one record for each name that arrived.
+///
+/// Each record holds a copy of one name, because the caller keeps the names for
+/// the screen and the writer takes a whole record.
+///
+/// # Errors
+///
+/// Returns [`RunError::Write`] when a record does not reach the file.
+fn write_names<W: Write>(writer: &mut Writer<W>, names: &[NameRecord]) -> Result<(), RunError> {
     for name in names {
-        writer.write(&Record::Name(name)).map_err(RunError::Write)?;
+        writer
+            .write(&Record::Name(name.clone()))
+            .map_err(RunError::Write)?;
     }
     Ok(())
 }
@@ -212,6 +241,10 @@ fn write_names<W: Write>(writer: &mut Writer<W>, names: Vec<NameRecord>) -> Resu
 /// names that already arrived. Between two asks it sleeps for [`POLL`] at the
 /// longest, and never past the end of the grace.
 ///
+/// The names of the drain reach no screen. The drain runs while the run closes,
+/// and the display of a run that closes shows nothing more. Every one of them
+/// reaches the file, so a replay of that file names the address.
+///
 /// # Errors
 ///
 /// Returns [`RunError::Write`] when a record does not reach the file.
@@ -222,7 +255,7 @@ fn drain_names<W: Write>(
 ) -> Result<(), RunError> {
     let end = Instant::now() + grace;
     loop {
-        write_names(writer, namer.names(&[], Utc::now()))?;
+        write_names(writer, &namer.names(&[], Utc::now()))?;
         if !namer.waits() {
             return Ok(());
         }

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -1453,4 +1453,54 @@ mod tests {
         );
         assert_eq!(ran.screen.seqs(), [7, 3, 9]);
     }
+
+    /// A live table names the host of a row, so every name that the run writes
+    /// reaches the screen as well as the file.
+    #[test]
+    fn a_name_that_arrives_reaches_the_screen() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "screen-name",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds(1),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        let names = &ran.screen.names;
+        assert_eq!(names.len(), 1, "the run showed one name: {names:?}");
+        assert_eq!(
+            names[0].addr,
+            address(FIRST_HOP),
+            "the name that reached the screen names the address of the hop"
+        );
+        assert_eq!(
+            names[0].host, FIRST_HOP_NAME,
+            "and it holds the name that the lookup gave"
+        );
+    }
+
+    /// The last ask of a run runs while that run closes, and the display of a
+    /// run that closes shows nothing more. The name still reaches the file, so
+    /// a replay of that file names the address.
+    #[test]
+    fn the_names_that_a_run_writes_while_it_closes_reach_no_screen() {
+        let resolver = FakeResolver::new(&[(FIRST_HOP, &[Lookup::Pending, named(FIRST_HOP_NAME)])]);
+        let ran = ran_with(
+            "screen-name-drain",
+            &a_stream(&rounds_of(&[1])),
+            &after_rounds(1),
+            &|| false,
+            &mut a_namer(&resolver),
+        );
+        assert_eq!(
+            kinds_of(&ran.recording),
+            ["run", "round", "name", "end"],
+            "the name that arrived after the last round reached the file"
+        );
+        assert!(
+            ran.screen.names.is_empty(),
+            "and it reached no screen: {:?}",
+            ran.screen.names
+        );
+    }
 }

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -336,8 +336,8 @@ mod tests {
         EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
         RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
-    use crate::live::Screen;
-    use crate::testing::{address, named, FakeResolver};
+    use crate::live::{Command, RunFacts, Screen, Table};
+    use crate::testing::{address, named, FakeKeys, FakeResolver};
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::cell::{Cell, RefCell};
@@ -451,6 +451,45 @@ mod tests {
     /// The second question follows the first turn, so the run stops on the turn
     /// that comes straight after the round it recorded.
     const STOP_AFTER_ONE_TURN: u64 = 1;
+
+    /// The number of terminal columns that the live table of a test draws in.
+    ///
+    /// The nominal frame is 97 columns wide: every column of the table, with a
+    /// Host column of 30.
+    const WIDTH: u16 = 97;
+
+    /// The period of one round of the run that a live table shows.
+    const AN_INTERVAL: Duration = Duration::from_secs(1);
+
+    /// The word that a table which holds where it stands writes under itself.
+    ///
+    /// The test spells the word, and the module of the table spells it again.
+    /// That is on purpose: a test that read the constant of that module would
+    /// agree with every word the module ever holds, and this word is what a
+    /// reader of the screen sees.
+    const PAUSED: &str = "paused";
+
+    /// The sequence that starts every frame of a live table.
+    ///
+    /// A draw clears the screen first, so the text between two of these
+    /// sequences is one frame.
+    const CLEAR: &str = "\u{1b}[2J";
+
+    /// The number of frames that the run of a held table drew.
+    ///
+    /// One frame at the pause, one at the release of that pause, and one for
+    /// the round that arrived after the release. The rounds that arrived while
+    /// the table held drew none.
+    const FRAMES_OF_A_HELD_RUN: usize = 3;
+
+    /// The number of rounds that arrive while the table holds.
+    const ROUNDS_WHILE_HELD: u64 = 3;
+
+    /// The number of rounds of the run of a held table.
+    const ROUNDS_OF_A_HELD_RUN: u64 = 4;
+
+    /// The number of rounds that a table which folded none names.
+    const NO_ROUND: u64 = 0;
 
     /// The number of turns that a run takes before its screen stops it.
     ///
@@ -706,6 +745,53 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    /// A sink that the test reads while a live table writes into it.
+    ///
+    /// A table owns its sink and gives it back to nobody, so the bytes live
+    /// behind a handle that the test keeps. One test and one table share the
+    /// handle, on one thread.
+    #[derive(Clone)]
+    struct Shared {
+        /// The bytes that reached the sink.
+        bytes: Rc<RefCell<Vec<u8>>>,
+    }
+
+    impl Shared {
+        /// A sink that holds nothing.
+        fn new() -> Self {
+            Self {
+                bytes: Rc::new(RefCell::new(Vec::new())),
+            }
+        }
+
+        /// The text that reached the sink.
+        fn text(&self) -> String {
+            String::from_utf8(self.bytes.borrow().clone()).expect("the sink must hold UTF-8 text")
+        }
+    }
+
+    impl Write for Shared {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes.borrow_mut().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        /// The sink holds every byte in memory, so it flushes nothing.
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// The frames that a live table drew, in the order they reached the sink.
+    fn frames(painted: &str) -> Vec<&str> {
+        painted.split(CLEAR).skip(1).collect()
+    }
+
+    /// The text of a header line that names this number of rounds.
+    fn rounds_in_header(rounds: u64) -> String {
+        format!("round {rounds}")
     }
 
     /// A namer of the test run that asks this resolver.
@@ -1534,6 +1620,83 @@ mod tests {
             ran.screen.names.is_empty(),
             "and it reached no screen: {:?}",
             ran.screen.names
+        );
+    }
+
+    /// The acceptance of the live table: a table that the user holds still
+    /// records every round.
+    ///
+    /// The display is one view of the recording, and the pause key holds that
+    /// view alone. The file behind it takes every round while the view stands
+    /// still, and the fold behind it takes every round too, so the frame of the
+    /// release names the rounds that arrived while the table held.
+    ///
+    /// The key of the first turn holds the table, and the key of the fourth
+    /// turn lets it move again. Three rounds arrive between those two turns.
+    #[test]
+    fn a_run_whose_table_is_paused_keeps_writing_every_round() {
+        // The name of the file stands in the header line of every frame, so
+        // the label of it holds no word that a frame is read for.
+        let file = TempFile::absent("held-table");
+        let painted = Shared::new();
+        let mut screen = Table::new(
+            RunFacts {
+                destination: TARGET_ARG.to_owned(),
+                address: address(TARGET_ADDRESS),
+                source: address(SOURCE_ADDRESS),
+                interval: AN_INTERVAL,
+                path: file.path().to_owned(),
+            },
+            painted.clone(),
+            FakeKeys::of(&[&[Command::Pause], &[], &[], &[Command::Pause]]),
+            WIDTH,
+        );
+        let outcome = ran_on(
+            file.path(),
+            &a_stream(&rounds_of(&[1, 2, 3, 4])),
+            &after_rounds(ROUNDS_OF_A_HELD_RUN),
+            &|| false,
+            &mut a_nameless_namer(),
+            &mut screen,
+        );
+        let recording = Recording::read(file.path()).expect("the test file must read");
+
+        assert_eq!(
+            seqs_of(&recording),
+            [1, 2, 3, 4],
+            "every round of the run reached the file, and the pause held none of them back"
+        );
+        match &outcome {
+            Ok(outcome) => assert_eq!(outcome.rounds, ROUNDS_OF_A_HELD_RUN),
+            Err(error) => panic!("the run must reach its round limit: {error:?}"),
+        }
+
+        let text = painted.text();
+        let drawn = frames(&text);
+        assert_eq!(
+            drawn.len(),
+            FRAMES_OF_A_HELD_RUN,
+            "the rounds that arrived while the table held drew nothing: {drawn:?}"
+        );
+        assert!(
+            drawn[0].contains(PAUSED) && drawn[0].contains(&rounds_in_header(NO_ROUND)),
+            "the first frame marks the pause, and the table under it folded no round: {:?}",
+            drawn[0]
+        );
+        assert!(
+            drawn[1].contains(&rounds_in_header(ROUNDS_WHILE_HELD)),
+            "the frame of the release names the rounds that arrived while the table held: {:?}",
+            drawn[1]
+        );
+        assert!(
+            !drawn[1].contains(PAUSED),
+            "and it carries no mark of a pause: {:?}",
+            drawn[1]
+        );
+        assert!(
+            drawn[2].contains(&rounds_in_header(ROUNDS_OF_A_HELD_RUN)),
+            "the round that arrived after the release drew the frame of it: {:?}",
+            drawn[2]
         );
     }
 }

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -331,12 +331,12 @@ fn close<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{record, Limits, Outcome, RunError};
+    use crate::live::{Command, RunFacts, Screen, Table};
     use crate::names::{Lookup, Namer, NoLookups};
     use crate::record::{
         EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
         RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
-    use crate::live::{Command, RunFacts, Screen, Table};
     use crate::testing::{address, named, FakeKeys, FakeResolver};
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -333,7 +333,7 @@ fn close<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{record, Limits, Outcome, RunError};
-    use crate::live::{Command, RunFacts, Screen, Table};
+    use crate::live::{Command, RunFacts, Screen, Table, Window};
     use crate::names::{Lookup, Namer, NoLookups};
     use crate::record::{
         EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
@@ -459,6 +459,14 @@ mod tests {
     /// The nominal frame is 97 columns wide: every column of the table, with a
     /// Host column of 30.
     const WIDTH: u16 = 97;
+
+    /// The rows of the window that the live table of a test draws in.
+    ///
+    /// No probe measured that window, so the table fits its frames to no
+    /// height and draws every line of them. A test of this file reads what a
+    /// frame holds, and a height that left rows out would take those lines off
+    /// the frame.
+    const NO_ROWS: Option<u16> = None;
 
     /// The period of one round of the run that a live table shows.
     const AN_INTERVAL: Duration = Duration::from_secs(1);
@@ -1651,7 +1659,7 @@ mod tests {
             },
             painted.clone(),
             FakeKeys::of(&[&[Command::Pause], &[], &[], &[Command::Pause]]),
-            WIDTH,
+            Window::new(WIDTH, NO_ROWS),
         );
         let outcome = ran_on(
             file.path(),

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -406,6 +406,12 @@ mod tests {
     /// that comes straight after the round it recorded.
     const STOP_AFTER_ONE_TURN: u64 = 1;
 
+    /// The number of turns that a run takes before its screen stops it.
+    ///
+    /// The screen answers the first turn, and the run records the round of that
+    /// turn. The second answer stops the run, so the run holds one round.
+    const SCREEN_STOPS_AFTER: usize = 1;
+
     /// The fault of a sink that takes no more records.
     const THE_SINK_IS_FULL: &str = "the sink takes no more records";
 
@@ -689,6 +695,15 @@ mod tests {
                 rounds: Vec::new(),
                 names: Vec::new(),
             }
+        }
+
+        /// A screen that asks for the stop of the run on the turn that follows
+        /// this many turns.
+        fn that_stops_after(turns: usize) -> Self {
+            let mut screen = Self::new();
+            screen.stops = vec![false; turns].into();
+            screen.stops.push_back(true);
+            screen
         }
 
         /// The number of every round that reached the screen, in the order they
@@ -1390,6 +1405,29 @@ mod tests {
             "the run showed no round: {:?}",
             ran.screen.seqs()
         );
+    }
+
+    /// The key of a live table stops the run, and the signal of a headless run
+    /// stops it the same way. The stop closure of this run asks for nothing, so
+    /// the screen is the one thing that stopped it.
+    #[test]
+    fn a_screen_that_asks_to_stop_ends_the_run_with_a_quit() {
+        let ran = ran_seeing(
+            "screen-quit",
+            &a_stream(&rounds_of(&[1, 2])),
+            &NO_LIMIT,
+            &|| false,
+            &mut a_nameless_namer(),
+            Recorder::that_stops_after(SCREEN_STOPS_AFTER),
+        );
+        assert_eq!(outcome_of(&ran).reason, EndReason::Quit);
+        assert_eq!(outcome_of(&ran).rounds, 1);
+        assert_eq!(
+            seqs_of(&ran.recording),
+            [1],
+            "the run recorded the round of the turn before the screen stopped it"
+        );
+        assert_eq!(end_of(&ran.recording).reason, EndReason::Quit);
     }
 
     #[test]

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -487,10 +487,11 @@ mod tests {
 
     /// The number of frames that the run of a held table drew.
     ///
-    /// One frame at the pause, one at the release of that pause, and one for
-    /// the round that arrived after the release. The rounds that arrived while
-    /// the table held drew none.
-    const FRAMES_OF_A_HELD_RUN: usize = 3;
+    /// One frame at the moment the table took the terminal, one at the pause,
+    /// one at the release of that pause, and one for the round that arrived
+    /// after the release. The rounds that arrived while the table held drew
+    /// none.
+    const FRAMES_OF_A_HELD_RUN: usize = 4;
 
     /// The number of rounds that arrive while the table holds.
     const ROUNDS_WHILE_HELD: u64 = 3;
@@ -1643,6 +1644,8 @@ mod tests {
     ///
     /// The key of the first turn holds the table, and the key of the fourth
     /// turn lets it move again. Three rounds arrive between those two turns.
+    /// The table draws one frame in front of all of that, at the moment it
+    /// takes the terminal, and that frame counts no round and marks no pause.
     #[test]
     fn a_run_whose_table_is_paused_keeps_writing_every_round() {
         // The name of the file stands in the header line of every frame, so
@@ -1689,24 +1692,29 @@ mod tests {
             "the rounds that arrived while the table held drew nothing: {drawn:?}"
         );
         assert!(
-            drawn[0].contains(PAUSED) && drawn[0].contains(&rounds_in_header(NO_ROUND)),
-            "the first frame marks the pause, and the table under it folded no round: {:?}",
+            drawn[0].contains(&rounds_in_header(NO_ROUND)) && !drawn[0].contains(PAUSED),
+            "the table drew the frame of no round when it took the terminal, and no key marked a pause in front of it: {:?}",
             drawn[0]
         );
         assert!(
-            drawn[1].contains(&rounds_in_header(ROUNDS_WHILE_HELD)),
+            drawn[1].contains(PAUSED) && drawn[1].contains(&rounds_in_header(NO_ROUND)),
+            "the frame of the first key marks the pause, and the table under it folded no round: {:?}",
+            drawn[1]
+        );
+        assert!(
+            drawn[2].contains(&rounds_in_header(ROUNDS_WHILE_HELD)),
             "the frame of the release names the rounds that arrived while the table held: {:?}",
-            drawn[1]
-        );
-        assert!(
-            !drawn[1].contains(PAUSED),
-            "and it carries no mark of a pause: {:?}",
-            drawn[1]
-        );
-        assert!(
-            drawn[2].contains(&rounds_in_header(ROUNDS_OF_A_HELD_RUN)),
-            "the round that arrived after the release drew the frame of it: {:?}",
             drawn[2]
+        );
+        assert!(
+            !drawn[2].contains(PAUSED),
+            "and it carries no mark of a pause: {:?}",
+            drawn[2]
+        );
+        assert!(
+            drawn[3].contains(&rounds_in_header(ROUNDS_OF_A_HELD_RUN)),
+            "the round that arrived after the release drew the frame of it: {:?}",
+            drawn[3]
         );
     }
 }

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -1,6 +1,6 @@
 //! The run loop: the record that opens a run, one record for each name that a
 //! reverse lookup gave, one record for each round, the record that closes it,
-//! and one status line for each round.
+//! and the screen that shows the run while it stands.
 //!
 //! A reverse lookup takes a time that no round waits for, so the loop asks the
 //! namer of `names.rs` on every turn and writes whatever the namer hands back.
@@ -22,6 +22,7 @@
 //! recording is the whole purpose of the tool, and a run that keeps a display
 //! while it silently records nothing is worse than a run that stops.
 
+use crate::live::Screen;
 use crate::names::Namer;
 use crate::record::{
     EndReason, EndRecord, NameRecord, Record, RoundRecord, RunId, RunRecord, Writer,
@@ -105,7 +106,9 @@ pub(crate) enum RunError {
 /// that the last round reported arrives after that round, and this last ask is
 /// what puts it in the file.
 ///
-/// Each round that the run records also prints one status line to `status`.
+/// Each round that the run records also reaches `screen`, and the recording
+/// comes first: a round reaches the file before it reaches the screen, so a
+/// screen that fails loses one frame and no record.
 ///
 /// A failed write of any record stops the run. The recording is the whole
 /// purpose of the tool, and a run that keeps a display while it silently
@@ -115,14 +118,14 @@ pub(crate) enum RunError {
 ///
 /// Returns [`RunError::Write`] when a record does not reach the file, and
 /// [`RunError::Tracer`] when the tracer thread stops before a limit does.
-pub(crate) fn record<W: Write, S: Write>(
+pub(crate) fn record<W: Write>(
     start: &RunRecord,
     rounds: &Receiver<RoundRecord>,
     limits: &Limits,
     stop: &dyn Fn() -> bool,
     namer: &mut Namer,
     writer: &mut Writer<W>,
-    status: &mut S,
+    screen: &mut dyn Screen,
 ) -> Result<Outcome, RunError> {
     writer
         .write(&Record::Run(start.clone()))
@@ -139,7 +142,6 @@ pub(crate) fn record<W: Write, S: Write>(
         }
         match rounds.recv_timeout(wait(limits.deadline)) {
             Ok(round) => {
-                let line = crate::live::status_line(&round);
                 // The names that arrived stand before the round of the same
                 // turn. A name always lands on a later turn than the round that
                 // first reported its address, because the first ask of an
@@ -148,11 +150,6 @@ pub(crate) fn record<W: Write, S: Write>(
                 writer
                     .write(&Record::Round(round))
                     .map_err(RunError::Write)?;
-                // A line that does not print stops nothing. The recording is
-                // the purpose of the tool, and the line is one view of it, so a
-                // reader who closes the pipe of the display loses the display
-                // and keeps the recording.
-                drop(writeln!(status, "{line}"));
                 recorded += 1;
             }
             // No round arrived inside the wait. The loop takes another turn, so
@@ -287,10 +284,12 @@ mod tests {
         EndReason, EndRecord, Family, Hop, NameRecord, Privilege, Record, Recording, RoundRecord,
         RunConfig, RunId, RunRecord, SourceKind, SourceLabel, Target, TtlRange, Writer,
     };
+    use crate::live::Screen;
     use crate::testing::{address, named, FakeResolver};
     use crate::{Multipath, Protocol};
     use chrono::{DateTime, Utc};
     use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
     use std::fs;
     use std::io::{self, Write};
     use std::path::{Path, PathBuf};
@@ -359,9 +358,6 @@ mod tests {
 
     /// The time that a round of one answer takes, in milliseconds.
     const LOST_ROUND_MS: u64 = 1004;
-
-    /// The status line of the first round of a run that answered the whole path.
-    const A_WHOLE_PATH_LINE: &str = "round 1  2 hops  reached  1s";
 
     /// The grace that every test run gives its names.
     ///
@@ -664,14 +660,60 @@ mod tests {
         Namer::new(Box::new(NoLookups), RunId::from(RUN))
     }
 
+    /// A screen that keeps what the run showed on it.
+    ///
+    /// A run hands its screen every round and every name that it recorded, and
+    /// a test of the loop asks what reached the screen. This screen keeps both,
+    /// and it answers the stop question from a script.
+    struct Recorder {
+        /// The answer of each turn, the next turn first. A turn past the end of
+        /// the script asks for no stop of the run.
+        stops: VecDeque<bool>,
+        /// The rounds that reached the screen, in the order they arrived.
+        rounds: Vec<RoundRecord>,
+        /// The names that reached the screen, in the order they arrived.
+        names: Vec<NameRecord>,
+    }
+
+    impl Recorder {
+        /// A screen that asks for no stop of the run.
+        fn new() -> Self {
+            Self {
+                stops: VecDeque::new(),
+                rounds: Vec::new(),
+                names: Vec::new(),
+            }
+        }
+
+        /// The number of every round that reached the screen, in the order they
+        /// arrived.
+        fn seqs(&self) -> Vec<u64> {
+            self.rounds.iter().map(|round| round.seq).collect()
+        }
+    }
+
+    impl Screen for Recorder {
+        fn poll(&mut self) -> bool {
+            self.stops.pop_front().unwrap_or(false)
+        }
+
+        fn round(&mut self, round: &RoundRecord) {
+            self.rounds.push(round.clone());
+        }
+
+        fn names(&mut self, names: &[NameRecord]) {
+            self.names.extend_from_slice(names);
+        }
+    }
+
     /// What one recorded run produced.
     struct Ran {
         /// What the run loop gave back.
         outcome: Result<Outcome, RunError>,
         /// What the recorded file holds.
         recording: Recording,
-        /// What the run printed.
-        status: String,
+        /// What the run showed on its screen.
+        screen: Recorder,
     }
 
     /// Records one run that looks nothing up to a real file, and reads the file
@@ -695,25 +737,50 @@ mod tests {
         stop: &dyn Fn() -> bool,
         namer: &mut Namer,
     ) -> Ran {
+        ran_seeing(label, rounds, limits, stop, namer, Recorder::new())
+    }
+
+    /// Records one run that shows itself on this screen, and reads the file
+    /// back.
+    fn ran_seeing(
+        label: &str,
+        rounds: &Receiver<RoundRecord>,
+        limits: &Limits,
+        stop: &dyn Fn() -> bool,
+        namer: &mut Namer,
+        mut screen: Recorder,
+    ) -> Ran {
         let file = TempFile::absent(label);
-        let mut status: Vec<u8> = Vec::new();
-        let outcome = {
-            let mut writer = Writer::append(file.path()).expect("the test file must open");
-            record(
-                &a_run_record(),
-                rounds,
-                limits,
-                stop,
-                namer,
-                &mut writer,
-                &mut status,
-            )
-        };
+        let outcome = ran_on(file.path(), rounds, limits, stop, namer, &mut screen);
         Ran {
             outcome,
             recording: Recording::read(file.path()).expect("the test file must read"),
-            status: String::from_utf8(status).expect("the status must hold UTF-8 text"),
+            screen,
         }
+    }
+
+    /// Records one run whose screen the caller owns, into the file at `path`.
+    ///
+    /// The writer of the run drops before the call answers, so the caller reads
+    /// a file that holds every record of the run.
+    fn ran_on(
+        path: &Path,
+        rounds: &Receiver<RoundRecord>,
+        limits: &Limits,
+        stop: &dyn Fn() -> bool,
+        namer: &mut Namer,
+        screen: &mut dyn Screen,
+    ) -> Result<Outcome, RunError> {
+        let mut writer = Writer::append(path).expect("the test file must open");
+        record(
+            &a_run_record(),
+            rounds,
+            limits,
+            stop,
+            namer,
+            &mut writer,
+            screen,
+        )
     }
 
     /// The outcome of a run that reached a limit.
@@ -914,7 +981,7 @@ mod tests {
             &|| false,
             &mut a_nameless_namer(),
             &mut writer,
-            &mut Vec::new(),
+            &mut Recorder::new(),
         );
         assert!(
             matches!(outcome, Err(RunError::Write(_))),
@@ -938,7 +1005,7 @@ mod tests {
             &|| false,
             &mut a_nameless_namer(),
             &mut writer,
-            &mut Vec::new(),
+            &mut Recorder::new(),
         );
         assert!(
             matches!(outcome, Err(RunError::Write(_))),
@@ -1097,7 +1164,7 @@ mod tests {
             &|| false,
             &mut a_namer(&resolver),
             &mut writer,
-            &mut Vec::new(),
+            &mut Recorder::new(),
         );
         assert!(
             matches!(outcome, Err(RunError::Write(_))),
@@ -1292,40 +1359,41 @@ mod tests {
         assert_eq!(outcome_of(&ran).rounds, 1);
     }
 
-    // The status lines that the loop prints. The line of one round is the work
-    // of `live::status_line`, and the tests of that line stand beside it.
-
-    /// The status lines that a run printed, without the newline of each one.
-    fn lines_of(ran: &Ran) -> Vec<&str> {
-        ran.status.lines().collect()
-    }
+    // What the run shows on its screen. The one line that a headless screen
+    // prints for a round is the work of `live::status_line`, and the tests of
+    // that line stand beside it.
 
     #[test]
-    fn a_run_of_three_rounds_prints_one_line_for_each_round() {
+    fn a_run_of_three_rounds_hands_the_screen_three_rounds() {
         let ran = ran(
-            "status-three",
+            "screen-three",
             &rounds_of(&[1, 2, 3]),
             &after_rounds(3),
             &|| false,
         );
-        assert_eq!(
-            lines_of(&ran),
-            [
-                A_WHOLE_PATH_LINE,
-                "round 2  2 hops  reached  1s",
-                "round 3  2 hops  reached  1s",
-            ]
+        assert_eq!(ran.screen.seqs(), [1, 2, 3]);
+        assert_eq!(outcome_of(&ran).rounds, 3);
+    }
+
+    #[test]
+    fn a_run_that_records_no_round_hands_the_screen_nothing() {
+        let ran = ran("screen-none", &rounds_of(&[1, 2]), &NO_LIMIT, &|| true);
+        assert_eq!(outcome_of(&ran).rounds, 0);
+        assert!(
+            ran.screen.rounds.is_empty(),
+            "the run showed no round: {:?}",
+            ran.screen.seqs()
         );
     }
 
     #[test]
-    fn a_run_that_records_no_round_prints_nothing() {
-        let ran = ran("status-none", &rounds_of(&[1, 2]), &NO_LIMIT, &|| true);
-        assert_eq!(outcome_of(&ran).rounds, 0);
-        assert!(
-            ran.status.is_empty(),
-            "the run printed no line: {:?}",
-            ran.status
+    fn every_round_reaches_the_screen_in_the_order_the_tracer_sent_them() {
+        let ran = ran(
+            "screen-order",
+            &rounds_of(&[7, 3, 9]),
+            &after_rounds(3),
+            &|| false,
         );
+        assert_eq!(ran.screen.seqs(), [7, 3, 9]);
     }
 }

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -132,7 +132,10 @@ pub(crate) fn record<W: Write>(
         .map_err(RunError::Write)?;
     let mut recorded: u64 = 0;
     loop {
-        if let Some(reason) = stopped(recorded, limits, stop) {
+        // The ask of the screen draws it, so one turn asks one time. The answer
+        // then travels to the decision as a value.
+        let asked = screen.poll();
+        if let Some(reason) = stopped(recorded, limits, stop, asked) {
             drain_names(writer, namer, limits.name_grace)?;
             close(writer, &start.run, recorded, reason)?;
             return Ok(Outcome {
@@ -234,9 +237,19 @@ fn drain_names<W: Write>(
 /// Why the run stops at the top of this turn. A run that goes on stops for
 /// nothing.
 ///
-/// The user comes first, then the number of rounds, then the moment.
-fn stopped(recorded: u64, limits: &Limits, stop: &dyn Fn() -> bool) -> Option<EndReason> {
-    if stop() {
+/// `asked` is what the screen of this turn answered. The ask of a screen draws
+/// it, so the turn asks one time and hands the answer here as a value.
+///
+/// The user comes first, then the number of rounds, then the moment. The screen
+/// and the stop flag are two doors of the same user: the key of a live table and
+/// the signal of a headless run both give [`EndReason::Quit`].
+fn stopped(
+    recorded: u64,
+    limits: &Limits,
+    stop: &dyn Fn() -> bool,
+    asked: bool,
+) -> Option<EndReason> {
+    if asked || stop() {
         return Some(EndReason::Quit);
     }
     if limits.rounds.is_some_and(|limit| recorded >= limit) {

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -26,8 +26,6 @@ use crate::names::Namer;
 use crate::record::{
     EndReason, EndRecord, NameRecord, Record, RoundRecord, RunId, RunRecord, Writer,
 };
-use crate::ui::render_duration;
-use crate::{counted, HOP, NEVER_REACHED, REACHED, ROUND, SUMMARY_SEPARATOR};
 use chrono::Utc;
 use std::io::Write;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
@@ -141,7 +139,7 @@ pub(crate) fn record<W: Write, S: Write>(
         }
         match rounds.recv_timeout(wait(limits.deadline)) {
             Ok(round) => {
-                let line = status_line(&round);
+                let line = crate::live::status_line(&round);
                 // The names that arrived stand before the round of the same
                 // turn. A name always lands on a later turn than the round that
                 // first reported its address, because the first ask of an
@@ -228,31 +226,6 @@ fn drain_names<W: Write>(
         }
         std::thread::sleep(left.min(POLL));
     }
-}
-
-/// Writes the one line that a run prints for one round.
-///
-/// The line holds the number of the round, the number of hops that answered,
-/// whether the round reached the target, and the time that the round took. Two
-/// spaces separate the fields, as they do in the closing line of the run.
-///
-/// A hop that did not answer is absent from the record, so the count is the
-/// number of hops that answered and not the length of the path.
-///
-/// A later slice replaces this line with the live table.
-fn status_line(round: &RoundRecord) -> String {
-    let reached = if round.reached {
-        REACHED
-    } else {
-        NEVER_REACHED
-    };
-    [
-        format!("{ROUND} {}", round.seq),
-        counted(round.hops.len(), HOP),
-        reached.to_owned(),
-        render_duration(Duration::from_millis(round.dur_ms)),
-    ]
-    .join(SUMMARY_SEPARATOR)
 }
 
 /// Why the run stops at the top of this turn. A run that goes on stops for
@@ -390,12 +363,6 @@ mod tests {
     /// The status line of the first round of a run that answered the whole path.
     const A_WHOLE_PATH_LINE: &str = "round 1  2 hops  reached  1s";
 
-    /// The number of the round that answered one hop.
-    const LOST_ROUND_SEQ: u64 = 2;
-
-    /// The status line of a round that answered one hop and reached nothing.
-    const A_LOST_ROUND_LINE: &str = "round 2  1 hop  never reached  1004ms";
-
     /// The grace that every test run gives its names.
     ///
     /// The fake resolver of a test answers at once, so no test waits for a
@@ -500,24 +467,6 @@ mod tests {
                     icmp: ECHO_REPLY.to_owned(),
                 },
             ],
-        }
-    }
-
-    /// One round that answered one hop and reached nothing.
-    fn a_lost_round(seq: u64) -> RoundRecord {
-        RoundRecord {
-            run: RunId::from(RUN),
-            seq,
-            ts: moment(ROUND_START),
-            dur_ms: LOST_ROUND_MS,
-            ttl_range: TtlRange::new(FIRST_TTL, TARGET_TTL).expect("the test range must hold"),
-            reached: false,
-            hops: vec![Hop {
-                ttl: FIRST_TTL,
-                addr: address(FIRST_HOP),
-                rtt_ms: FIRST_HOP_RTT_MS,
-                icmp: TIME_EXCEEDED.to_owned(),
-            }],
         }
     }
 
@@ -1343,36 +1292,12 @@ mod tests {
         assert_eq!(outcome_of(&ran).rounds, 1);
     }
 
-    // The status line of one round. A later slice replaces this line with the
-    // live table.
+    // The status lines that the loop prints. The line of one round is the work
+    // of `live::status_line`, and the tests of that line stand beside it.
 
     /// The status lines that a run printed, without the newline of each one.
     fn lines_of(ran: &Ran) -> Vec<&str> {
         ran.status.lines().collect()
-    }
-
-    #[test]
-    fn a_round_that_answered_two_hops_and_reached_the_target_prints_one_line() {
-        let ran = ran(
-            "status-reached",
-            &rounds_of(&[1]),
-            &after_rounds(1),
-            &|| false,
-        );
-        assert_eq!(ran.status, format!("{A_WHOLE_PATH_LINE}\n"));
-    }
-
-    /// One hop keeps the singular name, and a round that reached nothing says
-    /// so.
-    #[test]
-    fn a_round_that_answered_one_hop_and_reached_nothing_prints_the_singular_name() {
-        let ran = ran(
-            "status-lost",
-            &[a_lost_round(LOST_ROUND_SEQ)],
-            &after_rounds(1),
-            &|| false,
-        );
-        assert_eq!(ran.status, format!("{A_LOST_ROUND_LINE}\n"));
     }
 
     #[test]

--- a/src/krt/src/run.rs
+++ b/src/krt/src/run.rs
@@ -147,9 +147,15 @@ pub(crate) fn record<W: Write>(
                 // first reported its address, because the first ask of an
                 // address starts the lookup of that address.
                 write_names(writer, namer.names(&round.hops, Utc::now()))?;
+                // The recording comes first. The round reaches the file before
+                // it reaches the screen, so a screen that fails loses one frame
+                // and no record, and the file of a run whose display the user
+                // held holds every round of it. The record takes a copy of the
+                // round, because the screen reads the round after the write.
                 writer
-                    .write(&Record::Round(round))
+                    .write(&Record::Round(round.clone()))
                     .map_err(RunError::Write)?;
+                screen.round(&round);
                 recorded += 1;
             }
             // No round arrived inside the wait. The loop takes another turn, so

--- a/src/krt/src/testing.rs
+++ b/src/krt/src/testing.rs
@@ -12,9 +12,14 @@
 //! lookup and answers no name, so a test that wants that behavior programs
 //! `Lookup::Pending` first. A test of the fold programs a name first.
 //!
+//! The fake key source stands here for the same reason. A test of the live
+//! table and a test of the run loop both script the keys of a turn, and one
+//! script serves both.
+//!
 //! This module compiles under `cfg(test)` alone, so nothing it holds reaches
 //! the binary.
 
+use crate::live::{Command, Keys};
 use crate::names::{Lookup, Resolver};
 use crate::record::{Hop, RoundRecord, RunId, TtlRange};
 use chrono::{DateTime, Utc};
@@ -137,5 +142,28 @@ impl FakeResolver {
 impl Resolver for Rc<FakeResolver> {
     fn lookup(&self, addr: IpAddr) -> Lookup {
         self.answer(addr)
+    }
+}
+
+/// A key source that hands back one list of commands for each turn.
+///
+/// A turn past the end of the script took no key.
+pub(crate) struct FakeKeys {
+    /// The commands of each turn, the next turn first.
+    turns: VecDeque<Vec<Command>>,
+}
+
+impl FakeKeys {
+    /// A key source of one script.
+    pub(crate) fn of(script: &[&[Command]]) -> Self {
+        Self {
+            turns: script.iter().map(|turn| turn.to_vec()).collect(),
+        }
+    }
+}
+
+impl Keys for FakeKeys {
+    fn presses(&mut self) -> Vec<Command> {
+        self.turns.pop_front().unwrap_or_default()
     }
 }

--- a/src/krt/src/ui.rs
+++ b/src/krt/src/ui.rs
@@ -841,6 +841,35 @@ pub(crate) fn frame_columns() -> u16 {
     frame_columns_of(termsize::controlling_columns())
 }
 
+/// The number of terminal columns that a frame draws in, and the number of
+/// rows that the window holds.
+///
+/// The columns follow the rule of [`frame_columns`], and the rows come straight
+/// off the probe. The rows are `None` for a window that no probe measured: a
+/// run whose standard output is no terminal, a terminal that the probe failed
+/// to read, and a terminal that carries no window. A caller that holds no row
+/// count holds no height to fit a frame to, and it draws every line of that
+/// frame.
+///
+/// One probe answers both numbers, because the terminal answers both of them in
+/// one ioctl. A second call would ask the same terminal the same question, and
+/// a window that changed size between the two would answer with a width of one
+/// window and a height of another.
+///
+/// A live table asks this question, because it draws its frames into a window
+/// that holds a fixed number of rows. A replay asks [`frame_columns`], because
+/// it prints its lines into whatever scrollback the terminal keeps.
+pub(crate) fn frame_size() -> (u16, Option<u16>) {
+    if !std::io::stdout().is_terminal() {
+        return (frame_columns_of(None), None);
+    }
+    let size = termsize::controlling_size();
+    (
+        frame_columns_of(size.map(|(columns, _)| columns)),
+        size.map(|(_, rows)| rows),
+    )
+}
+
 /// The number of terminal columns that a frame draws in, from the answer that
 /// the terminal gave.
 ///

--- a/src/krt/src/ui.rs
+++ b/src/krt/src/ui.rs
@@ -517,6 +517,16 @@ const HEADER_LINES: u16 = 2;
 /// The number of lines of the column header.
 const COLUMN_HEADER_LINES: u16 = 1;
 
+/// The number of lines of a frame that stand above the rows of the path.
+///
+/// A caller that fits a frame to the window of a terminal keeps these lines and
+/// drops rows, so the reader keeps the destination, the count of the rounds,
+/// the size of the recorded file, and the name of every column. The count comes
+/// off the two constants above, because a head that grew by one line would
+/// otherwise take one row of the path with it and no line of that caller would
+/// say so.
+pub(crate) const HEAD_LINES: u16 = HEADER_LINES + COLUMN_HEADER_LINES;
+
 /// The host of a TTL that never answered.
 const NO_HOST: &str = "???";
 

--- a/src/krt/tests/cli.rs
+++ b/src/krt/tests/cli.rs
@@ -214,6 +214,48 @@ fn the_long_help_names_no_part_of_the_tool_that_does_not_exist() {
     }
 }
 
+/// The key of the live table that lists every key of that table, as the help
+/// page writes it.
+///
+/// The backticks are part of the match. The help page writes the name of a
+/// flag and the name of a command in backticks, so the three characters
+/// together name a key and one bare question mark does not.
+const KEY_THAT_LISTS_THE_KEYS: &str = "`?`";
+
+/// The help page names the key that lists the keys of the live table.
+///
+/// The help page says that a run under a terminal takes the keys of that
+/// terminal, and the list of those keys stands behind a key press. A reader
+/// who learns that keys exist and reads the name of no key has no way to reach
+/// that list. One key name in the help page opens it.
+///
+/// The help page names that one key and no other, because `live::KEYS` is the
+/// one list that says what a key does. `live::tests` holds the name in this
+/// test and that list together.
+///
+/// The test reads the usage heading first, so a binary that printed nothing
+/// fails there in the place of the assertion below it.
+#[test]
+fn the_long_help_names_the_key_that_lists_the_keys() {
+    let result = run(&[FLAG_HELP]);
+    assert!(
+        result.success,
+        "`krt {FLAG_HELP}` must exit with success; stderr: {}",
+        result.stderr
+    );
+    assert!(
+        result.stdout.contains(USAGE_HEADING),
+        "`krt {FLAG_HELP}` must print a help page, but it printed {:?}",
+        result.stdout
+    );
+
+    assert!(
+        result.stdout.contains(KEY_THAT_LISTS_THE_KEYS),
+        "the help page must name {KEY_THAT_LISTS_THE_KEYS} as the key that lists the keys of the live table, but it printed {:?}",
+        result.stdout
+    );
+}
+
 /// The block that `krt 1.2.3.4 -6` prints before it stops.
 ///
 /// A trace prints the block that names what it will do, and then it acts. This

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -54,8 +54,9 @@ use std::{env, fs, process};
 /// The number of rows of every pseudo terminal below.
 ///
 /// The frames of these tests hold six lines at the most, so no run of them
-/// scrolls. The number is a part of the size that the terminal reports, and a
-/// terminal that reports a zero in either number reports no window at all.
+/// scrolls and the live table leaves no row of a path out of a frame. The
+/// number is a part of the size that the terminal reports, and a terminal that
+/// reports a zero in either number reports no window at all.
 const ROWS: u16 = 40;
 
 /// The number of columns of a terminal that holds the whole frame.
@@ -294,9 +295,11 @@ impl Terminal {
     /// The lines of the frame, from the header line to the end of the text.
     ///
     /// The terminal returns a carriage on each line of its own, and the live
-    /// table writes one of those itself, so each line ends with one carriage or
-    /// with two. The reader takes every carriage off the end of a line, and
-    /// what stays is the text that a reader of the terminal sees.
+    /// table writes one of those between two lines of a frame, so a line ends
+    /// with one carriage or with two. The last line of a live frame carries no
+    /// line end at all, because a line end there scrolls the window. The reader
+    /// takes every carriage off the end of a line, and what stays is the text
+    /// that a reader of the terminal sees.
     fn frame(&self) -> Vec<String> {
         let shown = self.shown();
         shown

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -618,6 +618,29 @@ fn stale(path: &Path) -> bool {
         .is_some_and(|age| age > STALE_LOCK)
 }
 
+/// A waiter that takes a stale lock over keeps patience for the run it starts.
+///
+/// The waiter of a file that a killed run left behind pays [`STALE_LOCK`] in
+/// front of the moment that file counts as stale. It removes the file then, and
+/// it takes the lock on the turn after that, so the patience it has left is
+/// [`LOCK_PATIENCE`] less the age. [`TracerLock::take`] reads its deadline after
+/// the removal, so a waiter of no patience left fails on the very turn that
+/// freed the lock, and the turn it fails on is one it never controlled: the
+/// clock of the age starts when the dead holder made the file, and the clock of
+/// the patience starts when the waiter arrives.
+///
+/// Twice the age is therefore the bound. A waiter that pays the whole wait for
+/// a stale file keeps half of its patience at the least, and that half is what
+/// it holds the lock with.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_waiter_that_takes_a_stale_lock_over_keeps_patience_for_the_run_it_starts() {
+    assert!(
+        LOCK_PATIENCE >= STALE_LOCK * 2,
+        "the patience of a waiter must stand clear of the age of a stale lock: {LOCK_PATIENCE:?} against {STALE_LOCK:?}"
+    );
+}
+
 /// One live run of the loopback, and the hold that run takes on the machine.
 #[cfg(target_os = "macos")]
 struct LiveRun {

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -1,8 +1,10 @@
 //! Black-box coverage for the parts of `krt` that a pipe cannot reach.
 //!
-//! `cargo test` hands a test binary a pipe, and `krt` reads a terminal for the
-//! width that a frame draws in. A pseudo terminal is a terminal, so these tests
-//! give the binary one and drive it through that.
+//! `cargo test` hands a test binary a pipe, and three parts of `krt` answer
+//! nothing without a terminal: the width that a frame draws in, the keys that a
+//! live run reads, and the hold that a live run takes on the terminal it draws
+//! on. A pseudo terminal is a terminal, so these tests give the binary one and
+//! drive it through that.
 //!
 //! Every pseudo terminal below carries a size. A pseudo terminal that nobody
 //! sized answers the `TIOCGWINSZ` ioctl with zero columns, and that ioctl
@@ -15,6 +17,16 @@
 //! writes nothing waits for ever, and a test that waits for ever holds every
 //! commit of the repository. A wait that runs out fails with the text that the
 //! terminal showed, so a reader of the failure sees how far the run got.
+//!
+//! The tests of a live run stand on macOS alone. macOS sends its probes without
+//! privileges, so a run there reaches the loop that draws the table. Linux and
+//! Windows stop such a run at the privilege gate, in front of every line that
+//! these tests read.
+//!
+//! Those runs stay offline. The destination is the loopback, `--source` names
+//! the loopback, and `--no-dns` looks nothing up. A run that names no source
+//! asks a public service for the address that the internet sees, and every
+//! `cargo test` then reaches the internet.
 
 // Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
 #![deny(unsafe_code)]
@@ -22,15 +34,22 @@
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,
-    reason = "each unwrap here is an assertion about the harness, not an unhandled error: the open of the pseudo terminal, and the spawn of the freshly built binary under it. A failure of either one is a broken harness, and a panic names it at once"
+    reason = "each unwrap here is an assertion about the harness, not an unhandled error: the open of the pseudo terminal, the spawn of the freshly built binary, the write of one key into that terminal, and the read of the file that the run recorded. A failure of any one is a broken harness, and a panic names it at once"
 )]
 
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[cfg(target_os = "macos")]
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_os = "macos")]
+use std::{env, fs, process};
 
 /// The number of rows of every pseudo terminal below.
 ///
@@ -56,9 +75,10 @@ const NARROW: u16 = 60;
 
 /// The longest that any wait below runs.
 ///
-/// A replay reads one file and prints one frame, which takes a moment. Thirty
-/// seconds is far longer than that, and it is short enough that a run which
-/// stopped writing fails the suite in the place of holding it.
+/// A run of the loopback takes one round each second, and the first frame draws
+/// at the first round. Thirty seconds is far longer than that, and it is short
+/// enough that a run which stopped drawing fails the suite in the place of
+/// holding it.
 const PATIENCE: Duration = Duration::from_secs(30);
 
 /// The time between two reads of the state that a wait waits for.
@@ -106,14 +126,81 @@ const AVG_HEADING: &str = "Avg";
 /// The start of the column header of every frame.
 ///
 /// The TTL column and the Host column never drop, so this text starts the
-/// column header at every width.
+/// column header at every width. A wait for a frame of a live run waits for it.
 const COLUMN_HEADER_START: &str = " TTL  Host";
+
+/// The loopback address of ip version 4. Every machine holds a route to it.
+#[cfg(target_os = "macos")]
+const LOOPBACK: &str = "127.0.0.1";
+
+/// The flag that names the address the probes leave from.
+#[cfg(target_os = "macos")]
+const FLAG_SOURCE: &str = "--source";
+
+/// The flag that turns the reverse lookups off.
+///
+/// A lookup of the loopback answers inside the machine, and this flag makes no
+/// lookup at all. It is what says, at the command line of the test, that the
+/// run reaches no name server.
+#[cfg(target_os = "macos")]
+const FLAG_NO_DNS: &str = "--no-dns";
+
+/// The flag that names the recorded file.
+#[cfg(target_os = "macos")]
+const FLAG_OUTPUT: &str = "--output";
+
+/// The byte that a terminal sends for Ctrl-C.
+///
+/// Raw mode clears `ISIG`, so this byte reaches the process as a key press and
+/// never as a `SIGINT`.
+#[cfg(target_os = "macos")]
+const CTRL_C: u8 = 0x03;
+
+/// The byte that a terminal sends for the `q` key.
+#[cfg(target_os = "macos")]
+const Q: u8 = b'q';
+
+/// The exit code of a run that stopped the way the user asked it to.
+#[cfg(target_os = "macos")]
+const EXIT_SUCCESS: u32 = 0;
+
+/// The control sequence that enters the alternate screen.
+#[cfg(target_os = "macos")]
+const ENTER_ALTERNATE_SCREEN: &str = "\u{1b}[?1049h";
+
+/// The control sequence that leaves the alternate screen.
+#[cfg(target_os = "macos")]
+const LEAVE_ALTERNATE_SCREEN: &str = "\u{1b}[?1049l";
+
+/// The control sequence that shows the cursor.
+#[cfg(target_os = "macos")]
+const SHOW_CURSOR: &str = "\u{1b}[?25h";
+
+/// The start of the line that a run prints when it stops.
+#[cfg(target_os = "macos")]
+const RECORDED: &str = "recorded ";
+
+/// The name of the field that names what kind of record one line holds.
+#[cfg(target_os = "macos")]
+const TYPE_FIELD: &str = "type";
+
+/// The kind of the record that closes a run.
+#[cfg(target_os = "macos")]
+const END_RECORD: &str = "end";
+
+/// The name of the field that says why a run stopped.
+#[cfg(target_os = "macos")]
+const REASON_FIELD: &str = "reason";
+
+/// The reason of a run that the user stopped.
+#[cfg(target_os = "macos")]
+const QUIT_REASON: &str = "quit";
 
 /// One run of `krt` under a pseudo terminal, and the text that terminal showed.
 ///
 /// The terminal carries standard output, standard error, and standard input of
 /// the run, and it is the controlling terminal of that run. `krt` therefore
-/// measures it, and it draws in the columns that the terminal reports.
+/// measures it, holds it, and reads the keys that this harness writes into it.
 ///
 /// A thread reads the terminal, because a read of a terminal waits for the
 /// child to write and the test has other work while it waits. Every wait of the
@@ -121,6 +208,8 @@ const COLUMN_HEADER_START: &str = " TTL  Host";
 struct Terminal {
     /// The hold on the terminal. The drop of it closes the terminal.
     _master: Box<dyn MasterPty + Send>,
+    /// Where a key of the test goes.
+    keys: Box<dyn Write + Send>,
     /// Every byte that the terminal showed.
     shown: Arc<Mutex<Vec<u8>>>,
     /// Whether the terminal closed, which is the end of the text it showed.
@@ -159,6 +248,10 @@ impl Terminal {
             .master
             .try_clone_reader()
             .expect("the pseudo terminal must answer with a reader");
+        let keys = pair
+            .master
+            .take_writer()
+            .expect("the pseudo terminal must answer with a writer");
         let shown = Arc::new(Mutex::new(Vec::new()));
         let closed = Arc::new(AtomicBool::new(false));
         let filled = Arc::clone(&shown);
@@ -181,6 +274,7 @@ impl Terminal {
         });
         Self {
             _master: pair.master,
+            keys,
             shown,
             closed,
             child,
@@ -210,6 +304,33 @@ impl Terminal {
             .skip_while(|line| !line.starts_with(FRAME_START))
             .map(|line| line.trim_end_matches('\r').to_owned())
             .collect()
+    }
+
+    /// Waits until the terminal shows `text`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when [`PATIENCE`] runs out, and names the text that the terminal
+    /// showed. A wait of no deadline holds every commit of the repository.
+    fn wait_for(&self, text: &str) {
+        let deadline = Instant::now() + PATIENCE;
+        while !self.shown().contains(text) {
+            assert!(
+                Instant::now() < deadline,
+                "the run must show {text:?} inside {PATIENCE:?}, and it showed {:?}",
+                self.shown()
+            );
+            thread::sleep(GLANCE);
+        }
+    }
+
+    /// Writes one key into the terminal.
+    #[cfg(target_os = "macos")]
+    fn press(&mut self, key: u8) {
+        self.keys
+            .write_all(&[key])
+            .expect("the pseudo terminal must take the key");
+        self.keys.flush().expect("the key must reach the run");
     }
 
     /// Waits for the run to stop, and answers the code it stopped with.
@@ -292,4 +413,326 @@ fn a_replay_under_a_narrow_terminal_drops_the_columns_that_drop_first() {
             "and it keeps the {stands} column, which never drops: {header:?}"
         );
     }
+}
+
+/// A path under the temporary directory of the machine.
+///
+/// The name keys on the process and on the moment, so two copies of one test
+/// that run at the same time never share a file. `CLAUDE.md` demands it.
+#[cfg(target_os = "macos")]
+fn temp_path(name: &str) -> PathBuf {
+    let moment = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("the clock must sit after the epoch")
+        .as_nanos();
+    env::temp_dir().join(format!("{name}-{}-{moment}.jsonl", process::id()))
+}
+
+/// The file that one run recorded. The file goes away when the test ends, and
+/// also when the test panics.
+#[cfg(target_os = "macos")]
+struct Recording {
+    /// The path of the file.
+    path: PathBuf,
+}
+
+#[cfg(target_os = "macos")]
+impl Recording {
+    /// Holds a path that no file uses yet, and that no other run reaches.
+    fn at(name: &str) -> Self {
+        Self {
+            path: temp_path(name),
+        }
+    }
+
+    /// The path of the file, as the command line of a run spells it.
+    fn argument(&self) -> String {
+        self.path
+            .to_str()
+            .expect("the temporary path must be text")
+            .to_owned()
+    }
+
+    /// Why the `end` record of the file says the run stopped, and `None` when
+    /// the file holds no such record.
+    ///
+    /// The file holds one JSON object for each line, so the reader parses each
+    /// line and reads the field that names its kind. A search of the text for
+    /// the two words would pass on a file whose `end` record names one reason
+    /// and whose other records name the word beside it.
+    fn end_reason(&self) -> Option<String> {
+        let text = fs::read_to_string(&self.path).expect("the recorded file must read");
+        text.lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line)
+                    .expect("each line of the recorded file must parse")
+            })
+            .find(|record| {
+                record.get(TYPE_FIELD).and_then(serde_json::Value::as_str) == Some(END_RECORD)
+            })
+            .and_then(|record| {
+                record
+                    .get(REASON_FIELD)
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for Recording {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// The name of the file that holds the one tracer of the machine.
+///
+/// The name is fixed, where every other path of this file keys on the process
+/// and on the moment. That is the purpose of it: a lock that two processes
+/// spell differently locks nothing.
+#[cfg(target_os = "macos")]
+const TRACER_LOCK: &str = "krt-live-tracer.lock";
+
+/// The longest that a wait for the tracer of the machine runs.
+///
+/// One holder takes a few seconds, and [`PATIENCE`] bounds the longest one. Two
+/// test binaries of three live runs each therefore take well under this bound,
+/// and a wait that reaches it says that something outside these tests holds the
+/// lock.
+#[cfg(target_os = "macos")]
+const LOCK_PATIENCE: Duration = Duration::from_mins(2);
+
+/// The age at which a lock file belongs to a run that is no longer there.
+///
+/// A holder gives the lock back at the end of its test, and the panic of a test
+/// gives it back too. A file that a killed process left behind never comes
+/// back, so a file older than any holder ever lives is a file to take over.
+#[cfg(target_os = "macos")]
+const STALE_LOCK: Duration = Duration::from_mins(2);
+
+/// The hold of one test on the tracer of the machine.
+///
+/// Two tracers of one machine collide. macOS hands the ICMP replies of one
+/// process to the socket of every other process that reads that protocol, so a
+/// tracer reads the answer of a probe that another tracer sent. The probe of
+/// that answer stands in no state that an answer belongs to, and the tracer
+/// then stops with a fault. Three live runs of this file collided that way, and
+/// two of the three failed.
+///
+/// The lock is a file, and not a mutex of the process. `cargo test` runs the
+/// tests of one binary on many threads, and more than one `cargo test` can run
+/// at once, so a mutex holds one of the two cases and the file holds both.
+#[cfg(target_os = "macos")]
+struct TracerLock {
+    /// The path of the lock file.
+    path: PathBuf,
+}
+
+#[cfg(target_os = "macos")]
+impl TracerLock {
+    /// Waits for the tracer of the machine, and takes it.
+    ///
+    /// # Panics
+    ///
+    /// Panics when [`LOCK_PATIENCE`] runs out. A test that waited with no
+    /// deadline holds every commit of the repository.
+    fn take() -> Self {
+        let path = env::temp_dir().join(TRACER_LOCK);
+        let deadline = Instant::now() + LOCK_PATIENCE;
+        loop {
+            if fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .is_ok()
+            {
+                return Self { path };
+            }
+            // A file that no run holds any more goes away, and the next turn of
+            // this loop takes the lock. Two waiters can both read the same file
+            // as stale and both take it away, which costs one turn of the loop
+            // and no more: the taker of the lock is the one that makes the file,
+            // and one process alone can make a file that is not there.
+            if stale(&path) {
+                let _ = fs::remove_file(&path);
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the tracer of the machine must come free inside {LOCK_PATIENCE:?}: {}",
+                path.display()
+            );
+            thread::sleep(GLANCE);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for TracerLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Whether a lock file belongs to a run that is no longer there.
+///
+/// A file whose age this machine cannot read counts as fresh. A lock that a
+/// test takes away for a reason it could not check is worse than a lock that a
+/// test waits for.
+#[cfg(target_os = "macos")]
+fn stale(path: &Path) -> bool {
+    fs::metadata(path)
+        .and_then(|data| data.modified())
+        .ok()
+        .and_then(|made| SystemTime::now().duration_since(made).ok())
+        .is_some_and(|age| age > STALE_LOCK)
+}
+
+/// One live run of the loopback, and the hold that run takes on the machine.
+#[cfg(target_os = "macos")]
+struct LiveRun {
+    /// The terminal of the run.
+    terminal: Terminal,
+    /// The hold on the tracer of the machine.
+    ///
+    /// The field stands under the terminal, because a field drops in the order
+    /// it stands: the drop of the terminal stops the run, and the lock then
+    /// goes back to the next test. A lock that went back first would let that
+    /// test start its tracer beside a tracer that still stands.
+    _lock: TracerLock,
+}
+
+/// Starts a live run of the loopback under a terminal of [`WIDE`] columns, and
+/// waits until the table draws its first frame.
+///
+/// The run stays offline for the reason that the file documentation states: the
+/// destination is the loopback, [`FLAG_SOURCE`] names the loopback, and
+/// [`FLAG_NO_DNS`] looks nothing up.
+#[cfg(target_os = "macos")]
+fn live_run(recording: &Recording) -> LiveRun {
+    let lock = TracerLock::take();
+    let output = recording.argument();
+    let terminal = Terminal::open(
+        WIDE,
+        &[
+            LOOPBACK,
+            FLAG_SOURCE,
+            LOOPBACK,
+            FLAG_NO_DNS,
+            FLAG_OUTPUT,
+            &output,
+        ],
+    );
+    // The table draws its first frame at the first round. A key that arrived in
+    // front of the terminal going into raw mode reaches the line discipline and
+    // not the run, so every test below presses its key after this wait.
+    terminal.wait_for(COLUMN_HEADER_START);
+    LiveRun {
+        terminal,
+        _lock: lock,
+    }
+}
+
+/// Asserts that a live run which one key stopped exits with success and closes
+/// its recorded file with the reason of a quit.
+#[cfg(target_os = "macos")]
+fn a_key_stops_a_live_run(name: &str, key: u8) {
+    let recording = Recording::at(name);
+    let mut run = live_run(&recording);
+
+    run.terminal.press(key);
+    let code = run.terminal.wait_for_exit();
+
+    assert_eq!(
+        code,
+        EXIT_SUCCESS,
+        "the run stops the way the user asked it to, and it showed {:?}",
+        run.terminal.shown()
+    );
+    assert_eq!(
+        recording.end_reason().as_deref(),
+        Some(QUIT_REASON),
+        "the recorded file closes with the reason of a quit, and the run showed {:?}",
+        run.terminal.shown()
+    );
+}
+
+/// The `q` key stops a live run, and the run closes its file.
+///
+/// The run holds the terminal in raw mode, so the byte of the key reaches the
+/// run and the line discipline holds none of it.
+#[cfg(target_os = "macos")]
+#[test]
+fn the_q_key_stops_a_live_run_and_writes_the_end_record_of_a_quit() {
+    a_key_stops_a_live_run("krt-terminal-q", Q);
+}
+
+/// Ctrl-C stops a live run, and the run closes its file.
+///
+/// This is the test of the design of the live table. Raw mode clears `ISIG`, so
+/// the terminal sends the byte of Ctrl-C and the process takes no `SIGINT`. The
+/// key handler of the run is therefore the one thing that can stop it, and a
+/// run that lost that handler would take Ctrl-C and go on recording.
+#[cfg(target_os = "macos")]
+#[test]
+fn ctrl_c_stops_a_live_run_and_writes_the_end_record_of_a_quit() {
+    a_key_stops_a_live_run("krt-terminal-ctrl-c", CTRL_C);
+}
+
+/// A live run holds the terminal until it stops, and then gives it back.
+///
+/// The test reads the order of four things in one stream of bytes: the run
+/// enters the alternate screen, it draws its table there, it leaves that screen
+/// and shows the cursor again, and it prints its closing line last of all.
+///
+/// The order is the whole of what this test covers. A run that gave the
+/// terminal back at the start of itself writes every one of the four, and it
+/// draws its table over the lines of the reader and hides none of the cursor
+/// that drags across it. A run that gave the terminal back at the end of itself
+/// but printed its closing line in front of that puts the one line a reader
+/// waits for on a screen that the terminal then takes away.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_live_run_gives_the_terminal_back_when_it_stops() {
+    let recording = Recording::at("krt-terminal-restore");
+    let mut run = live_run(&recording);
+
+    run.terminal.press(Q);
+    run.terminal.wait_for_exit();
+    let shown = run.terminal.shown();
+
+    let entered = shown
+        .find(ENTER_ALTERNATE_SCREEN)
+        .unwrap_or_else(|| panic!("the run must enter the alternate screen: {shown:?}"));
+    // The last frame and the last restoration, because the run draws one frame
+    // for each round and the table draws one more for the key that stopped it.
+    let drawn = shown
+        .rfind(COLUMN_HEADER_START)
+        .unwrap_or_else(|| panic!("the run must draw its table: {shown:?}"));
+    let left = shown
+        .rfind(LEAVE_ALTERNATE_SCREEN)
+        .unwrap_or_else(|| panic!("the run must leave the alternate screen: {shown:?}"));
+    let cursor = shown
+        .rfind(SHOW_CURSOR)
+        .unwrap_or_else(|| panic!("the run must show the cursor again: {shown:?}"));
+    let closing = shown
+        .find(RECORDED)
+        .unwrap_or_else(|| panic!("the run must print its closing line: {shown:?}"));
+
+    assert!(
+        entered < drawn,
+        "the table draws on the alternate screen, and not over the lines of the reader: {shown:?}"
+    );
+    assert!(
+        drawn < left,
+        "and the run holds that screen for the whole of itself: {shown:?}"
+    );
+    assert!(
+        left < closing,
+        "the closing line stands after the alternate screen went away, so the reader keeps it: {shown:?}"
+    );
+    assert!(
+        cursor < closing,
+        "and the cursor stands again in front of that line: {shown:?}"
+    );
 }

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -1,0 +1,295 @@
+//! Black-box coverage for the parts of `krt` that a pipe cannot reach.
+//!
+//! `cargo test` hands a test binary a pipe, and `krt` reads a terminal for the
+//! width that a frame draws in. A pseudo terminal is a terminal, so these tests
+//! give the binary one and drive it through that.
+//!
+//! Every pseudo terminal below carries a size. A pseudo terminal that nobody
+//! sized answers the `TIOCGWINSZ` ioctl with zero columns, and that ioctl
+//! succeeds. `termsize` reads the zero as no answer, and `krt` then draws the
+//! nominal frame of 97 columns. A test of the width under such a terminal
+//! therefore passes or fails for a reason that has nothing to do with the code
+//! it reads.
+//!
+//! Every wait below carries a deadline. A read of a pseudo terminal whose child
+//! writes nothing waits for ever, and a test that waits for ever holds every
+//! commit of the repository. A wait that runs out fails with the text that the
+//! terminal showed, so a reader of the failure sees how far the run got.
+
+// Mirrors the crate-root attributes in src/main.rs; see "Lint Configuration" in CLAUDE.md.
+#![deny(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "each unwrap here is an assertion about the harness, not an unhandled error: the open of the pseudo terminal, and the spawn of the freshly built binary under it. A failure of either one is a broken harness, and a panic names it at once"
+)]
+
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// The number of rows of every pseudo terminal below.
+///
+/// The frames of these tests hold six lines at the most, so no run of them
+/// scrolls. The number is a part of the size that the terminal reports, and a
+/// terminal that reports a zero in either number reports no window at all.
+const ROWS: u16 = 40;
+
+/// The number of columns of a terminal that holds the whole frame.
+///
+/// The nominal frame takes 97 columns, so this terminal is wider than every
+/// column of the table needs. Nothing drops, and the Host column takes the 23
+/// columns that are left over.
+const WIDE: u16 = 120;
+
+/// The number of columns of a terminal too narrow for the whole frame.
+///
+/// The frame drops its columns in the order that `src/krt/src/ui.rs` states,
+/// first dropped first: `Recent`, `StDev`, `Max`, `Min`, `Last`, `Sent`,
+/// `Loss%`. Sixty columns take the first three of that order away and leave the
+/// rest standing.
+const NARROW: u16 = 60;
+
+/// The longest that any wait below runs.
+///
+/// A replay reads one file and prints one frame, which takes a moment. Thirty
+/// seconds is far longer than that, and it is short enough that a run which
+/// stopped writing fails the suite in the place of holding it.
+const PATIENCE: Duration = Duration::from_secs(30);
+
+/// The time between two reads of the state that a wait waits for.
+const GLANCE: Duration = Duration::from_millis(20);
+
+/// The recorded file that the repository holds, which carries two runs.
+const FIXTURE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/fixtures/two-runs.jsonl");
+
+/// The name of the command that folds a recorded file.
+const REPLAY: &str = "replay";
+
+/// The start of the header line of a frame.
+///
+/// A replay writes its frame to standard output, and it writes the note about
+/// the run it picked to standard error. One pseudo terminal carries both of
+/// them, so the reader of the terminal takes the frame from this line onward.
+const FRAME_START: &str = " krt  ";
+
+/// The column header of the frame at [`WIDE`] columns.
+///
+/// The nominal header takes 94 columns with a Host column of 30. This terminal
+/// holds 120 columns where the nominal frame takes 97, so the Host column takes
+/// 23 more of them and the header takes 117.
+///
+/// The test spells the header, and the render draws it from the list of columns
+/// that it holds. That is on purpose: a heading that moved would otherwise
+/// agree with itself, and these headings are what a reader of the table sees.
+const WIDE_COLUMN_HEADER: &str = " TTL  Host                                                    Loss%   Sent   Last    Min    Avg    Max  StDev  Recent";
+
+/// The heading of the column of the recent round-trip times.
+const RECENT_HEADING: &str = "Recent";
+
+/// The heading of the column of the standard deviation.
+const STDEV_HEADING: &str = "StDev";
+
+/// The heading of the column of the TTL.
+const TTL_HEADING: &str = "TTL";
+
+/// The heading of the column of the router that answered.
+const HOST_HEADING: &str = "Host";
+
+/// The heading of the column of the mean round-trip time.
+const AVG_HEADING: &str = "Avg";
+
+/// The start of the column header of every frame.
+///
+/// The TTL column and the Host column never drop, so this text starts the
+/// column header at every width.
+const COLUMN_HEADER_START: &str = " TTL  Host";
+
+/// One run of `krt` under a pseudo terminal, and the text that terminal showed.
+///
+/// The terminal carries standard output, standard error, and standard input of
+/// the run, and it is the controlling terminal of that run. `krt` therefore
+/// measures it, and it draws in the columns that the terminal reports.
+///
+/// A thread reads the terminal, because a read of a terminal waits for the
+/// child to write and the test has other work while it waits. Every wait of the
+/// test reads the bytes that the thread collected, under the lock.
+struct Terminal {
+    /// The hold on the terminal. The drop of it closes the terminal.
+    _master: Box<dyn MasterPty + Send>,
+    /// Every byte that the terminal showed.
+    shown: Arc<Mutex<Vec<u8>>>,
+    /// Whether the terminal closed, which is the end of the text it showed.
+    closed: Arc<AtomicBool>,
+    /// The run under the terminal.
+    child: Box<dyn Child + Send + Sync>,
+}
+
+impl Terminal {
+    /// Starts `krt` with `arguments` under a terminal of `columns` columns.
+    fn open(columns: u16, arguments: &[&str]) -> Self {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: ROWS,
+                cols: columns,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("the pseudo terminal must open");
+        let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_krt"));
+        for argument in arguments {
+            command.arg(argument);
+        }
+        // The name of the terminal reaches the child, so the run reads one
+        // terminal and not whichever one started `cargo test`.
+        command.env("TERM", "xterm-256color");
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .expect("the binary must start under the pseudo terminal");
+        // The child holds the one side of the terminal that is left. The read
+        // of the other side then ends when the run ends, and a wait for that
+        // end waits for the whole of the text.
+        drop(pair.slave);
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .expect("the pseudo terminal must answer with a reader");
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+        let filled = Arc::clone(&shown);
+        let ended = Arc::clone(&closed);
+        thread::spawn(move || {
+            let mut chunk = [0_u8; 4096];
+            // A closed terminal answers a read with no bytes, and it answers
+            // one with a fault on some platforms. Both of them are the end of
+            // the text, so both of them end this thread.
+            while let Ok(read) = reader.read(&mut chunk) {
+                if read == 0 {
+                    break;
+                }
+                filled
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .extend_from_slice(&chunk[..read]);
+            }
+            ended.store(true, Ordering::SeqCst);
+        });
+        Self {
+            _master: pair.master,
+            shown,
+            closed,
+            child,
+        }
+    }
+
+    /// The text that the terminal showed so far.
+    ///
+    /// A poisoned lock still holds bytes. The state under it is a buffer that
+    /// one thread appends to, and a panic of a test never leaves half a byte in
+    /// it.
+    fn shown(&self) -> String {
+        String::from_utf8_lossy(&self.shown.lock().unwrap_or_else(PoisonError::into_inner))
+            .into_owned()
+    }
+
+    /// The lines of the frame, from the header line to the end of the text.
+    ///
+    /// The terminal returns a carriage on each line of its own, and the live
+    /// table writes one of those itself, so each line ends with one carriage or
+    /// with two. The reader takes every carriage off the end of a line, and
+    /// what stays is the text that a reader of the terminal sees.
+    fn frame(&self) -> Vec<String> {
+        let shown = self.shown();
+        shown
+            .split('\n')
+            .skip_while(|line| !line.starts_with(FRAME_START))
+            .map(|line| line.trim_end_matches('\r').to_owned())
+            .collect()
+    }
+
+    /// Waits for the run to stop, and answers the code it stopped with.
+    ///
+    /// The wait runs on past the stop, until the terminal closes. The run
+    /// writes its closing line last of all, and a test that read the text at
+    /// the moment of the stop reads a text that misses it.
+    ///
+    /// # Panics
+    ///
+    /// Panics when [`PATIENCE`] runs out, and names the text that the terminal
+    /// showed. A run that never stops holds every commit of the repository.
+    fn wait_for_exit(&mut self) -> u32 {
+        let deadline = Instant::now() + PATIENCE;
+        loop {
+            if let Ok(Some(status)) = self.child.try_wait() {
+                while !self.closed.load(Ordering::SeqCst) && Instant::now() < deadline {
+                    thread::sleep(GLANCE);
+                }
+                return status.exit_code();
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the run must stop inside {PATIENCE:?}, and it showed {:?}",
+                self.shown()
+            );
+            thread::sleep(GLANCE);
+        }
+    }
+}
+
+impl Drop for Terminal {
+    fn drop(&mut self) {
+        // A run that the test left standing takes a probe each second for as
+        // long as the machine stands. The kill reaches the run that stopped as
+        // well, and it does nothing there.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn a_replay_under_a_terminal_draws_the_table_at_the_width_of_that_terminal() {
+    let mut terminal = Terminal::open(WIDE, &[REPLAY, FIXTURE]);
+    terminal.wait_for_exit();
+    let frame = terminal.frame();
+
+    assert!(
+        frame.iter().any(|line| line == WIDE_COLUMN_HEADER),
+        "the frame draws at the width of the terminal, and the Host column takes the columns that are left over: {frame:?}"
+    );
+    for line in &frame {
+        assert!(
+            line.chars().count() <= usize::from(WIDE),
+            "no line of the frame runs past the {WIDE} columns of the terminal: {line:?}"
+        );
+    }
+}
+
+#[test]
+fn a_replay_under_a_narrow_terminal_drops_the_columns_that_drop_first() {
+    let mut terminal = Terminal::open(NARROW, &[REPLAY, FIXTURE]);
+    terminal.wait_for_exit();
+    let frame = terminal.frame();
+    let header = frame
+        .iter()
+        .find(|line| line.starts_with(COLUMN_HEADER_START))
+        .unwrap_or_else(|| panic!("the frame must carry a column header: {frame:?}"))
+        .clone();
+
+    for gone in [RECENT_HEADING, STDEV_HEADING] {
+        assert!(
+            !header.contains(gone),
+            "a terminal of {NARROW} columns drops the {gone} column: {header:?}"
+        );
+    }
+    for stands in [TTL_HEADING, HOST_HEADING, AVG_HEADING] {
+        assert!(
+            header.contains(stands),
+            "and it keeps the {stands} column, which never drops: {header:?}"
+        );
+    }
+}

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -1,10 +1,18 @@
-//! Black-box coverage for the parts of `krt` that a pipe cannot reach.
+//! Black-box coverage for the parts of `krt` that need a real terminal, and
+//! for the parts that need the one tracer of the machine.
 //!
 //! `cargo test` hands a test binary a pipe, and three parts of `krt` answer
 //! nothing without a terminal: the width that a frame draws in, the keys that a
 //! live run reads, and the hold that a live run takes on the terminal it draws
 //! on. A pseudo terminal is a terminal, so these tests give the binary one and
 //! drive it through that.
+//!
+//! One test below gives the binary a pipe on purpose, because the answer it
+//! covers is the one a pipe produces: such a run draws no table. It stands here
+//! beside the runs of a terminal for the other reason of this file. Every live
+//! run takes the one tracer of the machine, and every test of a live run holds
+//! the lock of that tracer while it does. A second lock in a second file locks
+//! nothing, so a live run belongs here whatever its standard output is.
 //!
 //! Every pseudo terminal below carries a size. A pseudo terminal that nobody
 //! sized answers the `TIOCGWINSZ` ioctl with zero columns, and that ioctl
@@ -154,6 +162,37 @@ const FLAG_OUTPUT: &str = "--output";
 #[cfg(target_os = "macos")]
 const FLAG_INTERVAL: &str = "--interval";
 
+/// The flag that names the number of rounds which stops a run.
+#[cfg(target_os = "macos")]
+const FLAG_ROUNDS: &str = "--rounds";
+
+/// The flag that names the last TTL that a round probes.
+#[cfg(target_os = "macos")]
+const FLAG_MAX_TTL: &str = "--max-ttl";
+
+/// The flag that asks for the status lines in the place of the table.
+#[cfg(target_os = "macos")]
+const FLAG_HEADLESS: &str = "--headless";
+
+/// The number one, as a limit of rounds and as a limit of TTLs.
+#[cfg(target_os = "macos")]
+const ONE: &str = "1";
+
+/// The flags of a run that records one round of one TTL and then stops.
+///
+/// The round limit is what stops such a run, and it is what bounds the wait of
+/// each test that takes these flags. One of those waits carries no deadline of
+/// its own, so a reader who takes the round limit away leaves a test that holds
+/// every commit of the repository.
+///
+/// The TTL limit is what makes the status line of that round read the same in
+/// each run. The tracer holds more than one TTL in the air at a time, and the
+/// loopback answers every one of them, so a round of the whole range reports
+/// one hop in one run and two hops in the next. A round of one TTL reports one
+/// hop always.
+#[cfg(target_os = "macos")]
+const ONE_ROUND_OF_ONE_TTL: [&str; 4] = [FLAG_ROUNDS, ONE, FLAG_MAX_TTL, ONE];
+
 /// The period of one round of a run whose first round no test waits for.
 ///
 /// `src/krt/src/trace.rs` hands this period to the tracer as the shortest round
@@ -223,6 +262,25 @@ const REASON_FIELD: &str = "reason";
 /// The reason of a run that the user stopped.
 #[cfg(target_os = "macos")]
 const QUIT_REASON: &str = "quit";
+
+/// The reason of a run that the round limit stopped.
+#[cfg(target_os = "macos")]
+const ROUNDS_REASON: &str = "rounds";
+
+/// The start of the status line of the first round of a run of the loopback.
+///
+/// The line names the round, the number of the TTLs that answered, whether the
+/// round reached the target, and the time that round took. A probe of the
+/// loopback answers at the first TTL and reaches the target, so the first three
+/// fields of the line stand as this text spells them. The time is different in
+/// each run, so the text stops in front of it.
+///
+/// The test spells the line, and `src/krt/src/live.rs` builds it out of the
+/// fields of the round. That is on purpose: this line is the whole picture that
+/// a run without a table gives of one round, and it is what a reader of such a
+/// run sees.
+#[cfg(target_os = "macos")]
+const STATUS_LINE_START: &str = "round 1  1 hop  reached  ";
 
 /// One run of `krt` under a pseudo terminal, and the text that terminal showed.
 ///
@@ -665,46 +723,74 @@ struct LiveRun {
     _lock: TracerLock,
 }
 
-/// Starts a live run of the loopback under a terminal of [`WIDE`] columns, and
-/// waits until the table draws its first frame.
-///
-/// The run stays offline for the reason that the file documentation states: the
-/// destination is the loopback, [`FLAG_SOURCE`] names the loopback, and
-/// [`FLAG_NO_DNS`] looks nothing up.
-#[cfg(target_os = "macos")]
-fn live_run(recording: &Recording) -> LiveRun {
-    live_run_with(recording, &[])
-}
-
-/// Starts such a run with `flags` behind the flags that every live run of this
-/// file takes, and waits until the table draws its first frame.
+/// The command line of a live run of the loopback, with `flags` behind the
+/// flags that every live run of this file takes.
 ///
 /// A test that needs one more flag names that flag alone. The flags of the run
 /// which keep it offline stand here, in one place, so no test of this file can
-/// start a run that reaches the network.
+/// start a run that reaches the network. The run stays offline for the reason
+/// that the file documentation states: the destination is the loopback,
+/// [`FLAG_SOURCE`] names the loopback, and [`FLAG_NO_DNS`] looks nothing up.
 #[cfg(target_os = "macos")]
-fn live_run_with(recording: &Recording, flags: &[&str]) -> LiveRun {
-    let lock = TracerLock::take();
-    let output = recording.argument();
+fn live_arguments<'a>(output: &'a str, flags: &[&'a str]) -> Vec<&'a str> {
     let mut arguments = vec![
         LOOPBACK,
         FLAG_SOURCE,
         LOOPBACK,
         FLAG_NO_DNS,
         FLAG_OUTPUT,
-        &output,
+        output,
     ];
     arguments.extend_from_slice(flags);
-    let terminal = Terminal::open(WIDE, &arguments);
+    arguments
+}
+
+/// Starts a live run of the loopback under a terminal of [`WIDE`] columns, and
+/// waits until the table draws its first frame.
+#[cfg(target_os = "macos")]
+fn live_run(recording: &Recording) -> LiveRun {
+    live_run_with(recording, &[])
+}
+
+/// Starts such a run with `flags`, and waits until the table draws its first
+/// frame.
+#[cfg(target_os = "macos")]
+fn live_run_with(recording: &Recording, flags: &[&str]) -> LiveRun {
+    let run = live_run_under(recording, flags);
     // The table draws its first frame at the moment the run takes the
     // terminal, so a frame on the screen says that raw mode stands. A key that
     // arrived in front of raw mode reaches the line discipline and not the run,
     // so every test below presses its key after this wait.
-    terminal.wait_for(COLUMN_HEADER_START);
+    run.terminal.wait_for(COLUMN_HEADER_START);
+    run
+}
+
+/// Starts such a run with `flags`, and waits for nothing.
+///
+/// A run that draws no table shows no frame, so a test of that run waits for a
+/// text of its own. Every other caller takes [`live_run_with`], which waits for
+/// the first frame of the table.
+#[cfg(target_os = "macos")]
+fn live_run_under(recording: &Recording, flags: &[&str]) -> LiveRun {
+    let lock = TracerLock::take();
+    let output = recording.argument();
+    let terminal = Terminal::open(WIDE, &live_arguments(&output, flags));
     LiveRun {
         terminal,
         _lock: lock,
     }
+}
+
+/// The number of status lines that `text` holds.
+///
+/// A terminal returns a carriage at the end of each line it shows, and a pipe
+/// returns none, so the reader takes every carriage off the end of a line. What
+/// stays is the line that a reader of either one sees.
+#[cfg(target_os = "macos")]
+fn status_lines(text: &str) -> usize {
+    text.split('\n')
+        .filter(|line| line.trim_end_matches('\r').starts_with(STATUS_LINE_START))
+        .count()
 }
 
 /// Asserts that a live run which one key stopped exits with success and closes
@@ -840,4 +926,95 @@ fn a_live_run_draws_its_table_in_front_of_the_first_round() {
         "and the key of the reader stops the run, so the test leaves no tracer behind: {:?}",
         run.terminal.shown()
     );
+}
+
+/// A live run whose standard output is a pipe draws no table.
+///
+/// This is the one test of this file that gives the binary a pipe. The run has
+/// no terminal to hold, no key to read, and no screen to clear, so it writes
+/// one status line for the round it made and nothing else. A table there would
+/// write a whole frame of control sequences into the file of the reader for
+/// each round, and the alternate screen is the first of those sequences.
+///
+/// The recorded file carries the other half of the answer. Standard output says
+/// what the reader of a pipe sees, and the reason in that file says how the run
+/// stopped: the round limit stopped it, and no fault did.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_live_run_whose_standard_output_is_a_pipe_draws_no_table() {
+    let recording = Recording::at("krt-terminal-piped");
+    // The lock stands under the recording, so the drop of the lock comes first
+    // and the removal of the file comes after it. That is the order of every
+    // other live test of this file.
+    let _lock = TracerLock::take();
+    let output = recording.argument();
+    // `wait_with_output` waits with no deadline, and the round limit of
+    // [`ONE_ROUND_OF_ONE_TTL`] is what bounds it: the run stops on its own.
+    let finished = process::Command::new(env!("CARGO_BIN_EXE_krt"))
+        .args(live_arguments(&output, &ONE_ROUND_OF_ONE_TTL))
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()
+        .expect("the binary must start with its standard output on a pipe")
+        .wait_with_output()
+        .expect("the run must answer with the text it wrote");
+    let shown = String::from_utf8_lossy(&finished.stdout).into_owned();
+
+    assert!(
+        finished.status.success(),
+        "the round limit stops the run, and it showed {shown:?}"
+    );
+    assert_eq!(
+        status_lines(&shown),
+        1,
+        "the run writes one status line for the one round it made: {shown:?}"
+    );
+    for sequence in [ENTER_ALTERNATE_SCREEN, LEAVE_ALTERNATE_SCREEN] {
+        assert!(
+            !shown.contains(sequence),
+            "and it writes no control sequence of the alternate screen into a pipe: {shown:?}"
+        );
+    }
+    assert_eq!(
+        recording.end_reason().as_deref(),
+        Some(ROUNDS_REASON),
+        "the recorded file closes with the reason of the round limit, and the run showed {shown:?}"
+    );
+}
+
+/// The `--headless` flag draws no table under a terminal either.
+///
+/// The terminal of this run is a real one, so the flag is the only thing that
+/// keeps the table away. That is what makes this a test of the flag: a run
+/// which read the terminal alone would draw its table here, and the reader who
+/// asked for the status lines would get a screen that clears itself instead.
+#[cfg(target_os = "macos")]
+#[test]
+fn the_headless_flag_draws_no_table_under_a_terminal() {
+    let recording = Recording::at("krt-terminal-headless");
+    // The test presses no key, so the round limit of [`ONE_ROUND_OF_ONE_TTL`]
+    // is what stops this run.
+    let mut flags = ONE_ROUND_OF_ONE_TTL.to_vec();
+    flags.push(FLAG_HEADLESS);
+    let mut run = live_run_under(&recording, &flags);
+
+    let code = run.terminal.wait_for_exit();
+    let shown = run.terminal.shown();
+
+    assert_eq!(
+        code, EXIT_SUCCESS,
+        "the round limit stops the run, and it showed {shown:?}"
+    );
+    assert_eq!(
+        status_lines(&shown),
+        1,
+        "the run writes one status line for the one round it made: {shown:?}"
+    );
+    for sequence in [ENTER_ALTERNATE_SCREEN, LEAVE_ALTERNATE_SCREEN] {
+        assert!(
+            !shown.contains(sequence),
+            "and the flag keeps it off the alternate screen of the terminal it holds: {shown:?}"
+        );
+    }
 }

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -526,20 +526,30 @@ const TRACER_LOCK: &str = "krt-live-tracer.lock";
 
 /// The longest that a wait for the tracer of the machine runs.
 ///
-/// One holder takes a few seconds, and [`PATIENCE`] bounds the longest one. Two
-/// test binaries of three live runs each therefore take well under this bound,
-/// and a wait that reaches it says that something outside these tests holds the
-/// lock.
+/// One holder takes a few seconds. A live test carries two waits of
+/// [`PATIENCE`], one for the first frame and one for the stop, so twice
+/// PATIENCE bounds a holder that passes. Two test binaries of four live runs
+/// each therefore take well under this bound, and a wait that reaches it says
+/// that something outside these tests holds the lock.
+///
+/// The bound is more than twice [`STALE_LOCK`], so a waiter that pays the whole
+/// wait for a stale file keeps most of its patience for the lock it then takes.
 #[cfg(target_os = "macos")]
-const LOCK_PATIENCE: Duration = Duration::from_mins(2);
+const LOCK_PATIENCE: Duration = Duration::from_mins(4);
 
 /// The age at which a lock file belongs to a run that is no longer there.
 ///
 /// A holder gives the lock back at the end of its test, and the panic of a test
 /// gives it back too. A file that a killed process left behind never comes
 /// back, so a file older than any holder ever lives is a file to take over.
+///
+/// Ninety seconds is three times [`PATIENCE`], and twice PATIENCE bounds the
+/// longest holder that passes, so no live test takes the lock of another one.
+/// The age also stands well inside [`LOCK_PATIENCE`]: a waiter pays this
+/// age at the most for the file of a killed run, and the rest of its patience
+/// then holds the lock that it took.
 #[cfg(target_os = "macos")]
-const STALE_LOCK: Duration = Duration::from_mins(2);
+const STALE_LOCK: Duration = Duration::from_secs(90);
 
 /// The hold of one test on the tracer of the machine.
 ///

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -150,6 +150,33 @@ const FLAG_NO_DNS: &str = "--no-dns";
 #[cfg(target_os = "macos")]
 const FLAG_OUTPUT: &str = "--output";
 
+/// The flag that names the period of one round.
+#[cfg(target_os = "macos")]
+const FLAG_INTERVAL: &str = "--interval";
+
+/// The period of one round of a run whose first round no test waits for.
+///
+/// `src/krt/src/trace.rs` hands this period to the tracer as the shortest round
+/// and as the longest one, so the first round of such a run lands two minutes
+/// after the start. That is four times [`PATIENCE`], so every frame that a test
+/// of this period reads is a frame that stands in front of the first round.
+#[cfg(target_os = "macos")]
+const A_LONG_INTERVAL: &str = "2m";
+
+/// The start of the header line of a live table that folded no round.
+///
+/// The line names the destination, the address it resolved to, the source, the
+/// count of the rounds, and the period of one round. The name of the recorded
+/// file ends it, and each run of a test names a file of its own, so the text
+/// holds the start of the line and not the whole of it.
+///
+/// The test spells the line, and the table builds it out of the fields it
+/// holds. That is on purpose: `round 0` is what says that the frame stands in
+/// front of the first round of the run, and this line is what a reader of the
+/// terminal sees.
+#[cfg(target_os = "macos")]
+const NO_ROUND_HEADER: &str = " krt  127.0.0.1 → 127.0.0.1   src 127.0.0.1   round 0   2m   ";
+
 /// The byte that a terminal sends for Ctrl-C.
 ///
 /// Raw mode clears `ISIG`, so this byte reaches the process as a key press and
@@ -613,19 +640,29 @@ struct LiveRun {
 /// [`FLAG_NO_DNS`] looks nothing up.
 #[cfg(target_os = "macos")]
 fn live_run(recording: &Recording) -> LiveRun {
+    live_run_with(recording, &[])
+}
+
+/// Starts such a run with `flags` behind the flags that every live run of this
+/// file takes, and waits until the table draws its first frame.
+///
+/// A test that needs one more flag names that flag alone. The flags of the run
+/// which keep it offline stand here, in one place, so no test of this file can
+/// start a run that reaches the network.
+#[cfg(target_os = "macos")]
+fn live_run_with(recording: &Recording, flags: &[&str]) -> LiveRun {
     let lock = TracerLock::take();
     let output = recording.argument();
-    let terminal = Terminal::open(
-        WIDE,
-        &[
-            LOOPBACK,
-            FLAG_SOURCE,
-            LOOPBACK,
-            FLAG_NO_DNS,
-            FLAG_OUTPUT,
-            &output,
-        ],
-    );
+    let mut arguments = vec![
+        LOOPBACK,
+        FLAG_SOURCE,
+        LOOPBACK,
+        FLAG_NO_DNS,
+        FLAG_OUTPUT,
+        &output,
+    ];
+    arguments.extend_from_slice(flags);
+    let terminal = Terminal::open(WIDE, &arguments);
     // The table draws its first frame at the first round. A key that arrived in
     // front of the terminal going into raw mode reaches the line discipline and
     // not the run, so every test below presses its key after this wait.
@@ -737,5 +774,36 @@ fn a_live_run_gives_the_terminal_back_when_it_stops() {
     assert!(
         cursor < closing,
         "and the cursor stands again in front of that line: {shown:?}"
+    );
+}
+
+/// A live run draws its table when it takes the terminal, in front of the first
+/// round of that run.
+///
+/// The period of the run is what makes this a test. A run of
+/// [`A_LONG_INTERVAL`] takes its first round two minutes after the start, which
+/// is four times [`PATIENCE`], so the frame that this test reads is a frame
+/// that no round drew. A table that drew at the first round alone leaves the
+/// reader in front of an empty alternate screen for those two minutes, and that
+/// screen hides the lines which the run printed in front of it, so nothing at
+/// all says that the run started.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_live_run_draws_its_table_in_front_of_the_first_round() {
+    let recording = Recording::at("krt-terminal-opening-frame");
+    let mut run = live_run_with(&recording, &[FLAG_INTERVAL, A_LONG_INTERVAL]);
+    let shown = run.terminal.shown();
+
+    assert!(
+        shown.contains(NO_ROUND_HEADER),
+        "the header line of that frame names the run and the round it stands in front of: {shown:?}"
+    );
+
+    run.terminal.press(Q);
+    assert_eq!(
+        run.terminal.wait_for_exit(),
+        EXIT_SUCCESS,
+        "and the key of the reader stops the run, so the test leaves no tracer behind: {:?}",
+        run.terminal.shown()
     );
 }

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -76,10 +76,10 @@ const NARROW: u16 = 60;
 
 /// The longest that any wait below runs.
 ///
-/// A run of the loopback takes one round each second, and the first frame draws
-/// at the first round. Thirty seconds is far longer than that, and it is short
-/// enough that a run which stopped drawing fails the suite in the place of
-/// holding it.
+/// A run draws its first frame at the moment it takes the terminal, and a run
+/// of the loopback takes one round each second after that. Thirty seconds is
+/// far longer than either of them, and it is short enough that a run which
+/// stopped drawing fails the suite in the place of holding it.
 const PATIENCE: Duration = Duration::from_secs(30);
 
 /// The time between two reads of the state that a wait waits for.
@@ -663,9 +663,10 @@ fn live_run_with(recording: &Recording, flags: &[&str]) -> LiveRun {
     ];
     arguments.extend_from_slice(flags);
     let terminal = Terminal::open(WIDE, &arguments);
-    // The table draws its first frame at the first round. A key that arrived in
-    // front of the terminal going into raw mode reaches the line discipline and
-    // not the run, so every test below presses its key after this wait.
+    // The table draws its first frame at the moment the run takes the
+    // terminal, so a frame on the screen says that raw mode stands. A key that
+    // arrived in front of raw mode reaches the line discipline and not the run,
+    // so every test below presses its key after this wait.
     terminal.wait_for(COLUMN_HEADER_START);
     LiveRun {
         terminal,


### PR DESCRIPTION
## What this does

This branch joins the parts of `krt` into a live run. A run folds each round as
it arrives, draws the live table, and reads the keyboard. The per-round status
line moves to `--headless`, which prints one line for each minute of a run.

Closes #372.

## The keys of the live table

| Key | Action |
| --- | ------ |
| `q`, `Ctrl-C` | Write the `end` record, flush the file, give the terminal back, exit 0. |
| `p` | Hold the display. The recording continues. |
| `n` | Swap a name for the address of it, and back. |
| `r` | Empty the aggregates. The file stays as it is. |
| `?` | Show the list of the keys under the table. |

The pause key holds the display and never the recording. The reset key empties
the aggregates and never the file. The recording is the purpose of the tool, so
both facts hold.

## The terminal

A guard holds the terminal of a live run and gives it back. A normal exit, an
error exit, and a panic thus take the same path. A panic hook gives the terminal
back before the message prints, and that hook chains to the hook that stood
before the run. The run puts the earlier hook back when it ends, so a later
panic in the same process reaches the hook the process installed.

A run asks the terminal for the screen it draws on. A run that holds no terminal
gets the headless screen, and a run under a terminal gets the live table.

## Tests

Each commit pair is a red test and the code that makes it green. Two tests draw
through a real pty at the width of a real terminal, because `script -q /dev/null`
alone gives a pty of no size.

## Documentation

`README.md` and `TLDR.md` both name the live table and its keys. The help of a
run names the live table too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
