### PR TITLE
fix(krt): a run reads only the answers of its own probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,14 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
   - macOS sends the probes without privileges. Linux needs `CAP_NET_RAW`, and Windows needs an
     elevated prompt. A platform that needs privileges and does not hold them prints the remedy and
     stops, and `krt` never falls back to a degraded trace without saying so.
+  - Two runs of one machine each record the path that it probed. macOS hands the ICMP answers of
+    one process to the socket of every other process that reads that protocol, so each run there
+    reads every answer the machine took. Each run therefore marks its own probes and drops every
+    answer that carries another mark. An ICMP probe carries the identifier of the process that sent
+    it. A UDP probe leaves from a source port of that process, of the range 33535 through 49151,
+    which stands above the destination ports a traceroute probes and under the ports that the
+    machine hands out on its own. A TCP probe varies its source port already. So a second `krt` in
+    a second window costs the first one nothing, and neither of the two records a hop of the other.
   - `krt` takes its tracer from [`trippy-core`](https://trippy.rs) and its resolver from
     [`trippy-dns`](https://trippy.rs), and both of them are Apache-2.0. This repository is MIT.
     Apache-2.0 is permissive, and it imposes no copyleft on a binary that links it, so the two

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -1177,6 +1177,13 @@ this platform needs raw socket privileges to send probes.
     /// own. A traceroute probes it first, as a destination.
     const THE_CLASSIC_SOURCE_PORT: u16 = 33_434;
 
+    /// The last destination port that a traceroute probes.
+    ///
+    /// The range that starts at [`THE_CLASSIC_SOURCE_PORT`] and ends here is
+    /// the range a firewall reads as a traceroute, and the source port of `krt`
+    /// stands above all of it.
+    const THE_LAST_TRACEROUTE_PORT: u16 = 33_534;
+
     /// The destination port that a TCP trace holds while the source port
     /// varies. It is the port of HTTP.
     const TCP_DESTINATION_PORT: u16 = 80;
@@ -1435,21 +1442,24 @@ this platform needs raw socket privileges to send probes.
         }
     }
 
-    /// No process identifier maps onto the port that a traceroute probes first.
+    /// No process identifier maps onto a port that a traceroute probes.
     ///
-    /// That port is the one every UDP run of `krt` held before this fold, and
-    /// it is the one that `a_live_udp_run_stands_while_another_program_holds_
-    /// the_port_of_a_traceroute` holds while it measures. The walk covers the
-    /// whole range of the fold and one value past it, so it reaches every port
-    /// the function can give.
+    /// A traceroute probes the destination ports [`THE_CLASSIC_SOURCE_PORT`]
+    /// through [`THE_LAST_TRACEROUTE_PORT`], and a source port of `krt` never
+    /// wears one of those numbers. A firewall that reads a probe of `krt` thus
+    /// never reads it as a traceroute. The first of the two is the port every
+    /// UDP run of `krt` held before this fold. The live test of a held port
+    /// holds that port while it measures, and `src/krt/tests/terminal.rs` holds
+    /// that test. The walk covers the whole range of the fold and one value
+    /// past it, so it reaches every port the function can give.
     #[test]
-    fn no_process_identifier_maps_onto_the_port_that_a_traceroute_probes_first() {
+    fn no_process_identifier_maps_onto_a_port_that_a_traceroute_probes() {
         let ports = u32::from(UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) + 1;
         for process in 0..=ports {
-            assert_ne!(
-                udp_source_port(process),
-                THE_CLASSIC_SOURCE_PORT,
-                "process {process}"
+            let port = udp_source_port(process);
+            assert!(
+                !(THE_CLASSIC_SOURCE_PORT..=THE_LAST_TRACEROUTE_PORT).contains(&port),
+                "process {process} takes port {port}, which a traceroute probes"
             );
         }
     }

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -13,6 +13,15 @@
 //! that needs them and holds none stops, and the message names the remedy of
 //! each platform.
 //!
+//! Every probe of a run carries a mark of the process that sent it, and a run
+//! drops every answer that carries another mark. macOS hands the ICMP answers
+//! of one process to the socket of every other process that reads that
+//! protocol, so a run there reads every answer the machine took, and a run
+//! without a mark records the path of another run. [`probe_identifier`] gives
+//! the mark of an ICMP probe, and [`udp_source_port`] gives the mark of a UDP
+//! probe. A TCP probe varies its source port already, and the tracer takes the
+//! next one when a port is in use.
+//!
 //! The interface of the wall is one type and three functions. [`TraceConfig`]
 //! states one run in the words that `krt` owns, and [`spawn`] starts the
 //! tracer of that run and gives back a receiver of completed rounds.

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -150,7 +150,7 @@ const UDP_SOURCE_PORTS: u32 = (UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) as 
 /// A port of the range that another program already holds stops the run, as the
 /// one fixed port of every run did before. The next run holds another process
 /// identifier and takes another port.
-fn udp_source_port(process: u32) -> u16 {
+const fn udp_source_port(process: u32) -> u16 {
     // The remainder stands below `UDP_SOURCE_PORTS`, which is far inside the
     // range of a `u16`, so the conversion of it takes nothing away.
     let offset = (process % UDP_SOURCE_PORTS) as u16;

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -105,11 +105,48 @@ pub(crate) enum PrivilegeError {
     },
 }
 
-/// The source port that a UDP trace holds while the destination port varies.
+/// The first source port that a UDP trace of `krt` takes.
 ///
 /// A fixed source port to a varying destination port is the direction of a UDP
-/// trace, and 33434 is the first port of the range that traceroute probes.
-const UDP_SOURCE_PORT: u16 = 33_434;
+/// trace. A traceroute probes the destination ports 33434 through 33534, so the
+/// source port of `krt` starts one above that range and never wears the number
+/// of a destination that a firewall reads as a traceroute.
+const UDP_FIRST_SOURCE_PORT: u16 = 33_535;
+
+/// The last source port that a UDP trace of `krt` takes.
+///
+/// 49151 is the last registered port. Above it stands the range that macOS
+/// hands to a socket which asks for any port, so a source port of that higher
+/// range would stand where an outgoing connection of any program can already
+/// be.
+const UDP_LAST_SOURCE_PORT: u16 = 49_151;
+
+/// The number of source ports that a UDP trace of `krt` chooses from.
+const UDP_SOURCE_PORTS: u32 = (UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) as u32 + 1;
+
+/// The source port that a UDP trace of one process holds.
+///
+/// The port is what tells two UDP runs of one machine apart, and it does so
+/// twice over. The unprivileged path of macOS binds the source port for each
+/// probe it sends, so two runs of one port cannot both send, and the tracer of
+/// the second one stops on the port it cannot take. The answers carry the port
+/// too: the tracer drops an answer whose original datagram left from another
+/// port.
+///
+/// The process identifier is the source, for the reason that
+/// [`probe_identifier`] states. The fold maps no two process identifiers of one
+/// window of [`UDP_SOURCE_PORTS`] onto one port, so two runs that a user starts
+/// one after the other take two ports.
+///
+/// A port of the range that another program already holds stops the run, as the
+/// one fixed port of every run did before. The next run holds another process
+/// identifier and takes another port.
+fn udp_source_port(process: u32) -> u16 {
+    // The remainder stands below `UDP_SOURCE_PORTS`, which is far inside the
+    // range of a `u16`, so the conversion of it takes nothing away.
+    let offset = (process % UDP_SOURCE_PORTS) as u16;
+    UDP_FIRST_SOURCE_PORT + offset
+}
 
 /// The destination port that a TCP trace holds while the source port varies.
 ///
@@ -239,9 +276,9 @@ fn tracer_of(config: &TraceConfig) -> Result<trippy_core::Tracer, TraceError> {
         // run start.
         .port_direction(match config.protocol {
             crate::Protocol::Icmp => trippy_core::PortDirection::None,
-            crate::Protocol::Udp => {
-                trippy_core::PortDirection::FixedSrc(trippy_core::Port(UDP_SOURCE_PORT))
-            }
+            crate::Protocol::Udp => trippy_core::PortDirection::FixedSrc(trippy_core::Port(
+                udp_source_port(std::process::id()),
+            )),
             crate::Protocol::Tcp => {
                 trippy_core::PortDirection::FixedDest(trippy_core::Port(TCP_DESTINATION_PORT))
             }
@@ -599,7 +636,7 @@ fn to_lookup(entry: &DnsEntry) -> Lookup {
 mod tests {
     use super::{
         choose_privilege, icmp_kind, next_seq, probe_identifier, to_lookup, to_round_record,
-        tracer_of, IcmpKind, PrivilegeError, TraceConfig, TraceError,
+        tracer_of, udp_source_port, IcmpKind, PrivilegeError, TraceConfig, TraceError,
     };
     use crate::names::Lookup;
     use crate::record::{Privilege, Record, RoundRecord, RunId};
@@ -1119,9 +1156,17 @@ this platform needs raw socket privileges to send probes.
     /// The last TTL that a test run probes.
     const A_MAX_TTL: u8 = 20;
 
-    /// The source port that a UDP trace holds while the destination port
-    /// varies. It is the first port of the range that traceroute probes.
-    const UDP_SOURCE_PORT: u16 = 33_434;
+    /// The first source port that a UDP trace of `krt` takes. It stands one
+    /// above the last destination port that a traceroute probes.
+    const UDP_FIRST_SOURCE_PORT: u16 = 33_535;
+
+    /// The last source port that a UDP trace of `krt` takes. It is the last
+    /// registered port, under the range that macOS hands out on its own.
+    const UDP_LAST_SOURCE_PORT: u16 = 49_151;
+
+    /// The port that every UDP trace of `krt` held before it held one of its
+    /// own. A traceroute probes it first, as a destination.
+    const THE_CLASSIC_SOURCE_PORT: u16 = 33_434;
 
     /// The destination port that a TCP trace holds while the source port
     /// varies. It is the port of HTTP.
@@ -1350,11 +1395,67 @@ this platform needs raw socket privileges to send probes.
     /// `Builder::build` refuses a UDP trace whose port direction is `None`,
     /// and `None` is the direction that the builder holds by default, so this
     /// run reaches a tracer only because the mapping names a direction.
+    ///
+    /// The port is the one of this process. Two UDP runs of one machine that
+    /// held one port could not both send, because the unprivileged path of
+    /// macOS binds the source port for each probe.
     #[test]
-    fn a_udp_trace_fixes_the_source_port() {
+    fn a_udp_trace_fixes_the_source_port_of_its_process() {
         assert_eq!(
             tracer_of_protocol(Protocol::Udp).port_direction(),
-            trippy_core::PortDirection::FixedSrc(Port(UDP_SOURCE_PORT))
+            trippy_core::PortDirection::FixedSrc(Port(udp_source_port(process::id())))
+        );
+    }
+
+    /// A process identifier of every shape maps onto a source port of the
+    /// range.
+    ///
+    /// The rows walk the fold onto its edges: the first process, the last port
+    /// of the range, and the value that wraps back onto the first port. The
+    /// last row is a process identifier of the size that macOS hands out.
+    #[test]
+    fn every_process_identifier_maps_onto_a_source_port_of_the_range() {
+        let ports = u32::from(UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) + 1;
+        for (process, expected) in [
+            (0_u32, UDP_FIRST_SOURCE_PORT),
+            (ports - 1, UDP_LAST_SOURCE_PORT),
+            (ports, UDP_FIRST_SOURCE_PORT),
+            (42_659, 44_960),
+        ] {
+            assert_eq!(udp_source_port(process), expected, "process {process}");
+        }
+    }
+
+    /// No process identifier maps onto the port that a traceroute probes first.
+    ///
+    /// That port is the one every UDP run of `krt` held before this fold, and
+    /// it is the one that `a_live_udp_run_stands_while_another_program_holds_
+    /// the_port_of_a_traceroute` holds while it measures. The walk covers the
+    /// whole range of the fold and one value past it, so it reaches every port
+    /// the function can give.
+    #[test]
+    fn no_process_identifier_maps_onto_the_port_that_a_traceroute_probes_first() {
+        let ports = u32::from(UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) + 1;
+        for process in 0..=ports {
+            assert_ne!(
+                udp_source_port(process),
+                THE_CLASSIC_SOURCE_PORT,
+                "process {process}"
+            );
+        }
+    }
+
+    /// Two processes of one window of the fold hold two source ports.
+    ///
+    /// This is the property that lets two UDP runs of one machine both send.
+    #[test]
+    fn two_processes_of_one_window_hold_two_source_ports() {
+        let ports = u32::from(UDP_LAST_SOURCE_PORT - UDP_FIRST_SOURCE_PORT) + 1;
+        let taken: std::collections::HashSet<u16> = (0..ports).map(udp_source_port).collect();
+        assert_eq!(
+            taken.len(),
+            ports as usize,
+            "the fold maps two processes of one window onto one port"
         );
     }
 

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -1120,6 +1120,33 @@ this platform needs raw socket privileges to send probes.
         })
     }
 
+    /// The identifier that the tracer reads as the answer of any run.
+    ///
+    /// `trippy` takes an answer whose identifier is this one, whatever run sent
+    /// the probe. That is the answer of a UDP trace and of a TCP trace, which
+    /// carry no identifier and which the ports tell apart. An ICMP trace of
+    /// this identifier therefore takes the answers of every other ICMP trace of
+    /// the machine.
+    const ANY_RUN: TraceId = TraceId(0);
+
+    /// The probes of a run carry an identifier that no other run reads.
+    ///
+    /// macOS hands the ICMP answers of one process to the socket of every other
+    /// process that reads that protocol, so a tracer reads the answer of a probe
+    /// that another tracer sent. The identifier of the probe is what tells the
+    /// two apart: `trippy` drops an answer whose identifier is neither
+    /// [`ANY_RUN`] nor the one that the run holds. A run that names no
+    /// identifier holds [`ANY_RUN`], and two such runs of one machine read each
+    /// other.
+    #[test]
+    fn the_probes_of_a_run_carry_an_identifier_of_their_own() {
+        let identifier = tracer_from(&a_config()).trace_identifier();
+        assert_ne!(
+            identifier, ANY_RUN,
+            "a run of this identifier reads the answers of every other run of the machine"
+        );
+    }
+
     #[test]
     fn the_target_of_the_configuration_reaches_the_tracer() {
         assert_eq!(

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -1506,7 +1506,7 @@ this platform needs raw socket privileges to send probes.
 
         assert_eq!(
             tracer_of_protocol(Protocol::Udp).port_direction(),
-            trippy_core::PortDirection::FixedSrc(Port(UDP_SOURCE_PORT)),
+            trippy_core::PortDirection::FixedSrc(Port(udp_source_port(process::id()))),
             "the free destination port of a UDP run carries the number of the round, and that is what makes `one flow for each round` true. A direction that held both ports would hold one flow for the whole run, and the help of `paris` and of `dublin` would then be false"
         );
 

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -120,6 +120,44 @@ const TCP_DESTINATION_PORT: u16 = 80;
 /// The number of the first round of a run. The schema counts from one.
 const FIRST_ROUND: u64 = 1;
 
+/// The number of identifiers that a probe of `krt` can carry.
+///
+/// The field is 16 bits wide, and zero is not one of the values that `krt`
+/// takes: the tracer reads a zero identifier as the answer of any run. The
+/// range is therefore 1 through 65535, which is 65535 values.
+const PROBE_IDENTIFIERS: u32 = u16::MAX as u32;
+
+/// The identifier that the probes of one process carry.
+///
+/// macOS hands the ICMP answers of one process to the socket of every other
+/// process that reads that protocol, so a tracer there reads the answer of a
+/// probe that another tracer sent. The identifier is what tells the two apart.
+/// The tracer drops an answer whose identifier is neither zero nor the one that
+/// the run holds, so a run of an identifier of its own reads its own answers
+/// and no other run's.
+///
+/// Zero is the one value that the answer must never take. The tracer reads a
+/// zero as the answer of any run, which is what a UDP trace and a TCP trace
+/// need, because those two carry no identifier and the ports tell them apart. A
+/// run of `krt` that held zero would read every ICMP answer of the machine, and
+/// that is the defect this function exists to close.
+///
+/// The process identifier is the source, because two processes that stand at
+/// one moment hold two of them. The fold keeps the answer inside the range and
+/// away from zero, and it maps no two process identifiers of one window of
+/// 65535 onto one value. Two runs that a user starts one after the other hold
+/// two process identifiers a few apart, so they never land on one value. Two
+/// runs whose process identifiers differ by exactly 65535 do land on one, and
+/// those two read each other as they did before this fold.
+const fn probe_identifier(process: u32) -> u16 {
+    // The remainder stands in 0 through 65534, which is inside the range of a
+    // `u16`, so the conversion of it takes nothing away, and clippy reads the
+    // remainder and raises no truncation of its own. The one that the sum adds
+    // then puts the answer in 1 through 65535.
+    let folded = (process % PROBE_IDENTIFIERS) as u16;
+    folded + 1
+}
+
 /// The configuration of one tracing run, in the words that `krt` owns.
 ///
 /// No field holds a type of a trippy crate, so a caller states a whole run
@@ -173,6 +211,9 @@ pub(crate) enum TraceError {
 /// Returns [`TraceError::Build`] when the tracer refuses the configuration.
 fn tracer_of(config: &TraceConfig) -> Result<trippy_core::Tracer, TraceError> {
     trippy_core::Builder::new(config.target)
+        // The identifier of the process, so the run reads the answers of its
+        // own probes and no other run's. [`probe_identifier`] states why.
+        .trace_identifier(probe_identifier(std::process::id()))
         .min_round_duration(config.interval)
         .max_round_duration(config.interval)
         .first_ttl(config.first_ttl)
@@ -557,14 +598,15 @@ fn to_lookup(entry: &DnsEntry) -> Lookup {
 #[cfg(test)]
 mod tests {
     use super::{
-        choose_privilege, icmp_kind, next_seq, to_lookup, to_round_record, tracer_of, IcmpKind,
-        PrivilegeError, TraceConfig, TraceError,
+        choose_privilege, icmp_kind, next_seq, probe_identifier, to_lookup, to_round_record,
+        tracer_of, IcmpKind, PrivilegeError, TraceConfig, TraceError,
     };
     use crate::names::Lookup;
     use crate::record::{Privilege, Record, RoundRecord, RunId};
     use crate::testing::address;
     use crate::{Multipath, Protocol, PROGRAM};
     use chrono::{DateTime, Utc};
+    use std::process;
     use std::sync::atomic::AtomicU64;
     use std::time::{Duration, SystemTime};
     use trippy_core::{
@@ -1144,6 +1186,70 @@ this platform needs raw socket privileges to send probes.
         assert_ne!(
             identifier, ANY_RUN,
             "a run of this identifier reads the answers of every other run of the machine"
+        );
+    }
+
+    /// That identifier is the one of this process. Two tracers of one process
+    /// therefore hold one identifier, and the answers of a run reach the tracer
+    /// of that run whichever of them read the socket.
+    #[test]
+    fn the_identifier_of_a_run_is_the_identifier_of_its_process() {
+        assert_eq!(
+            tracer_from(&a_config()).trace_identifier(),
+            TraceId(probe_identifier(process::id()))
+        );
+    }
+
+    /// A process identifier of every shape maps onto an identifier that a probe
+    /// can carry.
+    ///
+    /// The first four rows walk the fold onto its edges: the first process, the
+    /// last value of the range, the value one past it that wraps onto the first
+    /// one, and the value that a plain mask of the low sixteen bits would map
+    /// onto zero. The last row is a process identifier of the size that macOS
+    /// hands out.
+    #[test]
+    fn every_process_identifier_maps_onto_an_identifier_that_a_probe_carries() {
+        for (process, expected) in [
+            (1_u32, 2_u16),
+            (65_534, 65_535),
+            (65_535, 1),
+            (65_536, 2),
+            (42_659, 42_660),
+        ] {
+            assert_eq!(probe_identifier(process), expected, "process {process}");
+        }
+    }
+
+    /// No process identifier maps onto the identifier that the tracer reads as
+    /// the answer of any run.
+    ///
+    /// The walk covers the whole range of the fold and one value past it, so it
+    /// reaches every answer the function can give.
+    #[test]
+    fn no_process_identifier_maps_onto_the_identifier_of_any_run() {
+        for process in 0..=u32::from(u16::MAX) + 1 {
+            assert_ne!(
+                TraceId(probe_identifier(process)),
+                ANY_RUN,
+                "process {process}"
+            );
+        }
+    }
+
+    /// Two processes of one window of the fold hold two identifiers.
+    ///
+    /// This is the property that closes the defect. A machine that hands out
+    /// two process identifiers at one moment hands out two different ones, and
+    /// the two runs then read two different sets of answers.
+    #[test]
+    fn two_processes_of_one_window_hold_two_identifiers() {
+        let identifiers: std::collections::HashSet<u16> =
+            (0..u32::from(u16::MAX)).map(probe_identifier).collect();
+        assert_eq!(
+            identifiers.len(),
+            u32::from(u16::MAX) as usize,
+            "the fold maps two processes of one window onto one identifier"
         );
     }
 

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -1,5 +1,5 @@
 //! Black-box coverage for the parts of `krt` that need a real terminal, and
-//! for the parts that need the one tracer of the machine.
+//! for the parts that need a known count of the live runs of the machine.
 //!
 //! `cargo test` hands a test binary a pipe, and three parts of `krt` answer
 //! nothing without a terminal: the width that a frame draws in, the keys that a
@@ -7,12 +7,13 @@
 //! on. A pseudo terminal is a terminal, so these tests give the binary one and
 //! drive it through that.
 //!
-//! One test below gives the binary a pipe on purpose, because the answer it
-//! covers is the one a pipe produces: such a run draws no table. It stands here
-//! beside the runs of a terminal for the other reason of this file. Every live
-//! run takes the one tracer of the machine, and every test of a live run holds
-//! the lock of that tracer while it does. A second lock in a second file locks
-//! nothing, so a live run belongs here whatever its standard output is.
+//! Two tests below give the binary a pipe on purpose. One covers the answer a
+//! pipe produces, which is that such a run draws no table. The other starts two
+//! runs at one moment and reads what each of them recorded. Both stand here
+//! beside the runs of a terminal for the other reason of this file. Every test
+//! of a live run holds the lock of the live runs of the machine while that run
+//! stands. A second lock in a second file locks nothing, so a live run belongs
+//! here whatever its standard output is.
 //!
 //! Every pseudo terminal below carries a size. A pseudo terminal that nobody
 //! sized answers the `TIOCGWINSZ` ioctl with zero columns, and that ioctl
@@ -52,6 +53,8 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
+use std::net;
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
@@ -185,6 +188,33 @@ const FLAG_MAX_TTL: &str = "--max-ttl";
 /// The flag that asks for the status lines in the place of the table.
 #[cfg(target_os = "macos")]
 const FLAG_HEADLESS: &str = "--headless";
+
+/// The flag that names the protocol of a probe.
+#[cfg(target_os = "macos")]
+const FLAG_PROTOCOL: &str = "--protocol";
+
+/// The protocol that `krt` probes with by default.
+#[cfg(target_os = "macos")]
+const ICMP: &str = "icmp";
+
+/// The protocol of a trace that holds its source port and varies the
+/// destination port.
+#[cfg(target_os = "macos")]
+const UDP: &str = "udp";
+
+/// The protocol of a trace that holds its destination port and varies the
+/// source port.
+#[cfg(target_os = "macos")]
+const TCP: &str = "tcp";
+
+/// The first port of the range that a traceroute probes.
+///
+/// Every UDP run of `krt` fixed this port as its source port once, and the
+/// unprivileged path of macOS binds the source port for each probe it sends. So
+/// one program that held this port stopped every UDP run of the machine, and
+/// two runs stopped each other.
+#[cfg(target_os = "macos")]
+const THE_CLASSIC_SOURCE_PORT: u16 = 33_434;
 
 /// The number one, as a limit of rounds and as a limit of TTLs.
 #[cfg(target_os = "macos")]
@@ -640,7 +670,7 @@ impl Drop for Recording {
     }
 }
 
-/// The name of the file that holds the one tracer of the machine.
+/// The name of the file that holds the live runs of the machine.
 ///
 /// The name is fixed, where every other path of this file keys on the process
 /// and on the moment. That is the purpose of it: a lock that two processes
@@ -648,13 +678,15 @@ impl Drop for Recording {
 #[cfg(target_os = "macos")]
 const TRACER_LOCK: &str = "krt-live-tracer.lock";
 
-/// The longest that a wait for the tracer of the machine runs.
+/// The longest that a wait for the live runs of the machine runs.
 ///
 /// One holder takes a few seconds. A live test carries two waits of
 /// [`PATIENCE`], one for the first frame and one for the stop, so twice
-/// PATIENCE bounds a holder that passes. Two test binaries of four live runs
-/// each therefore take well under this bound, and a wait that reaches it says
-/// that something outside these tests holds the lock.
+/// PATIENCE bounds a holder that passes. The test of two runs at one time waits
+/// for no frame, and the round limit of its two runs stops both of them inside
+/// a second. Two test binaries of the live tests of this file therefore take
+/// well under this bound, and a wait that reaches it says that something
+/// outside these tests holds the lock.
 ///
 /// The bound is more than twice [`STALE_LOCK`], so a waiter that pays the whole
 /// wait for a stale file keeps most of its patience for the lock it then takes.
@@ -675,14 +707,26 @@ const LOCK_PATIENCE: Duration = Duration::from_mins(4);
 #[cfg(target_os = "macos")]
 const STALE_LOCK: Duration = Duration::from_secs(90);
 
-/// The hold of one test on the tracer of the machine.
+/// The hold of one test on the live runs of the machine.
 ///
-/// Two tracers of one machine collide. macOS hands the ICMP replies of one
-/// process to the socket of every other process that reads that protocol, so a
-/// tracer reads the answer of a probe that another tracer sent. The probe of
-/// that answer stands in no state that an answer belongs to, and the tracer
-/// then stops with a fault. Three live runs of this file collided that way, and
-/// two of the three failed.
+/// A test that holds this lock knows the number of live runs of the machine:
+/// it is the number of runs that the test itself started. Every other test of
+/// this file waits.
+///
+/// The lock started as a workaround, and that is no longer the reason it
+/// stands. macOS hands the ICMP replies of one process to the socket of every
+/// other process that reads that protocol, so a tracer reads the answer of a
+/// probe that another tracer sent. `krt` named no identifier of its own once,
+/// so every run took every answer. Three live runs of this file collided that
+/// way, and two of the three failed. `src/krt/src/trace.rs` closes that defect:
+/// each run carries the identifier of its process, and the tracer drops every
+/// answer that carries another one.
+///
+/// What the lock gives now is the count above, and one test reads that count.
+/// [`two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes`]
+/// starts two runs and asks what each of them recorded. A third run beside them
+/// would make a failure of that test read as a defect of `krt`, when it was a
+/// test of this file running at the same moment.
 ///
 /// The lock is a file, and not a mutex of the process. `cargo test` runs the
 /// tests of one binary on many threads, and more than one `cargo test` can run
@@ -695,7 +739,7 @@ struct TracerLock {
 
 #[cfg(target_os = "macos")]
 impl TracerLock {
-    /// Waits for the tracer of the machine, and takes it.
+    /// Waits for the live runs of the machine, and takes the hold on them.
     ///
     /// # Panics
     ///
@@ -723,7 +767,7 @@ impl TracerLock {
             }
             assert!(
                 Instant::now() < deadline,
-                "the tracer of the machine must come free inside {LOCK_PATIENCE:?}: {}",
+                "the live runs of the machine must come free inside {LOCK_PATIENCE:?}: {}",
                 path.display()
             );
             thread::sleep(GLANCE);
@@ -780,12 +824,12 @@ fn a_waiter_that_takes_a_stale_lock_over_keeps_patience_for_the_run_it_starts() 
 struct LiveRun {
     /// The terminal of the run.
     terminal: Terminal,
-    /// The hold on the tracer of the machine.
+    /// The hold on the live runs of the machine.
     ///
     /// The field stands under the terminal, because a field drops in the order
     /// it stands: the drop of the terminal stops the run, and the lock then
     /// goes back to the next test. A lock that went back first would let that
-    /// test start its tracer beside a tracer that still stands.
+    /// test start its run beside a run that still stands.
     _lock: TracerLock,
 }
 
@@ -1086,36 +1130,23 @@ fn the_headless_flag_draws_no_table_under_a_terminal() {
     }
 }
 
-/// Two live runs of one machine each record the answers of its own probes, and
-/// no answer of the other run.
+/// Asserts that two live runs of `protocol`, which stand at one moment, each
+/// record the answers of its own probes and no answer of the other run.
 ///
-/// This is the test of the identifier that `src/krt/src/trace.rs` gives each
-/// run. macOS hands the ICMP answers of one process to the socket of every
-/// other process that reads that protocol, so each of these two runs reads
-/// every answer that the machine took. A run that reads a foreign answer as its
-/// own records the path of another run, and the tracer of a debug build stops
-/// with a fault on the way, because that answer belongs to no probe of the
-/// state which the tracer holds.
+/// One run probes [`LOOPBACK`], which answers every probe, and the other probes
+/// [`OTHER_LOOPBACK`], which answers none as [`LOOPBACK`]. That is what makes
+/// the answers tell the two runs apart: a [`LOOPBACK`] hop in the file of the
+/// second run is an answer that the first run earned.
 ///
-/// The two destinations are what make the answers tell the two runs apart. The
-/// run of [`LOOPBACK`] gets an answer for each probe, and the run of
-/// [`OTHER_LOOPBACK`] gets none that names [`LOOPBACK`]. So a [`LOOPBACK`] hop
-/// in the file of the second run is an answer that the first run earned.
-///
-/// The test holds the lock of the tracer for both runs, so the number of live
-/// runs of the machine while it measures is the two that it started. A third
-/// run beside them would make a failure read as a defect of `krt` when it was a
-/// test of this file running beside this one.
+/// The caller holds the lock of the live runs of the machine, so the number of
+/// runs while this helper measures is the two that it starts.
 #[cfg(target_os = "macos")]
-#[test]
-fn two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes() {
-    let answered = Recording::at("krt-collide-answered");
-    let silent = Recording::at("krt-collide-silent");
-    // The lock stands under the two recordings, so the drop of the lock comes
-    // first and the removal of the two files comes after it. That is the order
-    // of every other live test of this file.
-    let _lock = TracerLock::take();
+fn two_live_runs_of(name: &str, protocol: &str) {
+    let answered = Recording::at(&format!("krt-collide-{name}-answered"));
+    let silent = Recording::at(&format!("krt-collide-{name}-silent"));
     let flags = [
+        FLAG_PROTOCOL,
+        protocol,
         FLAG_ROUNDS,
         FIVE,
         FLAG_MAX_TTL,
@@ -1127,7 +1158,9 @@ fn two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes()
 
     // The two runs start one after the other and then stand together. The round
     // limit of each one stops it, so neither wait below carries a deadline of
-    // its own.
+    // its own. The output of a headless run of five rounds is a few hundred
+    // bytes, which is far under the buffer of a pipe, so the run that this
+    // thread does not wait for never stalls on a full pipe.
     let answered_output = answered.argument();
     let silent_output = silent.argument();
     let mut running: Vec<process::Child> = [
@@ -1157,7 +1190,7 @@ fn two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes()
     for (finished, destination) in finished.iter().zip([LOOPBACK, OTHER_LOOPBACK]) {
         assert!(
             finished.status.success(),
-            "the round limit stops the run of {destination}, and no answer of the other run does: {} said {:?}",
+            "the round limit stops the {protocol} run of {destination}, and no answer of the other run does: {} said {:?}",
             finished.status,
             String::from_utf8_lossy(&finished.stderr)
         );
@@ -1166,17 +1199,124 @@ fn two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes()
         assert_eq!(
             recording.end_reason().as_deref(),
             Some(ROUNDS_REASON),
-            "the file of the run of {destination} closes with the reason of the round limit"
+            "the file of the {protocol} run of {destination} closes with the reason of the round limit"
         );
     }
     assert!(
         answered.hop_addresses().iter().any(|hop| hop == LOOPBACK),
-        "the run of {LOOPBACK} records the answers of its own probes: {:?}",
+        "the {protocol} run of {LOOPBACK} records the answers of its own probes: {:?}",
         answered.hop_addresses()
     );
     assert!(
         !silent.hop_addresses().iter().any(|hop| hop == LOOPBACK),
-        "and the run of {OTHER_LOOPBACK} records no answer that the other run earned: {:?}",
+        "and the {protocol} run of {OTHER_LOOPBACK} records no answer that the other run earned: {:?}",
         silent.hop_addresses()
+    );
+}
+
+/// Two live ICMP runs of one machine each record the answers of its own probes.
+///
+/// This is the test of the identifier that `src/krt/src/trace.rs` gives each
+/// run. macOS hands the ICMP answers of one process to the socket of every
+/// other process that reads that protocol, so each of these two runs reads
+/// every answer that the machine took. A run that reads a foreign answer as its
+/// own records the path of another run, and the tracer of a debug build stops
+/// with a fault on the way, because that answer belongs to no probe of the
+/// state which the tracer holds.
+#[cfg(target_os = "macos")]
+#[test]
+fn two_live_icmp_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes() {
+    // The lock stands over the runs of the helper, and the recordings of that
+    // helper drop inside it, so the drop of the lock comes after the runs stop
+    // and before the next test starts one.
+    let _lock = TracerLock::take();
+    two_live_runs_of("icmp", ICMP);
+}
+
+/// Two live UDP runs of one machine each record the answers of its own probes.
+///
+/// The source port is what tells two UDP runs apart. A UDP trace holds its
+/// source port while the destination port varies, and the unprivileged path of
+/// macOS binds that port for each probe, so two runs of one port cannot both
+/// send. The tracer of the second one stops on the port it cannot take, and the
+/// answers of the two would carry one port besides.
+#[cfg(target_os = "macos")]
+#[test]
+fn two_live_udp_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes() {
+    let _lock = TracerLock::take();
+    two_live_runs_of("udp", UDP);
+}
+
+/// Two live TCP runs of one machine each record the answers of its own probes.
+///
+/// A TCP trace holds its destination port while the source port varies, and the
+/// tracer takes the next source port when one is in use, so two TCP runs stand
+/// beside each other already. The test holds that answer in place.
+#[cfg(target_os = "macos")]
+#[test]
+fn two_live_tcp_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes() {
+    let _lock = TracerLock::take();
+    two_live_runs_of("tcp", TCP);
+}
+
+/// A live UDP run stands while another program holds the port that a traceroute
+/// probes first.
+///
+/// This is the answer of the test above, said once and for certain. The two
+/// runs of that test meet on a port that each of them binds for a moment and
+/// then gives back, so they meet on it often and not on every run. This test
+/// holds the port for the whole run, so a run that wanted that one port stops
+/// every time.
+///
+/// The port that the run takes in its place is a port of the range which stands
+/// above the ports a traceroute probes and under the ports that macOS hands to
+/// a socket asking for any port. `src/krt/src/trace.rs` states the range and
+/// the fold onto it.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_live_udp_run_stands_while_another_program_holds_the_port_of_a_traceroute() {
+    let recording = Recording::at("krt-udp-classic-port");
+    // The lock stands under the recording, so the drop of the lock comes first
+    // and the removal of the file comes after it.
+    let _lock = TracerLock::take();
+    let held = net::UdpSocket::bind((LOOPBACK, THE_CLASSIC_SOURCE_PORT))
+        .expect("the port that a traceroute probes first must be free for this test to hold");
+    let output = recording.argument();
+    let flags = [
+        FLAG_PROTOCOL,
+        UDP,
+        FLAG_ROUNDS,
+        ONE,
+        FLAG_MAX_TTL,
+        ONE,
+        FLAG_HEADLESS,
+    ];
+
+    let finished = process::Command::new(env!("CARGO_BIN_EXE_krt"))
+        .args(live_arguments(LOOPBACK, &output, &flags))
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()
+        .expect("the binary must start")
+        .wait_with_output()
+        .expect("the run must stop on its round limit");
+    drop(held);
+
+    assert!(
+        finished.status.success(),
+        "the round limit stops the run, and the held port does not: {} said {:?}",
+        finished.status,
+        String::from_utf8_lossy(&finished.stderr)
+    );
+    assert_eq!(
+        recording.end_reason().as_deref(),
+        Some(ROUNDS_REASON),
+        "the file closes with the reason of the round limit"
+    );
+    assert!(
+        recording.hop_addresses().iter().any(|hop| hop == LOOPBACK),
+        "and the run records the answer of the probe it sent: {:?}",
+        recording.hop_addresses()
     );
 }

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -142,6 +142,18 @@ const COLUMN_HEADER_START: &str = " TTL  Host";
 #[cfg(target_os = "macos")]
 const LOOPBACK: &str = "127.0.0.1";
 
+/// A second address of the loopback network, which no test expects an answer
+/// from.
+///
+/// The test of two runs at one time needs the answers of the two runs to be
+/// different, and it needs no interface to answer as [`LOOPBACK`] for a probe
+/// that went here. Both hold: this machine answers a probe of this address as
+/// this address, or it answers nothing at all. A [`LOOPBACK`] hop in the file
+/// of a run that probed this address is therefore the answer of the other run,
+/// on every machine that runs the test.
+#[cfg(target_os = "macos")]
+const OTHER_LOOPBACK: &str = "127.0.0.2";
+
 /// The flag that names the address the probes leave from.
 #[cfg(target_os = "macos")]
 const FLAG_SOURCE: &str = "--source";
@@ -177,6 +189,23 @@ const FLAG_HEADLESS: &str = "--headless";
 /// The number one, as a limit of rounds and as a limit of TTLs.
 #[cfg(target_os = "macos")]
 const ONE: &str = "1";
+
+/// The number of rounds that each run of the collision test records.
+///
+/// The two runs start at one moment and each round of each of them sends one
+/// probe, so five rounds give the two runs five chances each to read the
+/// answer of the other. One chance is enough to show the defect, and five
+/// stand well clear of a machine that scheduled the two runs apart.
+#[cfg(target_os = "macos")]
+const FIVE: &str = "5";
+
+/// The period of one round of the collision test.
+///
+/// The two runs of that test record [`FIVE`] rounds each, so this period puts
+/// the whole test inside one second. Every other live test of this file takes
+/// the period that `krt` holds by default.
+#[cfg(target_os = "macos")]
+const A_SHORT_INTERVAL: &str = "200ms";
 
 /// The flags of a run that records one round of one TTL and then stops.
 ///
@@ -258,6 +287,19 @@ const END_RECORD: &str = "end";
 /// The name of the field that says why a run stopped.
 #[cfg(target_os = "macos")]
 const REASON_FIELD: &str = "reason";
+
+/// The kind of the record that holds one round.
+#[cfg(target_os = "macos")]
+const ROUND_RECORD: &str = "round";
+
+/// The name of the field of a `round` record that holds the hops which
+/// answered.
+#[cfg(target_os = "macos")]
+const HOPS_FIELD: &str = "hops";
+
+/// The name of the field of a hop that holds the address which answered.
+#[cfg(target_os = "macos")]
+const ADDR_FIELD: &str = "addr";
 
 /// The reason of a run that the user stopped.
 #[cfg(target_os = "macos")]
@@ -541,20 +583,26 @@ impl Recording {
             .to_owned()
     }
 
-    /// Why the `end` record of the file says the run stopped, and `None` when
-    /// the file holds no such record.
+    /// Every record of the file, in the order that the run appended them.
     ///
     /// The file holds one JSON object for each line, so the reader parses each
-    /// line and reads the field that names its kind. A search of the text for
-    /// the two words would pass on a file whose `end` record names one reason
-    /// and whose other records name the word beside it.
-    fn end_reason(&self) -> Option<String> {
+    /// line. A search of the text for a word would pass on a file whose record
+    /// of one kind names the word that a record of another kind carries.
+    fn records(&self) -> Vec<serde_json::Value> {
         let text = fs::read_to_string(&self.path).expect("the recorded file must read");
         text.lines()
             .map(|line| {
                 serde_json::from_str::<serde_json::Value>(line)
                     .expect("each line of the recorded file must parse")
             })
+            .collect()
+    }
+
+    /// Why the `end` record of the file says the run stopped, and `None` when
+    /// the file holds no such record.
+    fn end_reason(&self) -> Option<String> {
+        self.records()
+            .into_iter()
             .find(|record| {
                 record.get(TYPE_FIELD).and_then(serde_json::Value::as_str) == Some(END_RECORD)
             })
@@ -564,6 +612,24 @@ impl Recording {
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_owned)
             })
+    }
+
+    /// The address of every hop that the `round` records of the file report.
+    ///
+    /// A hop that did not answer is absent from a `round` record, so this list
+    /// names the routers that answered a probe of the run, one entry for each
+    /// answer and in the order that the rounds recorded them.
+    fn hop_addresses(&self) -> Vec<String> {
+        self.records()
+            .iter()
+            .filter(|record| {
+                record.get(TYPE_FIELD).and_then(serde_json::Value::as_str) == Some(ROUND_RECORD)
+            })
+            .filter_map(|record| record.get(HOPS_FIELD).and_then(serde_json::Value::as_array))
+            .flatten()
+            .filter_map(|hop| hop.get(ADDR_FIELD).and_then(serde_json::Value::as_str))
+            .map(str::to_owned)
+            .collect()
     }
 }
 
@@ -723,18 +789,19 @@ struct LiveRun {
     _lock: TracerLock,
 }
 
-/// The command line of a live run of the loopback, with `flags` behind the
+/// The command line of a live run of `destination`, with `flags` behind the
 /// flags that every live run of this file takes.
 ///
 /// A test that needs one more flag names that flag alone. The flags of the run
 /// which keep it offline stand here, in one place, so no test of this file can
 /// start a run that reaches the network. The run stays offline for the reason
-/// that the file documentation states: the destination is the loopback,
-/// [`FLAG_SOURCE`] names the loopback, and [`FLAG_NO_DNS`] looks nothing up.
+/// that the file documentation states: the destination is of the loopback
+/// network, [`FLAG_SOURCE`] names the loopback, and [`FLAG_NO_DNS`] looks
+/// nothing up.
 #[cfg(target_os = "macos")]
-fn live_arguments<'a>(output: &'a str, flags: &[&'a str]) -> Vec<&'a str> {
+fn live_arguments<'a>(destination: &'a str, output: &'a str, flags: &[&'a str]) -> Vec<&'a str> {
     let mut arguments = vec![
-        LOOPBACK,
+        destination,
         FLAG_SOURCE,
         LOOPBACK,
         FLAG_NO_DNS,
@@ -774,7 +841,7 @@ fn live_run_with(recording: &Recording, flags: &[&str]) -> LiveRun {
 fn live_run_under(recording: &Recording, flags: &[&str]) -> LiveRun {
     let lock = TracerLock::take();
     let output = recording.argument();
-    let terminal = Terminal::open(WIDE, &live_arguments(&output, flags));
+    let terminal = Terminal::open(WIDE, &live_arguments(LOOPBACK, &output, flags));
     LiveRun {
         terminal,
         _lock: lock,
@@ -951,7 +1018,7 @@ fn a_live_run_whose_standard_output_is_a_pipe_draws_no_table() {
     // `wait_with_output` waits with no deadline, and the round limit of
     // [`ONE_ROUND_OF_ONE_TTL`] is what bounds it: the run stops on its own.
     let finished = process::Command::new(env!("CARGO_BIN_EXE_krt"))
-        .args(live_arguments(&output, &ONE_ROUND_OF_ONE_TTL))
+        .args(live_arguments(LOOPBACK, &output, &ONE_ROUND_OF_ONE_TTL))
         .stdin(process::Stdio::null())
         .stdout(process::Stdio::piped())
         .stderr(process::Stdio::piped())
@@ -1017,4 +1084,99 @@ fn the_headless_flag_draws_no_table_under_a_terminal() {
             "and the flag keeps it off the alternate screen of the terminal it holds: {shown:?}"
         );
     }
+}
+
+/// Two live runs of one machine each record the answers of its own probes, and
+/// no answer of the other run.
+///
+/// This is the test of the identifier that `src/krt/src/trace.rs` gives each
+/// run. macOS hands the ICMP answers of one process to the socket of every
+/// other process that reads that protocol, so each of these two runs reads
+/// every answer that the machine took. A run that reads a foreign answer as its
+/// own records the path of another run, and the tracer of a debug build stops
+/// with a fault on the way, because that answer belongs to no probe of the
+/// state which the tracer holds.
+///
+/// The two destinations are what make the answers tell the two runs apart. The
+/// run of [`LOOPBACK`] gets an answer for each probe, and the run of
+/// [`OTHER_LOOPBACK`] gets none that names [`LOOPBACK`]. So a [`LOOPBACK`] hop
+/// in the file of the second run is an answer that the first run earned.
+///
+/// The test holds the lock of the tracer for both runs, so the number of live
+/// runs of the machine while it measures is the two that it started. A third
+/// run beside them would make a failure read as a defect of `krt` when it was a
+/// test of this file running beside this one.
+#[cfg(target_os = "macos")]
+#[test]
+fn two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes() {
+    let answered = Recording::at("krt-collide-answered");
+    let silent = Recording::at("krt-collide-silent");
+    // The lock stands under the two recordings, so the drop of the lock comes
+    // first and the removal of the two files comes after it. That is the order
+    // of every other live test of this file.
+    let _lock = TracerLock::take();
+    let flags = [
+        FLAG_ROUNDS,
+        FIVE,
+        FLAG_MAX_TTL,
+        ONE,
+        FLAG_INTERVAL,
+        A_SHORT_INTERVAL,
+        FLAG_HEADLESS,
+    ];
+
+    // The two runs start one after the other and then stand together. The round
+    // limit of each one stops it, so neither wait below carries a deadline of
+    // its own.
+    let answered_output = answered.argument();
+    let silent_output = silent.argument();
+    let mut running: Vec<process::Child> = [
+        (LOOPBACK, &answered_output),
+        (OTHER_LOOPBACK, &silent_output),
+    ]
+    .iter()
+    .map(|(destination, output)| {
+        process::Command::new(env!("CARGO_BIN_EXE_krt"))
+            .args(live_arguments(destination, output, &flags))
+            .stdin(process::Stdio::null())
+            .stdout(process::Stdio::piped())
+            .stderr(process::Stdio::piped())
+            .spawn()
+            .expect("the binary must start")
+    })
+    .collect();
+    let finished: Vec<process::Output> = running
+        .drain(..)
+        .map(|child| {
+            child
+                .wait_with_output()
+                .expect("the run must stop on its round limit")
+        })
+        .collect();
+
+    for (finished, destination) in finished.iter().zip([LOOPBACK, OTHER_LOOPBACK]) {
+        assert!(
+            finished.status.success(),
+            "the round limit stops the run of {destination}, and no answer of the other run does: {} said {:?}",
+            finished.status,
+            String::from_utf8_lossy(&finished.stderr)
+        );
+    }
+    for (recording, destination) in [(&answered, LOOPBACK), (&silent, OTHER_LOOPBACK)] {
+        assert_eq!(
+            recording.end_reason().as_deref(),
+            Some(ROUNDS_REASON),
+            "the file of the run of {destination} closes with the reason of the round limit"
+        );
+    }
+    assert!(
+        answered.hop_addresses().iter().any(|hop| hop == LOOPBACK),
+        "the run of {LOOPBACK} records the answers of its own probes: {:?}",
+        answered.hop_addresses()
+    );
+    assert!(
+        !silent.hop_addresses().iter().any(|hop| hop == LOOPBACK),
+        "and the run of {OTHER_LOOPBACK} records no answer that the other run earned: {:?}",
+        silent.hop_addresses()
+    );
 }

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -7,13 +7,13 @@
 //! on. A pseudo terminal is a terminal, so these tests give the binary one and
 //! drive it through that.
 //!
-//! Two tests below give the binary a pipe on purpose. One covers the answer a
-//! pipe produces, which is that such a run draws no table. The other starts two
-//! runs at one moment and reads what each of them recorded. Both stand here
-//! beside the runs of a terminal for the other reason of this file. Every test
-//! of a live run holds the lock of the live runs of the machine while that run
-//! stands. A second lock in a second file locks nothing, so a live run belongs
-//! here whatever its standard output is.
+//! Some tests below give the binary a pipe on purpose. One covers the answer a
+//! pipe produces, which is that such a run draws no table. The others read a
+//! recorded file in place of a drawn table, and a terminal gives them nothing.
+//! They all stand here beside the runs of a terminal for the other reason of
+//! this file. Every test of a live run holds the lock of the live runs of the
+//! machine while that run stands. A second lock in a second file locks nothing,
+//! so a live run belongs here whatever its standard output is.
 //!
 //! Every pseudo terminal below carries a size. A pseudo terminal that nobody
 //! sized answers the `TIOCGWINSZ` ioctl with zero columns, and that ioctl
@@ -713,9 +713,9 @@ const STALE_LOCK: Duration = Duration::from_secs(90);
 
 /// The hold of one test on the live runs of the machine.
 ///
-/// A test that holds this lock knows the number of live runs of the machine:
-/// it is the number of runs that the test itself started. Every other test of
-/// this file waits.
+/// A test that holds this lock knows the live runs that `cargo test` started.
+/// They are the runs that the test itself started, and every other test of this
+/// file waits. A `krt` that a user started by hand stands outside that count.
 ///
 /// The lock started as a workaround, and that is no longer the reason it
 /// stands. macOS hands the ICMP replies of one process to the socket of every
@@ -726,11 +726,11 @@ const STALE_LOCK: Duration = Duration::from_secs(90);
 /// each run carries the identifier of its process, and the tracer drops every
 /// answer that carries another one.
 ///
-/// What the lock gives now is the count above, and one test reads that count.
-/// [`two_live_runs_of_one_machine_each_record_only_the_answers_of_its_own_probes`]
-/// starts two runs and asks what each of them recorded. A third run beside them
-/// would make a failure of that test read as a defect of `krt`, when it was a
-/// test of this file running at the same moment.
+/// What the lock gives now is the count above, and three tests read it. Each of
+/// them calls [`two_live_runs_of`], which starts two runs of one protocol and
+/// asks what each of them recorded. A third run of this file beside them can
+/// make a failure read as a defect of `krt`. The cause is then a test of this
+/// file that stands at the same moment.
 ///
 /// The lock is a file, and not a mutex of the process. `cargo test` runs the
 /// tests of one binary on many threads, and more than one `cargo test` can run
@@ -1045,7 +1045,7 @@ fn a_live_run_draws_its_table_in_front_of_the_first_round() {
 
 /// A live run whose standard output is a pipe draws no table.
 ///
-/// This is the one test of this file that gives the binary a pipe. The run has
+/// This is the one test of this file that reads what a pipe holds. The run has
 /// no terminal to hold, no key to read, and no screen to clear, so it writes
 /// one status line for the round it made and nothing else. A table there would
 /// write a whole frame of control sequences into the file of the reader for

--- a/src/krt/tests/terminal.rs
+++ b/src/krt/tests/terminal.rs
@@ -220,6 +220,10 @@ const THE_CLASSIC_SOURCE_PORT: u16 = 33_434;
 #[cfg(target_os = "macos")]
 const ONE: &str = "1";
 
+/// The number of rounds of the run that measures a UDP source port.
+#[cfg(target_os = "macos")]
+const TWO: &str = "2";
+
 /// The number of rounds that each run of the collision test records.
 ///
 /// The two runs start at one moment and each round of each of them sends one
@@ -1272,6 +1276,13 @@ fn two_live_tcp_runs_of_one_machine_each_record_only_the_answers_of_its_own_prob
 /// above the ports a traceroute probes and under the ports that macOS hands to
 /// a socket asking for any port. `src/krt/src/trace.rs` states the range and
 /// the fold onto it.
+///
+/// The run records two rounds, and the first of them reports no hop. A UDP
+/// trace carries the sequence of a probe in the destination port, and the first
+/// sequence of a run is 33434, so the first probe of the run arrives at the
+/// socket that this test holds. That socket takes the datagram, the machine
+/// answers no port unreachable for it, and the hop of that round is therefore
+/// absent. The second probe carries 33435, which nothing holds.
 #[cfg(target_os = "macos")]
 #[test]
 fn a_live_udp_run_stands_while_another_program_holds_the_port_of_a_traceroute() {
@@ -1286,9 +1297,11 @@ fn a_live_udp_run_stands_while_another_program_holds_the_port_of_a_traceroute() 
         FLAG_PROTOCOL,
         UDP,
         FLAG_ROUNDS,
-        ONE,
+        TWO,
         FLAG_MAX_TTL,
         ONE,
+        FLAG_INTERVAL,
+        A_SHORT_INTERVAL,
         FLAG_HEADLESS,
     ];
 
@@ -1316,7 +1329,7 @@ fn a_live_udp_run_stands_while_another_program_holds_the_port_of_a_traceroute() 
     );
     assert!(
         recording.hop_addresses().iter().any(|hop| hop == LOOPBACK),
-        "and the run records the answer of the probe it sent: {:?}",
+        "and the run records the answer of the probe that the held socket did not take: {:?}",
         recording.hop_addresses()
     );
 }


### PR DESCRIPTION
Closes #390.

Two `krt` runs on one machine read each other's answers. The kernel gives every
raw ICMP socket a copy of each ICMP answer, so one run counted the answers of
the other run as its own.

- A run matches an ICMP echo answer on the identifier of its own probes.
- A UDP run binds a source port of its own, and matches an answer on that port.
  The port of the machine is no longer part of the match.
- `README.md` says what two runs of one machine do.

Tests live in `src/krt/tests/terminal.rs`. The four Rust gates (fmt, machete,
clippy, test) ran by hand, because the pre-commit hook is gated on staged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)