### PR TITLE
fix(krt): a multipath mode needs udp, and each mode says the flow krt sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ See [src/gitscratch/README.md](src/gitscratch/README.md) for the full list of gu
     | `--first-ttl <N>` | `1` | The first TTL that a round probes. |
     | `--max-ttl <N>` | `30` | The last TTL that a round probes. |
     | `--protocol <P>` | `icmp` | `icmp`, `udp`, or `tcp`. |
-    | `--multipath <M>` | `classic` | `classic`, `paris`, or `dublin`. UDP and TCP only. |
+    | `--multipath <M>` | `classic` | `classic`, `paris`, or `dublin`. UDP only. |
     | `-4`, `-6` | the resolver decides | Force the address family. |
     | `--no-dns` | off | Skip every reverse lookup, and show the addresses alone. |
     | `--source <IP>` | discovered | Name the source of the derived filename, and skip the lookup of the public address. |

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -202,14 +202,25 @@ enum Protocol {
 }
 
 /// The way a probe keeps or varies the flow of a packet.
+// `paris` and `dublin` each hold one flow for one round, and not for one run,
+// because a UDP run of `krt` holds the source port and lets the destination
+// port vary. The tracer writes the number of the round into that free port for
+// both of the two modes, and it carries the number of the probe in another
+// field: the UDP checksum for `paris`, and the IP header for `dublin`. A run
+// that held both ports would hold one flow for the whole run, and `krt` builds
+// no such direction. `trace.rs` holds the three sentences below beside the
+// direction of the ports, in
+// `the_multipath_help_stands_beside_the_port_direction_that_makes_it_true`.
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Multipath {
     /// Let each probe take its own flow, as traceroute always did.
     Classic,
-    /// Hold one flow for every probe, as Paris traceroute does.
+    /// Hold one flow for each round, and carry the probe number in the UDP
+    /// checksum.
     Paris,
-    /// Walk the flows to find every path, as Dublin traceroute does.
+    /// Hold one flow for each round, and carry the probe number in the IP
+    /// header.
     Dublin,
 }
 

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -326,7 +326,7 @@ struct Cli {
     #[arg(long, value_name = "P", value_enum, default_value_t = Protocol::Icmp)]
     protocol: Protocol,
 
-    /// The multipath mode. UDP and TCP only.
+    /// The multipath mode. UDP only.
     #[arg(long, value_name = "M", value_enum, default_value_t = Multipath::Classic)]
     multipath: Multipath,
 
@@ -435,7 +435,11 @@ impl Cli {
     ///
     /// Returns the reason as text when two flags contradict each other. A first
     /// TTL above the max TTL leaves no hop to probe. A multipath mode other
-    /// than `classic` needs UDP or TCP, because ICMP carries no flow to vary.
+    /// than `classic` needs UDP, because no other protocol lets the mode
+    /// change a packet. ICMP carries no port to hold or to vary. A TCP probe
+    /// puts the probe number in its source port under every mode, so the mode
+    /// changes nothing, and the record then names a mode that the run did not
+    /// use.
     fn resolve(self) -> Result<ResolvedConfig, String> {
         if self.first_ttl > self.max_ttl {
             return Err(format!(
@@ -444,10 +448,10 @@ impl Cli {
             ));
         }
 
-        let carries_a_flow = matches!(self.protocol, Protocol::Udp | Protocol::Tcp);
-        if self.multipath != Multipath::Classic && !carries_a_flow {
+        let carries_a_mode = matches!(self.protocol, Protocol::Udp);
+        if self.multipath != Multipath::Classic && !carries_a_mode {
             return Err(format!(
-                "`--multipath {}` needs `--protocol udp` or `--protocol tcp`, but the protocol is `{}`",
+                "`--multipath {}` needs `--protocol udp`, but the protocol is `{}`",
                 value_name(&self.multipath),
                 value_name(&self.protocol)
             ));
@@ -2401,23 +2405,19 @@ resolved configuration:
     }
 
     #[test]
-    fn a_multipath_mode_resolves_with_udp_and_with_tcp() {
-        for (mode, protocol) in [("paris", "udp"), ("dublin", "tcp")] {
+    fn every_multipath_mode_resolves_with_udp() {
+        for (mode, expected) in [("paris", Multipath::Paris), ("dublin", Multipath::Dublin)] {
             let config = resolve(&[
                 "krt",
                 "example.com",
                 "--multipath",
                 mode,
                 "--protocol",
-                protocol,
+                "udp",
             ]);
             assert_eq!(
-                config.multipath,
-                match mode {
-                    "paris" => Multipath::Paris,
-                    _ => Multipath::Dublin,
-                },
-                "`--multipath {mode} --protocol {protocol}`"
+                config.multipath, expected,
+                "`--multipath {mode} --protocol udp`"
             );
         }
     }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -1359,9 +1359,9 @@ fn main() {
 mod tests {
     use super::{
         closing_line, display_of, host_name_or, name_grace, parse_duration, pick_address,
-        resolve_target, run_config, source_from, stop_reason, user_stopped, AddressFamily, Cli,
-        Command, Display, EndReason, Family, Multipath, Protocol, ResolveError, ResolvedConfig,
-        SourceKind, SourceLabel, RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
+        resolve_target, run_config, source_from, stop_reason, user_stopped, value_name,
+        AddressFamily, Cli, Command, Display, EndReason, Family, Multipath, Protocol, ResolveError,
+        ResolvedConfig, SourceKind, SourceLabel, RESOLVE_PORT, SOURCE_FALLBACK, UNKNOWN,
     };
     use crate::record::{Privilege, RunConfig};
     use crate::run::Outcome;
@@ -1369,7 +1369,7 @@ mod tests {
     use crate::testing::address;
     use crate::ui::render_duration;
     use clap::error::{ContextKind, ContextValue, ErrorKind};
-    use clap::{CommandFactory, Parser};
+    use clap::{CommandFactory, Parser, ValueEnum};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::path::Path;
     use std::path::PathBuf;
@@ -2338,6 +2338,64 @@ resolved configuration:
             assert!(
                 message.contains(part),
                 "the message names `{part}`: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_a_multipath_mode_beside_tcp() {
+        let message = contradiction(&[
+            "krt",
+            "example.com",
+            "--multipath",
+            "dublin",
+            "--protocol",
+            "tcp",
+        ]);
+        for part in ["--multipath", "dublin", "--protocol", "tcp"] {
+            assert!(
+                message.contains(part),
+                "the message names `{part}`: {message}"
+            );
+        }
+    }
+
+    /// The help of one flag of the command line, by the id of that flag. The
+    /// long help stands when the flag carries one, and the short help stands
+    /// otherwise.
+    fn flag_help(id: &str) -> String {
+        let command = Cli::command();
+        let argument = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == id)
+            .expect("the command line carries the flag");
+        argument
+            .get_long_help()
+            .or_else(|| argument.get_help())
+            .expect("the flag carries help")
+            .to_string()
+    }
+
+    #[test]
+    fn the_help_of_the_multipath_flag_names_every_protocol_that_carries_a_mode() {
+        let help = flag_help("multipath");
+        for protocol in Protocol::value_variants() {
+            let name = value_name(protocol);
+            let accepted = parse(&[
+                "krt",
+                "example.com",
+                "--multipath",
+                "paris",
+                "--protocol",
+                name.as_str(),
+            ])
+            .resolve()
+            .is_ok();
+            let in_the_help = name.to_uppercase();
+            assert_eq!(
+                help.contains(&in_the_help),
+                accepted,
+                "the help names `{in_the_help}` when `--multipath paris` takes `--protocol {name}`: {help}"
             );
         }
     }

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -2416,7 +2416,7 @@ resolved configuration:
     }
 
     #[test]
-    fn every_multipath_mode_resolves_with_udp() {
+    fn a_multipath_mode_other_than_classic_resolves_with_udp() {
         for (mode, expected) in [("paris", Multipath::Paris), ("dublin", Multipath::Dublin)] {
             let config = resolve(&[
                 "krt",

--- a/src/krt/src/main.rs
+++ b/src/krt/src/main.rs
@@ -2433,11 +2433,34 @@ resolved configuration:
         }
     }
 
+    /// The refusal of a mode other than `classic` reaches UDP alone, so
+    /// `classic` is what keeps every protocol of the command line usable.
+    ///
+    /// This test therefore resolves `classic` beside each protocol in turn,
+    /// and it is the one test that asks `resolve` to accept `--protocol tcp`
+    /// and `--protocol udp` at all.
     #[test]
     fn the_classic_multipath_mode_resolves_with_every_protocol() {
-        let config = resolve(&["krt", "example.com", "--multipath", "classic"]);
-        assert_eq!(config.multipath, Multipath::Classic);
-        assert_eq!(config.protocol, Protocol::Icmp);
+        for protocol in Protocol::value_variants() {
+            let name = value_name(protocol);
+            let config = resolve(&[
+                "krt",
+                "example.com",
+                "--multipath",
+                "classic",
+                "--protocol",
+                name.as_str(),
+            ]);
+            assert_eq!(
+                config.multipath,
+                Multipath::Classic,
+                "`--multipath classic --protocol {name}`"
+            );
+            assert_eq!(
+                config.protocol, *protocol,
+                "`--multipath classic --protocol {name}`"
+            );
+        }
     }
 
     #[test]

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -1225,6 +1225,69 @@ this platform needs raw socket privileges to send probes.
         );
     }
 
+    /// The sentence that `krt --help` prints for each multipath mode.
+    ///
+    /// `clap` builds the help of a value out of the doc comment of the variant
+    /// that carries it, and it drops the period at the end. Each sentence
+    /// below therefore stops without one.
+    const MULTIPATH_HELP: [(Multipath, &str); 3] = [
+        (
+            Multipath::Classic,
+            "Let each probe take its own flow, as traceroute always did",
+        ),
+        (
+            Multipath::Paris,
+            "Hold one flow for each round, and carry the probe number in the UDP checksum",
+        ),
+        (
+            Multipath::Dublin,
+            "Hold one flow for each round, and carry the probe number in the IP header",
+        ),
+    ];
+
+    /// The help of each multipath mode stands beside the port direction that
+    /// makes that help true.
+    ///
+    /// A UDP run of `krt` holds the source port and lets the destination port
+    /// vary. The tracer writes the number of the round into that free port for
+    /// `paris` and for `dublin`, so each of the two modes holds one flow for
+    /// one round. A direction that held both ports would hold one flow for the
+    /// whole run, and the help of the two modes would then be false.
+    ///
+    /// The direction and the three sentences therefore live in one test. An
+    /// edit of the direction above breaks this test, and no reader of
+    /// `krt --help` then reads a sentence which the code left behind.
+    #[test]
+    fn the_multipath_help_stands_beside_the_port_direction_that_makes_it_true() {
+        use clap::{CommandFactory, ValueEnum};
+
+        assert_eq!(
+            tracer_of_protocol(Protocol::Udp).port_direction(),
+            trippy_core::PortDirection::FixedSrc(Port(UDP_SOURCE_PORT)),
+            "the free destination port of a UDP run carries the number of the round, and that is what makes `one flow for each round` true. A direction that held both ports would hold one flow for the whole run, and the help of `paris` and of `dublin` would then be false"
+        );
+
+        let page = crate::Cli::command().render_long_help().to_string();
+        for (mode, sentence) in MULTIPATH_HELP {
+            let value = mode
+                .to_possible_value()
+                .expect("every multipath mode carries a name");
+            let help = value
+                .get_help()
+                .expect("every multipath mode carries help")
+                .to_string();
+            assert_eq!(
+                help, sentence,
+                "the doc comment of `{mode:?}` in `main.rs` writes this sentence on the help page, and the port direction above is what makes it true. An edit of that direction must change the doc comment with it"
+            );
+            let name = value.get_name();
+            assert!(
+                page.contains(name),
+                "the long help names the `{name}` mode, so the sentence of that mode reaches the page a reader reads: {page}"
+            );
+        }
+    }
+
     /// `Builder::build` refuses a TCP trace whose port direction is `None`, as
     /// it refuses such a UDP trace.
     #[test]

--- a/src/krt/src/trace.rs
+++ b/src/krt/src/trace.rs
@@ -1267,7 +1267,15 @@ this platform needs raw socket privileges to send probes.
             "the free destination port of a UDP run carries the number of the round, and that is what makes `one flow for each round` true. A direction that held both ports would hold one flow for the whole run, and the help of `paris` and of `dublin` would then be false"
         );
 
-        let page = crate::Cli::command().render_long_help().to_string();
+        // `term_width(0)` stands for an unbounded width in `clap` 4, so the
+        // page below wraps no line. A page of the default width of 100 columns
+        // carries the longest sentence of a mode in 96 of them, and a sentence
+        // that grew past that margin would wrap and break the assertion below
+        // for a reason that no reader of `krt --help` ever meets.
+        let page = crate::Cli::command()
+            .term_width(0)
+            .render_long_help()
+            .to_string();
         for (mode, sentence) in MULTIPATH_HELP {
             let value = mode
                 .to_possible_value()
@@ -1282,8 +1290,8 @@ this platform needs raw socket privileges to send probes.
             );
             let name = value.get_name();
             assert!(
-                page.contains(name),
-                "the long help names the `{name}` mode, so the sentence of that mode reaches the page a reader reads: {page}"
+                page.contains(sentence),
+                "the long help carries the sentence of the `{name}` mode, so that sentence reaches the page a reader reads. `clap` writes the name of a mode onto the page under every outcome, the bare `[possible values: ...]` line included, so the name alone says nothing about the sentence: {page}"
             );
         }
     }


### PR DESCRIPTION
Closes #394.

The doc comments on `Multipath` promised the textbook Paris and Dublin
traceroutes. Clap turns each comment into a possible value of `krt --help`, so
the overstatement reached the user. `krt` holds one port and lets the other one
vary, so `paris` and `dublin` hold one flow for one round, and not for one run.

## What changed

- **`paris` and `dublin` now refuse TCP.** A TCP probe puts the probe number in
  its source port under every mode, so the mode changes nothing. The old code
  accepted the pair and wrote a mode into the record that the run did not use.
  `--multipath <M>` now reads `UDP only`, and the error message names `udp`
  alone.
- **Each mode says the flow that `krt` really sends.** `paris` says it holds one
  flow for each round and carries the probe number in the UDP checksum.
  `dublin` says it holds one flow for each round and carries the probe number in
  the IP header.

## Tests

- `rejects_a_multipath_mode_beside_tcp` — the contradiction names both flags.
- `the_help_of_the_multipath_flag_names_every_protocol_that_carries_a_mode` —
  the help of the flag and the set of protocols that `resolve` accepts cannot
  drift apart.
- `the_multipath_help_stands_beside_the_port_direction_that_makes_it_true` — the
  three sentences stand beside the port direction in `trace.rs` that makes them
  true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
